### PR TITLE
添加本地安装路径配置，直接启动原神

### DIFF
--- a/BetterGenshinImpact/BetterGenshinImpact.csproj
+++ b/BetterGenshinImpact/BetterGenshinImpact.csproj
@@ -32,6 +32,7 @@
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
 		<PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.16.1" />
 		<PackageReference Include="Microsoft.ML.OnnxRuntime.Managed" Version="1.16.1" />
+		<PackageReference Include="Ookii.Dialogs.Wpf" Version="5.0.1" />
 		<PackageReference Include="OpenCvSharp4.Extensions" Version="4.8.0.20230708" />
 		<PackageReference Include="OpenCvSharp4.Windows" Version="4.8.0.20230708" />
 		<PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.77" />

--- a/BetterGenshinImpact/Core/Config/AllConfig.cs
+++ b/BetterGenshinImpact/Core/Config/AllConfig.cs
@@ -73,6 +73,12 @@ namespace BetterGenshinImpact.Core.Config
         /// </summary>
         public HotKeyConfig HotKeyConfig { get; set; } = new();
 
+        /// <summary>
+        /// 原神安装路径
+        /// </summary>
+        [ObservableProperty]
+        private string _installPath = "";
+
         [JsonIgnore] public Action? OnAnyChangedAction { get; set; }
 
         public void InitEvent()

--- a/BetterGenshinImpact/GameTask/GameLoading/GameLoading.cs
+++ b/BetterGenshinImpact/GameTask/GameLoading/GameLoading.cs
@@ -1,0 +1,64 @@
+﻿using BetterGenshinImpact.Core.Recognition;
+using BetterGenshinImpact.Core.Simulator;
+using BetterGenshinImpact.GameTask.AutoSkip.Assets;
+using BetterGenshinImpact.GameTask.Model;
+using OpenCvSharp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BetterGenshinImpact.GameTask.GameLoading
+{
+    public class GameLoadingTrigger : ITaskTrigger
+    {
+        private RecognitionObject? _startGameRo;
+
+        public string Name => "GameLoading";
+
+        public bool IsEnabled { get; set; }
+
+        public int Priority => 999;
+
+        public bool IsExclusive => false;
+
+        public void Init()
+        {
+            var info = TaskContext.Instance().SystemInfo;
+            _startGameRo = new RecognitionObject
+            {
+                Name = "StartGame",
+                RecognitionType = RecognitionTypes.Ocr,
+                // ROI 应该时捕捉窗口的中间底部部分
+                RegionOfInterest = new Rect((int)(info.CaptureAreaRect.Width / 2 - 100),
+                    (int)(info.CaptureAreaRect.Height - 100),
+                    200,
+                    100),
+                OneContainMatchText = new List<string>
+            {
+                "点", "击", "进", "入"
+            },
+                DrawOnWindow = true
+            }.InitTemplate();
+            IsEnabled = true;
+        }
+
+        public void OnCapture(CaptureContent content)
+        {
+            using var foundRectArea = content.CaptureRectArea.Find(_startGameRo!);
+            if (!foundRectArea.IsEmpty())
+            {
+                // 在游戏窗口中心点击
+                var info = TaskContext.Instance().SystemInfo;
+                var x = info.CaptureAreaRect.Right - (info.CaptureAreaRect.Width / 2);
+                var y = info.CaptureAreaRect.Bottom - (info.CaptureAreaRect.Height / 2);
+                Simulation.MouseEvent.Click(x, y);
+                // 一旦进入游戏，这个触发器就不再需要了
+                // TODO：如果其他触发器成功，这个触发器同样也不再需要了，考虑使用其他触发器的成功来禁用该事件
+                IsEnabled = false;
+            }
+        }
+    }
+
+}

--- a/BetterGenshinImpact/GameTask/GameTaskManager.cs
+++ b/BetterGenshinImpact/GameTask/GameTaskManager.cs
@@ -26,7 +26,8 @@ namespace BetterGenshinImpact.GameTask
                 { "RecognitionTest", new TestTrigger() },
                 { "AutoPick", new AutoPick.AutoPickTrigger() },
                 { "AutoSkip", new AutoSkip.AutoSkipTrigger() },
-                { "AutoFishing", new AutoFishing.AutoFishingTrigger() }
+                { "AutoFishing", new AutoFishing.AutoFishingTrigger() },
+                { "GameLoading", new GameLoading.GameLoadingTrigger() }
             };
 
             var loadedTriggers = TriggerDictionary.Values.ToList();

--- a/BetterGenshinImpact/GameTask/SystemControl.cs
+++ b/BetterGenshinImpact/GameTask/SystemControl.cs
@@ -1,6 +1,8 @@
-﻿using System;
+﻿using BetterGenshinImpact.Core.Simulator;
+using System;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using Vanara.PInvoke;
 
 namespace BetterGenshinImpact.GameTask;
@@ -10,6 +12,14 @@ public class SystemControl
     public static nint FindGenshinImpactHandle()
     {
         return FindHandleByProcessName("YuanShen", "GenshinImpact", "Genshin Impact Cloud Game");
+    }
+
+    public static nint StartFromLocal(string path)
+    {
+        // 使用 path 在新的线程中启动游戏
+        var process = Process.Start(new ProcessStartInfo(path) { UseShellExecute = true });
+        Thread.Sleep(10000);
+        return FindGenshinImpactHandle();
     }
 
     public static bool IsGenshinImpactActiveByProcess()

--- a/BetterGenshinImpact/View/Pages/HomePage.xaml
+++ b/BetterGenshinImpact/View/Pages/HomePage.xaml
@@ -106,6 +106,35 @@
                 </Grid>
             </ui:CardExpander.Header>
             <StackPanel>
+                <Grid Margin="16" >
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <ui:TextBlock 
+                        Grid.Row="0"
+                        Margin="0,0,0,5"
+                        Grid.Column="0"
+                        FontTypography="Body"
+                        Text="安装位置"
+                        TextWrapping="Wrap" />
+                    <ui:TextBox x:Name="InstallPathTextBox"
+                        Grid.Row="1"
+                        Grid.Column="0"
+                        MinWidth="90"
+                        Margin="0,0,10,0"
+                        Text="{Binding Config.InstallPath, Mode=TwoWay}" />
+                    <ui:Button x:Name="SelectInstallPathButton"
+                        Grid.Row="1"
+                        Grid.Column="1"
+                        Margin="0,0,36,0"
+                        Command="{Binding SelectInstallPathCommand}"
+                        Content="..." />
+                </Grid>
                 <Grid Margin="16">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />


### PR DESCRIPTION
1. 新增本地安装路径配置，选择原神安装路径后点击启动可以直接拉起原神
2. 新增加载页面触发器，直接启动原神后识别加载完成直接进入游戏
![image](https://github.com/babalae/better-genshin-impact/assets/20398347/93d6d43c-2150-4042-84bd-760a98b5a132)
