### PR TITLE
修复七圣召唤启动报错

### DIFF
--- a/BetterGenshinImpact/GameTask/GameTaskManager.cs
+++ b/BetterGenshinImpact/GameTask/GameTaskManager.cs
@@ -91,7 +91,7 @@ namespace BetterGenshinImpact.GameTask
                 throw new FileNotFoundException($"未找到{featName}中的{assertName}文件");
             }
 
-            var mat = new Mat(filePath, flags);
+            var mat = Mat.FromStream(File.OpenRead(filePath), flags);
             if (info.GameScreenSize.Width != 1920)
             {
                 mat = ResizeHelper.Resize(mat, info.AssetScale);


### PR DESCRIPTION
fix #64 
用`Mat.FromStream`绕过`imread`