### PR TITLE
修复游戏安装路径中分隔符不统一

### DIFF
--- a/BetterGenshinImpact/Genshin/Paths/GameExePath.cs
+++ b/BetterGenshinImpact/Genshin/Paths/GameExePath.cs
@@ -46,7 +46,7 @@ internal class GameExePath
                 var str = File.ReadAllText(configPath);
                 var installPath = Regex.Match(str, @"game_install_path=(.+)").Groups[1].Value.Trim();
                 var exeName = Regex.Match(str, @"game_start_name=(.+)").Groups[1].Value.Trim();
-                var exePath = Path.Join(installPath, exeName);
+                var exePath = Path.GetFullPath(exeName, installPath);
                 if (File.Exists(exePath))
                 {
                     return exePath;


### PR DESCRIPTION
只影响自动检测的路径。本来也没有影响但是看着难受
修复前
![image](https://github.com/babalae/better-genshin-impact/assets/8700123/ac3762df-1c3f-462e-8cb6-5106ad3898bf)
修复后
![image](https://github.com/babalae/better-genshin-impact/assets/8700123/39237a3a-c651-4462-a39b-b9f5b9ed1bd8)
