### PR TITLE
改进键鼠脚本录制与回放精度

### DIFF
--- a/BetterGenshinImpact/Core/Recorder/KeyMouseMacroPlayer.cs
+++ b/BetterGenshinImpact/Core/Recorder/KeyMouseMacroPlayer.cs
@@ -41,9 +41,18 @@ public class KeyMouseMacroPlayer
     public static async Task PlayMacro(List<MacroEvent> macroEvents, CancellationToken ct)
     {
         WorkingArea = PrimaryScreen.WorkingArea;
+        var startTime = DateTime.UtcNow;
         foreach (var e in macroEvents)
         {
-            await Task.Delay((int)Math.Round(e.Time), ct);
+            var timeToWait = (int)(e.Time - (DateTime.UtcNow - startTime).TotalMilliseconds);
+            if (timeToWait < 0)
+            {
+                TaskControl.Logger.LogWarning("无法原速重放事件{Event}，落后{TimeToWait}ms", e.Type.ToString(), -timeToWait);
+            }
+            else
+            {
+                await Task.Delay(timeToWait, ct);
+            }
             switch (e.Type)
             {
                 case MacroEventType.KeyDown:


### PR DESCRIPTION
### 主要的修改

1. 将原本基于相对时间的脚本录制与回放修改为基于绝对时间
2. 脚本录制完成后，对鼠标移动事件进行合并，避免回放时丢步