### PR TITLE
通过在录制脚本时记录相机视角改善回放精度

### DIFF
--- a/BetterGenshinImpact/Core/Recorder/KeyMouseMacroPlayer.cs
+++ b/BetterGenshinImpact/Core/Recorder/KeyMouseMacroPlayer.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 using BetterGenshinImpact.GameTask;
 using BetterGenshinImpact.GameTask.Common;
+using BetterGenshinImpact.GameTask.Common.Map;
 using Microsoft.Extensions.Logging;
 using Vanara.PInvoke;
 
@@ -134,6 +135,18 @@ public class KeyMouseMacroPlayer
                     break;
 
                 case MacroEventType.MouseMoveBy:
+                    if (e.CameraOrientation != null)
+                    {
+                        var cao = CameraOrientation.Compute(TaskControl.CaptureToRectArea().SrcGreyMat);
+                        var diff = (cao - (int)e.CameraOrientation + 180) % 360 - 180;
+                        diff += diff < -180 ? 360 : 0;
+                        //过滤一下特别大的角度偏差
+                        if (diff != 0 && diff < 8 && diff > -8)
+                        {
+                            TaskControl.Logger.LogWarning("视角重放偏差{diff}°，尝试修正", diff);
+                            e.MouseX -= diff;
+                        }
+                    }
                     Simulation.SendInput.Mouse.MoveMouseBy(e.MouseX, e.MouseY);
                     break;
 

--- a/BetterGenshinImpact/Core/Recorder/KeyMouseRecorder.cs
+++ b/BetterGenshinImpact/Core/Recorder/KeyMouseRecorder.cs
@@ -7,6 +7,8 @@ using System.Text.Json.Serialization;
 using System.Windows.Forms;
 using SharpDX.DirectInput;
 using BetterGenshinImpact.GameTask;
+using BetterGenshinImpact.GameTask.Common.Map;
+using BetterGenshinImpact.GameTask.Common;
 
 namespace BetterGenshinImpact.Core.Recorder;
 
@@ -15,6 +17,8 @@ public class KeyMouseRecorder
     public List<MacroEvent> MacroEvents { get; } = [];
 
     public DateTime StartTime { get; set; } = DateTime.UtcNow;
+
+    public DateTime LastOrientationDetection { get; set; } = DateTime.UtcNow;
 
     public double MergedEventTimeMax { get; set; } = 20.0;
 
@@ -151,12 +155,20 @@ public class KeyMouseRecorder
 
     public void MouseMoveBy(MouseState state)
     {
+        var now = DateTime.UtcNow;
+        int? cao = null;
+        if ((now - LastOrientationDetection).TotalMilliseconds > 100.0)
+        {
+            LastOrientationDetection = now;
+            cao = CameraOrientation.Compute(TaskControl.CaptureToRectArea().SrcGreyMat);
+        }
         MacroEvents.Add(new MacroEvent
         {
             Type = MacroEventType.MouseMoveBy,
             MouseX = state.X,
             MouseY = state.Y,
-            Time = (DateTime.UtcNow - StartTime).TotalMilliseconds
+            Time = (now - StartTime).TotalMilliseconds,
+            CameraOrientation = cao,
         });
     }
 }

--- a/BetterGenshinImpact/Core/Recorder/Model/MacroEvent.cs
+++ b/BetterGenshinImpact/Core/Recorder/Model/MacroEvent.cs
@@ -11,6 +11,8 @@ public class MacroEvent
     public int MouseY { get; set; }
     public string? MouseButton { get; set; }
     public double Time { get; set; }
+
+    public int? CameraOrientation { get; set; }
 }
 
 public enum MacroEventType


### PR DESCRIPTION
目前有两个可调参数我还不知道咋调节：

1. KeyMouseRecorder.cs里面的`MergedEventTimeMax`参数，这个参数控制回放时合并的频率
2. KeyMouseRecorder.cs第160行的`if ((now - LastOrientationDetection).TotalMilliseconds > 100.0)`，这个参数控制相机视角记录频率

如果要加开关的话，给第160行的记录功能加开关应该就可以了，回放部分在遇到没有记录相机数据的脚本时，和之前相比表现没有变化

https://github.com/user-attachments/assets/34b6de42-ec97-4531-a5a8-c6ff9c73800f

