### PR TITLE
修复虹灵的净土秘境消失的问题

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoTrackPath/Assets/tp.json
+++ b/BetterGenshinImpact/GameTask/AutoTrackPath/Assets/tp.json
@@ -5362,6 +5362,18 @@
     "mapIndex": 0
   },
   {
+    "country": "纳塔",
+    "type": "Domain",
+    "description": "Domain",
+    "name": "虹灵的净土",
+    "position": [
+      -2421.48,
+      213.12,
+      9041.29
+    ],
+    "mapIndex": 0
+  },
+  {
     "country": "须弥",
     "description": "往昔的恒纳兰那",
     "position": [


### PR DESCRIPTION
修复了自动秘境中纳塔-虹灵的净土秘境消失的问题