### PR TITLE
修正windows10_1909版本WGC故障

### DIFF
--- a/Fischless.GameCapture/Graphics/GraphicsCapture.cs
+++ b/Fischless.GameCapture/Graphics/GraphicsCapture.cs
@@ -1,6 +1,6 @@
-﻿using Fischless.GameCapture.Graphics.Helpers;
+﻿using System.Diagnostics;
+using Fischless.GameCapture.Graphics.Helpers;
 using SharpDX.Direct3D11;
-using System.Diagnostics;
 using Vanara.PInvoke;
 using Windows.Foundation.Metadata;
 using Windows.Graphics.Capture;
@@ -55,7 +55,10 @@ public class GraphicsCapture : IGameCapture
         }
 
         _captureSession = _captureFramePool.CreateCaptureSession(_captureItem);
-        _captureSession.IsCursorCaptureEnabled = false;
+        if (ApiInformation.IsPropertyPresent("Windows.Graphics.Capture.GraphicsCaptureSession", "IsCursorCaptureEnabled"))
+        {
+            _captureSession.IsCursorCaptureEnabled = false;
+        }
         if (ApiInformation.IsWriteablePropertyPresent("Windows.Graphics.Capture.GraphicsCaptureSession", "IsBorderRequired"))
         {
             _captureSession.IsBorderRequired = false;


### PR DESCRIPTION
windows10_1909版本的WGC不支持IsCursorCaptureEnabled，加了个动态判断防止异常与抓屏失败等。

但是这样就有可能会抓到光标导致图像识别失败，但是个人认为瘦死的骆驼比马大，没有这个api就不调用即可，好歹还能用一下 如果有必要，后面可以考虑加一个弹窗警告一下啥的，但是这样可能会让用户糟心，总不能逼人家换个系统吧？但是不弹窗呢又好像向用户隐藏了某些可能存在的错误，好像又不太对啥的。

只能说云原神的限制还是大了一点，要不要加弹窗我无法决策，还是由其他人来吧。