### PR TITLE
路径追踪增加增加  允许在jsScript脚本中启用此路径追踪配置、覆盖JS中的自动战斗配置 。

### DIFF
--- a/BetterGenshinImpact/Core/Config/PathingPartyConfig.cs
+++ b/BetterGenshinImpact/Core/Config/PathingPartyConfig.cs
@@ -61,6 +61,14 @@ public partial class PathingPartyConfig : ObservableObject
     [ObservableProperty]
     private bool _onlyInTeleportRecover = false;
     
+    //允许在jsScript脚本中使用此路径追踪配置
+    [ObservableProperty]
+    private bool _jsScriptUseEnabled = false;
+    
+    //允许在此调度器中（一般在JS脚本中）调用自动战斗任务时，采用此追踪配置里的战斗策略
+    [ObservableProperty]
+    private bool _soloTaskUseFightEnabled = false;
+    
     // 使用小道具的间隔时间
     [ObservableProperty]
     private int _useGadgetIntervalMs = 0;

--- a/BetterGenshinImpact/Core/Script/Dependence/AutoPathingScript.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/AutoPathingScript.cs
@@ -5,17 +5,29 @@ using BetterGenshinImpact.Core.Config;
 
 namespace BetterGenshinImpact.Core.Script.Dependence;
 
-public class AutoPathingScript(string rootPath)
+public class AutoPathingScript
 {
+   private  object? _config = null;
+    private string _rootPath;
+    public AutoPathingScript(string rootPath, object? config) {
+
+        _config = config;
+        _rootPath = rootPath;
+    }
+    
     public async Task Run(string json)
     {
         var task = PathingTask.BuildFromJson(json);
-        await new PathExecutor(CancellationContext.Instance.Cts.Token).Pathing(task);
+        var pathExecutor = new  PathExecutor(CancellationContext.Instance.Cts.Token);
+        if (_config != null && _config is PathingPartyConfig patyConfig ) {
+            pathExecutor.PartyConfig = patyConfig;
+        }
+        await pathExecutor.Pathing(task);
     }
 
     public async Task RunFile(string path)
     {
-        var json = await new LimitedFile(rootPath).ReadText(path);
+        var json = await new LimitedFile(_rootPath).ReadText(path);
         await Run(json);
     }
     

--- a/BetterGenshinImpact/Core/Script/Dependence/Dispatcher.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/Dispatcher.cs
@@ -8,11 +8,17 @@ using BetterGenshinImpact.GameTask.AutoFight;
 using BetterGenshinImpact.GameTask.AutoWood;
 using BetterGenshinImpact.GameTask.Model.Enum;
 using BetterGenshinImpact.GameTask.AutoGeniusInvokation;
+using BetterGenshinImpact.GameTask.AutoPathing.Handler;
 
 namespace BetterGenshinImpact.Core.Script.Dependence;
 
 public class Dispatcher
 {
+    private object _config=null;
+    public  Dispatcher(object config)
+    {
+        _config = config;
+    }
     public void RunTask()
     {
     }
@@ -77,13 +83,15 @@ public class Dispatcher
                 break;
 
             case "AutoFight":
-                if (taskSettingsPageViewModel.GetFightStrategy(out var path1))
+                
+                /*if (taskSettingsPageViewModel.GetFightStrategy(out var path1))
                 {
                     return;
                 }
                 var autoFightConfig = TaskContext.Instance().Config.AutoFightConfig;
                 var param = new AutoFightParam(path1, autoFightConfig);
-                await new AutoFightTask(param).Start(CancellationContext.Instance.Cts.Token);
+                await new AutoFightTask(param).Start(CancellationContext.Instance.Cts.Token);*/
+                await new AutoFightHandler().RunAsyncByScript(CancellationContext.Instance.Cts.Token, null,_config);
                 break;
 
             case "AutoDomain":

--- a/BetterGenshinImpact/Core/Script/EngineExtend.cs
+++ b/BetterGenshinImpact/Core/Script/EngineExtend.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using OpenCvSharp;
 using BetterGenshinImpact.Core.Recognition;
 using BetterGenshinImpact.GameTask.Model.Area;
+using BetterGenshinImpact.Core.Config;
 
 namespace BetterGenshinImpact.Core.Script;
 
@@ -17,19 +18,19 @@ public class EngineExtend
     /// <param name="engine"></param>
     /// <param name="workDir"></param>
     /// <param name="searchPaths"></param>
-    public static void InitHost(IScriptEngine engine, string workDir, string[]? searchPaths = null)
+    public static void InitHost(IScriptEngine engine, string workDir, string[]? searchPaths = null, object? config = null)
     {
         // engine.AddHostObject("xHost", new ExtendedHostFunctions());  // 有越权的安全风险
 
         // 添加我的自定义实例化对象
         engine.AddHostObject("keyMouseScript", new KeyMouseScript(workDir));
-        engine.AddHostObject("pathingScript", new AutoPathingScript(workDir));
+        engine.AddHostObject("pathingScript", new AutoPathingScript(workDir, config));
         engine.AddHostObject("genshin", new Dependence.Genshin());
         engine.AddHostObject("log", new Log());
         engine.AddHostObject("file", new LimitedFile(workDir)); // 限制文件访问
 
         // 任务调度器
-        engine.AddHostObject("dispatcher", new Dispatcher());
+        engine.AddHostObject("dispatcher", new Dispatcher(config));
         engine.AddHostType("RealtimeTimer", typeof(RealtimeTimer));
         engine.AddHostType("SoloTask", typeof(SoloTask));
 

--- a/BetterGenshinImpact/Core/Script/Group/ScriptGroupProject.cs
+++ b/BetterGenshinImpact/Core/Script/Group/ScriptGroupProject.cs
@@ -138,7 +138,14 @@ public partial class ScriptGroupProject : ObservableObject
                 throw new Exception("JS脚本未初始化");
             }
             JsScriptSettingsObject ??= new ExpandoObject();
-            await Project.ExecuteAsync(JsScriptSettingsObject);
+            
+            var pathingPartyConfig = GroupInfo?.Config.PathingConfig;
+            if (!(pathingPartyConfig is {Enabled:true,JsScriptUseEnabled:true}))
+            {
+                pathingPartyConfig = null;
+            }
+
+            await Project.ExecuteAsync(JsScriptSettingsObject,pathingPartyConfig);
         }
         if (Type == "KeyMouse")
         {

--- a/BetterGenshinImpact/Core/Script/Project/ScriptProject.cs
+++ b/BetterGenshinImpact/Core/Script/Project/ScriptProject.cs
@@ -57,20 +57,20 @@ public class ScriptProject
         return stackPanel;
     }
 
-    public IScriptEngine BuildScriptEngine()
+    public IScriptEngine BuildScriptEngine(PathingPartyConfig? partyConfig = null)
     {
         IScriptEngine engine = new V8ScriptEngine(V8ScriptEngineFlags.UseCaseInsensitiveMemberBinding | V8ScriptEngineFlags.EnableTaskPromiseConversion);
-        EngineExtend.InitHost(engine, ProjectPath, Manifest.Library);
+        EngineExtend.InitHost(engine, ProjectPath, Manifest.Library,partyConfig);
         return engine;
     }
 
-    public async Task ExecuteAsync(dynamic? context = null)
+    public async Task ExecuteAsync(dynamic? context = null, PathingPartyConfig? partyConfig=null)
     {
         // 默认值
         GlobalMethod.SetGameMetrics(1920, 1080);
         // 加载代码
         var code = await LoadCode();
-        var engine = BuildScriptEngine();
+        var engine = BuildScriptEngine(partyConfig);
         if (context != null)
         {
             // 写入配置的内容

--- a/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
@@ -437,13 +437,13 @@ public class AutoFightTask : ISoloTask
 
         Simulation.SendInput.SimulateAction(GIActions.Drop);
         Logger.LogInformation($"未识别到战斗结束{b3.Item0},{b3.Item1},{b3.Item2}");
-        
+        /**
         if (!Bv.IsInMainUi(ra))
         {
             // 如果不在主界面，说明异常，直接结束战斗继续下一步（路径追踪下一步会进入异常处理）
             Logger.LogInformation("当前不在主界面，直接结束战斗！");
             return true;
-        }
+        }**/
         
         _lastFightFlagTime = DateTime.Now;
         return false;

--- a/BetterGenshinImpact/GameTask/AutoPathing/Handler/AutoFightHandler.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/Handler/AutoFightHandler.cs
@@ -12,6 +12,15 @@ namespace BetterGenshinImpact.GameTask.AutoPathing.Handler;
 
 internal class AutoFightHandler : IActionHandler
 {
+    public async Task RunAsyncByScript(CancellationToken ct, WaypointForTrack? waypointForTrack = null, object? config = null)
+    {
+        if (!(config != null && config is PathingPartyConfig patyConfig && patyConfig is {AutoFightEnabled:true,JsScriptUseEnabled:true,SoloTaskUseFightEnabled:true}  ))
+        {
+            config = null;
+        }
+        await StartFight(ct, config);
+    }
+
     public async Task RunAsync(CancellationToken ct, WaypointForTrack? waypointForTrack = null, object? config = null)
     {
         await StartFight(ct, config);

--- a/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
@@ -195,8 +195,8 @@ public class PathExecutor
                                 }
                             }
 
-                            //skipOtherOperations如果重试，则跳过相关操作
-                            if (!string.IsNullOrEmpty(waypoint.Action) && !_skipOtherOperations)
+                            //skipOtherOperations如果重试，则跳过相关操作，
+                            if ((!string.IsNullOrEmpty(waypoint.Action) && !_skipOtherOperations) || waypoint.Action == ActionEnum.CombatScript.Code)
                             {
                                 // 执行 action
                                 await AfterMoveToTarget(waypoint);

--- a/BetterGenshinImpact/View/Pages/View/ScriptGroupConfigView.xaml
+++ b/BetterGenshinImpact/View/Pages/View/ScriptGroupConfigView.xaml
@@ -232,8 +232,56 @@
                                          IsChecked="{Binding PathingConfig.OnlyInTeleportRecover, Mode=TwoWay}" />
 
                     </Grid>
+                    <Grid Margin="16">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <ui:TextBlock Grid.Row="0"
+                                      Grid.Column="0"
+                                      FontTypography="Body"
+                                      Text="允许在JsScript中使用"
+                                      TextWrapping="Wrap" />
+                        <ui:TextBlock Grid.Row="1"
+                                      Grid.Column="0"
+                                      Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                      Text="允许在jsScript脚本中启用此路径追踪配置"
+                                      TextWrapping="Wrap" />
+                        <ui:ToggleSwitch Grid.Row="0"
+                                         Grid.RowSpan="2"
+                                         Grid.Column="1"
+                                         IsChecked="{Binding PathingConfig.JsScriptUseEnabled, Mode=TwoWay}" />
 
+                    </Grid>
+                    <Grid Margin="16">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <ui:TextBlock Grid.Row="0"
+                                      Grid.Column="0"
+                                      FontTypography="Body"
+                                      Text="覆盖JS中的自动战斗配置"
+                                      TextWrapping="Wrap" />
+                        <ui:TextBlock Grid.Row="1"
+                                      Grid.Column="0"
+                                      Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                      Text="需启用上方允许JS中使用此路径追踪配置才生效，允许在此调度器中（一般在JS脚本中）调用自动战斗任务时，采用此追踪配置里的战斗策略。"
+                                      TextWrapping="Wrap" />
+                        <ui:ToggleSwitch Grid.Row="0"
+                                         Grid.RowSpan="2"
+                                         Grid.Column="1"
+                                         IsChecked="{Binding PathingConfig.SoloTaskUseFightEnabled, Mode=TwoWay}" />
 
+                    </Grid>
                 </StackPanel>
             </ui:CardExpander>
             <ui:CardExpander Margin="0,0,0,12"


### PR DESCRIPTION
路径追踪增加  允许在jsScript脚本中启用此路径追踪配置、覆盖JS中的自动战斗配置 。默认为否，开启后可以使JS脚本中的路径追踪和自动战斗，使用该调度器所配置的参数运行