### PR TITLE
优化锄地战斗后捡掉落物的逻辑

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoFight/AutoFightConfig.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/AutoFightConfig.cs
@@ -72,6 +72,40 @@ public partial class AutoFightConfig : ObservableObject
     [ObservableProperty]
     private bool _pickDropsAfterFightEnabled = true;
 
+    [Serializable]
+    public partial class PickDropsAfterFightConfig : ObservableObject
+    {
+        /// <summary>
+        /// 前进次数
+        /// </summary>
+        [ObservableProperty]
+        private int _forwardTimes = 6;
+
+        /// <summary>
+        /// 校准次数
+        /// </summary>
+        [ObservableProperty]
+        private int _calibrationTimes = 15;
+
+        /// <summary>
+        /// 衰减因子
+        /// </summary>
+        [ObservableProperty]
+        private double _decayFactor = 0.7;
+
+        /// <summary>
+        /// 前进量（秒），设置为0时在[1,3]中随机
+        /// </summary>
+        [ObservableProperty]
+        private int _forwardSeconds = 2;
+
+    }
+    /// <summary>
+    /// 掉落寻物相关配置
+    /// </summary>   
+    [ObservableProperty]
+    private PickDropsAfterFightConfig _pickDropsConfig = new();
+
     /// <summary>
     /// 战斗结束后，如果存在枫原万叶，则使用该角色捡材料
     /// </summary>

--- a/BetterGenshinImpact/GameTask/Common/Job/ScanPickTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/ScanPickTask.cs
@@ -64,7 +64,6 @@ public class ScanPickTask
 
                 if (pickItems.Count > 0)
                 {
-                    Logger.LogInformation("PickItems: {PickItems}", pickItems);
                     hasDrops = true;
                     await MoveTowardsFirstDrop(ct, 300 * _dpi);
                     break;
@@ -91,14 +90,11 @@ public class ScanPickTask
 
     private async Task MoveTowardsFirstDrop(CancellationToken ct, double step)
     {
-        //通过每次微调之前的一半来缩小范围，可能有一定开销
+        //通过每次缩小之前的步长来定位，可能有一定开销
         var decayFactor = TaskContext.Instance().Config.AutoFightConfig.PickDropsConfig.DecayFactor;
         var calibrationTimes = TaskContext.Instance().Config.AutoFightConfig.PickDropsConfig.CalibrationTimes;
 
         var found = false;
-        Logger.LogInformation("MoveTowards:step: {step}", step);
-        Logger.LogInformation("MoveTowards:decayFactor: {decayFactor}", decayFactor);
-        Logger.LogInformation("MoveTowards:calibrationTimes: {calibrationTimes}", calibrationTimes);
         for (var i = 0; i < calibrationTimes; i++)
         {
             var ra = CaptureToRectArea();
@@ -112,7 +108,6 @@ public class ScanPickTask
                 //只关心横坐标
                 var centerX = (pickItems.First().Left + pickItems.First().Right) / 2;
                 var dx = centerX - ra.Width / 2;
-                Logger.LogInformation("MoveTowards:dx: {dx}", dx);
                 if (dx > 0)
                     Simulation.SendInput.Mouse.MoveMouseBy((int)step, 0);
                 else if (dx < 0)
@@ -125,9 +120,9 @@ public class ScanPickTask
                 break;
             }
         }
-        if (found) //仅在找到物品时前进（有时会误判进入该函数）
+        if (found) //仅在找到物品时前进（在误判进入该函数时避免远离原地）
         {
-            Logger.LogInformation("MoveTowards:Forward");
+            Logger.LogInformation("前进采集");
             var forwardms = TaskContext.Instance().Config.AutoFightConfig.PickDropsConfig.ForwardSeconds * 1000;
             if (forwardms == 0)
                 forwardms = new Random().Next(1000, 3000);

--- a/BetterGenshinImpact/GameTask/Common/Job/ScanPickTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/ScanPickTask.cs
@@ -44,13 +44,15 @@ public class ScanPickTask
 
     public async Task DoOnce(CancellationToken ct)
     {
-        await ResetCamera(ct);
-        
-        for (int n = 0; n < 5; n++) // 最多跑5次
+        var forwardTimes = TaskContext.Instance().Config.AutoFightConfig.PickDropsConfig.ForwardTimes;
+        for (int n = 0; n < forwardTimes; n++) // 直走次数
         {
+            await ResetCamera(ct);
             var hasDrops = false;
 
             // 旋转视角
+            var step = 300 * _dpi; // TODO:把300换成一个更加普适的值
+            step = n % 2 == 0 ? step : -step;
             for (var i = 0; i < 20; i++)
             {
                 var ra = CaptureToRectArea();
@@ -62,19 +64,16 @@ public class ScanPickTask
 
                 if (pickItems.Count > 0)
                 {
+                    Logger.LogInformation("PickItems: {PickItems}", pickItems);
                     hasDrops = true;
-                    // 把鼠标位置和物品位置重合
-                    MoveCursorTo(pickItems.First(), ra);
-                    await Delay(100, ct);
-                    // 物体越小，距离越远
-                    await WalkForward(ct);
+                    await MoveTowardsFirstDrop(ct, 300 * _dpi);
                     break;
                 }
 
-                Simulation.SendInput.Mouse.MoveMouseBy((int)(300 * _dpi), 0);
+                Simulation.SendInput.Mouse.MoveMouseBy((int)step, 0);
                 await Delay(100, ct);
             }
-            
+
             if (!hasDrops)
             {
                 break;
@@ -83,11 +82,58 @@ public class ScanPickTask
 
     }
 
-    private static async Task WalkForward(CancellationToken ct)
+    private static async Task WalkForward(CancellationToken ct, int ms = 1000)
     {
         Simulation.SendInput.SimulateAction(GIActions.MoveForward, KeyType.KeyDown);
-        await Delay(1000, ct);
+        await Delay(ms, ct);
         Simulation.SendInput.SimulateAction(GIActions.MoveForward, KeyType.KeyUp);
+    }
+
+    private async Task MoveTowardsFirstDrop(CancellationToken ct, double step)
+    {
+        //通过每次微调之前的一半来缩小范围，可能有一定开销
+        var decayFactor = TaskContext.Instance().Config.AutoFightConfig.PickDropsConfig.DecayFactor;
+        var calibrationTimes = TaskContext.Instance().Config.AutoFightConfig.PickDropsConfig.CalibrationTimes;
+
+        var found = false;
+        Logger.LogInformation("MoveTowards:step: {step}", step);
+        Logger.LogInformation("MoveTowards:decayFactor: {decayFactor}", decayFactor);
+        Logger.LogInformation("MoveTowards:calibrationTimes: {calibrationTimes}", calibrationTimes);
+        for (var i = 0; i < calibrationTimes; i++)
+        {
+            var ra = CaptureToRectArea();
+            var resultDic = _predictor.Detect(ra);
+            var pickItems = resultDic.Where(x => x.Key is "drops" or "ore")
+                .SelectMany(x => x.Value).ToList();
+            if (pickItems.Count > 0)
+            {
+                step *= decayFactor;
+                found = true;
+                //只关心横坐标
+                var centerX = (pickItems.First().Left + pickItems.First().Right) / 2;
+                var dx = centerX - ra.Width / 2;
+                Logger.LogInformation("MoveTowards:dx: {dx}", dx);
+                if (dx > 0)
+                    Simulation.SendInput.Mouse.MoveMouseBy((int)step, 0);
+                else if (dx < 0)
+                    Simulation.SendInput.Mouse.MoveMouseBy(-(int)step, 0);
+                await Delay(100, ct);
+            }
+            else
+            {
+                //也许已经对准，被人物挡住
+                break;
+            }
+        }
+        if (found) //仅在找到物品时前进（有时会误判进入该函数）
+        {
+            Logger.LogInformation("MoveTowards:Forward");
+            var forwardms = TaskContext.Instance().Config.AutoFightConfig.PickDropsConfig.ForwardSeconds * 1000;
+            if (forwardms == 0)
+                forwardms = new Random().Next(1000, 3000);
+
+            await WalkForward(ct, forwardms);
+        }
     }
 
     private void MoveCursorTo(Rect item, ImageRegion ra)
@@ -103,8 +149,8 @@ public class ScanPickTask
     // 回正 并下移视角
     private async Task ResetCamera(CancellationToken ct)
     {
-        // Simulation.SendInput.Keyboard.Mouse.MiddleButtonClick();
-        // await Delay(500, ct);
+        Simulation.SendInput.Keyboard.Mouse.MiddleButtonClick();
+        await Delay(500, ct);
         Simulation.SendInput.Keyboard.Mouse.MoveMouseBy(0, (int)(500 * _dpi));
         await Delay(100, ct);
     }

--- a/BetterGenshinImpact/View/Pages/TaskSettingsPage.xaml
+++ b/BetterGenshinImpact/View/Pages/TaskSettingsPage.xaml
@@ -624,33 +624,147 @@
                     </ui:CardExpander>
                 </Grid>
                 <Separator Margin="-18,0" BorderThickness="0,1,0,0" />
+                <Grid Margin="16,10,52,0">
 
+                    <ui:CardExpander Margin="0,0,0,12"
+                                     ContentPadding="0"
+                                     IsExpanded="False">
 
-                <Grid Margin="16">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                    </Grid.RowDefinitions>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*" />
-                        <ColumnDefinition Width="Auto" />
-                    </Grid.ColumnDefinitions>
-                    <ui:TextBlock Grid.Row="0"
-                                  Grid.Column="0"
-                                  FontTypography="Body"
-                                  Text="战斗结束后自动拾取掉落物"
-                                  TextWrapping="Wrap" />
-                    <ui:TextBlock Grid.Row="1"
-                                  Grid.Column="0"
-                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
-                                  Text="战斗结束后自动拾取掉落物"
-                                  TextWrapping="Wrap" />
-                    <ui:ToggleSwitch Grid.Row="0"
-                                     Grid.RowSpan="2"
-                                     Grid.Column="1"
-                                     Margin="0,0,36,0"
-                                     IsChecked="{Binding Config.AutoFightConfig.PickDropsAfterFightEnabled, Mode=TwoWay}" />
+                        <ui:CardExpander.Header>
+                            <Grid>
+
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <ui:TextBlock Grid.Row="0"
+                                              Grid.Column="0"
+                                              FontTypography="Body"
+                                              Text="自动拾取掉落物"
+                                              TextWrapping="Wrap"/>
+                                <ui:TextBlock Grid.Row="1"
+                                              Grid.Column="0"
+                                              Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                              Text="战斗结束后尽可能拾取周围掉落物（与万叶配合更佳）"
+                                              TextWrapping="Wrap"/>
+                                <ui:ToggleSwitch Grid.Row="0"
+                                                 Grid.RowSpan="2"
+                                                 Grid.Column="1"
+                                                 Margin="0,0,36,0"
+                                                 IsChecked="{Binding Config.AutoFightConfig.PickDropsAfterFightEnabled}"/>
+                            </Grid>
+                        </ui:CardExpander.Header>
+                        <StackPanel>
+                            <Grid Margin="16">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <ui:TextBlock Grid.Row="0"
+                                              Grid.Column="0"
+                                              FontTypography="Body"
+                                              Text="前进次数"
+                                              TextWrapping="Wrap"/>
+                                <ui:TextBlock Grid.Row="1"
+                                              Grid.Column="0"
+                                              Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                              Text="通过往前走来接近掉落物的次数"
+                                              TextWrapping="Wrap"/>
+                                <ui:TextBox Grid.Row="0"
+                                            Grid.RowSpan="2"
+                                            Grid.Column="1"
+                                            MinWidth="120"
+                                            Text="{Binding Config.AutoFightConfig.PickDropsConfig.ForwardTimes}"/>
+                            </Grid>
+                            <Grid Margin="16">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <ui:TextBlock Grid.Row="0"
+                                              Grid.Column="0"
+                                              FontTypography="Body"
+                                              Text="校准次数"
+                                              TextWrapping="Wrap"/>
+                                <ui:TextBlock Grid.Row="1"
+                                              Grid.Column="0"
+                                              Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                              Text="视角调整次数，理论上越高越好"
+                                              TextWrapping="Wrap"/>
+                                <ui:TextBox Grid.Row="0"
+                                            Grid.RowSpan="2"
+                                            Grid.Column="1"
+                                            MinWidth="120"
+                                            Text="{Binding Config.AutoFightConfig.PickDropsConfig.CalibrationTimes}"/>
+                            </Grid>
+                            <Grid Margin="16">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <ui:TextBlock Grid.Row="0"
+                                              Grid.Column="0"
+                                              FontTypography="Body"
+                                              Text="衰减因子"
+                                              TextWrapping="Wrap"/>
+                                <ui:TextBlock Grid.Row="1"
+                                              Grid.Column="0"
+                                              Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                              Text="视角调整的精细程度，应在0.5到1之间（数值越小越精细，数值越高校准范围越大）"
+                                              TextWrapping="Wrap"/>
+                                <ui:TextBox Grid.Row="0"
+                                            Grid.RowSpan="2"
+                                            Grid.Column="1"
+                                            MinWidth="120"
+                                            Text="{Binding Config.AutoFightConfig.PickDropsConfig.DecayFactor}"/>
+                            </Grid>
+                            <Grid Margin="16">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <ui:TextBlock Grid.Row="0"
+                                              Grid.Column="0"
+                                              FontTypography="Body"
+                                              Text="前进量"
+                                              TextWrapping="Wrap"/>
+                                <ui:TextBlock Grid.Row="1"
+                                              Grid.Column="0"
+                                              Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                              Text="每次视角校准后前进的时长（秒）。设置为0时，前进量在1到3秒内随机（大了可能跑到奇奇怪怪的地方去，小了可能采集不到，可以和前进次数配合）"
+                                              TextWrapping="Wrap"/>
+                                <ui:TextBox Grid.Row="0"
+                                            Grid.RowSpan="2"
+                                            Grid.Column="1"
+                                            MinWidth="120"
+                                            Text="{Binding Config.AutoFightConfig.PickDropsConfig.ForwardSeconds}"/>
+                            </Grid>
+
+                        </StackPanel>
+                    </ui:CardExpander>
+
                 </Grid>
+                <Separator Margin="-18,0" BorderThickness="0,1,0,0" />
                 <Grid Margin="16">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />


### PR DESCRIPTION
优化了锄地战斗后捡掉落物的逻辑，具体为

1. 把原本将指针移到识别框内的逻辑改成向人物中线的左或者右反复微调。
2. 暴露一些参数供用户调整（在 独立任务-自动战斗-自动拾取凋落物 处）