### PR TITLE
auto pathing: add `Orientation` to `WaypointType`

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoPathing/Model/Enum/ActionEnum.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/Model/Enum/ActionEnum.cs
@@ -2,23 +2,23 @@
 
 namespace BetterGenshinImpact.GameTask.AutoPathing.Model.Enum;
 
-public class ActionEnum(string code, string msg)
+public class ActionEnum(string code, string msg, ActionUseWaypointTypeEnum useWaypointTypeEnum)
 {
-    public static readonly ActionEnum StopFlying = new("stop_flying", "下落攻击");
-    public static readonly ActionEnum ForceTp = new("force_tp", "当前点传送");
-    public static readonly ActionEnum NahidaCollect = new("nahida_collect", "纳西妲长按E收集");
-    public static readonly ActionEnum PickAround = new("pick_around", "尝试在周围拾取");
-    public static readonly ActionEnum Fight = new("fight", "战斗");
-    public static readonly ActionEnum UpDownGrabLeaf = new("up_down_grab_leaf", "四叶印");
+    public static readonly ActionEnum StopFlying = new("stop_flying", "下落攻击", ActionUseWaypointTypeEnum.Custom);
+    public static readonly ActionEnum ForceTp = new("force_tp", "当前点传送", ActionUseWaypointTypeEnum.Custom);
+    public static readonly ActionEnum NahidaCollect = new("nahida_collect", "纳西妲长按E收集", ActionUseWaypointTypeEnum.Custom);
+    public static readonly ActionEnum PickAround = new("pick_around", "尝试在周围拾取", ActionUseWaypointTypeEnum.Custom);
+    public static readonly ActionEnum Fight = new("fight", "战斗", ActionUseWaypointTypeEnum.Path);
+    public static readonly ActionEnum UpDownGrabLeaf = new("up_down_grab_leaf", "四叶印", ActionUseWaypointTypeEnum.Custom);
 
-    public static readonly ActionEnum HydroCollect = new("hydro_collect", "水元素力采集");
-    public static readonly ActionEnum ElectroCollect = new("electro_collect", "雷元素力采集");
-    public static readonly ActionEnum AnemoCollect = new("anemo_collect", "风元素力采集");
-    
-    public static readonly ActionEnum CombatScript = new("combat_script", "战斗策略脚本"); // 这个必须要 action_params 里面有脚本
-    
-    public static readonly ActionEnum Mining = new("mining", "挖矿");
-    public static readonly ActionEnum LogOutput = new("log_output", "输出日志");
+    public static readonly ActionEnum HydroCollect = new("hydro_collect", "水元素力采集", ActionUseWaypointTypeEnum.Target);
+    public static readonly ActionEnum ElectroCollect = new("electro_collect", "雷元素力采集", ActionUseWaypointTypeEnum.Target);
+    public static readonly ActionEnum AnemoCollect = new("anemo_collect", "风元素力采集", ActionUseWaypointTypeEnum.Target);
+
+    public static readonly ActionEnum CombatScript = new("combat_script", "战斗策略脚本", ActionUseWaypointTypeEnum.Custom); // 这个必须要 action_params 里面有脚本
+
+    public static readonly ActionEnum Mining = new("mining", "挖矿", ActionUseWaypointTypeEnum.Custom);
+    public static readonly ActionEnum LogOutput = new("log_output", "输出日志", ActionUseWaypointTypeEnum.Custom);
 
     // 还有要加入的其他动作
     // 滚轮F
@@ -29,14 +29,31 @@ public class ActionEnum(string code, string msg)
 
     public static IEnumerable<ActionEnum> Values
     {
-        get
-        {
-            yield return StopFlying;
-        }
+        get { yield return StopFlying; }
     }
 
     public string Code { get; private set; } = code;
     public string Msg { get; private set; } = msg;
+
+    public ActionUseWaypointTypeEnum UseWaypointTypeEnum { get; private set; } = useWaypointTypeEnum;
+
+    public static ActionEnum? GetEnumByCode(string? code)
+    {
+        if (string.IsNullOrEmpty(code))
+        {
+            return null;
+        }
+
+        foreach (var item in Values)
+        {
+            if (item.Code == code)
+            {
+                return item;
+            }
+        }
+
+        return null;
+    }
 
     public static string GetMsgByCode(string code)
     {
@@ -47,6 +64,14 @@ public class ActionEnum(string code, string msg)
                 return item.Msg;
             }
         }
+
         return code;
     }
+}
+
+public enum ActionUseWaypointTypeEnum
+{
+    Custom, // 跟随路径点 Type
+    Path, // 强制 Path
+    Target // 强制 Target
 }

--- a/BetterGenshinImpact/GameTask/AutoPathing/Model/Enum/WaypointType.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/Model/Enum/WaypointType.cs
@@ -7,6 +7,7 @@ public class WaypointType(string code, string msg)
     public static readonly WaypointType Path = new("path", "途径点");
     public static readonly WaypointType Target = new("target", "目标点");
     public static readonly WaypointType Teleport = new("teleport", "传送点");
+    public static readonly WaypointType Orientation = new("Orientation", "方位点");
 
     public static IEnumerable<WaypointType> Values
     {
@@ -15,6 +16,7 @@ public class WaypointType(string code, string msg)
             yield return Path;
             yield return Target;
             yield return Teleport;
+            yield return Orientation;
         }
     }
 

--- a/BetterGenshinImpact/GameTask/AutoPathing/Model/Enum/WaypointType.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/Model/Enum/WaypointType.cs
@@ -7,7 +7,7 @@ public class WaypointType(string code, string msg)
     public static readonly WaypointType Path = new("path", "途径点");
     public static readonly WaypointType Target = new("target", "目标点");
     public static readonly WaypointType Teleport = new("teleport", "传送点");
-    public static readonly WaypointType Orientation = new("Orientation", "方位点");
+    public static readonly WaypointType Orientation = new("orientation", "方位点");
 
     public static IEnumerable<WaypointType> Values
     {

--- a/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
@@ -178,24 +178,34 @@ public class PathExecutor
                         {
                             await BeforeMoveToTarget(waypoint);
 
-                            // Path不用走得很近，Target需要接近，但都需要先移动到对应位置
-                            await MoveTo(waypoint);
+                            if (waypoint.Type == WaypointType.Orientation.Code)
+                                // 方位点，只需要朝向
+                                await FaceTo(waypoint);
+                            else
+                                // Path不用走得很近，Target需要接近，但都需要先移动到对应位置
+                                await MoveTo(waypoint);
 
                             await BeforeMoveCloseToTarget(waypoint);
 
-                            if (waypoint.Type == WaypointType.Target.Code
-                                // 除了 fight mining stop_flying 之外的 action 都需要接近
-                                || (!string.IsNullOrEmpty(waypoint.Action)
-                                    && waypoint.Action != ActionEnum.StopFlying.Code
-                                    && waypoint.Action != ActionEnum.NahidaCollect.Code
-                                    && waypoint.Action != ActionEnum.Fight.Code
-                                    && waypoint.Action != ActionEnum.CombatScript.Code
-                                    && waypoint.Action != ActionEnum.Mining.Code))
+                            if (
+                                waypoint.Type != WaypointType.Orientation.Code // 方位点不需要接近
+                                && waypoint.Action != ActionEnum.Fight.Code // 战斗action强制不接近
+                                && (
+                                        waypoint.Type == WaypointType.Target.Code
+                                        || (
+                                                !string.IsNullOrEmpty(waypoint.Action)
+                                                && waypoint.Action != ActionEnum.StopFlying.Code
+                                                && waypoint.Action != ActionEnum.NahidaCollect.Code
+                                                && waypoint.Action != ActionEnum.CombatScript.Code
+                                                && waypoint.Action != ActionEnum.Mining.Code
+                                            // 除了上述之外的actions都强制接近，即时类型是Path（真的需要这样吗？）
+                                            // force_tp, up_down_grab_leaf, log_output, 这几个不需要接近；
+                                            // pick_around, hydro_collect, electro_collect, anemo_collect, 这几个现存脚本中没有用target？
+                                            )
+                                    )
+                                )
                             {
-                                if (waypoint.Action != ActionEnum.Fight.Code) // 战斗action强制不接近
-                                {
-                                    await MoveCloseTo(waypoint);
-                                }
+                                await MoveCloseTo(waypoint);
                             }
 
                             //skipOtherOperations如果重试，则跳过相关操作，
@@ -565,6 +575,16 @@ public class PathExecutor
         var (tprX, tprY) = MapCoordinate.GameToMain2048(tpX, tpY);
         EntireMap.Instance.SetPrevPosition((float)tprX, (float)tprY); // 通过上一个位置直接进行局部特征匹配
         await Delay(500, ct); // 多等一会
+    }
+
+    private async Task FaceTo(WaypointForTrack waypoint)
+    {
+        var screen = CaptureToRectArea();
+        var position = await GetPosition(screen);
+        var targetOrientation = Navigation.GetTargetOrientation(waypoint, position);
+        Logger.LogInformation("朝向点，位置({x2},{y2})", $"{waypoint.GameX:F1}", $"{waypoint.GameY:F1}");
+        await _rotateTask.WaitUntilRotatedTo(targetOrientation, 2);
+        await Delay(500, ct);
     }
 
     private async Task MoveTo(WaypointForTrack waypoint)

--- a/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
@@ -178,32 +178,21 @@ public class PathExecutor
                         {
                             await BeforeMoveToTarget(waypoint);
 
+                            // Path不用走得很近，Target需要接近，但都需要先移动到对应位置
                             if (waypoint.Type == WaypointType.Orientation.Code)
+                            {
                                 // 方位点，只需要朝向
+                                // 考虑到方位点大概率是作为执行action的最后一个点，所以放在此处处理，不和传送点一样单独处理
                                 await FaceTo(waypoint);
+                            }
                             else
-                                // Path不用走得很近，Target需要接近，但都需要先移动到对应位置
+                            {
                                 await MoveTo(waypoint);
+                            }
 
                             await BeforeMoveCloseToTarget(waypoint);
 
-                            if (
-                                waypoint.Type != WaypointType.Orientation.Code // 方位点不需要接近
-                                && waypoint.Action != ActionEnum.Fight.Code // 战斗action强制不接近
-                                && (
-                                        waypoint.Type == WaypointType.Target.Code
-                                        || (
-                                                !string.IsNullOrEmpty(waypoint.Action)
-                                                && waypoint.Action != ActionEnum.StopFlying.Code
-                                                && waypoint.Action != ActionEnum.NahidaCollect.Code
-                                                && waypoint.Action != ActionEnum.CombatScript.Code
-                                                && waypoint.Action != ActionEnum.Mining.Code
-                                            // 除了上述之外的actions都强制接近，即时类型是Path（真的需要这样吗？）
-                                            // force_tp, up_down_grab_leaf, log_output, 这几个不需要接近；
-                                            // pick_around, hydro_collect, electro_collect, anemo_collect, 这几个现存脚本中没有用target？
-                                            )
-                                    )
-                                )
+                            if (IsTargetPoint(waypoint))
                             {
                                 await MoveCloseTo(waypoint);
                             }
@@ -262,6 +251,25 @@ public class PathExecutor
                 }
             }
         }
+    }
+
+    private bool IsTargetPoint(WaypointForTrack waypoint)
+    {
+        // 方位点不需要接近
+        if (waypoint.Type == WaypointType.Orientation.Code)
+        {
+            return false;
+        }
+        
+        var action = ActionEnum.GetEnumByCode(waypoint.Action);
+        if (action is not null && action.UseWaypointTypeEnum != ActionUseWaypointTypeEnum.Custom)
+        {
+            // 强制点位类型的 action，以 action 为准
+            return action.UseWaypointTypeEnum == ActionUseWaypointTypeEnum.Target;
+        }
+
+        // 其余情况和没有action的情况以点位类型为准
+        return waypoint.Type == WaypointType.Target.Code;
     }
 
     private async Task<bool> SwitchPartyBefore(PathingTask task)


### PR DESCRIPTION
添加一个朝向类型的节点，只转向目标点，不移动。
大佬看一下，这样添加是不是就可以了。

必要性：
脚本中实现固定朝向一个点很不稳定：用path精度不够，且可能会绕点弧线或有偏离，导致最终朝向不是两点连线的方向；用target可能走过去又回头。

另外，这段代码大佬看一下，
```
if (
...
  !string.IsNullOrEmpty(waypoint.Action)
  && waypoint.Action != ActionEnum.StopFlying.Code
  && waypoint.Action != ActionEnum.NahidaCollect.Code
  && waypoint.Action != ActionEnum.CombatScript.Code
  && waypoint.Action != ActionEnum.Mining.Code
...
)
{
  await MoveCloseTo(waypoint);
}
```
这是让非target类型，且不是上述动作，的节点强制去小碎步接近。

force_tp, up_down_grab_leaf, log_output这几个其实也不用；

就这几个 pick_around, hydro_collect, electro_collect, anemo_collect，
如果这几个没有大量现存不用target的脚本，上述特殊判断可以删掉，以后让脚本中按需指定成target类型；如果有历史包袱，用waypoint.Action == ...这几个特例可能会好看一点。
