### PR TITLE
bugfix: 战斗结束检测

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
@@ -457,7 +457,7 @@ public class AutoFightTask : ISoloTask
         await Delay(450, _ct);
         var ra = CaptureToRectArea();
         var b3 = ra.SrcMat.At<Vec3b>(50, 790); //进度条颜色
-        var whiteTile = ra.SrcMat.At<Vec3b>(50, 772); //白块
+        var whiteTile = ra.SrcMat.At<Vec3b>(50, 768); //白块
         if (IsWhite(whiteTile.Item2, whiteTile.Item1, whiteTile.Item0) && IsYellow(b3.Item2, b3.Item1, b3.Item0) /* AreDifferencesWithinBounds(_finishDetectConfig.BattleEndProgressBarColor, (b3.Item0, b3.Item1, b3.Item2), _finishDetectConfig.BattleEndProgressBarColorTolerance)*/)
         {
             Logger.LogInformation("识别到战斗结束");
@@ -466,7 +466,8 @@ public class AutoFightTask : ISoloTask
         }
 
         Simulation.SendInput.SimulateAction(GIActions.Drop);
-        Logger.LogInformation($"未识别到战斗结束{b3.Item0},{b3.Item1},{b3.Item2}");
+        Logger.LogInformation($"未识别到战斗结束yellow{b3.Item0},{b3.Item1},{b3.Item2}");
+        Logger.LogInformation($"未识别到战斗结束white{whiteTile.Item0},{whiteTile.Item1},{whiteTile.Item2}");
         /**
         if (!Bv.IsInMainUi(ra))
         {
@@ -476,10 +477,6 @@ public class AutoFightTask : ISoloTask
         }**/
         
         _lastFightFlagTime = DateTime.Now;
-        return false;
-
-        //  }
-
         return false;
     }
 


### PR DESCRIPTION
我发现战斗结束的白块检测点在我机器上并没有对准，导致战斗结束判断正确率不到5成，于是调了下坐标
在2K和1080P下都测试了，下面是在白点不动之后的截图
1080P：
![1080P](https://github.com/user-attachments/assets/694a5ef4-385e-4b74-9f8f-10f55904415a)
2K：
![2K](https://github.com/user-attachments/assets/52c65fdb-f68b-40ae-ab38-089e6a4f527e)

如果有人白块坐标不一样请附图告知我