### PR TITLE
Fix the issue of WebView2 UserDataFolder cannot be created

### DIFF
--- a/BetterGenshinImpact/View/Controls/Webview/WebpagePanel.cs
+++ b/BetterGenshinImpact/View/Controls/Webview/WebpagePanel.cs
@@ -4,6 +4,7 @@ using Microsoft.Web.WebView2.Wpf;
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Security.AccessControl;
 using System.Text;
 using System.Threading;
 using System.Windows;
@@ -31,6 +32,7 @@ public class WebpagePanel : UserControl
         }
         else
         {
+            EnsureWebView2DataFolder();
             _webView = new WebView2()
             {
                 CreationProperties = new CoreWebView2CreationProperties
@@ -155,4 +157,19 @@ public class WebpagePanel : UserControl
 
         return button;
     }
+
+    private void EnsureWebView2DataFolder()
+    {
+        try
+        {
+            string folder = Path.Combine(new FileInfo(Environment.ProcessPath!).DirectoryName!, @"WebView2Data\\");
+            Directory.CreateDirectory(folder);
+            DirectoryInfo info = new DirectoryInfo(folder);
+            DirectorySecurity access = info.GetAccessControl();
+            access.AddAccessRule(new FileSystemAccessRule("Everyone", FileSystemRights.FullControl, AccessControlType.Allow));
+            info.SetAccessControl(access);
+        }
+        catch { }
+    }
+
 }


### PR DESCRIPTION
#1065

WebView2 进程不会继承 parent process 的管理员权限，所以当 BGI 安装在 Program Files 文件夹内时无法创建数据目录；
解决方法时在 WebView2 进程启动前创建一个 EveryOne 拥有完全控制权限的文件夹。