### PR TITLE
支持鼠标虚拟键代码

### DIFF
--- a/BetterGenshinImpact/Core/Script/Dependence/GlobalMethod.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/GlobalMethod.cs
@@ -6,6 +6,7 @@ using System;
 using System.Threading.Tasks;
 using BetterGenshinImpact.GameTask.Common;
 using Vanara.PInvoke;
+using static Vanara.PInvoke.User32;
 
 namespace BetterGenshinImpact.Core.Script.Dependence;
 
@@ -20,17 +21,77 @@ public class GlobalMethod
 
     public static void KeyDown(string key)
     {
-        Simulation.SendInput.Keyboard.KeyDown(ToVk(key));
+        switch (key)
+        {
+            case "VK_LBUTTON":
+                Simulation.SendInput.Mouse.LeftButtonDown();
+                break;
+            case "VK_RBUTTON":
+                Simulation.SendInput.Mouse.RightButtonDown();
+                break;
+            case "VK_MBUTTON":
+                Simulation.SendInput.Mouse.MiddleButtonDown();
+                break;
+            case "VK_XBUTTON1":
+                Simulation.SendInput.Mouse.XButtonDown(0x0001);
+                break;
+            case "VK_XBUTTON2":
+                Simulation.SendInput.Mouse.XButtonDown(0x0001);
+                break;
+            default:
+                Simulation.SendInput.Keyboard.KeyDown(ToVk(key));
+                break;
+        }
     }
 
     public static void KeyUp(string key)
     {
-        Simulation.SendInput.Keyboard.KeyUp(ToVk(key));
+        switch (key)
+        {
+            case "VK_LBUTTON":
+                Simulation.SendInput.Mouse.LeftButtonUp();
+                break;
+            case "VK_RBUTTON":
+                Simulation.SendInput.Mouse.RightButtonUp();
+                break;
+            case "VK_MBUTTON":
+                Simulation.SendInput.Mouse.MiddleButtonUp();
+                break;
+            case "VK_XBUTTON1":
+                Simulation.SendInput.Mouse.XButtonUp(0x0001);
+                break;
+            case "VK_XBUTTON2":
+                Simulation.SendInput.Mouse.XButtonUp(0x0001);
+                break;
+            default:
+                Simulation.SendInput.Keyboard.KeyUp(ToVk(key));
+                break;
+        }
     }
 
     public static void KeyPress(string key)
     {
-        Simulation.SendInput.Keyboard.KeyPress(ToVk(key));
+        switch (key)
+        {
+            case "VK_LBUTTON":
+                Simulation.SendInput.Mouse.LeftButtonClick();
+                break;
+            case "VK_RBUTTON":
+                Simulation.SendInput.Mouse.RightButtonClick();
+                break;
+            case "VK_MBUTTON":
+                Simulation.SendInput.Mouse.MiddleButtonClick();
+                break;
+            case "VK_XBUTTON1":
+                Simulation.SendInput.Mouse.XButtonClick(0x0001);
+                break;
+            case "VK_XBUTTON2":
+                Simulation.SendInput.Mouse.XButtonClick(0x0001);
+                break;
+            default:
+                Simulation.SendInput.Keyboard.KeyPress(ToVk(key));
+                break;
+        }
     }
 
     private static User32.VK ToVk(string key)

--- a/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
@@ -676,18 +676,78 @@ public class Avatar
     public void KeyDown(string key)
     {
         var vk = User32Helper.ToVk(key);
-        Simulation.SendInput.Keyboard.KeyDown(vk);
+        switch (key)
+        {
+            case "VK_LBUTTON":
+                Simulation.SendInput.Mouse.LeftButtonDown();
+                break;
+            case "VK_RBUTTON":
+                Simulation.SendInput.Mouse.RightButtonDown();
+                break;
+            case "VK_MBUTTON":
+                Simulation.SendInput.Mouse.MiddleButtonDown();
+                break;
+            case "VK_XBUTTON1":
+                Simulation.SendInput.Mouse.XButtonDown(0x0001);
+                break;
+            case "VK_XBUTTON2":
+                Simulation.SendInput.Mouse.XButtonDown(0x0001);
+                break;
+            default:
+                Simulation.SendInput.Keyboard.KeyDown(vk);
+                break;
+        }
     }
 
     public void KeyUp(string key)
     {
         var vk = User32Helper.ToVk(key);
-        Simulation.SendInput.Keyboard.KeyUp(vk);
+        switch (key)
+        {
+            case "VK_LBUTTON":
+                Simulation.SendInput.Mouse.LeftButtonUp();
+                break;
+            case "VK_RBUTTON":
+                Simulation.SendInput.Mouse.RightButtonUp();
+                break;
+            case "VK_MBUTTON":
+                Simulation.SendInput.Mouse.MiddleButtonUp();
+                break;
+            case "VK_XBUTTON1":
+                Simulation.SendInput.Mouse.XButtonUp(0x0001);
+                break;
+            case "VK_XBUTTON2":
+                Simulation.SendInput.Mouse.XButtonUp(0x0001);
+                break;
+            default:
+                Simulation.SendInput.Keyboard.KeyUp(vk);
+                break;
+        }
     }
 
     public void KeyPress(string key)
     {
         var vk = User32Helper.ToVk(key);
-        Simulation.SendInput.Keyboard.KeyPress(vk);
+        switch (key)
+        {
+            case "VK_LBUTTON":
+                Simulation.SendInput.Mouse.LeftButtonClick();
+                break;
+            case "VK_RBUTTON":
+                Simulation.SendInput.Mouse.RightButtonClick();
+                break;
+            case "VK_MBUTTON":
+                Simulation.SendInput.Mouse.MiddleButtonClick();
+                break;
+            case "VK_XBUTTON1":
+                Simulation.SendInput.Mouse.XButtonClick(0x0001);
+                break;
+            case "VK_XBUTTON2":
+                Simulation.SendInput.Mouse.XButtonClick(0x0001);
+                break;
+            default:
+                Simulation.SendInput.Keyboard.KeyPress(vk);
+                break;
+        }
     }
 }


### PR DESCRIPTION
使 **JS脚本** 中的 `keyDown()`, `keyUp()`, `keyPress()` 方法 和 **战斗策略脚本** 中的 `keydown(),` `keyup(),` `keypress()` 方法 可以直接使用 **虚拟键代码** 来执行 **鼠标操作** , 而无需额外使用类似 `leftButtonDown()`, `rightButtonUp()` 等方法, 降低学习成本.