### PR TITLE
在换队/换人/采集之前取消攀爬

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
@@ -451,6 +451,7 @@ public class AutoFightTask : ISoloTask
         }
         **/
 
+        Simulation.SendInput.SimulateAction(GIActions.Drop);//在换队前取消爬墙状态
         await Delay(delayTime, _ct);
         Logger.LogInformation("打开编队界面检查战斗是否结束");
         // 最终方案确认战斗结束
@@ -462,11 +463,9 @@ public class AutoFightTask : ISoloTask
         if (IsWhite(whiteTile.Item2, whiteTile.Item1, whiteTile.Item0) && IsYellow(b3.Item2, b3.Item1, b3.Item0) /* AreDifferencesWithinBounds(_finishDetectConfig.BattleEndProgressBarColor, (b3.Item0, b3.Item1, b3.Item2), _finishDetectConfig.BattleEndProgressBarColorTolerance)*/)
         {
             Logger.LogInformation("识别到战斗结束");
-            Simulation.SendInput.SimulateAction(GIActions.Drop);
             return true;
         }
 
-        Simulation.SendInput.SimulateAction(GIActions.Drop);
         Logger.LogInformation($"未识别到战斗结束yellow{b3.Item0},{b3.Item1},{b3.Item2}");
         Logger.LogInformation($"未识别到战斗结束white{whiteTile.Item0},{whiteTile.Item1},{whiteTile.Item2}");
         /**

--- a/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
@@ -188,7 +188,7 @@ public class Avatar
     /// <returns></returns>
     public bool TrySwitch(int tryTimes = 4, bool needLog = true)
     {
-        for (var i = 0; i < 3; i++)
+        for (var i = 0; i < tryTimes; i++)
         {
             if (Ct is { IsCancellationRequested: true })
             {
@@ -208,7 +208,7 @@ public class Avatar
 
                 return true;
             }
-
+            Simulation.SendInput.SimulateAction(GIActions.Drop); //反正会重试就不等落地了
             switch (Index)
             {
                 case 1:

--- a/BetterGenshinImpact/GameTask/Common/Job/ScanPickTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/ScanPickTask.cs
@@ -47,6 +47,7 @@ public class ScanPickTask
         var forwardTimes = TaskContext.Instance().Config.AutoFightConfig.PickDropsConfig.ForwardTimes;
         for (int n = 0; n < forwardTimes; n++) // 直走次数
         {
+            Simulation.SendInput.SimulateAction(GIActions.Drop);//取消爬墙状态
             await ResetCamera(ct);
             var hasDrops = false;
 


### PR DESCRIPTION
攀爬时没法切队切人，所以提前取消攀爬。

采集前取消攀爬也有点用，在墙上一直按W会一直上墙。

~~**注：改动未经本人测试，只通过了编译**
但应该不至于影响别的功能（我测了会删掉这两行，也欢迎帮我测试）~~

经测试显著减少挂墙上的情况

PS：linter一看tryTimes是灰的没绷住，顺手改了