### PR TITLE
修复因原神更新引起的地图缩放问题

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoTrackPath/TpConfig.cs
+++ b/BetterGenshinImpact/GameTask/AutoTrackPath/TpConfig.cs
@@ -32,23 +32,23 @@ public partial class TpConfig : ObservableObject
 
     [ObservableProperty]
     [property: JsonIgnore]
-    private int _zoomOutButtonY = 654; //  y-coordinate for zoom-out button
+    private int _zoomOutButtonY = 635; //  y-coordinate for zoom-out button
 
     [ObservableProperty]
     [property: JsonIgnore]
-    private int _zoomInButtonY = 428; //  y-coordinate for zoom-in button
+    private int _zoomInButtonY = 443; //  y-coordinate for zoom-in button
 
     [ObservableProperty]
     [property: JsonIgnore]
-    private int _zoomButtonX = 49; // x-coordinate for zoom button
+    private int _zoomButtonX = 47; // x-coordinate for zoom button
 
     [ObservableProperty]
     [property: JsonIgnore]
-    private int _zoomStartY = 453; // y-coordinate for zoom start
+    private int _zoomStartY = 467; // y-coordinate for zoom start
 
     [ObservableProperty]
     [property: JsonIgnore]
-    private int _zoomEndY = 628; // y-coordinate for zoom end
+    private int _zoomEndY = 611; // y-coordinate for zoom end
 
     [ObservableProperty]
     private double _tolerance = 200; // 允许的移动误差

--- a/BetterGenshinImpact/GameTask/Common/BgiVision/BvStatus.cs
+++ b/BetterGenshinImpact/GameTask/Common/BgiVision/BvStatus.cs
@@ -120,9 +120,9 @@ public static partial class Bv
             throw new Exception("当前未处于大地图界面，不能使用GetBigMapScale方法");
         }
 
-        // 452 ~ 627 间隔 35 和截图有关的，截图高24
-        var start = QuickTeleportAssets.MapScaleButton1080StartY;
-        var end = QuickTeleportAssets.MapScaleButton1080EndY;
+        // 原先这里的起止区间和config里写死的值差1
+        var start = TaskContext.Instance().Config.TpConfig.ZoomStartY - 1;
+        var end = TaskContext.Instance().Config.TpConfig.ZoomEndY + 1;
         var cur = (scaleRa.Y + scaleRa.Height / 2.0) * TaskContext.Instance().SystemInfo.ZoomOutMax1080PRatio; // 转换到1080p坐标系,主要是小于1080p的情况
 
         return (end * 1.0 - cur) / (end - start);

--- a/BetterGenshinImpact/GameTask/QuickTeleport/Assets/QuickTeleportAssets.cs
+++ b/BetterGenshinImpact/GameTask/QuickTeleport/Assets/QuickTeleportAssets.cs
@@ -18,9 +18,6 @@ public class QuickTeleportAssets : BaseAssets<QuickTeleportAssets>
 
     public RecognitionObject MapUndergroundSwitchButtonRo;
     public RecognitionObject MapUndergroundToGroundButtonRo;
-    
-    public const int MapScaleButton1080StartY = 452;
-    public const int MapScaleButton1080EndY = 627;
 
     private QuickTeleportAssets()
     {


### PR DESCRIPTION
修改了缩放图标和缩放轴的定位
经测试在BGI定义的4.50缩放级别下能显示传送锚点