### PR TITLE
feat: 全局按键映射支持

### DIFF
--- a/BetterGenshinImpact/Core/Config/KeyBindingsConfig.cs
+++ b/BetterGenshinImpact/Core/Config/KeyBindingsConfig.cs
@@ -14,6 +14,12 @@ namespace BetterGenshinImpact.Core.Config;
 public partial class KeyBindingsConfig:ObservableObject
 {
 
+    /// <summary>
+    /// 是否启用全局按键映射
+    /// </summary>
+    [ObservableProperty]
+    private bool _globalKeyMappingEnabled = false;
+
     #region Actions（操作）
 
     /// <summary>

--- a/BetterGenshinImpact/Core/Script/Dependence/GlobalMethod.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/GlobalMethod.cs
@@ -7,6 +7,8 @@ using System.Threading.Tasks;
 using BetterGenshinImpact.GameTask.Common;
 using Vanara.PInvoke;
 using static Vanara.PInvoke.User32;
+using BetterGenshinImpact.Core.Simulator.Extensions;
+using BetterGenshinImpact.Core.Config;
 
 namespace BetterGenshinImpact.Core.Script.Dependence;
 
@@ -21,6 +23,7 @@ public class GlobalMethod
 
     public static void KeyDown(string key)
     {
+        var vk = MappingKey(ToVk(key));
         switch (key)
         {
             case "VK_LBUTTON":
@@ -39,13 +42,14 @@ public class GlobalMethod
                 Simulation.SendInput.Mouse.XButtonDown(0x0001);
                 break;
             default:
-                Simulation.SendInput.Keyboard.KeyDown(ToVk(key));
+                Simulation.SendInput.Keyboard.KeyDown(vk);
                 break;
         }
     }
 
     public static void KeyUp(string key)
     {
+        var vk = MappingKey(ToVk(key));
         switch (key)
         {
             case "VK_LBUTTON":
@@ -64,13 +68,14 @@ public class GlobalMethod
                 Simulation.SendInput.Mouse.XButtonUp(0x0001);
                 break;
             default:
-                Simulation.SendInput.Keyboard.KeyUp(ToVk(key));
+                Simulation.SendInput.Keyboard.KeyUp(vk);
                 break;
         }
     }
 
     public static void KeyPress(string key)
     {
+        var vk = MappingKey(ToVk(key));
         switch (key)
         {
             case "VK_LBUTTON":
@@ -89,7 +94,7 @@ public class GlobalMethod
                 Simulation.SendInput.Mouse.XButtonClick(0x0001);
                 break;
             default:
-                Simulation.SendInput.Keyboard.KeyPress(ToVk(key));
+                Simulation.SendInput.Keyboard.KeyPress(vk);
                 break;
         }
     }
@@ -104,6 +109,67 @@ public class GlobalMethod
         {
             throw new ArgumentException($"键盘编码必须是VirtualKeyCodes枚举中的值，当前传入的 {key} 不合法");
         }
+    }
+
+    /// <summary>
+    /// 根据默认键位，将脚本中写死的按键映射为实际的按键
+    /// </summary>
+    /// <param name="source"></param>
+    /// <returns></returns>
+    private static VK MappingKey(VK source)
+    {
+        if (TaskContext.Instance().Config.KeyBindingsConfig.GlobalKeyMappingEnabled)
+        {
+            // NOTE: 普攻、鼠标的冲刺、元素视野、视角居中和派蒙菜单不支持改键，此处不会进行映射
+            return source switch
+            {
+                VK.VK_W => GIActions.MoveForward.ToActionKey().ToVK(),
+                VK.VK_S => GIActions.MoveBackward.ToActionKey().ToVK(),
+                VK.VK_A => GIActions.MoveLeft.ToActionKey().ToVK(),
+                VK.VK_D => GIActions.MoveRight.ToActionKey().ToVK(),
+                VK.VK_LCONTROL => GIActions.SwitchToWalkOrRun.ToActionKey().ToVK(),
+                VK.VK_E => GIActions.ElementalSkill.ToActionKey().ToVK(),
+                VK.VK_Q => GIActions.ElementalBurst.ToActionKey().ToVK(),
+                VK.VK_LSHIFT => GIActions.SprintKeyboard.ToActionKey().ToVK(),
+                VK.VK_R => GIActions.SwitchAimingMode.ToActionKey().ToVK(),
+                VK.VK_SPACE => GIActions.Jump.ToActionKey().ToVK(),
+                VK.VK_X => GIActions.Drop.ToActionKey().ToVK(),
+                VK.VK_F => GIActions.PickUpOrInteract.ToActionKey().ToVK(),
+                VK.VK_Z => GIActions.QuickUseGadget.ToActionKey().ToVK(),
+                VK.VK_T => GIActions.InteractionInSomeMode.ToActionKey().ToVK(),
+                VK.VK_V => GIActions.QuestNavigation.ToActionKey().ToVK(),
+                VK.VK_P => GIActions.AbandonChallenge.ToActionKey().ToVK(),
+                VK.VK_1 => GIActions.SwitchMember1.ToActionKey().ToVK(),
+                VK.VK_2 => GIActions.SwitchMember2.ToActionKey().ToVK(),
+                VK.VK_3 => GIActions.SwitchMember3.ToActionKey().ToVK(),
+                VK.VK_4 => GIActions.SwitchMember4.ToActionKey().ToVK(),
+                VK.VK_5 => GIActions.SwitchMember5.ToActionKey().ToVK(),
+                VK.VK_TAB => GIActions.ShortcutWheel.ToActionKey().ToVK(),
+                VK.VK_B => GIActions.OpenInventory.ToActionKey().ToVK(),
+                VK.VK_C => GIActions.OpenCharacterScreen.ToActionKey().ToVK(),
+                VK.VK_M => GIActions.OpenMap.ToActionKey().ToVK(),
+                VK.VK_F1 => GIActions.OpenAdventurerHandbook.ToActionKey().ToVK(),
+                VK.VK_F2 => GIActions.OpenCoOpScreen.ToActionKey().ToVK(),
+                VK.VK_F3 => GIActions.OpenWishScreen.ToActionKey().ToVK(),
+                VK.VK_F4 => GIActions.OpenBattlePassScreen.ToActionKey().ToVK(),
+                VK.VK_F5 => GIActions.OpenTheEventsMenu.ToActionKey().ToVK(),
+                VK.VK_F6 => GIActions.OpenTheSettingsMenu.ToActionKey().ToVK(),
+                VK.VK_F7 => GIActions.OpenTheFurnishingScreen.ToActionKey().ToVK(),
+                VK.VK_F8 => GIActions.OpenStellarReunion.ToActionKey().ToVK(),
+                VK.VK_J => GIActions.OpenQuestMenu.ToActionKey().ToVK(),
+                VK.VK_Y => GIActions.OpenNotificationDetails.ToActionKey().ToVK(),
+                VK.VK_RETURN => GIActions.OpenChatScreen.ToActionKey().ToVK(),
+                VK.VK_U => GIActions.OpenSpecialEnvironmentInformation.ToActionKey().ToVK(),
+                VK.VK_G => GIActions.CheckTutorialDetails.ToActionKey().ToVK(),
+                VK.VK_LMENU => GIActions.ShowCursor.ToActionKey().ToVK(),
+                VK.VK_L => GIActions.OpenPartySetupScreen.ToActionKey().ToVK(),
+                VK.VK_O => GIActions.OpenFriendsScreen.ToActionKey().ToVK(),
+                VK.VK_OEM_2 => GIActions.HideUI.ToActionKey().ToVK(),
+                // 其他按键（保留的？）不作转换
+                _ => source,
+            };
+        }
+        return source;
     }
 
     #endregion 键盘操作

--- a/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
@@ -675,7 +675,7 @@ public class Avatar
 
     public void KeyDown(string key)
     {
-        var vk = User32Helper.ToVk(key);
+        var vk = MappingKey(User32Helper.ToVk(key));
         switch (key)
         {
             case "VK_LBUTTON":
@@ -701,7 +701,7 @@ public class Avatar
 
     public void KeyUp(string key)
     {
-        var vk = User32Helper.ToVk(key);
+        var vk = MappingKey(User32Helper.ToVk(key));
         switch (key)
         {
             case "VK_LBUTTON":
@@ -727,7 +727,7 @@ public class Avatar
 
     public void KeyPress(string key)
     {
-        var vk = User32Helper.ToVk(key);
+        var vk = MappingKey(User32Helper.ToVk(key));
         switch (key)
         {
             case "VK_LBUTTON":
@@ -749,5 +749,67 @@ public class Avatar
                 Simulation.SendInput.Keyboard.KeyPress(vk);
                 break;
         }
+    }
+
+    /// <summary>
+    /// 根据默认键位，将脚本中写死的按键映射为实际的按键
+    /// </summary>
+    /// <param name="source"></param>
+    /// <returns></returns>
+    private static User32.VK MappingKey(User32.VK source)
+    {
+        if (TaskContext.Instance().Config.KeyBindingsConfig.GlobalKeyMappingEnabled)
+        {
+            // NOTE: 普攻、鼠标的冲刺、元素视野、视角居中和派蒙菜单不支持改键，此处不会进行映射
+            return source switch
+            {
+                User32.VK.VK_W => GIActions.MoveForward.ToActionKey().ToVK(),
+                User32.VK.VK_S => GIActions.MoveBackward.ToActionKey().ToVK(),
+                User32.VK.VK_A => GIActions.MoveLeft.ToActionKey().ToVK(),
+                User32.VK.VK_D => GIActions.MoveRight.ToActionKey().ToVK(),
+                User32.VK.VK_LCONTROL => GIActions.SwitchToWalkOrRun.ToActionKey().ToVK(),
+                User32.VK.VK_E => GIActions.ElementalSkill.ToActionKey().ToVK(),
+                User32.VK.VK_Q => GIActions.ElementalBurst.ToActionKey().ToVK(),
+                User32.VK.VK_LSHIFT => GIActions.SprintKeyboard.ToActionKey().ToVK(),
+                User32.VK.VK_R => GIActions.SwitchAimingMode.ToActionKey().ToVK(),
+                User32.VK.VK_SPACE => GIActions.Jump.ToActionKey().ToVK(),
+                User32.VK.VK_X => GIActions.Drop.ToActionKey().ToVK(),
+                User32.VK.VK_F => GIActions.PickUpOrInteract.ToActionKey().ToVK(),
+                User32.VK.VK_Z => GIActions.QuickUseGadget.ToActionKey().ToVK(),
+                User32.VK.VK_T => GIActions.InteractionInSomeMode.ToActionKey().ToVK(),
+                User32.VK.VK_V => GIActions.QuestNavigation.ToActionKey().ToVK(),
+                User32.VK.VK_P => GIActions.AbandonChallenge.ToActionKey().ToVK(),
+                User32.VK.VK_1 => GIActions.SwitchMember1.ToActionKey().ToVK(),
+                User32.VK.VK_2 => GIActions.SwitchMember2.ToActionKey().ToVK(),
+                User32.VK.VK_3 => GIActions.SwitchMember3.ToActionKey().ToVK(),
+                User32.VK.VK_4 => GIActions.SwitchMember4.ToActionKey().ToVK(),
+                User32.VK.VK_5 => GIActions.SwitchMember5.ToActionKey().ToVK(),
+                User32.VK.VK_TAB => GIActions.ShortcutWheel.ToActionKey().ToVK(),
+                User32.VK.VK_B => GIActions.OpenInventory.ToActionKey().ToVK(),
+                User32.VK.VK_C => GIActions.OpenCharacterScreen.ToActionKey().ToVK(),
+                User32.VK.VK_M => GIActions.OpenMap.ToActionKey().ToVK(),
+                User32.VK.VK_F1 => GIActions.OpenAdventurerHandbook.ToActionKey().ToVK(),
+                User32.VK.VK_F2 => GIActions.OpenCoOpScreen.ToActionKey().ToVK(),
+                User32.VK.VK_F3 => GIActions.OpenWishScreen.ToActionKey().ToVK(),
+                User32.VK.VK_F4 => GIActions.OpenBattlePassScreen.ToActionKey().ToVK(),
+                User32.VK.VK_F5 => GIActions.OpenTheEventsMenu.ToActionKey().ToVK(),
+                User32.VK.VK_F6 => GIActions.OpenTheSettingsMenu.ToActionKey().ToVK(),
+                User32.VK.VK_F7 => GIActions.OpenTheFurnishingScreen.ToActionKey().ToVK(),
+                User32.VK.VK_F8 => GIActions.OpenStellarReunion.ToActionKey().ToVK(),
+                User32.VK.VK_J => GIActions.OpenQuestMenu.ToActionKey().ToVK(),
+                User32.VK.VK_Y => GIActions.OpenNotificationDetails.ToActionKey().ToVK(),
+                User32.VK.VK_RETURN => GIActions.OpenChatScreen.ToActionKey().ToVK(),
+                User32.VK.VK_U => GIActions.OpenSpecialEnvironmentInformation.ToActionKey().ToVK(),
+                User32.VK.VK_G => GIActions.CheckTutorialDetails.ToActionKey().ToVK(),
+                User32.VK.VK_LMENU => GIActions.ShowCursor.ToActionKey().ToVK(),
+                User32.VK.VK_L => GIActions.OpenPartySetupScreen.ToActionKey().ToVK(),
+                User32.VK.VK_O => GIActions.OpenFriendsScreen.ToActionKey().ToVK(),
+                User32.VK.VK_OEM_2 => GIActions.HideUI.ToActionKey().ToVK(),
+                // 其他按键（保留的？）不作转换
+                // NOTE: 是否可以在脚本中增加类似编译器预处理指令的语法，使全局按键映射功能在执行特定脚本（如用户自行编写且不推送到中央仓库的自用脚本）时禁用
+                _ => source,
+            };
+        }
+        return source;
     }
 }

--- a/BetterGenshinImpact/View/Pages/CommonSettingsPage.xaml
+++ b/BetterGenshinImpact/View/Pages/CommonSettingsPage.xaml
@@ -631,6 +631,38 @@
             </ui:CardControl.Header>
         </ui:CardControl>
 
+        <!--新增全局按键映射功能-->
+        <ui:CardControl Margin="0,0,0,12" Icon="{ui:SymbolIcon Symbol=KeyboardMouse16}">
+            <ui:CardControl.Header>
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <ui:TextBlock Grid.Row="0"
+                                  Grid.Column="0"
+                                  FontTypography="Body"
+                                  Text="启用全局按键映射"
+                                  TextWrapping="Wrap" />
+                    <ui:TextBlock Grid.Row="1"
+                                  Grid.Column="0"
+                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                  Text="使按键绑定设置对外部脚本生效"
+                                  TextWrapping="Wrap" />
+                    <ui:ToggleSwitch Grid.Row="0"
+                               Grid.RowSpan="2"
+                               Grid.Column="1"
+                               Margin="0,0,36,0"
+                               IsChecked="{Binding Config.KeyBindingsConfig.GlobalKeyMappingEnabled}"/>
+                </Grid>
+
+            </ui:CardControl.Header>
+        </ui:CardControl>
+
         <ui:TextBlock Margin="0,0,0,8"
                       FontTypography="BodyStrong"
                       Text="通知设置" />

--- a/BetterGenshinImpact/View/Pages/KeyBindingsSettingsPage.xaml
+++ b/BetterGenshinImpact/View/Pages/KeyBindingsSettingsPage.xaml
@@ -32,7 +32,7 @@
         <ui:TextBlock Grid.Row="1"
                       Margin="0,0,0,8"
                       Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
-                      Text="此处的按键绑定设置对除自动拾取、钓鱼、音游、伐木外的功能有效。请手动设置拾取按键、星之归还按键、隐藏主界面按键。"
+                      Text="此处的按键设置默认对除自动拾取、钓鱼、音游、伐木外的内置功能有效，在设置中打开“启用全局按键映射”开关可对JS脚本、战斗脚本和路径追踪内包含的简易策略脚本生效。请手动设置拾取按键、星之归还按键、隐藏主界面按键。"
                       TextWrapping="Wrap" />
 
         <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="0,0,0,8">


### PR DESCRIPTION
~~_嗨嗨嗨，我又来污染仓库了_~~

最近在执行JS脚本`AutoArtifacts_A_B_Extra`时发现，角色走到某些地方的行为有点奇怪，要么日墙卡死要么莫名其妙摔死，但是并未在脚本仓库看到相关Issue的提出，遂自查发现是由于路径跟踪中的简易脚本无法正常执行（如`【额外】狗粮-纳塔-鸡屁股+7个-f.json`中附身龙并遁地的操作就因为我将特殊玩法的按键改为Q而无法正常执行），导致路径追踪出现意外情况，于是灵机一动去改了`Avatar.cs`和`GlobalMethod.cs`中模拟键盘输入的代码，使其在执行脚本或战斗宏遇到KeyDown、KeyUp、KeyPress时能够从默认键位映射到实际的键位；对鼠标按键则不进行映射，毕竟原神本来也不支持修改。

* 全局按键映射功能默认关闭，需要在设置页手动启用
* 部分玩法中的按键绑定独立于按键绑定设置，且无法更改，暂不清楚中央仓库中是否有脚本会在执行期间进入特殊玩法，或许需要在功能开关的UI加上“（实验性）”描述文本提示用户谨慎开启

### 奇思妙想
* 或许需要提供一个在脚本执行期间临时关闭全局按键映射的方法