### PR TITLE
优化传送逻辑

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoTrackPath/TpConfig.cs
+++ b/BetterGenshinImpact/GameTask/AutoTrackPath/TpConfig.cs
@@ -64,4 +64,9 @@ public partial class TpConfig : ObservableObject
     
     [ObservableProperty]
     private double _mapScaleFactor = 2.661;  // 游戏坐标和 mapZoomLevel=1 时的像素比例因子。
+    
+    [ObservableProperty]
+    [property: JsonIgnore]
+    private double _precisionThreshold = 0.05;
+    
 }


### PR DESCRIPTION
1. MoveMapTo之前保证缩放大于2，以保证初始中心点识别不会出错；
2. 重构MoveMapTo，主要去除了首次的试探过程（由于直接使用游戏坐标来确定需要移动的距离，试探已经不再需要）。