### PR TITLE
fix #1178 修复保存键鼠脚本时丢失最后一个MacroEvent的问题

### DIFF
--- a/BetterGenshinImpact/Core/Recorder/KeyMouseRecorder.cs
+++ b/BetterGenshinImpact/Core/Recorder/KeyMouseRecorder.cs
@@ -95,6 +95,10 @@ public class KeyMouseRecorder
                     break;
             }
         }
+        if (currentMerge != null)
+        {
+            mergedMacroEvents.Add(currentMerge);
+        }
         KeyMouseScript keyMouseScript = new()
         {
             MacroEvents = mergedMacroEvents,


### PR DESCRIPTION
- 合并鼠标事件后，输出JSON前判断`currentMerge`是否为`null`，若否，则将`currentMerge`添加到`mergedMacroEvents`的末尾，防止丢失最后一个`MacroEvent`

实测最后一个`MacroEvent`有很大概率会直接丢失，即使是`MouseMoveBy`或`MouseMoveTo`事件，只不过坐标一般很小，难以察觉。