### PR TITLE
咬钩后拉扯框识别的优化，以及着手优化抛竿

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoFishing/AutoFishingTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFishing/AutoFishingTask.cs
@@ -115,13 +115,13 @@ namespace BetterGenshinImpact.GameTask.AutoFishing
                         break;
                     }
 
-                    var bitmap = TaskControl.CaptureGameBitmapNoRetry(TaskTriggerDispatcher.Instance().GameCapture);
+                    using var bitmap = TaskControl.CaptureGameBitmapNoRetry(TaskTriggerDispatcher.Instance().GameCapture);
                     if (bitmap == null)
                     {
                         _logger.LogWarning("截图失败");
                         continue;
                     }
-                    var content = new CaptureContent(bitmap, 0, 0);
+                    using var content = new CaptureContent(bitmap, 0, 0);
                     behaviourTree.Tick(content.CaptureRectArea);
 
                     if (behaviourTree.Status != BehaviourStatus.Running)

--- a/BetterGenshinImpact/GameTask/AutoFishing/AutoFishingTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFishing/AutoFishingTask.cs
@@ -77,7 +77,7 @@ namespace BetterGenshinImpact.GameTask.AutoFishing
                                                     .PushLeaf(() => new ThrowRod("抛竿", blackboard, _logger, param.SaveScreenshotOnKeyTick, input))
                                                 .End()
                                             .End()
-                                            .Do("冒泡-抛竿-缺鱼检查", _ => blackboard.noTargetFish ? BehaviourStatus.Failed : BehaviourStatus.Succeeded)
+                                            .Do("冒泡-抛竿-缺鱼检查", _ => blackboard.throwRodNoTargetFish ? BehaviourStatus.Failed : BehaviourStatus.Succeeded)
                                             .PushLeaf(() => new CheckThrowRod("检查抛竿结果", _logger, param.SaveScreenshotOnKeyTick))
                                             .MySimpleParallel("下杆中", SimpleParallelPolicy.OnlyOneMustSucceed)
                                                 .PushLeaf(() => new FishBite("自动提竿", _logger, param.SaveScreenshotOnKeyTick, input))

--- a/BetterGenshinImpact/GameTask/AutoFishing/AutoFishingTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFishing/AutoFishingTask.cs
@@ -47,21 +47,6 @@ namespace BetterGenshinImpact.GameTask.AutoFishing
             this.blackboard = new Blackboard(predictor, this.Sleep);
         }
 
-        public class Blackboard : AutoFishing.Blackboard
-        {
-            public bool noFish = false;
-
-            public Blackboard(YoloV8Predictor predictor, Action<int> sleep) : base(predictor, sleep)
-            {
-            }
-
-            internal override void Reset()
-            {
-                base.Reset();
-                noFish = false;
-            }
-        }
-
         public Task Start(CancellationToken ct)
         {
             this._ct = ct;

--- a/BetterGenshinImpact/GameTask/AutoFishing/Behaviours.cs
+++ b/BetterGenshinImpact/GameTask/AutoFishing/Behaviours.cs
@@ -197,6 +197,7 @@ namespace BetterGenshinImpact.GameTask.AutoFishing
         {
             noPlacementTimes = 0;
             noTargetFishTimes = 0;
+            prevTargetFishRect = Rect.Empty;
 
             input.Mouse.LeftButtonDown();
             blackboard.pitchReset = true;
@@ -213,7 +214,12 @@ namespace BetterGenshinImpact.GameTask.AutoFishing
             drawContent.RemoveRect("PrevFish");
         }
 
-        Rect prevTargetFishRect = Rect.Empty; // 记录上一个目标鱼的位置
+        Rect prevTargetFishRect; // 记录上一个目标鱼的位置
+
+        /// <summary>
+        /// 当前鱼
+        /// </summary>
+        public OneFish? currentFish { get; private set; }
 
         protected override BehaviourStatus Update(ImageRegion imageRegion)
         {
@@ -228,6 +234,7 @@ namespace BetterGenshinImpact.GameTask.AutoFishing
             var result = blackboard.predictor.Detect(memoryStream);
             Debug.WriteLine($"YOLOv8识别: {result.Speed}");
             var fishpond = new Fishpond(result, includeTarget: timeProvider.GetLocalNow() <= ignoreObtainedEndTime);
+            blackboard.fishpond = fishpond;
             Random _rd = new();
             if (fishpond.TargetRect == null || fishpond.TargetRect == Rect.Empty)
             {
@@ -261,7 +268,7 @@ namespace BetterGenshinImpact.GameTask.AutoFishing
             Rect fishpondTargetRect = (Rect)fishpond.TargetRect;
 
             // 找到落点最近的鱼
-            OneFish? currentFish = null;
+            currentFish = null;
             if (prevTargetFishRect == Rect.Empty)
             {
                 var list = fishpond.FilterByBaitName(blackboard.selectedBaitName);

--- a/BetterGenshinImpact/GameTask/AutoFishing/Blackboard.cs
+++ b/BetterGenshinImpact/GameTask/AutoFishing/Blackboard.cs
@@ -30,7 +30,13 @@ namespace BetterGenshinImpact.GameTask.AutoFishing
         /// <summary>
         /// 是否没有目标鱼
         /// </summary>
-        public bool noTargetFish;
+        public bool throwRodNoTargetFish;
+
+        /// <summary>
+        /// 抛竿无目标鱼失败列表
+        /// 失败一次就加入一次鱼饵名，列表中同名鱼饵的数量代表该种失败了几次
+        /// </summary>
+        public List<string> throwRodNoTargetFishfailures = new List<string>();
 
         /// <summary>
         /// 拉条位置的识别框
@@ -69,7 +75,8 @@ namespace BetterGenshinImpact.GameTask.AutoFishing
         internal virtual void Reset()
         {
             noFish = false;
-            noTargetFish = false;
+            throwRodNoTargetFish = false;
+            throwRodNoTargetFishfailures = new List<string>();
             fishBoxRect = Rect.Empty;
             chooseBaitUIOpening = false;
             chooseBaitfailures = new List<string>();

--- a/BetterGenshinImpact/GameTask/AutoFishing/Blackboard.cs
+++ b/BetterGenshinImpact/GameTask/AutoFishing/Blackboard.cs
@@ -13,6 +13,11 @@ namespace BetterGenshinImpact.GameTask.AutoFishing
     public class Blackboard
     {
         /// <summary>
+        /// 没鱼啦，不钓了
+        /// </summary>
+        public bool noFish = false;
+
+        /// <summary>
         /// 已选择的鱼饵名
         /// </summary>
         public string selectedBaitName = string.Empty;
@@ -39,6 +44,12 @@ namespace BetterGenshinImpact.GameTask.AutoFishing
         public bool chooseBaitUIOpening = false;
 
         /// <summary>
+        /// 选鱼饵失败列表
+        /// 失败一次就加入一次鱼饵名，列表中同名鱼饵的数量代表该种失败了几次
+        /// </summary>
+        public List<string> chooseBaitfailures = new List<string>();
+
+        /// <summary>
         /// 镜头俯仰是否被行为重置
         /// 进入钓鱼模式后、以及提竿后，镜头的俯仰会被重置。进行相关动作前须优化俯仰角，避免鱼塘被脚下的悬崖遮挡。
         /// </summary>
@@ -57,9 +68,11 @@ namespace BetterGenshinImpact.GameTask.AutoFishing
 
         internal virtual void Reset()
         {
+            noFish = false;
             noTargetFish = false;
             fishBoxRect = Rect.Empty;
             chooseBaitUIOpening = false;
+            chooseBaitfailures = new List<string>();
             pitchReset = true;
             selectedBaitName = string.Empty;
         }

--- a/BetterGenshinImpact/GameTask/AutoFishing/Model/Fishpond.cs
+++ b/BetterGenshinImpact/GameTask/AutoFishing/Model/Fishpond.cs
@@ -129,39 +129,4 @@ public class Fishpond
 
         return new Rect(left, top, right - left, bottom - top);
     }
-
-    /// <summary>
-    /// 通过鱼饵名称过滤鱼
-    /// </summary>
-    /// <param name="baitName"></param>
-    /// <returns></returns>
-    public List<OneFish> FilterByBaitName(string baitName)
-    {
-        return [.. Fishes.Where(fish => fish.FishType.BaitName == baitName).OrderByDescending(fish => fish.Confidence)];
-    }
-
-    public OneFish? FilterByBaitNameAndRecently(string baitName, Rect prevTargetFishRect)
-    {
-        var fishes = FilterByBaitName(baitName);
-        if (fishes.Count == 0)
-        {
-            return null;
-        }
-
-        var min = double.MaxValue;
-        var c1 = prevTargetFishRect.GetCenterPoint();
-        OneFish? result = null;
-        foreach (var fish in fishes)
-        {
-            var c2 = fish.Rect.GetCenterPoint();
-            var distance = Math.Sqrt(Math.Pow(c1.X - c2.X, 2) + Math.Pow(c1.Y - c2.Y, 2));
-            if (distance < min)
-            {
-                min = distance;
-                result = fish;
-            }
-        }
-
-        return result;
-    }
 }

--- a/Test/BetterGenshinImpact.UnitTest/GameTaskTests/AutoFishingTests/BehavioursTests.ChooseBait.cs
+++ b/Test/BetterGenshinImpact.UnitTest/GameTaskTests/AutoFishingTests/BehavioursTests.ChooseBait.cs
@@ -98,11 +98,11 @@ namespace BetterGenshinImpact.UnitTest.GameTaskTests.AutoFishingTests
         }
 
         /// <summary>
-        /// 测试选鱼饵失败若干次，结果应得出“没有鱼”
+        /// 测试选鱼饵失败若干次，失败列表应符合预期
         /// 这个测试侧重连续选鱼饵失败、两次选鱼饵失败之间穿插一次选鱼饵成功的情况
         /// </summary>
         [Fact]
-        public void ChooseBaitTest_AllBaitIgnored_Case1_ShouldBeNoFish()
+        public void ChooseBaitTest_AllBaitIgnored_Case1_FailureListShouldBeExpected()
         {
             //
             Bitmap bitmap = new Bitmap(@$"..\..\..\Assets\AutoFishing\20250226161354285_ChooseBait_Succeeded.png");
@@ -199,16 +199,15 @@ namespace BetterGenshinImpact.UnitTest.GameTaskTests.AutoFishingTests
             Assert.True(String.IsNullOrEmpty(blackboard.selectedBaitName));
             Assert.Equal(BehaviourStatus.Failed, actual);
             Assert.Equal(2, blackboard.chooseBaitfailures.Where(f => f == "spinelgrain bait").Count());
-            Assert.True(blackboard.noFish);
             #endregion
         }
 
         /// <summary>
-        /// 测试选鱼饵失败若干次，结果应得出“没有鱼”
+        /// 测试选鱼饵失败若干次，失败列表应符合预期
         /// 这个测试侧重两种鱼饵交替失败的情况
         /// </summary>
         [Fact]
-        public void ChooseBaitTest_AllBaitIgnored_Case2_ShouldBeNoFish()
+        public void ChooseBaitTest_AllBaitIgnored_Case2_FailureListShouldBeExpected()
         {
             //
             Bitmap bitmap = new Bitmap(@$"..\..\..\Assets\AutoFishing\20250226161354285_ChooseBait_Succeeded.png");
@@ -289,7 +288,6 @@ namespace BetterGenshinImpact.UnitTest.GameTaskTests.AutoFishingTests
             Assert.True(String.IsNullOrEmpty(blackboard.selectedBaitName));
             Assert.Equal(BehaviourStatus.Failed, actual);
             Assert.Equal(2, blackboard.chooseBaitfailures.Where(f => f == "spinelgrain bait").Count());
-            Assert.True(blackboard.noFish);
             #endregion
         }
     }

--- a/Test/BetterGenshinImpact.UnitTest/GameTaskTests/AutoFishingTests/BehavioursTests.GetFishBoxArea.cs
+++ b/Test/BetterGenshinImpact.UnitTest/GameTaskTests/AutoFishingTests/BehavioursTests.GetFishBoxArea.cs
@@ -1,0 +1,72 @@
+﻿using BehaviourTree;
+using BetterGenshinImpact.GameTask.AutoFishing;
+using BetterGenshinImpact.GameTask.Model.Area.Converter;
+using BetterGenshinImpact.GameTask.Model.Area;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Drawing;
+using BetterGenshinImpact.Core.Recognition.ONNX.YOLO;
+using Microsoft.Extensions.Time.Testing;
+
+namespace BetterGenshinImpact.UnitTest.GameTaskTests.AutoFishingTests
+{
+    public partial class BehavioursTests
+    {
+        [Theory]
+        [InlineData(@"20250306111752769_GetFishBoxArea_Succeeded.png")]
+        /// <summary>
+        /// 测试获取钓鱼拉扯框，结果为成功
+        /// </summary>
+        public void GetFishBoxArea_ShouldSuccess(string screenshot1080p)
+        {
+            //
+            Bitmap bitmap = new Bitmap(@$"..\..\..\Assets\AutoFishing\{screenshot1080p}");
+            var imageRegion = new GameCaptureRegion(bitmap, 0, 0,  drawContent: new FakeDrawContent());
+
+            var blackboard = new Blackboard(null, sleep: i => { });
+
+            //
+            GetFishBoxArea sut = new GetFishBoxArea("-", blackboard, new FakeLogger(), false);
+            BehaviourStatus actual = sut.Tick(imageRegion);
+
+            //
+            Assert.Equal(BehaviourStatus.Succeeded, actual);
+        }
+
+        [Theory]
+        [InlineData(@"20250306111752769_GetFishBoxArea_Succeeded.png")]
+        [InlineData(@"202503012143011486@900p.png")]
+        /// <summary>
+        /// 测试获取钓鱼拉扯框，超时后，结果为失败
+        /// </summary>
+        public void GetFishBoxArea_ShouldFail(string screenshot1080p)
+        {
+            //
+            Bitmap bitmap = new Bitmap(@$"..\..\..\Assets\AutoFishing\{screenshot1080p}");
+            var imageRegion = new GameCaptureRegion(bitmap, 0, 0, drawContent: new FakeDrawContent());
+
+            var blackboard = new Blackboard(null, sleep: i => { });
+
+            FakeTimeProvider fakeTimeProvider = new FakeTimeProvider();
+
+            //
+            GetFishBoxArea sut = new GetFishBoxArea("-", blackboard, new FakeLogger(), false, fakeTimeProvider);
+            BehaviourStatus actual = sut.Tick(imageRegion);
+
+            //
+            Assert.NotEqual(BehaviourStatus.Failed, actual);
+
+            //
+            fakeTimeProvider.Advance(TimeSpan.FromSeconds(6));
+
+            //
+            actual = sut.Tick(imageRegion);
+
+            //
+            Assert.Equal(BehaviourStatus.Failed, actual);
+        }
+    }
+}

--- a/Test/BetterGenshinImpact.UnitTest/GameTaskTests/AutoFishingTests/BehavioursTests.ThrowRod.cs
+++ b/Test/BetterGenshinImpact.UnitTest/GameTaskTests/AutoFishingTests/BehavioursTests.ThrowRod.cs
@@ -43,7 +43,7 @@ namespace BetterGenshinImpact.UnitTest.GameTaskTests.AutoFishingTests
             BehaviourStatus actual = sut.Tick(imageRegion);
 
             //
-            Assert.False(blackboard.noTargetFish);
+            Assert.False(blackboard.throwRodNoTargetFish);
             Assert.Equal(BehaviourStatus.Succeeded, actual);
         }
 
@@ -74,7 +74,7 @@ namespace BetterGenshinImpact.UnitTest.GameTaskTests.AutoFishingTests
             BehaviourStatus actual = sut.Tick(imageRegion);
 
             //
-            Assert.False(blackboard.noTargetFish);
+            Assert.False(blackboard.throwRodNoTargetFish);
             Assert.Equal(BehaviourStatus.Running, actual);
         }
 

--- a/Test/BetterGenshinImpact.UnitTest/GameTaskTests/AutoFishingTests/BehavioursTests.ThrowRod.cs
+++ b/Test/BetterGenshinImpact.UnitTest/GameTaskTests/AutoFishingTests/BehavioursTests.ThrowRod.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using System.Drawing;
 using BetterGenshinImpact.Core.Config;
 using Compunet.YoloV8;
+using Microsoft.Extensions.Time.Testing;
 
 namespace BetterGenshinImpact.UnitTest.GameTaskTests.AutoFishingTests
 {
@@ -35,8 +36,11 @@ namespace BetterGenshinImpact.UnitTest.GameTaskTests.AutoFishingTests
                 selectedBaitName = selectedBaitName
             };
 
+            DateTimeOffset dateTime = new DateTimeOffset(2025, 2, 26, 16, 13, 54, 285, TimeSpan.FromHours(8));
+            FakeTimeProvider fakeTimeProvider = new FakeTimeProvider(dateTime);
+
             //
-            ThrowRod sut = new ThrowRod("-", blackboard, new FakeLogger(), false, new FakeInputSimulator(), drawContent: new FakeDrawContent());
+            ThrowRod sut = new ThrowRod("-", blackboard, new FakeLogger(), false, new FakeInputSimulator(), fakeTimeProvider, drawContent: new FakeDrawContent());
             BehaviourStatus actual = sut.Tick(imageRegion);
 
             //
@@ -64,8 +68,11 @@ namespace BetterGenshinImpact.UnitTest.GameTaskTests.AutoFishingTests
                 selectedBaitName = selectedBaitName
             };
 
+            DateTimeOffset dateTime = new DateTimeOffset(2025, 2, 26, 16, 13, 54, 285, TimeSpan.FromHours(8));
+            FakeTimeProvider fakeTimeProvider = new FakeTimeProvider(dateTime);
+
             //
-            ThrowRod sut = new ThrowRod("-", blackboard, new FakeLogger(), false, new FakeInputSimulator(), drawContent: new FakeDrawContent());
+            ThrowRod sut = new ThrowRod("-", blackboard, new FakeLogger(), false, new FakeInputSimulator(), fakeTimeProvider, drawContent: new FakeDrawContent());
             BehaviourStatus actual = sut.Tick(imageRegion);
 
             //

--- a/Test/BetterGenshinImpact.UnitTest/GameTaskTests/AutoFishingTests/BehavioursTests.ThrowRod.cs
+++ b/Test/BetterGenshinImpact.UnitTest/GameTaskTests/AutoFishingTests/BehavioursTests.ThrowRod.cs
@@ -36,8 +36,7 @@ namespace BetterGenshinImpact.UnitTest.GameTaskTests.AutoFishingTests
                 selectedBaitName = selectedBaitName
             };
 
-            DateTimeOffset dateTime = new DateTimeOffset(2025, 2, 26, 16, 13, 54, 285, TimeSpan.FromHours(8));
-            FakeTimeProvider fakeTimeProvider = new FakeTimeProvider(dateTime);
+            FakeTimeProvider fakeTimeProvider = new FakeTimeProvider();
 
             //
             ThrowRod sut = new ThrowRod("-", blackboard, new FakeLogger(), false, new FakeInputSimulator(), fakeTimeProvider, drawContent: new FakeDrawContent());
@@ -68,8 +67,7 @@ namespace BetterGenshinImpact.UnitTest.GameTaskTests.AutoFishingTests
                 selectedBaitName = selectedBaitName
             };
 
-            DateTimeOffset dateTime = new DateTimeOffset(2025, 2, 26, 16, 13, 54, 285, TimeSpan.FromHours(8));
-            FakeTimeProvider fakeTimeProvider = new FakeTimeProvider(dateTime);
+            FakeTimeProvider fakeTimeProvider = new FakeTimeProvider();
 
             //
             ThrowRod sut = new ThrowRod("-", blackboard, new FakeLogger(), false, new FakeInputSimulator(), fakeTimeProvider, drawContent: new FakeDrawContent());
@@ -78,6 +76,47 @@ namespace BetterGenshinImpact.UnitTest.GameTaskTests.AutoFishingTests
             //
             Assert.False(blackboard.noTargetFish);
             Assert.Equal(BehaviourStatus.Running, actual);
+        }
+
+        /// <summary>
+        /// 抛竿时，给定三条炮鲀鱼，并且确定算法能将下杆点从鱼的左侧移动到最左侧的炮鲀鱼上，此时希望“当前鱼”能始终锁定在最左侧的鱼上
+        /// 由于偶尔观测到“摇摆”行为的出现，故设计此测试
+        /// </summary>
+        [Fact]
+        public void ThrowRodTest_Target_ShouldBeTheLeftOne()
+        {
+            //
+            Bitmap bitmap = new Bitmap(@$"..\..\..\Assets\AutoFishing\202503082114541115.png");
+            var imageRegion = new GameCaptureRegion(bitmap, 0, 0, new DesktopRegion(new FakeMouseSimulator()), converter: new ScaleConverter(1d), drawContent: new FakeDrawContent());
+
+            var predictor = YoloV8Builder.CreateDefaultBuilder().UseOnnxModel(Global.Absolute(@"Assets\Model\Fish\bgi_fish.onnx")).Build();
+
+            var blackboard = new Blackboard(predictor, sleep: i => { })
+            {
+                selectedBaitName = "fake fly bait"
+            };
+
+            //
+            ThrowRod sut = new ThrowRod("-", blackboard, new FakeLogger(), false, new FakeInputSimulator(), new FakeTimeProvider(), drawContent: new FakeDrawContent());
+            sut.Tick(imageRegion);
+            var actual = sut.currentFish;
+
+            //
+            Assert.True(blackboard.fishpond.TargetRect != null && blackboard.fishpond.TargetRect.Value != OpenCvSharp.Rect.Empty);
+            Assert.Equal(3, blackboard.fishpond.Fishes.Count(f => f.FishType.Name == "pufferfish"));
+            Assert.Equal(blackboard.fishpond.Fishes.OrderBy(f => f.Rect.X).First(), actual);
+
+            //
+            bitmap = new Bitmap(@$"..\..\..\Assets\AutoFishing\202503082114560489.png");
+            imageRegion = new GameCaptureRegion(bitmap, 0, 0, new DesktopRegion(new FakeMouseSimulator()), converter: new ScaleConverter(1d), drawContent: new FakeDrawContent());
+
+            //
+            sut.Tick(imageRegion);
+            actual = sut.currentFish;
+
+            //
+            Assert.Equal(3, blackboard.fishpond.Fishes.Count(f => f.FishType.Name == "pufferfish"));
+            Assert.Equal(blackboard.fishpond.Fishes.OrderBy(f => f.Rect.X).First(), actual);
         }
     }
 }


### PR DESCRIPTION
一个是今天上午群友发现的在钓雷鸣仙时，因“文字块”识别通过而误识别了鱼咬钩，于是进入寻找拉扯框的死循环的Bug；
还有就是现阶段抛竿还有有些问题，要进行一些优化。
但咬钩识别、和抛竿这两块儿的主体是沿用的旧代码，hutao的那块是个黑箱可以不管，但外围仍有一些逻辑，需要先理清现有思路，再看看怎么优化，最好还能配上测试用例