### PR TITLE
修复 #1262 自动拾取按文档指引改键无效

### DIFF
--- a/BetterGenshinImpact/View/Pages/TriggerSettingsPage.xaml
+++ b/BetterGenshinImpact/View/Pages/TriggerSettingsPage.xaml
@@ -183,7 +183,7 @@
                               Grid.Column="1"
                               Width="80"
                               Margin="0,0,36,0"
-                              ItemsSource="{Binding DefaultPickButtonNames}"
+                              ItemsSource="{Binding PickButtonNames}"
                               SelectedItem="{Binding Config.AutoPickConfig.PickKey, Mode=TwoWay}" />
                 </Grid>
             </StackPanel>

--- a/BetterGenshinImpact/ViewModel/Pages/TriggerSettingsPageViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/TriggerSettingsPageViewModel.cs
@@ -1,4 +1,5 @@
-﻿using BetterGenshinImpact.Core.Config;
+﻿using System;
+using BetterGenshinImpact.Core.Config;
 using BetterGenshinImpact.GameTask.AutoPick;
 using BetterGenshinImpact.GameTask.AutoSkip.Assets;
 using BetterGenshinImpact.Service.Interface;
@@ -9,6 +10,7 @@ using CommunityToolkit.Mvvm.Input;
 using System.Collections.Generic;
 using System.Diagnostics;
 using BetterGenshinImpact.GameTask.AutoSkip.Model;
+using SharpCompress;
 using Wpf.Ui;
 using Wpf.Ui.Controls;
 
@@ -24,9 +26,9 @@ public partial class TriggerSettingsPageViewModel : ObservableObject, INavigatio
 
     [ObservableProperty]
     private string[] _pickOcrEngineNames = [PickOcrEngineEnum.Paddle.ToString(), PickOcrEngineEnum.Yap.ToString()];
-
+    
     [ObservableProperty]
-    private string[] _defaultPickButtonNames = ["F", "E"];
+    private List<string> _pickButtonNames;
 
     public AllConfig Config { get; set; }
 
@@ -40,6 +42,15 @@ public partial class TriggerSettingsPageViewModel : ObservableObject, INavigatio
         Config = configService.Get();
         _navigationService = navigationService;
         _hangoutBranches = HangoutConfig.Instance.HangoutOptionsTitleList;
+        
+        _pickButtonNames = new List<string> { "F", "E"};
+        if (!string.IsNullOrEmpty(Config.AutoPickConfig.PickKey)
+            && Config.AutoPickConfig.PickKey.Length == 1
+            && char.IsUpper(Config.AutoPickConfig.PickKey[0])
+            && !_pickButtonNames.Contains(Config.AutoPickConfig.PickKey))
+        {
+            _pickButtonNames.Add(Config.AutoPickConfig.PickKey);
+        }
     }
 
     public void OnNavigatedTo()

--- a/BetterGenshinImpact/ViewModel/Pages/TriggerSettingsPageViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/TriggerSettingsPageViewModel.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using BetterGenshinImpact.Core.Config;
+﻿using BetterGenshinImpact.Core.Config;
 using BetterGenshinImpact.GameTask.AutoPick;
 using BetterGenshinImpact.GameTask.AutoSkip.Assets;
+using BetterGenshinImpact.GameTask.AutoSkip.Model;
 using BetterGenshinImpact.Service.Interface;
 using BetterGenshinImpact.View.Pages;
 using BetterGenshinImpact.View.Windows;
@@ -9,8 +9,6 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using System.Collections.Generic;
 using System.Diagnostics;
-using BetterGenshinImpact.GameTask.AutoSkip.Model;
-using SharpCompress;
 using Wpf.Ui;
 using Wpf.Ui.Controls;
 
@@ -26,7 +24,7 @@ public partial class TriggerSettingsPageViewModel : ObservableObject, INavigatio
 
     [ObservableProperty]
     private string[] _pickOcrEngineNames = [PickOcrEngineEnum.Paddle.ToString(), PickOcrEngineEnum.Yap.ToString()];
-    
+
     [ObservableProperty]
     private List<string> _pickButtonNames;
 
@@ -42,8 +40,8 @@ public partial class TriggerSettingsPageViewModel : ObservableObject, INavigatio
         Config = configService.Get();
         _navigationService = navigationService;
         _hangoutBranches = HangoutConfig.Instance.HangoutOptionsTitleList;
-        
-        _pickButtonNames = new List<string> { "F", "E"};
+
+        _pickButtonNames = new List<string> { "F", "E" };
         if (!string.IsNullOrEmpty(Config.AutoPickConfig.PickKey)
             && Config.AutoPickConfig.PickKey.Length == 1
             && char.IsUpper(Config.AutoPickConfig.PickKey[0])


### PR DESCRIPTION
按照文档里的原意并没有做成可以直接修改的下拉框
而是配置中有不一样的按键的时候加到下拉框的可选项里面
这样如果想自定义的话仍旧需要修改配置文件
个人认为比做到UI里面直接配置要好