### PR TITLE
fix: move mouse to center after adjust zoom level

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoTrackPath/TpTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoTrackPath/TpTask.cs
@@ -489,6 +489,7 @@ public class TpTask(CancellationToken ct)
         await Delay(50, ct);
         GlobalMethod.LeftButtonUp();
         await Delay(50, ct);
+        GameCaptureRegion.GameRegionMove((rect, scale) => (rect.Width / 2d, rect.Width / 2d));
     }
 
     /// <summary>


### PR DESCRIPTION
调整缩放等级之后把鼠标移动到屏幕中心，避免鼠标挡住图标影响 GetBigMapZoomLevel 获取当前的缩放等级而导致传送失败。