### PR TITLE
feat: add action_params(StopFlyingWaitTime) to stop_flying

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoPathing/Handler/ActionFactory.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/Handler/ActionFactory.cs
@@ -38,6 +38,7 @@ public class ActionFactory
             return key switch
             {
                 "up_down_grab_leaf" => new UpDownGrabLeaf(),
+                "stop_flying" => new StopFlyingHandler(),
                 _ => throw new ArgumentException("未知的前置 action 类型")
             };
         });

--- a/BetterGenshinImpact/GameTask/AutoPathing/Handler/StopFlyingHandler.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/Handler/StopFlyingHandler.cs
@@ -1,0 +1,50 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using BetterGenshinImpact.Core.Simulator;
+using BetterGenshinImpact.Core.Simulator.Extensions;
+using BetterGenshinImpact.GameTask.AutoPathing.Model;
+using BetterGenshinImpact.GameTask.Common.BgiVision;
+using Microsoft.Extensions.Logging;
+using static BetterGenshinImpact.GameTask.Common.TaskControl;
+
+namespace BetterGenshinImpact.GameTask.AutoPathing.Handler;
+
+public class StopFlyingHandler : IActionHandler
+{
+    public async Task RunAsync(CancellationToken ct, WaypointForTrack? waypointForTrack = null, object? config = null)
+    {
+        if (waypointForTrack != null && !string.IsNullOrEmpty(waypointForTrack.ActionParams))
+        {
+            var stopFlyingWaitTime = (int)double.Parse(waypointForTrack.ActionParams); // 毫秒级
+            Simulation.SendInput.SimulateAction(GIActions.Jump);
+            await Delay(stopFlyingWaitTime, ct);
+        }
+
+        //下落攻击接近目的地
+        Logger.LogInformation("动作：下落攻击");
+        Simulation.SendInput.SimulateAction(GIActions.NormalAttack);
+        int i;
+        for (i = 0; i < 50; i++)
+        {
+            var screen = CaptureToRectArea();
+            var isFlying = Bv.GetMotionStatus(screen) == MotionStatus.Fly;
+            if (isFlying)
+            {
+                await Delay(200, ct);
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        if (i == 50)
+        {
+            Logger.LogWarning("动作：下落攻击 超时结束");
+        }
+        else
+        {
+            Logger.LogInformation("动作：下落攻击 结束");
+        }
+    }
+}

--- a/BetterGenshinImpact/GameTask/AutoPathing/Handler/StopFlyingHandler.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/Handler/StopFlyingHandler.cs
@@ -13,9 +13,10 @@ public class StopFlyingHandler : IActionHandler
 {
     public async Task RunAsync(CancellationToken ct, WaypointForTrack? waypointForTrack = null, object? config = null)
     {
-        if (waypointForTrack != null && !string.IsNullOrEmpty(waypointForTrack.ActionParams))
+        if (waypointForTrack != null
+            && !string.IsNullOrEmpty(waypointForTrack.ActionParams)
+            && int.TryParse(waypointForTrack.ActionParams, out var stopFlyingWaitTime))
         {
-            var stopFlyingWaitTime = (int)double.Parse(waypointForTrack.ActionParams); // 毫秒级
             Simulation.SendInput.SimulateAction(GIActions.Jump);
             await Delay(stopFlyingWaitTime, ct);
         }

--- a/BetterGenshinImpact/GameTask/AutoPathing/Model/WaypointForTrack.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/Model/WaypointForTrack.cs
@@ -24,8 +24,6 @@ public class WaypointForTrack : Waypoint
     public CombatScript? CombatScript { get; set; }
     public string? LogInfo { get; set; }
     
-    public int? StopFlyingWaitTime { get; set; }
-
     public WaypointForTrack(Waypoint waypoint)
     {
         Type = waypoint.Type;
@@ -46,17 +44,6 @@ public class WaypointForTrack : Waypoint
         if (waypoint.Action == ActionEnum.LogOutput.Code && waypoint.ActionParams is not null)
         {
             LogInfo = waypoint.ActionParams;
-        }
-        if (waypoint.Action == ActionEnum.StopFlying.Code && waypoint.ActionParams is not null)
-        {
-            try 
-            {
-                StopFlyingWaitTime = (int)(double.Parse(waypoint.ActionParams) * 1000);
-            }
-            catch (FormatException)
-            {
-                StopFlyingWaitTime = -1;
-            }
         }
     }
 }

--- a/BetterGenshinImpact/GameTask/AutoPathing/Model/WaypointForTrack.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/Model/WaypointForTrack.cs
@@ -2,7 +2,6 @@
 using System;
 using BetterGenshinImpact.GameTask.AutoFight.Script;
 using BetterGenshinImpact.GameTask.AutoPathing.Model.Enum;
-using System.Diagnostics.Eventing.Reader;
 
 namespace BetterGenshinImpact.GameTask.AutoPathing.Model;
 
@@ -24,6 +23,8 @@ public class WaypointForTrack : Waypoint
     /// </summary>
     public CombatScript? CombatScript { get; set; }
     public string? LogInfo { get; set; }
+    
+    public int? StopFlyingWaitTime { get; set; }
 
     public WaypointForTrack(Waypoint waypoint)
     {
@@ -45,6 +46,17 @@ public class WaypointForTrack : Waypoint
         if (waypoint.Action == ActionEnum.LogOutput.Code && waypoint.ActionParams is not null)
         {
             LogInfo = waypoint.ActionParams;
+        }
+        if (waypoint.Action == ActionEnum.StopFlying.Code && waypoint.ActionParams is not null)
+        {
+            try 
+            {
+                StopFlyingWaitTime = (int)(double.Parse(waypoint.ActionParams) * 1000);
+            }
+            catch (FormatException)
+            {
+                StopFlyingWaitTime = -1;
+            }
         }
     }
 }

--- a/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
@@ -896,9 +896,27 @@ public class PathExecutor
         if (waypoint.MoveMode == MoveModeEnum.Fly.Code && waypoint.Action == ActionEnum.StopFlying.Code)
         {
             //下落攻击接近目的地
+            if (waypoint.StopFlyingWaitTime > 0)
+            {
+                Simulation.SendInput.SimulateAction(GIActions.Jump);
+                await Delay((int)waypoint.StopFlyingWaitTime, ct);
+            } 
+            else if (waypoint.StopFlyingWaitTime == -1)
+            {
+                Logger.LogWarning("错误的下落攻击等待时间，请检查 action_params 格式。");
+            }
             Logger.LogInformation("动作：下落攻击");
             Simulation.SendInput.SimulateAction(GIActions.NormalAttack);
-            await Delay(1000, ct);
+            for (int i = 0; i < 20; i++)
+            {
+                var screen = CaptureToRectArea();
+                var isFlying = Bv.GetMotionStatus(screen) == MotionStatus.Fly;
+                if (isFlying)
+                {
+                    await Delay(200, ct);
+                }
+            }
+            Logger.LogInformation("动作：下落攻击 结束");
         }
     }
 

--- a/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
@@ -358,7 +358,7 @@ public class PathExecutor
 
             if (forceTp) // 强制传送模式
             {
-                await new TpTask(ct).TpToStatueOfTheSeven();  // fix typos
+                await new TpTask(ct).TpToStatueOfTheSeven(); // fix typos
                 success = await new SwitchPartyTask().Start(partyName, ct);
             }
             else // 优先原地切换模式
@@ -383,7 +383,6 @@ public class PathExecutor
 
         return success;
     }
-
 
 
     private static string? FilterPartyNameByConditionConfig(PathingTask task)
@@ -606,7 +605,9 @@ public class PathExecutor
         await _rotateTask.WaitUntilRotatedTo(targetOrientation, 2);
         await Delay(500, ct);
     }
+
     public DateTime moveToStartTime;
+
     public async Task MoveTo(WaypointForTrack waypoint)
     {
         // 切人
@@ -895,28 +896,7 @@ public class PathExecutor
     {
         if (waypoint.MoveMode == MoveModeEnum.Fly.Code && waypoint.Action == ActionEnum.StopFlying.Code)
         {
-            //下落攻击接近目的地
-            if (waypoint.StopFlyingWaitTime > 0)
-            {
-                Simulation.SendInput.SimulateAction(GIActions.Jump);
-                await Delay((int)waypoint.StopFlyingWaitTime, ct);
-            } 
-            else if (waypoint.StopFlyingWaitTime == -1)
-            {
-                Logger.LogWarning("错误的下落攻击等待时间，请检查 action_params 格式。");
-            }
-            Logger.LogInformation("动作：下落攻击");
-            Simulation.SendInput.SimulateAction(GIActions.NormalAttack);
-            for (int i = 0; i < 20; i++)
-            {
-                var screen = CaptureToRectArea();
-                var isFlying = Bv.GetMotionStatus(screen) == MotionStatus.Fly;
-                if (isFlying)
-                {
-                    await Delay(200, ct);
-                }
-            }
-            Logger.LogInformation("动作：下落攻击 结束");
+            await ActionFactory.GetBeforeHandler(ActionEnum.StopFlying.Code).RunAsync(ct, waypoint);
         }
     }
 


### PR DESCRIPTION
1. feat: add action_params(StopFlyingWaitTime) to stop_flying;
2. fix: ensure next step only proceeds after stop_flying.

**测试用例：**
```
{
  "info": {
    "name": "下落攻击等待时间测试",
    "type": "collect",
    "author": "秋云",
    "version": "1.0",
    "description": "下落攻击等待时间测试，附赠火史莱姆。",
    "bgiVersion": "0.43.1"
  },
  "positions": [
    {
      "id": 1,
      "x": 1391.01,
      "y": 515.44,
      "action": "",
      "move_mode": "walk",
      "type": "teleport"
    },
    {
      "id": 2,
      "x": 1371.81,
      "y": 530.83,
      "action": "",
      "move_mode": "walk",
      "type": "path"
    },
    {
      "id": 3,
      "x": 1394.83,
      "y": 546.72,
      "action": "",
      "move_mode": "walk",
      "type": "path"
    },
    {
      "id": 4,
      "x": 1379.88,
      "y": 593.19,
      "action": "stop_flying",
      "move_mode": "fly",
      "type": "path",
      "action_params": "1000"
    },
    {
      "id": 5,
      "x": 1379.88,
      "y": 593.19,
      "action": "fight",
      "move_mode": "walk",
      "type": "path"
    }
  ]
}
```