### PR TITLE
:sparkles: 飞书通知时带有图片(需要配置app,并且在飞书后台增加上传图片权限)

### DIFF
--- a/BetterGenshinImpact/Service/Notification/NotificationConfig.cs
+++ b/BetterGenshinImpact/Service/Notification/NotificationConfig.cs
@@ -117,6 +117,8 @@ public partial class NotificationConfig : ObservableObject
     ///     飞书通知地址
     /// </summary>
     [ObservableProperty] private string _feishuWebhookUrl = string.Empty;
+    [ObservableProperty] private string _feishuAppId = string.Empty;
+    [ObservableProperty] private string _feishuAppSecret = string.Empty;
 
     [ObservableProperty] private string _fromEmail = string.Empty;
 

--- a/BetterGenshinImpact/Service/Notification/NotificationService.cs
+++ b/BetterGenshinImpact/Service/Notification/NotificationService.cs
@@ -140,7 +140,9 @@ public class NotificationService : IHostedService, IDisposable
         if (_notificationConfig?.FeishuNotificationEnabled == true)
             _notifierManager.RegisterNotifier(new FeishuNotifier(
                 _notifyHttpClient,
-                _notificationConfig.FeishuWebhookUrl
+                _notificationConfig.FeishuWebhookUrl,
+                _notificationConfig.FeishuAppId,
+                _notificationConfig.FeishuAppSecret
             ));
     }
 

--- a/BetterGenshinImpact/Service/Notifier/FeishuNotifier.cs
+++ b/BetterGenshinImpact/Service/Notifier/FeishuNotifier.cs
@@ -30,7 +30,7 @@ public class FeishuNotifier : INotifier
 
     private readonly HttpClient _httpClient;
 
-    private static readonly string _accesssTokenUrl = "https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal";
+    private static readonly string _accessTokenUrl = "https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal";
     private static readonly string _uploadImageUrl = "https://open.feishu.cn/open-apis/im/v1/images";
     
     public FeishuNotifier(HttpClient httpClient, string endpoint = "", string appId = "", string appSecret = "")
@@ -72,8 +72,8 @@ public class FeishuNotifier : INotifier
         Object feishuMessage;
         if (notificationData.Screenshot != null && AppId.Length > 0 && AppSecret.Length > 0)
         {
-            var acctessToken = await GetAccessToken();
-            var imageKey = await UploadImage(notificationData.Screenshot, acctessToken);
+            var accessToken = await GetAccessToken();
+            var imageKey = await UploadImage(notificationData.Screenshot, accessToken);
             feishuMessage = new
             {
                 msg_type = "post",
@@ -83,8 +83,8 @@ public class FeishuNotifier : INotifier
                     {
                         zh_cn = new
                         {
-                            content = new Object[] {
-                                new Object[] {
+                            content = new object[] {
+                                new object[] {
                                     new {
                                         tag = "text",
                                         text = notificationData.Message
@@ -126,7 +126,7 @@ public class FeishuNotifier : INotifier
         };
         var accessTokenBodySerializedData = JsonSerializer.Serialize(accessTokenBody);
         var accessTokenBodyContent = new StringContent(accessTokenBodySerializedData, Encoding.UTF8, "application/json");
-        using (var accessTokenResponse = await _httpClient.PostAsync(_accesssTokenUrl, accessTokenBodyContent))
+        using (var accessTokenResponse = await _httpClient.PostAsync(_accessTokenUrl, accessTokenBodyContent))
         {
             var tokenResponseContent = await accessTokenResponse.Content.ReadAsStringAsync();
             if (!accessTokenResponse.IsSuccessStatusCode)
@@ -153,7 +153,7 @@ public class FeishuNotifier : INotifier
         return tokenString;
     }
 
-    private async Task<String> UploadImage(Image image, string acessToken)
+    private async Task<String> UploadImage(Image image, string accessToken)
     {
         string imageKey = string.Empty;
         MultipartFormDataContent multipartContent = new MultipartFormDataContent();
@@ -168,7 +168,7 @@ public class FeishuNotifier : INotifier
         {
             Content = multipartContent
         };
-        uploadImageRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", acessToken);
+        uploadImageRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
         using (HttpResponseMessage uploadImageResponse = await _httpClient.SendAsync(uploadImageRequest))
         {
             var uploadResponseString = await uploadImageResponse.Content.ReadAsStringAsync();

--- a/BetterGenshinImpact/Service/Notifier/FeishuNotifier.cs
+++ b/BetterGenshinImpact/Service/Notifier/FeishuNotifier.cs
@@ -5,6 +5,16 @@ using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using BetterGenshinImpact.Service.Notification.Model;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Net.Http.Headers;
+using System;
+using BetterGenshinImpact.GameTask.Common;
+using Microsoft.Extensions.Logging;
+using Windows.UI.Notifications;
+using System.Drawing;
 
 namespace BetterGenshinImpact.Service.Notifier;
 
@@ -14,12 +24,21 @@ public class FeishuNotifier : INotifier
 
     public string Endpoint { get; set; }
 
+    public string AppId { get; set; }
+
+    public string AppSecret { get; set; }
+
     private readonly HttpClient _httpClient;
+
+    private static readonly string _accesssTokenUrl = "https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal";
+    private static readonly string _uploadImageUrl = "https://open.feishu.cn/open-apis/im/v1/images";
     
-    public FeishuNotifier(HttpClient httpClient, string endpoint = "")
+    public FeishuNotifier(HttpClient httpClient, string endpoint = "", string appId = "", string appSecret = "")
     {
         _httpClient = httpClient;
         Endpoint = endpoint;
+        AppId = appId;
+        AppSecret = appSecret;
     }
 
     public async Task SendAsync(BaseNotificationData content)
@@ -31,7 +50,7 @@ public class FeishuNotifier : INotifier
         
         try
         {
-            var response = await _httpClient.PostAsync(Endpoint, TransformData(content));
+            var response = await _httpClient.PostAsync(Endpoint, await TransformData(content));
 
             if (!response.IsSuccessStatusCode)
             {
@@ -48,19 +67,133 @@ public class FeishuNotifier : INotifier
         }
     }
 
-    private StringContent TransformData(BaseNotificationData notificationData)
+    private async Task<StringContent> TransformData(BaseNotificationData notificationData)
     {
-        var feishuMessage = new
+        Object feishuMessage;
+        if (notificationData.Screenshot != null && AppId.Length > 0 && AppSecret.Length > 0)
         {
-            msg_type = "text",
-            content = new
+            var acctessToken = await GetAccessToken();
+            var imageKey = await UploadImage(notificationData.Screenshot, acctessToken);
+            feishuMessage = new
             {
-                text = notificationData.Message
-            }
-        };
-
+                msg_type = "post",
+                content = new
+                {
+                    post = new
+                    {
+                        zh_cn = new
+                        {
+                            content = new Object[] {
+                                new Object[] {
+                                    new {
+                                        tag = "text",
+                                        text = notificationData.Message
+                                    },
+                                    new {
+                                        tag = "img",
+                                        image_key = imageKey,
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+        }
+        else
+        {
+            feishuMessage = new
+            {
+                msg_type = "text",
+                content = new
+                {
+                    text = notificationData.Message
+                }
+            };
+        }
         var serializedData = JsonSerializer.Serialize(feishuMessage);
-
         return new StringContent(serializedData, Encoding.UTF8, "application/json");
+    }
+
+    // obtain access tonken from feishu open api
+    private async Task<string> GetAccessToken()
+    {
+        string tokenString = string.Empty;
+        var accessTokenBody = new
+        {
+            app_id = AppId,
+            app_secret = AppSecret
+        };
+        var accessTokenBodySerializedData = JsonSerializer.Serialize(accessTokenBody);
+        var accessTokenBodyContent = new StringContent(accessTokenBodySerializedData, Encoding.UTF8, "application/json");
+        using (var accessTokenResponse = await _httpClient.PostAsync(_accesssTokenUrl, accessTokenBodyContent))
+        {
+            var tokenResponseContent = await accessTokenResponse.Content.ReadAsStringAsync();
+            if (!accessTokenResponse.IsSuccessStatusCode)
+            {
+                throw new NotifierException($"Feishu access token call failed with code: {accessTokenResponse.StatusCode}");
+            }
+            using (JsonDocument doc = JsonDocument.Parse(tokenResponseContent))
+            {
+                JsonElement root = doc.RootElement;
+                if (root.TryGetProperty("tenant_access_token", out JsonElement dataElement))
+                {
+                    var keyNullable = dataElement.GetString();
+                    if (keyNullable != null)
+                    {
+                        tokenString = keyNullable;
+                    }
+                }
+            }
+        }
+        if (string.IsNullOrEmpty(tokenString))
+        {
+            throw new NotifierException($"Feishu access token not found");
+        }
+        return tokenString;
+    }
+
+    private async Task<String> UploadImage(Image image, string acessToken)
+    {
+        string imageKey = string.Empty;
+        MultipartFormDataContent multipartContent = new MultipartFormDataContent();
+        MemoryStream ms = new MemoryStream();
+        image.Save(ms, ImageFormat.Png);
+        ms.Seek(0, SeekOrigin.Begin);
+        ByteArrayContent byteContent = new ByteArrayContent(ms.ToArray());
+        byteContent.Headers.ContentType = new MediaTypeHeaderValue("image/png");
+        multipartContent.Add(byteContent, "image", "image.png");
+        multipartContent.Add(new StringContent("message"), "image_type");
+        HttpRequestMessage uploadImageRequest = new HttpRequestMessage(HttpMethod.Post, _uploadImageUrl)
+        {
+            Content = multipartContent
+        };
+        uploadImageRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", acessToken);
+        using (HttpResponseMessage uploadImageResponse = await _httpClient.SendAsync(uploadImageRequest))
+        {
+            var uploadResponseString = await uploadImageResponse.Content.ReadAsStringAsync();
+            if (!uploadImageResponse.IsSuccessStatusCode)
+            {
+                throw new NotifierException($"Feishu upload image failed with code: {uploadImageResponse.StatusCode}");
+            }
+            using (JsonDocument doc = JsonDocument.Parse(uploadResponseString))
+            {
+                JsonElement root = doc.RootElement;
+                if (root.TryGetProperty("data", out JsonElement dataElement) &&
+                    dataElement.TryGetProperty("image_key", out JsonElement imageKeyElement))
+                {
+                    var keyNullable = imageKeyElement.GetString();
+                    if (keyNullable != null)
+                    {
+                        imageKey = keyNullable;
+                    }
+                }
+            }
+        }
+        if (string.IsNullOrEmpty(imageKey))
+        {
+            throw new NotifierException($"Feishu upload image not found image key");
+        }
+        return imageKey;
     }
 }

--- a/BetterGenshinImpact/View/Pages/NotificationSettingsPage.xaml
+++ b/BetterGenshinImpact/View/Pages/NotificationSettingsPage.xaml
@@ -439,6 +439,62 @@
                         <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="3*" />
+                        <ColumnDefinition Width="2*" />
+                    </Grid.ColumnDefinitions>
+                    <ui:TextBlock Grid.Row="0"
+                                  Grid.Column="0"
+                                  FontTypography="Body"
+                                  Text="飞书AppId"
+                                  TextWrapping="Wrap" />
+                    <ui:TextBlock Grid.Row="1"
+                                  Grid.Column="0"
+                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                  Text="若填写AppId、AppSecret则发送图片"
+                                  TextWrapping="Wrap" />
+                    <ui:TextBox Grid.Row="0"
+                                Grid.RowSpan="2"
+                                Grid.Column="1"
+                                MinWidth="180"
+                                MaxWidth="800"
+                                Margin="0,0,36,0"
+                                Text="{Binding Config.NotificationConfig.FeishuAppId, Mode=TwoWay}"
+                                TextWrapping="NoWrap" />
+                </Grid>
+                <Grid Margin="16">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="3*" />
+                        <ColumnDefinition Width="2*" />
+                    </Grid.ColumnDefinitions>
+                    <ui:TextBlock Grid.Row="0"
+                                  Grid.Column="0"
+                                  FontTypography="Body"
+                                  Text="飞书AppSecret"
+                                  TextWrapping="Wrap" />
+                    <ui:TextBlock Grid.Row="1"
+                                  Grid.Column="0"
+                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                  Text="若填写AppId、AppSecret则发送图片"
+                                  TextWrapping="Wrap" />
+                    <ui:TextBox Grid.Row="0"
+                                Grid.RowSpan="2"
+                                Grid.Column="1"
+                                MinWidth="180"
+                                MaxWidth="800"
+                                Margin="0,0,36,0"
+                                Text="{Binding Config.NotificationConfig.FeishuAppSecret, Mode=TwoWay}"
+                                TextWrapping="NoWrap" />
+                </Grid>
+                <Grid Margin="16">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*" />
                         <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>


### PR DESCRIPTION
为查看BGI任务状态提供便利, 编写了飞书图片推送的代码。

请您随意编辑代码, 以及合并或关闭PR。望对仓库有所帮助。

![WechatIMG26](https://github.com/user-attachments/assets/53efdd25-a1e4-47cc-b35a-5fb47563a482)

![WechatIMG25](https://github.com/user-attachments/assets/05a7a98e-f23e-44d3-9abc-59f20918cfa6)
