### PR TITLE
通过调度器启动时，添加sleep防止闪退

### DIFF
--- a/BetterGenshinImpact/Service/ScriptService.cs
+++ b/BetterGenshinImpact/Service/ScriptService.cs
@@ -300,6 +300,8 @@ public partial class ScriptService : IScriptService
                             TaskControl.Logger.LogInformation("当前不在游戏主界面，等待进入主界面后执行任务...");
                             TaskControl.Logger.LogInformation("如果你已经在游戏内的其他界面，请自行退出当前界面（ESC），使当前任务能够继续运行！");
                         }
+
+                        Thread.Sleep(500);
                     }
                 });
             }


### PR DESCRIPTION
发现通过调度器直接原神启动时，进入主界面前有概率闪退，可能是while (true)里的截图太频繁导致，添加sleep后测试该问题已解决