### PR TITLE
修了一下WGC

### DIFF
--- a/BetterGenshinImpact/Core/Recognition/OCR/PaddleOcrService.cs
+++ b/BetterGenshinImpact/Core/Recognition/OCR/PaddleOcrService.cs
@@ -6,6 +6,7 @@ using Sdcb.PaddleOCR.Models;
 using System;
 using System.Diagnostics;
 using System.IO;
+using static Vanara.PInvoke.Gdi32;
 
 namespace BetterGenshinImpact.Core.Recognition.OCR;
 
@@ -68,6 +69,16 @@ public class PaddleOcrService : IOcrService
     }
 
     public PaddleOcrResult OcrResult(Mat mat)
+    {
+        if (mat.Channels() == 4)
+        {
+            using var mat3 = mat.CvtColor(ColorConversionCodes.BGRA2BGR);
+            return _OcrResult(mat3);
+        }
+        return _OcrResult(mat);
+    }
+
+    private PaddleOcrResult _OcrResult(Mat mat)
     {
         lock (locker)
         {

--- a/Fischless.GameCapture/Graphics/GraphicsCapture.cs
+++ b/Fischless.GameCapture/Graphics/GraphicsCapture.cs
@@ -312,18 +312,18 @@ public class GraphicsCapture : IGameCapture
         IsCapturing = false;
 
         // 释放最新帧
-        // _frameAccessLock.EnterWriteLock();
-        // try
-        // {
-        //     _latestFrame?.Dispose();
-        //     _latestFrame = null;
-        // }
-        // finally
-        // {
-        //     _frameAccessLock.ExitWriteLock();
-        // }
-        //
-        // _frameAccessLock.Dispose();
+        _frameAccessLock.EnterWriteLock();
+        try
+        {
+            _latestFrame?.Dispose();
+            _latestFrame = null;
+        }
+        finally
+        {
+            _frameAccessLock.ExitWriteLock();
+        }
+
+        _frameAccessLock.Dispose();
     }
 
     private void CaptureItemOnClosed(GraphicsCaptureItem sender, object args)

--- a/Fischless.GameCapture/Graphics/Helpers/Direct3D11Helper.cs
+++ b/Fischless.GameCapture/Graphics/Helpers/Direct3D11Helper.cs
@@ -46,9 +46,11 @@ public static class Direct3D11Helper
         return CreateDevice(false);
     }
 
+    private static SharpDX.Direct3D11.Device? d3dDevice;
+
     public static IDirect3DDevice CreateDevice(bool useWARP)
     {
-        var d3dDevice = new SharpDX.Direct3D11.Device(
+        d3dDevice ??= new SharpDX.Direct3D11.Device(
             useWARP ? SharpDX.Direct3D.DriverType.Software : SharpDX.Direct3D.DriverType.Hardware,
             SharpDX.Direct3D11.DeviceCreationFlags.BgraSupport);
         var device = CreateDirect3DDeviceFromSharpDXDevice(d3dDevice);


### PR DESCRIPTION
我这边能观察到的是在GraphicsCapture类在反复Start()和Stop()时，内存占用会上升，测试手段是切到WGC模式以后狂点UI界面的启动停止。。。
把SharpDX.Direct3D11.Device静态化后，这个类只会实例化一次了，也就不管c++里面是什么情况了，这样做了以后内存上升速度肉眼可见地变慢了。但是之前为什么保留每次Start时做一次新的实例化呢？是不是有原因，我这样修会不会有其他问题；
然后Stop()里有一段被注释的代码，恢复后，内存占用基本保持一条水平线了，不再不断上升。
因为这个似乎Bug有点时间长了，还请大家提供测试方法，看看这样修有没有效果。。

另外，WGC在我测试OCR的时候报错了，截图给了BGRA，Paddle说它只吃3通道的，之前BitBlt模式没有出现过这情况，这个后续会限制WGC到3通道吗？姑且是在喂给Paddle前做了下cvtColor()