### PR TITLE
bitblt截图修改:复用缓冲区以减少每次截图时的内存分配

### DIFF
--- a/Fischless.GameCapture/BitBlt/BitBltCapture.cs
+++ b/Fischless.GameCapture/BitBlt/BitBltCapture.cs
@@ -1,6 +1,7 @@
 ﻿using System.Diagnostics;
 using OpenCvSharp;
 using Vanara.PInvoke;
+using static System.Console;
 
 namespace Fischless.GameCapture.BitBlt;
 
@@ -91,7 +92,7 @@ public class BitBltCapture : IGameCapture
         }
         catch (Exception e)
         {
-            Console.Error.WriteLine("Failed to create bitblt session", e);
+            Error.WriteLine("Failed to create bitblt session", e);
             return false;
         }
         finally

--- a/Fischless.GameCapture/BitBlt/BitBltCapture.cs
+++ b/Fischless.GameCapture/BitBlt/BitBltCapture.cs
@@ -92,7 +92,7 @@ public class BitBltCapture : IGameCapture
         }
         catch (Exception e)
         {
-            Error.WriteLine("Failed to create bitblt session", e);
+            Error.WriteLine("Failed to create bitblt session:{0}", e);
             return false;
         }
         finally

--- a/Fischless.GameCapture/BitBlt/BitBltCapture.cs
+++ b/Fischless.GameCapture/BitBlt/BitBltCapture.cs
@@ -57,14 +57,21 @@ public class BitBltCapture : IGameCapture
 
         try
         {
-            if (!User32.GetClientRect(_hWnd, out var windowRect))
+            if (_session is not null && _session.IsInvalid()) // 窗口状态变化可能会导致会话失效
             {
-                //    Debug.Fail("Failed to get client rectangle");
-                return false;
+                _session = null;
             }
 
+            if (!User32.GetClientRect(_hWnd, out var windowRect) || windowRect == default)
+            {
+                //    Debug.Fail("Failed to get client rectangle");
+                // 窗口获取不到或者最小化
+                _session = null;
+                return false;
+            }
             var width = windowRect.right - windowRect.left;
             var height = windowRect.bottom - windowRect.top;
+
             _session ??= new BitBltSession(_hWnd, width, height);
             if (_session.Width == width && _session.Height == height)
             {

--- a/Fischless.GameCapture/BitBlt/BitBltCapture.cs
+++ b/Fischless.GameCapture/BitBlt/BitBltCapture.cs
@@ -31,7 +31,7 @@ public class BitBltCapture : IGameCapture
             {
                 return;
             }
-
+            _session?.Dispose();
             _session = null;
             IsCapturing = true;
         }
@@ -59,6 +59,7 @@ public class BitBltCapture : IGameCapture
         {
             if (_session is not null && _session.IsInvalid()) // 窗口状态变化可能会导致会话失效
             {
+                _session.Dispose();
                 _session = null;
             }
 
@@ -66,6 +67,7 @@ public class BitBltCapture : IGameCapture
             {
                 //    Debug.Fail("Failed to get client rectangle");
                 // 窗口获取不到或者最小化
+                _session?.Dispose();
                 _session = null;
                 return false;
             }

--- a/Fischless.GameCapture/BitBlt/BitBltCapture.cs
+++ b/Fischless.GameCapture/BitBlt/BitBltCapture.cs
@@ -31,6 +31,7 @@ public class BitBltCapture : IGameCapture
             {
                 return;
             }
+
             _session = null;
             IsCapturing = true;
         }
@@ -38,6 +39,7 @@ public class BitBltCapture : IGameCapture
         {
             _lockSlim.ExitWriteLock();
         }
+
         CheckSession();
     }
 
@@ -71,7 +73,7 @@ public class BitBltCapture : IGameCapture
 
             // 窗口尺寸被改变，释放资源
             _session.Dispose();
-            Interlocked.Exchange(ref _session, new BitBltSession(_hWnd, width, height));
+            _session = new BitBltSession(_hWnd, width, height);
             return true;
         }
         catch (Exception)

--- a/Fischless.GameCapture/BitBlt/BitBltSession.cs
+++ b/Fischless.GameCapture/BitBlt/BitBltSession.cs
@@ -117,6 +117,11 @@ public class BitBltSession : IDisposable
                 : null;
         }
     }
+    
+    public bool IsInvalid()
+    {
+        return _hWnd.IsNull || _hdcSrc.IsInvalid || _hdcDest.IsInvalid || _hBitmap.IsInvalid || _bitsPtr == IntPtr.Zero;
+    }
 
 
     public void Dispose()

--- a/Fischless.GameCapture/BitBlt/BitBltSession.cs
+++ b/Fischless.GameCapture/BitBlt/BitBltSession.cs
@@ -117,7 +117,7 @@ public class BitBltSession : IDisposable
                 : null;
         }
     }
-    
+
     public bool IsInvalid()
     {
         return _hWnd.IsNull || _hdcSrc.IsInvalid || _hdcDest.IsInvalid || _hBitmap.IsInvalid || _bitsPtr == IntPtr.Zero;
@@ -145,7 +145,7 @@ public class BitBltSession : IDisposable
             _oldBitmap = Gdi32.SafeHBITMAP.Null;
         }
 
-        
+
         if (!_hBitmap.IsNull)
         {
             Gdi32.DeleteObject(_hBitmap);
@@ -161,16 +161,7 @@ public class BitBltSession : IDisposable
 
         if (_hdcSrc != IntPtr.Zero)
         {
-            if (_hWnd.IsNull)
-            {
-                Gdi32.DeleteDC(_hdcDest);
-            }
-            else
-            {
-                User32.ReleaseDC(_hWnd, _hdcSrc);
-            }
-
-
+            User32.ReleaseDC(_hWnd, _hdcSrc);
             _hdcSrc = User32.SafeReleaseHDC.Null;
         }
 

--- a/Fischless.GameCapture/BitBlt/BitBltSession.cs
+++ b/Fischless.GameCapture/BitBlt/BitBltSession.cs
@@ -138,17 +138,20 @@ public class BitBltSession : IDisposable
     /// </summary>
     private void ReleaseResources()
     {
+        if (!_oldBitmap.IsNull)
+        {
+            // 先选回资源再释放_hBitmap
+            Gdi32.SelectObject(_hdcDest, _oldBitmap);
+            _oldBitmap = Gdi32.SafeHBITMAP.Null;
+        }
+
+        
         if (!_hBitmap.IsNull)
         {
             Gdi32.DeleteObject(_hBitmap);
             _hBitmap = Gdi32.SafeHBITMAP.Null;
         }
 
-        if (!_oldBitmap.IsNull)
-        {
-            Gdi32.SelectObject(_hdcDest, _oldBitmap);
-            _oldBitmap = Gdi32.SafeHBITMAP.Null;
-        }
 
         if (!_hdcDest.IsNull)
         {

--- a/Fischless.GameCapture/BitBlt/BitBltSession.cs
+++ b/Fischless.GameCapture/BitBlt/BitBltSession.cs
@@ -1,0 +1,171 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using OpenCvSharp;
+using Vanara.PInvoke;
+
+namespace Fischless.GameCapture.BitBlt;
+
+public class BitBltSession : IDisposable
+{
+    // 窗口句柄
+    private readonly HWND _hWnd;
+
+    // 来源DC
+    private User32.SafeReleaseHDC _hdcSrc;
+
+    // 缓冲区 CompatibleDC
+    private Gdi32.SafeHDC _hdcDest;
+
+    // 位图句柄
+    private Gdi32.SafeHBITMAP _hBitmap;
+
+    // 位图指针，这个指针会在位图释放时自动释放
+    private IntPtr _bitsPtr;
+
+    // 旧位图，析构时一起释放掉
+    private HGDIOBJ _oldBitmap;
+    public int Width { get; }
+    public int Height { get; }
+
+    private static readonly object LockObject = new object();
+
+
+    public BitBltSession(HWND hWnd, int w, int h)
+    {
+        lock (LockObject)
+        {
+            try
+            {
+                if (hWnd.IsNull)
+                {
+                    throw new Exception("hWnd is invalid");
+                }
+
+                _hWnd = hWnd;
+                if (w <= 0 || h <= 0)
+                {
+                    throw new Exception("Invalid width or height");
+                }
+
+                Width = w;
+                Height = h;
+                _hdcSrc = User32.GetDC(_hWnd);
+                if (_hdcSrc.IsInvalid)
+                {
+                    throw new Exception("Failed to get DC for {_hWnd}");
+                }
+
+                _hdcDest = Gdi32.CreateCompatibleDC(_hdcSrc);
+                if (_hdcSrc.IsInvalid)
+                {
+                    Debug.Fail("Failed to create CompatibleDC");
+                    throw new Exception("Failed to create CompatibleDC for {_hWnd}");
+                }
+
+
+                var bmi = new Gdi32.BITMAPINFO
+                {
+                    bmiHeader = new Gdi32.BITMAPINFOHEADER
+                    {
+                        biSize = (uint)Marshal.SizeOf<Gdi32.BITMAPINFOHEADER>(),
+                        biWidth = Width,
+                        biHeight = -Height, // Top-down image
+                        biPlanes = 1,
+                        biBitCount = 32,
+                        biCompression = 0, // BI_RGB
+                        biSizeImage = 0
+                    }
+                };
+                _hBitmap = Gdi32.CreateDIBSection(_hdcDest, bmi, Gdi32.DIBColorMode.DIB_RGB_COLORS, out var bits,
+                    IntPtr.Zero);
+
+                if (_hBitmap.IsInvalid || bits == 0)
+                {
+                    if (!_hBitmap.IsInvalid)
+                    {
+                        Gdi32.DeleteObject(_hBitmap);
+                    }
+
+                    throw new Exception($"Failed to create dIB section for {_hWnd}");
+                }
+
+                _bitsPtr = bits;
+                _oldBitmap = Gdi32.SelectObject(_hdcDest, _hBitmap);
+                if (_oldBitmap.IsNull)
+                {
+                    throw new Exception("Failed to select object");
+                }
+            }
+            catch (Exception)
+            {
+                ReleaseResources();
+                throw;
+            }
+        }
+    }
+
+    /// <summary>
+    /// 调用bitblt复制并返回新的mat
+    /// </summary>
+    /// <returns></returns>
+    public Mat? BitBlt()
+    {
+        lock (LockObject)
+        {
+            return Gdi32.BitBlt(_hdcDest, 0, 0, Width, Height, _hdcSrc, 0, 0, Gdi32.RasterOperationMode.SRCCOPY)
+                ? Mat.FromPixelData(Height, Width, MatType.CV_8UC4, _bitsPtr)
+                : null;
+        }
+    }
+
+
+    public void Dispose()
+    {
+        lock (LockObject)
+        {
+            ReleaseResources();
+            GC.SuppressFinalize(this);
+        }
+    }
+
+    /// <summary>
+    /// 需加锁环境下访问，释放资源
+    /// </summary>
+    private void ReleaseResources()
+    {
+        if (!_hBitmap.IsNull)
+        {
+            Gdi32.DeleteObject(_hBitmap);
+            _hBitmap = Gdi32.SafeHBITMAP.Null;
+        }
+
+        if (!_oldBitmap.IsNull)
+        {
+            Gdi32.SelectObject(_hdcDest, _oldBitmap);
+            _oldBitmap = Gdi32.SafeHBITMAP.Null;
+        }
+
+        if (!_hdcDest.IsNull)
+        {
+            Gdi32.DeleteDC(_hdcDest);
+            _hdcDest = Gdi32.SafeHDC.Null;
+        }
+
+        if (_hdcSrc != IntPtr.Zero)
+        {
+            if (_hWnd.IsNull)
+            {
+                Gdi32.DeleteDC(_hdcDest);
+            }
+            else
+            {
+                User32.ReleaseDC(_hWnd, _hdcSrc);
+            }
+
+
+            _hdcSrc = User32.SafeReleaseHDC.Null;
+        }
+
+        _bitsPtr = IntPtr.Zero;
+    }
+}


### PR DESCRIPTION
rt。[重构 BitBltCapture 并添加 BitBltSession 以提高线程安全性](https://github.com/babalae/better-genshin-impact/commit/bc0aa8705de4eca893ede8414d329e9cd7d9e83a)

带来的变化:
现在截图尺寸可能不会实时响应窗口变化(最小化/尺寸变化)
但是目前游戏的应用场景不会存在频繁更改分辨率的问题。一般游戏也不会频繁变换窗口。实测可以有效降低cpu占用。(虽然没降多少（x

ps:DX截图爆炸修起来很头疼。不如优化一下bitblt，跑的也挺快的鸭。