### PR TITLE
👻更旧OpenCvSharp4相关包版本到4.10.0.20240616(据说这样OCR不容易爆炸)

### DIFF
--- a/BetterGenshinImpact/BetterGenshinImpact.csproj
+++ b/BetterGenshinImpact/BetterGenshinImpact.csproj
@@ -56,9 +56,9 @@
 		<PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
 		<PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2592.51" />
 		<PackageReference Include="Ookii.Dialogs.Wpf" Version="5.0.1" />
-		<PackageReference Include="OpenCvSharp4.WpfExtensions" Version="4.10.0.20241108" />
-		<PackageReference Include="OpenCvSharp4.Extensions" Version="4.10.0.20241108" />
-		<PackageReference Include="OpenCvSharp4.Windows" Version="4.10.0.20241108" />
+		<PackageReference Include="OpenCvSharp4.WpfExtensions" Version="4.10.0.20240616" />
+		<PackageReference Include="OpenCvSharp4.Extensions" Version="4.10.0.20240616" />
+		<PackageReference Include="OpenCvSharp4.Windows" Version="4.10.0.20240616" />
 		<PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.122" />
 		<PackageReference Include="Microsoft.ClearScript.V8" Version="7.4.5" />
 		<PackageReference Include="Microsoft.ClearScript.V8.Native.win-x64" Version="7.4.5" />

--- a/Fischless.GameCapture/Fischless.GameCapture.csproj
+++ b/Fischless.GameCapture/Fischless.GameCapture.csproj
@@ -19,8 +19,8 @@
 		<PackageReference Include="Vanara.PInvoke.User32" Version="4.0.2" />
 		<PackageReference Include="Vanara.PInvoke.SHCore" Version="4.0.2" />
 		<PackageReference Include="Vanara.Windows.Extensions" Version="4.0.2" />
-		<PackageReference Include="OpenCvSharp4.Extensions" Version="4.10.0.20241108" />
-		<PackageReference Include="OpenCvSharp4.Windows" Version="4.10.0.20241108" />
+		<PackageReference Include="OpenCvSharp4.Extensions" Version="4.10.0.20240616" />
+		<PackageReference Include="OpenCvSharp4.Windows" Version="4.10.0.20240616" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
灵！
来自 https://github.com/sdcb/PaddleSharp/issues/115