### PR TITLE
feat(js): 获取大地图和小地图中心点坐标

### DIFF
--- a/BetterGenshinImpact/Core/Script/Dependence/Genshin.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/Genshin.cs
@@ -6,8 +6,11 @@ using Vanara.PInvoke;
 using BetterGenshinImpact.GameTask.AutoFishing;
 using BetterGenshinImpact.ViewModel.Pages;
 using System;
-
+using BetterGenshinImpact.GameTask.AutoPathing;
+using BetterGenshinImpact.GameTask.Common.BgiVision;
+using OpenCvSharp;
 using static BetterGenshinImpact.GameTask.Common.TaskControl;
+using BetterGenshinImpact.GameTask.Common.Map;
 namespace BetterGenshinImpact.Core.Script.Dependence;
 
 public class Genshin
@@ -126,6 +129,33 @@ public class Genshin
         TpTask tpTask = new TpTask(CancellationContext.Instance.Cts.Token);
         await tpTask.TpToStatueOfTheSeven();
     }
+
+    /// <summary>
+    /// 获取当前在大地图上的位置坐标
+    /// </summary>
+    /// <returns>包含X和Y坐标的数组，索引0为X坐标，索引1为Y坐标</returns>
+    public float[] GetPositionFromBigMap()
+    {
+        TpTask tpTask = new TpTask(CancellationContext.Instance.Cts.Token);
+        Point2f position = tpTask.GetPositionFromBigMap();
+        // 转换为数组
+        return new float[] { position.X, position.Y };
+    }
+
+    /// <summary>
+    /// 获取当前在小地图上的位置坐标
+    /// </summary>
+    /// <returns>包含X和Y坐标的数组，索引0为X坐标，索引1为Y坐标</returns>
+    public float[] GetPositionFromMap(){
+        var imageRegion = CaptureToRectArea();
+        if (!Bv.IsInMainUi(imageRegion))
+        {
+            throw new InvalidOperationException("不在主界面，无法识别小地图坐标");
+        }
+        var position = MapCoordinate.Main2048ToGame(Navigation.GetPositionStable(imageRegion));
+        return new float[] { position.X, position.Y };
+    }
+
     #endregion 大地图操作
     /// <summary>
     /// 切换队伍

--- a/BetterGenshinImpact/Core/Script/Dependence/Genshin.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/Genshin.cs
@@ -133,27 +133,24 @@ public class Genshin
     /// <summary>
     /// 获取当前在大地图上的位置坐标
     /// </summary>
-    /// <returns>包含X和Y坐标的数组，索引0为X坐标，索引1为Y坐标</returns>
-    public float[] GetPositionFromBigMap()
+    /// <returns>包含X和Y坐标的Point2f结构体</returns>
+    public Point2f GetPositionFromBigMap()
     {
         TpTask tpTask = new TpTask(CancellationContext.Instance.Cts.Token);
-        Point2f position = tpTask.GetPositionFromBigMap();
-        // 转换为数组
-        return new float[] { position.X, position.Y };
+        return tpTask.GetPositionFromBigMap();
     }
 
     /// <summary>
     /// 获取当前在小地图上的位置坐标
     /// </summary>
-    /// <returns>包含X和Y坐标的数组，索引0为X坐标，索引1为Y坐标</returns>
-    public float[] GetPositionFromMap(){
+    /// <returns>包含X和Y坐标的Point2f结构体</returns>
+    public Point2f GetPositionFromMap(){
         var imageRegion = CaptureToRectArea();
         if (!Bv.IsInMainUi(imageRegion))
         {
             throw new InvalidOperationException("不在主界面，无法识别小地图坐标");
         }
-        var position = MapCoordinate.Main2048ToGame(Navigation.GetPositionStable(imageRegion));
-        return new float[] { position.X, position.Y };
+        return MapCoordinate.Main2048ToGame(Navigation.GetPositionStable(imageRegion));
     }
 
     #endregion 大地图操作

--- a/BetterGenshinImpact/Core/Script/EngineExtend.cs
+++ b/BetterGenshinImpact/Core/Script/EngineExtend.cs
@@ -43,6 +43,7 @@ public class EngineExtend
 
         // 识图模块相关
         engine.AddHostType("Mat", typeof(Mat));
+        engine.AddHostType("Point2f", typeof(Point2f)); // 添加Point2f类型暴露
         engine.AddHostType("RecognitionObject", typeof(RecognitionObject));
         engine.AddHostType("DesktopRegion", typeof(DesktopRegion));
         engine.AddHostType("GameCaptureRegion", typeof(GameCaptureRegion));

--- a/BetterGenshinImpact/GameTask/AutoPathing/PathRecorder.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/PathRecorder.cs
@@ -39,7 +39,7 @@ public class PathRecorder : Singleton<PathRecorder>
         TaskControl.Logger.LogInformation("开始路径点记录");
         var waypoint = new Waypoint();
         var screen = TaskControl.CaptureToRectArea();
-        var position = Navigation.GetPosition(screen);
+        var position = Navigation.GetPositionStable(screen);
         position = MapCoordinate.Main2048ToGame(position);
         waypoint.X = position.X;
         waypoint.Y = position.Y;
@@ -61,7 +61,7 @@ public class PathRecorder : Singleton<PathRecorder>
     {
         Waypoint waypoint = new();
         var screen = TaskControl.CaptureToRectArea();
-        var position = Navigation.GetPosition(screen);
+        var position = Navigation.GetPositionStable(screen);
         position = MapCoordinate.Main2048ToGame(position);
         waypoint.X = position.X;
         waypoint.Y = position.Y;


### PR DESCRIPTION
顺便意外发现了路径记录器在传送之后获取 (0,0) 的原因，修改之后已经修复了。

测试用例：

从小地图获取坐标
```js
(async function () {
    await genshin.returnMainUi();
    let position = genshin.getPositionFromMap();
    log.info(`当前位置: X=${position.X}, Y=${position.Y}`);
})();
```
从大地图获取坐标
```js
(async function () {
    await genshin.returnMainUi();
    keyPress('M');
    await sleep(1000);
    let position = genshin.getPositionFromBigMap();
    log.info(`当前大地图位置: X=${position.X}, Y=${position.Y}`);
    keyPress('VK_ESCAPE');
})();

```