### PR TITLE
bitblt 还能更快

### DIFF
--- a/Fischless.GameCapture/BitBlt/BitBltCapture.cs
+++ b/Fischless.GameCapture/BitBlt/BitBltCapture.cs
@@ -132,7 +132,7 @@ public class BitBltCapture : IGameCapture
                 // 没有成功创建会话，直接返回空
                 return null;
             }
-            mat = _session.BitBlt();
+            mat = _session.GetMat();
             
             if (mat is not null) // 成功执行
             {

--- a/Fischless.GameCapture/BitBlt/BitBltSession.cs
+++ b/Fischless.GameCapture/BitBlt/BitBltSession.cs
@@ -115,10 +115,10 @@ public class BitBltSession : IDisposable
     }
 
     /// <summary>
-    /// 调用bitblt复制并返回新的mat
+    /// 调用GDI复制到缓冲区并返回新的mat
     /// </summary>
-    /// <returns></returns>
-    public Mat? BitBlt()
+    /// <returns>MatType.CV_8UC3</returns>
+    public Mat? GetMat()
     {
         lock (_lockObject)
         {

--- a/Fischless.GameCapture/BitBlt/BitBltSession.cs
+++ b/Fischless.GameCapture/BitBlt/BitBltSession.cs
@@ -34,7 +34,7 @@ public class BitBltSession : IDisposable
         BlendOp = 0, //Gdi32.BlendOperation.AC_SRC_OVER,
         BlendFlags = 0,
         SourceConstantAlpha = 255,
-        AlphaFormat = 0, //Gdi32.AlphaFormat.AC_SRC_ALPHA
+        AlphaFormat = 0,
     };
 
     private readonly object _lockObject = new object();


### PR DESCRIPTION
[Bitblt:GDI直接返回转换后的位图，不再由CV二次转换](https://github.com/babalae/better-genshin-impact/commit/474d6bf99bd7838b8e9af43a3ce7986cdbdb7340)

测试环境为 8bit色深，不开启hdr