### PR TITLE
修复UseSkill调用之后没有正确调用cd计算函数的问题，增加注释

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
@@ -83,8 +83,8 @@ public class Avatar
     public CombatScenes CombatScenes { get; set; }
 
     public static string? LastActiveAvatar { get; internal set; } = null;
-    
-    
+
+
     public Avatar(CombatScenes combatScenes, string name, int index, Rect nameRect, double manualSkillCd = -1)
     {
         CombatScenes = combatScenes;
@@ -427,7 +427,7 @@ public class Avatar
 
             var region = CaptureToRectArea();
             ThrowWhenDefeated(region, Ct); // 检测是不是要跑神像
-            var cd = GetSkillCurrentCd(region);
+            var cd = AfterUseSkill(region);
             if (cd > 0)
             {
                 Logger.LogInformation(hold ? "{Name} 长按元素战技，cd:{Cd}" : "{Name} 点按元素战技，cd:{Cd}", Name, cd);
@@ -437,7 +437,8 @@ public class Avatar
     }
 
     /// <summary>
-    /// 使用完元素战技的回调,注意,不会在这里检测是不是需要跑七天神像
+    /// 使用完元素战技的回调,注意,不会在这里检测是不是需要跑七天神像 <br/>
+    /// UseSkill 方法内会调用，如果没有使用UseSkill但是释放了技能之后记得调用一下这个方法
     /// </summary>
     /// <returns>当前技能CD</returns>
     public double AfterUseSkill(ImageRegion? givenRegion = null)

--- a/BetterGenshinImpact/GameTask/AutoPathing/Handler/ElementalCollectHandler.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/Handler/ElementalCollectHandler.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using BetterGenshinImpact.Core.Config;
-using BetterGenshinImpact.GameTask.AutoFight.Config;
 using BetterGenshinImpact.GameTask.AutoGeniusInvokation.Model;
 using BetterGenshinImpact.GameTask.AutoPathing.Model;
 using Microsoft.Extensions.Logging;
@@ -50,7 +48,6 @@ public class ElementalCollectHandler(ElementalType elementalType) : IActionHandl
 
                     await combatScenesAvatar.WaitSkillCd(ct);
                     combatScenesAvatar.UseSkill();
-                    elementalCollectAvatar.LastUseSkillTime = DateTime.UtcNow;
                 }
             }
             else


### PR DESCRIPTION
啊啊啊啊啊非常抱歉！

我记得我明明有特别改了一下这边！我甚至还编译了一份测试过，可能是我没有push上去qaqqqq

另外: 现在 PathExecutor 中的 TryPartyHealing  https://github.com/babalae/better-genshin-impact/blob/0b6d0d231e2eeda90dd1df32b88da961aa400ea5/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs#L505 不知道还有没有必要。如果可以的话是不是改成战斗脚本更合适一些？现在就只有这边没办法正常计算cd了