### PR TITLE
修复手动设置cd不生效和快速跳过战斗时有时会导致刷屏的问题。

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
@@ -430,7 +430,8 @@ public class Avatar
             var cd = AfterUseSkill(region);
             if (cd > 0)
             {
-                Logger.LogInformation(hold ? "{Name} 长按元素战技，cd:{Cd}" : "{Name} 点按元素战技，cd:{Cd}", Name, cd);
+                Logger.LogInformation(hold ? "{Name} 长按元素战技，cd:{Cd} 秒" : "{Name} 点按元素战技，cd:{Cd} 秒", Name,
+                    Math.Round(cd, 2));
                 return;
             }
         }
@@ -883,10 +884,10 @@ public class Avatar
     /// 从配置字符串中查找角色cd
     /// 仅有角色名时返回 -1 ,没找到角色返回null
     /// </summary>
-    /// <param name="input">序列</param>
     /// <param name="avatarName">角色名</param>
+    /// <param name="input">序列</param>
     /// <returns></returns>
-    public static double? ParseActionSchedulerByCd(string input, string avatarName)
+    public static double? ParseActionSchedulerByCd(string avatarName, string input)
     {
         if (string.IsNullOrEmpty(input) || string.IsNullOrEmpty(avatarName))
             return null;

--- a/BetterGenshinImpact/GameTask/AutoFight/Model/CombatScenes.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Model/CombatScenes.cs
@@ -255,6 +255,31 @@ public class CombatScenes : IDisposable
         return avatars;
     }
 
+    /// <summary>
+    /// 更新角色手动设置的CD
+    /// </summary>
+    /// <param name="cdConfig">配置字符串</param>
+    /// <returns>返回配置中有效的角色名</returns>
+    public List<string> UpdateActionSchedulerByCd(string cdConfig)
+    {
+        if (string.IsNullOrEmpty(cdConfig))
+        {
+            return [];
+        }
+
+        List<string> names = [];
+        foreach (var t in Avatars)
+        {
+            var mCd = Avatar.ParseActionSchedulerByCd(t.Name, cdConfig);
+            // 手动cd不为0，不是麦当劳不是0
+            if (mCd is null) continue;
+            t.ManualSkillCd = (double)mCd;
+            names.Add(t.Name);
+        }
+
+        return names;
+    }
+
     public void BeforeTask(CancellationToken ct)
     {
         for (var i = 0; i < AvatarCount; i++)
@@ -315,7 +340,7 @@ public class CombatScenes : IDisposable
         {
             return Avatar.LastActiveAvatar;
         }
-        
+
         var imageRegion = region ?? CaptureToRectArea();
         string? avatarName = null;
 


### PR DESCRIPTION
把 UpdateActionSchedulerByCd 放到了 [CombatScenes.cs](https://github.com/babalae/better-genshin-impact/compare/main...Takaranoao:main-fix-cd?expand=1#diff-5db4c0c17e1f11cdc37ef5fb0af089ced3fb9249d5066d863308ce66c4c5ee7a) 里面

然后修复了跳过判定的逻辑，不过目前跳过的话还是只支持中文标准角色名，不支持英文和别名。

之前跳过判定逻辑有bug，会导致对不可跳过的角色进入跳过逻辑