### PR TITLE
让 bitblt 极速 使用GDI+ 生成 Bitmap 而不是 使用OpenCvSharp 生成 Mat

### DIFF
--- a/Fischless.GameCapture/BitBlt/BitBltCapture.cs
+++ b/Fischless.GameCapture/BitBlt/BitBltCapture.cs
@@ -136,7 +136,7 @@ public class BitBltCapture : IGameCapture
         {
             _lockSlim.EnterReadLock();
             var result = Capture0();
-            if (result is not null && !result.Empty())
+            if (result is not null)
             {
                 // 成功截图
                 _lastCaptureFailed = false;
@@ -166,9 +166,9 @@ public class BitBltCapture : IGameCapture
     /// 截图功能的实现。需要加锁后调用，一般只由 Capture 方法调用。
     /// </summary>
     /// <returns></returns>
-    private Mat? Capture0()
+    private Bitmap? Capture0()
     {
-        Mat? mat = null;
+        Bitmap? bitmap = null;
         try
         {
             if (_session is null)
@@ -176,27 +176,14 @@ public class BitBltCapture : IGameCapture
                 // 没有成功创建会话，直接返回空
                 return null;
             }
-
-            mat = _session.GetMat();
-
-            if (mat is null) return null; // 执行失败
-            if (!mat.Empty()) // 成功执行并且获取到了图
-            {
-                return mat;
-            }
-            else // 成功执行但是没有图，可能是截图过快导致的
-            {
-                mat.Dispose();
-                mat = null; // 防止二次释放
-            }
-
-            return null;
+            bitmap = _session.GetImage();
+            return bitmap;
         }
         catch (Exception e)
         {
             // 理论这里不应出现异常，除非窗口不存在了或者有什么bug
             // 出现异常的时候释放内存
-            mat?.Dispose();
+            bitmap?.Dispose();
             Error.WriteLine("[BitBlt]Failed to capture image {0}", e);
             return null;
         }

--- a/Fischless.GameCapture/BitBlt/BitBltSession.cs
+++ b/Fischless.GameCapture/BitBlt/BitBltSession.cs
@@ -183,16 +183,18 @@ public class BitBltSession : IDisposable
                 return null;
             }
 
+            // 这个是bitmap的结构信息，不用手动释放
+            if (bitmap.bmPlanes != 1 || bitmap.bmBitsPixel != 24)
+                // 不支持的位图格式
+                return null;
             // 直接返回转换后的位图
             var success = Gdi32.AlphaBlend(_hdcDest, 0, 0, _width, _height, _hdcSrc, 0, 0,
                 _width, _height, BlendFunction);
             if (!success || !Gdi32.GdiFlush()) return null;
 
-            // 这个是bitmap的结构信息，不用手动释放
-            if (bitmap.bmPlanes != 1 || bitmap.bmBitsPixel != 24)
-                // 不支持的位图格式
-                return null;
+            // return Mat.FromPixelData(bitmap.bmHeight, bitmap.bmWidth, MatType.CV_8UC3, bitmap.bmBits,bitmap.bmWidthBytes);
             return _hBitmap.ToBitmap();
+
             // 原始宏 ((((biWidth * biBitCount) + 31) & ~31) >> 3) => (biWidth * biBitCount + 3) & ~3) (在总位数是8的倍数时，两者等价)
             // 对齐 https://learn.microsoft.com/zh-cn/windows/win32/api/wingdi/ns-wingdi-bitmapinfoheader
 

--- a/Fischless.GameCapture/BitBlt/BitBltSession.cs
+++ b/Fischless.GameCapture/BitBlt/BitBltSession.cs
@@ -160,10 +160,9 @@ public class BitBltSession : IDisposable
 
 
     /// <summary>
-    ///     调用GDI复制到缓冲区并返回新的mat
+    ///     调用GDI复制到缓冲区并返回新Image
     /// </summary>
-    /// <returns>MatType.CV_8UC3</returns>
-    public Mat? GetMat()
+    public Bitmap? GetImage()
     {
         lock (_lockObject)
         {
@@ -193,8 +192,7 @@ public class BitBltSession : IDisposable
             if (bitmap.bmPlanes != 1 || bitmap.bmBitsPixel != 24)
                 // 不支持的位图格式
                 return null;
-            return Mat.FromPixelData(bitmap.bmHeight, bitmap.bmWidth, MatType.CV_8UC3, bitmap.bmBits,
-                bitmap.bmWidthBytes);
+            return _hBitmap.ToBitmap();
             // 原始宏 ((((biWidth * biBitCount) + 31) & ~31) >> 3) => (biWidth * biBitCount + 3) & ~3) (在总位数是8的倍数时，两者等价)
             // 对齐 https://learn.microsoft.com/zh-cn/windows/win32/api/wingdi/ns-wingdi-bitmapinfoheader
 


### PR DESCRIPTION
这样就算空指针也不会闪退