### PR TITLE
fix(js): 修复创建配置组添加js脚本后，首次编辑js脚本自定义配置时，组件无法正确绑定到setting.json中的默认值

### DIFF
--- a/BetterGenshinImpact/Model/SettingItem.cs
+++ b/BetterGenshinImpact/Model/SettingItem.cs
@@ -4,7 +4,6 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Data;
-using System.Xml.Linq;
 
 namespace BetterGenshinImpact.Model;
 
@@ -45,8 +44,12 @@ public class SettingItem
                 };
                 if (Default != null)
                 {
-                    textBox.Text = Default.ToString()!;
+                    if (context is IDictionary<string, object?> ctx)
+                    {
+                        ctx.TryAdd(Name, Default.ToString());
+                    }
                 }
+
                 BindingOperations.SetBinding(textBox, TextBox.TextProperty, binding);
                 list.Add(textBox);
                 break;
@@ -64,10 +67,15 @@ public class SettingItem
                         comboBox.Items.Add(option);
                     }
                 }
+
                 if (Default != null)
                 {
-                    comboBox.SelectedItem = Default;
+                    if (context is IDictionary<string, object?> ctx)
+                    {
+                        ctx.TryAdd(Name, Default.ToString());
+                    }
                 }
+
                 BindingOperations.SetBinding(comboBox, Selector.SelectedItemProperty, binding);
                 list.Add(comboBox);
                 break;
@@ -80,8 +88,15 @@ public class SettingItem
                 };
                 if (Default != null)
                 {
-                    checkBox.IsChecked = (bool)Default;
+                    if (context is IDictionary<string, object?> ctx)
+                    {
+                        if (bool.TryParse(Default.ToString(), out var value))
+                        {
+                            ctx.TryAdd(Name, value);
+                        }
+                    }
                 }
+
                 BindingOperations.SetBinding(checkBox, ToggleButton.IsCheckedProperty, binding);
                 list.Add(checkBox);
                 break;
@@ -89,6 +104,7 @@ public class SettingItem
             default:
                 throw new Exception($"Unknown setting type: {Type}");
         }
+
         return list;
     }
 }


### PR DESCRIPTION
修复问题：
1. 默认值赋值有问题，因为Default的类型是object,反序列化后Default是JsonElement的实例，而不是基本数据类型。因此，原先的`select`和`checkbox`的赋值会强转异常（如果setting.json中配置了default的话）。
```cs
public object? Default { get; set; }
```
```cs
comboBox.SelectedItem = Default;
checkBox.IsChecked = (bool)Default;
```
![image](https://github.com/user-attachments/assets/0b74150d-216b-4a04-985c-e23684cd249f)

2.当首次编辑js配置时，jsScriptSettingsObject是一个空对象，没有任何的属性，这时候双向绑定到组件上会导致无法正确显示setting.json的默认值（BindingOperations.SetBinding时会清空前面的赋值）。因此，当用户没有修改过配置时，先将默认值设置到上下文，再绑定到组件。