### PR TITLE
修复高DPI下TP地图移动

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoTrackPath/TpTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoTrackPath/TpTask.cs
@@ -592,9 +592,9 @@ public class TpTask(CancellationToken ct)
 
     private async Task MouseMoveMap(int pixelDeltaX, int pixelDeltaY, int steps = 10)
     {
-
-        int[] stepX = GenerateSteps(pixelDeltaX, steps);
-        int[] stepY = GenerateSteps(pixelDeltaY, steps);
+        double dpi = TaskContext.Instance().DpiScale;
+        int[] stepX = GenerateSteps((int)(pixelDeltaX / dpi), steps);
+        int[] stepY = GenerateSteps((int)(pixelDeltaY / dpi), steps);
 
         // 随机起点以避免地图移动无效
         GameCaptureRegion.GameRegionMove((rect, _) =>


### PR DESCRIPTION
BUG表现：地图追踪反复左右移动地图，有时候点到窗口外面
复现方法：显示器>100%缩放，游戏内地图缩放最大，执行地图追踪
可能相关：#1216