### PR TITLE
feat(action): set_time

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoPathing/Handler/ActionFactory.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/Handler/ActionFactory.cs
@@ -27,6 +27,7 @@ public class ActionFactory
                 "mining" => new MiningHandler(),
                 "fishing" => new FishingHandler(),
                 "exit_and_relogin" => new ExitAndReloginHandler(),
+                "set_time" => new SetTimeHandler(),
                 _ => throw new ArgumentException("未知的后置 action 类型")
             };
         });

--- a/BetterGenshinImpact/GameTask/AutoPathing/Handler/SetTimeHandler.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/Handler/SetTimeHandler.cs
@@ -1,0 +1,23 @@
+using System.Threading;
+using System.Threading.Tasks;
+using BetterGenshinImpact.GameTask.AutoPathing.Model;
+using BetterGenshinImpact.GameTask.Common.Job;
+
+namespace BetterGenshinImpact.GameTask.AutoPathing.Handler;
+
+public class SetTimeHandler : IActionHandler
+{
+    private readonly SetTimeTask _setTimeTask = new();
+
+    public async Task RunAsync(CancellationToken ct, WaypointForTrack? waypointForTrack = null, object? config = null)
+    {
+        if (waypointForTrack == null || string.IsNullOrEmpty(waypointForTrack.ActionParams)) return;
+        
+        string[] timeParts = waypointForTrack.ActionParams.Split(':');
+        int hour = int.Parse(timeParts[0]);
+        int minute = int.Parse(timeParts[1]);
+        
+        bool skipAnimation = timeParts.Length < 3 || bool.Parse(timeParts[2]);
+        await _setTimeTask.DoOnce(hour, minute, ct, skipAnimation);
+    }
+}

--- a/BetterGenshinImpact/GameTask/AutoPathing/Model/Enum/ActionEnum.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/Model/Enum/ActionEnum.cs
@@ -23,7 +23,7 @@ public class ActionEnum(string code, string msg, ActionUseWaypointTypeEnum useWa
     
     public static readonly ActionEnum Fishing = new("fishing", "钓鱼", ActionUseWaypointTypeEnum.Custom);
     public static readonly ActionEnum ExitAndRelogin = new("exit_and_relogin", "退出重新登录", ActionUseWaypointTypeEnum.Custom);
-
+    public static readonly ActionEnum SetTime = new("set_time", "设置时间", ActionUseWaypointTypeEnum.Custom);
 
     // 还有要加入的其他动作
     // 滚轮F

--- a/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
@@ -970,7 +970,8 @@ public class PathExecutor
             || waypoint.Action == ActionEnum.CombatScript.Code
             || waypoint.Action == ActionEnum.Mining.Code
             || waypoint.Action == ActionEnum.Fishing.Code
-            || waypoint.Action == ActionEnum.ExitAndRelogin.Code)
+            || waypoint.Action == ActionEnum.ExitAndRelogin.Code
+            || waypoint.Action == ActionEnum.SetTime.Code)
         {
             var handler = ActionFactory.GetAfterHandler(waypoint.Action);
             //,PartyConfig

--- a/BetterGenshinImpact/GameTask/Common/Job/ReturnMainUiTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/ReturnMainUiTask.cs
@@ -18,7 +18,7 @@ public class ReturnMainUiTask
             return;
         }
 
-        for (var i = 0; i < 3; i++)
+        for (var i = 0; i < 8; i++)
         {
             Simulation.SendInput.Keyboard.KeyPress(User32.VK.VK_ESCAPE);
             await Delay(1000, ct);

--- a/BetterGenshinImpact/GameTask/Common/Job/SetTimeTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/SetTimeTask.cs
@@ -20,12 +20,12 @@ public class SetTimeTask
 
     private readonly ReturnMainUiTask _returnMainUiTask = new();
 
-    public async Task Start(int hour, int minute, CancellationToken ct)
+    public async Task Start(int hour, int minute, CancellationToken ct, bool skipTimeAdjustmentAnimation = false)
     {
         try
         {
             await _returnMainUiTask.Start(ct);
-            await DoOnce(hour, minute, ct);
+            await DoOnce(hour, minute, ct, skipTimeAdjustmentAnimation);
         }
         catch (Exception e)
         {
@@ -38,7 +38,7 @@ public class SetTimeTask
         }
     }
 
-    public async Task DoOnce(int hour, int minute, CancellationToken ct)
+    public async Task DoOnce(int hour, int minute, CancellationToken ct, bool skipTimeAdjustmentAnimation = false)
     {
         // 半径
         const int r1 = 30;
@@ -56,15 +56,38 @@ public class SetTimeTask
         await SetTime(h, m, r1, r2, r3, stepDuration, ct);
         await Delay(1000, ct);
         GameCaptureRegion.GameRegion1080PPosClick(1500, 1000); // 确认
-        await Delay(3000, ct);
+        
+        if (skipTimeAdjustmentAnimation)
+        {
+            // 跳过调整动画
+            await Delay(1, ct);
+            await CancelAnimation(ct);
+            await Delay(1000, ct);
+            GameCaptureRegion.GameRegion1080PPosClick(45, 715);
+            await Delay(600, ct);
+            Simulation.SendInput.Keyboard.KeyPress(User32.VK.VK_ESCAPE);
+        }
+        else
+        {
+            await Delay(3000, ct);
 
-        // 出现X的时候代表时间切换成功
-        await NewRetry.WaitForAction(() => CaptureToRectArea().Find(ElementAssets.Instance.PageCloseWhiteRo).IsExist(), ct, 25);
+            // 出现X的时候代表时间切换成功
+            await NewRetry.WaitForAction(() => CaptureToRectArea().Find(ElementAssets.Instance.PageCloseWhiteRo).IsExist(), ct, 25);
+        }
 
         Simulation.SendInput.Keyboard.KeyPress(User32.VK.VK_ESCAPE);
         await Delay(2000, ct);
         Simulation.SendInput.Keyboard.KeyPress(User32.VK.VK_ESCAPE);
         await Delay(2000, ct);
+    }
+
+    // 取消动画函数
+    private async Task CancelAnimation(CancellationToken ct)
+    {
+        GameCaptureRegion.GameRegion1080PPosMove(200, 200);
+        Simulation.SendInput.Mouse.LeftButtonDown();
+        await Delay(10, ct);
+        Simulation.SendInput.Mouse.LeftButtonUp();
     }
 
     double[] GetPosition(double r, double index)

--- a/BetterGenshinImpact/GameTask/Common/Job/SetTimeTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/SetTimeTask.cs
@@ -65,20 +65,15 @@ public class SetTimeTask
             await Delay(1000, ct);
             GameCaptureRegion.GameRegion1080PPosClick(45, 715);
             await Delay(600, ct);
-            Simulation.SendInput.Keyboard.KeyPress(User32.VK.VK_ESCAPE);
+            await _returnMainUiTask.Start(ct);
         }
         else
         {
             await Delay(3000, ct);
-
             // 出现X的时候代表时间切换成功
             await NewRetry.WaitForAction(() => CaptureToRectArea().Find(ElementAssets.Instance.PageCloseWhiteRo).IsExist(), ct, 25);
+            await _returnMainUiTask.Start(ct);
         }
-
-        Simulation.SendInput.Keyboard.KeyPress(User32.VK.VK_ESCAPE);
-        await Delay(2000, ct);
-        Simulation.SendInput.Keyboard.KeyPress(User32.VK.VK_ESCAPE);
-        await Delay(2000, ct);
     }
 
     // 取消动画函数


### PR DESCRIPTION
钓鱼还是使用的老版本，需要显式设置 skipTimeAdjustmentAnimation 为 true。

测试用例（使用时瞬）：
```json
{
  "info": {
    "name": "setTimeTest",
    "type": "collect",
    "author": "秋云",
    "description": "测试设置时间"
  },
  "positions": [
    {
      "x": 7845.3203125,
      "y": -2048.837890625,
      "type": "teleport",
      "move_mode": "walk"
    },
    {
      "x": 7843.3994140625,
      "y": -2057.9306640625,
      "type": "path",
      "move_mode": "walk",
      "action": "set_time",
      "action_params": "18:00"
    }
  ]
}
```
测试用例（不使用时瞬）：
```json
{
  "info": {
    "name": "setTimeTest",
    "type": "collect",
    "author": "秋云",
    "description": "测试设置时间"
  },
  "positions": [
    {
      "x": 7845.3203125,
      "y": -2048.837890625,
      "type": "teleport",
      "move_mode": "walk"
    },
    {
      "x": 7843.3994140625,
      "y": -2057.9306640625,
      "type": "path",
      "move_mode": "walk",
      "action": "set_time",
      "action_params": "18:00:false"
    }
  ]
}
```