### PR TITLE
释放切换队伍失败状态到JS，未找到换队页面抛出异常。

### DIFF
--- a/BetterGenshinImpact/Core/Script/Dependence/Genshin.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/Genshin.cs
@@ -11,6 +11,7 @@ using BetterGenshinImpact.GameTask.Common.BgiVision;
 using OpenCvSharp;
 using static BetterGenshinImpact.GameTask.Common.TaskControl;
 using BetterGenshinImpact.GameTask.Common.Map;
+using BetterGenshinImpact.GameTask.Common.Exceptions;
 namespace BetterGenshinImpact.Core.Script.Dependence;
 
 public class Genshin
@@ -165,7 +166,7 @@ public class Genshin
         {
             return await new SwitchPartyTask().Start(partyName, CancellationContext.Instance.Cts.Token);
         }
-        catch (Exception ex)
+        catch (PartySetupFailedException ex)
         {
             return false;//释放失败状态到JS，否则失败后会退出任务。
         }

--- a/BetterGenshinImpact/Core/Script/Dependence/Genshin.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/Genshin.cs
@@ -159,9 +159,16 @@ public class Genshin
     /// </summary>
     /// <param name="partyName">队伍界面自定义的队伍名称</param>
     /// <returns></returns>
-    public async Task SwitchParty(string partyName)
+    public async Task<bool> SwitchParty(string partyName)
     {
-        await new SwitchPartyTask().Start(partyName, CancellationContext.Instance.Cts.Token);
+        try
+        {
+            return await new SwitchPartyTask().Start(partyName, CancellationContext.Instance.Cts.Token);
+        }
+        catch (Exception ex)
+        {
+            return false;//释放失败状态到JS，否则失败后会退出任务。
+        }
     }
 
 

--- a/BetterGenshinImpact/GameTask/Common/Job/SwitchPartyTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/SwitchPartyTask.cs
@@ -77,7 +77,7 @@ public class SwitchPartyTask
 
             if (!isOpened)
             {
-                Logger.LogWarning("未能打开队伍配置界面");
+                throw new PartySetupFailedException("未能打开队伍配置界面");
             }
         }
 

--- a/BetterGenshinImpact/GameTask/Common/Job/SwitchPartyTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/SwitchPartyTask.cs
@@ -45,17 +45,17 @@ public class SwitchPartyTask
             }
 
             // 尝试打开队伍配置页面
-            const int maxAttempts = 3;
+            const int maxAttempts = 2;
             bool isOpened = false;
             for (int attempt = 1; attempt <= maxAttempts; attempt++)
             {
                 Simulation.SendInput.SimulateAction(GIActions.OpenPartySetupScreen);
 
-                // 考虑加载时间 2s，共检查 5s，如果失败则抛出异常
+                // 考虑加载时间 2s，共检查 2.5s，如果失败则抛出异常
                 
-                for (int i = 0; i < 5; i++) // 检查 5 次
+                for (int i = 0; i < 3; i++) // 检查 3 次
                 {
-                    await Delay(1000, ct);
+                    await Delay(850, ct);
                     using var raCheck = CaptureToRectArea();
                     if (Bv.IsInPartyViewUi(raCheck))
                     {


### PR DESCRIPTION
1.释放切换队伍失败状态到JS,否则未能打开选择队伍页面后，js会直接退出任务。
2.未找到换队页面，恢复抛出异常，否则地图追踪无法捕获异常到七天神像。