### PR TITLE
fix(ui): 修复Prompt的TxtQuestion过长时，对话框无法完整显示

### DIFF
--- a/BetterGenshinImpact/View/Windows/PromptDialog.xaml
+++ b/BetterGenshinImpact/View/Windows/PromptDialog.xaml
@@ -13,6 +13,7 @@
                  ExtendsContentIntoTitleBar="True"
                  FontFamily="{DynamicResource TextThemeFontFamily}"
                  ResizeMode="CanMinimize"
+                 SizeToContent="Width"
                  WindowBackdropType="Mica"
                  WindowStartupLocation="CenterScreen"
                  WindowStyle="SingleBorderWindow"


### PR DESCRIPTION
问题：当Prompt的TxtQuestion文本过长时，无法PromptDialog无法自适应宽度来展示溢出的文本
修复：在保证`MinWidth`不变的情况下，配置SizeToContent="Width"

修复前：
<img width="665" alt="Snipaste_2025-05-04_13-15-44" src="https://github.com/user-attachments/assets/2f5a0267-49eb-48f4-a395-eba87c86d2d3" />
修复后：
<img width="648" alt="2" src="https://github.com/user-attachments/assets/d781e2cd-b657-475e-95ce-89d3130b88fe" />
