### PR TITLE
手动管理 CaptureContent Dispose

### DIFF
--- a/BetterGenshinImpact/GameTask/CaptureContent.cs
+++ b/BetterGenshinImpact/GameTask/CaptureContent.cs
@@ -42,9 +42,4 @@ public class CaptureContent : IDisposable
         CaptureRectArea.Dispose();
         GC.SuppressFinalize(this);
     }
-
-    ~CaptureContent()
-    {
-        Dispose();
-    }
 }


### PR DESCRIPTION
修复 #1561
顺手加的，没测地图追踪。
CaptureToRectArea函数返回后CaptureContent会被GC，导致后面访问CaptureRectArea都失败了。