### PR TITLE
截图优化

### DIFF
--- a/BetterGenshinImpact/GameTask/SystemControl.cs
+++ b/BetterGenshinImpact/GameTask/SystemControl.cs
@@ -12,7 +12,7 @@ public class SystemControl
 {
     public static nint FindGenshinImpactHandle()
     {
-        return FindHandleByProcessName("YuanShen", "GenshinImpact", "Genshin Impact Cloud Game");
+        return FindHandleByProcessName("YuanShen", "GenshinImpact", "Genshin Impact Cloud Game", "Genshin Impact Cloud");
     }
 
     public static async Task<nint> StartFromLocalAsync(string path)

--- a/BetterGenshinImpact/View/PickerWindow.xaml
+++ b/BetterGenshinImpact/View/PickerWindow.xaml
@@ -1,6 +1,7 @@
 ﻿<Window x:Class="BetterGenshinImpact.View.PickerWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:view="clr-namespace:BetterGenshinImpact.View"
         Title="选择捕获窗口"
         Width="800"
         Height="450"
@@ -143,7 +144,7 @@
                 </ListBox.ItemContainerStyle>
 
                 <ListBox.ItemTemplate>
-                    <DataTemplate>
+                    <DataTemplate DataType="{x:Type view:PickerWindow+CapturableWindow}">
                         <Grid Margin="12,8" Height="48">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto"/>

--- a/BetterGenshinImpact/View/PickerWindow.xaml.cs
+++ b/BetterGenshinImpact/View/PickerWindow.xaml.cs
@@ -10,27 +10,28 @@ using Vanara.PInvoke;
 using System.Windows.Media;
 using System.Collections.Generic;
 using System.Windows.Media.Imaging;
-using System.Runtime.InteropServices;
 
 namespace BetterGenshinImpact.View;
 
 public partial class PickerWindow : Window
 {
-    private static readonly string[] _ignoreProcesses = ["applicationframehost", "shellexperiencehost", "systemsettings", "winstore.app", "searchui"];
-    private bool _isSelected = false;
-    public PickerWindow()
+    private bool _isSelected;
+    private readonly bool _captureTest;
+
+    public PickerWindow(bool captureTest = false)
     {
         InitializeComponent();
         this.InitializeDpiAwareness();
         Loaded += OnLoaded;
+        _captureTest = captureTest;
     }
-    public class CapturableWindow
-    {
-        public string Name { get; set; }
-        public string ProcessName { get; set; }
 
-        public IntPtr Handle { get; set; }
-        public ImageSource Icon { get; set; }
+    public class CapturableWindow(IntPtr handle, string name, string processName, ImageSource? icon)
+    {
+        public IntPtr Handle { get; } = handle;
+        public string Name { get; } = name;
+        public string ProcessName { get; } = processName;
+        public ImageSource? Icon { get; } = icon;
     }
 
     private void OnLoaded(object sender, RoutedEventArgs e)
@@ -38,27 +39,31 @@ public partial class PickerWindow : Window
         FindWindows();
     }
 
-    public bool PickCaptureTarget(IntPtr hWnd,out IntPtr PickedWindow)
+    public bool PickCaptureTarget(IntPtr hWnd, out IntPtr pickedWindow)
     {
         new WindowInteropHelper(this).Owner = hWnd;
         ShowDialog();
         if(!_isSelected)
         {
-            PickedWindow = IntPtr.Zero;
+            pickedWindow = IntPtr.Zero;
             return false;
         }
-        PickedWindow = ((CapturableWindow?)WindowList.SelectedItem)?.Handle ?? IntPtr.Zero;
+        pickedWindow = ((CapturableWindow?)WindowList.SelectedItem)?.Handle ?? IntPtr.Zero;
         return true;
     }
 
-    private unsafe void FindWindows()
+    private void FindWindows()
     {
         var wih = new WindowInteropHelper(this);
         var windows = new List<CapturableWindow>();
-        
+
         User32.EnumWindows((hWnd, lParam) =>
         {
             if (!User32.IsWindowVisible(hWnd) || wih.Handle == hWnd)
+                return true;
+
+            var exStyle = User32.GetWindowLong<User32.WindowStylesEx>(hWnd, User32.WindowLongFlags.GWL_EXSTYLE);
+            if ((exStyle & (User32.WindowStylesEx.WS_EX_TOOLWINDOW | User32.WindowStylesEx.WS_EX_NOREDIRECTIONBITMAP)) != 0)
                 return true;
 
             var title = new StringBuilder(1024);
@@ -68,26 +73,22 @@ public partial class PickerWindow : Window
 
             _ = User32.GetWindowThreadProcessId(hWnd, out var processId);
             var process = Process.GetProcessById((int)processId);
-            if (_ignoreProcesses.Contains(process.ProcessName.ToLower()))
-                return true;
 
             // 获取窗口图标
             var icon = GetWindowIcon((IntPtr)hWnd);
-            
-            windows.Add(new CapturableWindow
-            {
-                Handle = (IntPtr)hWnd,
-                Name = title.ToString(),
-                ProcessName = process.ProcessName,
-                Icon = icon
-            });
+
+            windows.Add(new CapturableWindow((IntPtr)hWnd, title.ToString(), process.ProcessName, icon));
 
             return true;
         }, IntPtr.Zero);
 
-        WindowList.ItemsSource = windows;
+        var sortedWindows = windows.OrderByDescending(x => IsGenshinWindow(x.Name))
+            .ThenByDescending(x => x.Handle).ToList();
+
+        WindowList.ItemsSource = sortedWindows;
     }
-    private ImageSource GetWindowIcon(IntPtr hWnd)
+
+    private ImageSource? GetWindowIcon(IntPtr hWnd)
     {
         try
         {
@@ -126,13 +127,14 @@ public partial class PickerWindow : Window
         // 如果获取失败，返回一个默认图标或null
         return null;
     }
-    private bool IsGenshinWindow(string windowName)
+
+    private static bool IsGenshinWindow(string windowName)
     {
         // 判断是否包含原神相关的进程名 TODO：更加健壮的判断
-        return windowName == "原神";
+        return windowName is "原神" or "云·原神";
     }
 
-    private bool AskIsThisGenshinImpact(string windowName)
+    private static bool AskIsThisGenshinImpact(string windowName)
     {
         var res = MessageBox.Question(
             $"""
@@ -153,7 +155,7 @@ public partial class PickerWindow : Window
         if (selectedWindow == null) return;
 
         // 如果不是原神窗口，询问用户是否确认
-        if (!IsGenshinWindow(selectedWindow.Name))
+        if (!_captureTest && !IsGenshinWindow(selectedWindow.Name))
         {
             if (!AskIsThisGenshinImpact(selectedWindow.Name))
             {
@@ -163,10 +165,4 @@ public partial class PickerWindow : Window
         _isSelected = true;
         Close();
     }
-}
-
-public struct CapturableWindow
-{
-    public string Name { get; set; }
-    public IntPtr Handle { get; set; }
 }

--- a/BetterGenshinImpact/View/PickerWindow.xaml.cs
+++ b/BetterGenshinImpact/View/PickerWindow.xaml.cs
@@ -18,6 +18,10 @@ public partial class PickerWindow : Window
     private bool _isSelected;
     private readonly bool _captureTest;
 
+    private const User32.WindowStylesEx IgnoreExStyle = User32.WindowStylesEx.WS_EX_TOOLWINDOW |
+                                                        User32.WindowStylesEx.WS_EX_NOREDIRECTIONBITMAP |
+                                                        User32.WindowStylesEx.WS_EX_LAYERED;
+
     public PickerWindow(bool captureTest = false)
     {
         InitializeComponent();
@@ -63,7 +67,7 @@ public partial class PickerWindow : Window
                 return true;
 
             var exStyle = User32.GetWindowLong<User32.WindowStylesEx>(hWnd, User32.WindowLongFlags.GWL_EXSTYLE);
-            if ((exStyle & (User32.WindowStylesEx.WS_EX_TOOLWINDOW | User32.WindowStylesEx.WS_EX_NOREDIRECTIONBITMAP)) != 0)
+            if ((exStyle & IgnoreExStyle) != 0)
                 return true;
 
             var title = new StringBuilder(1024);

--- a/BetterGenshinImpact/ViewModel/Pages/HomePageViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/HomePageViewModel.cs
@@ -168,7 +168,7 @@ public partial class HomePageViewModel : ViewModel
     [RelayCommand]
     private void OnStartCaptureTest()
     {
-        var picker = new PickerWindow();
+        var picker = new PickerWindow(true);
 
         if (picker.PickCaptureTarget(new WindowInteropHelper(UIDispatcherHelper.MainWindow).Handle, out var hWnd))
         {

--- a/Fischless.GameCapture/DwmSharedSurface/SharedSurfaceCapture.cs
+++ b/Fischless.GameCapture/DwmSharedSurface/SharedSurfaceCapture.cs
@@ -56,7 +56,7 @@ public partial class SharedSurfaceCapture : IGameCapture
     /// </summary>
     /// <param name="hWnd"></param>
     /// <returns></returns>
-    private ResourceRegion? GetGameScreenRegion(nint hWnd)
+    private static ResourceRegion? GetGameScreenRegion(nint hWnd)
     {
         var exStyle = User32.GetWindowLong(hWnd, User32.WindowLongFlags.GWL_EXSTYLE);
         if ((exStyle & (int)User32.WindowStylesEx.WS_EX_TOPMOST) != 0)
@@ -67,7 +67,7 @@ public partial class SharedSurfaceCapture : IGameCapture
         ResourceRegion region = new();
         User32.GetWindowRect(hWnd, out var windowWithShadowRect);
         DwmApi.DwmGetWindowAttribute<RECT>(hWnd, DwmApi.DWMWINDOWATTRIBUTE.DWMWA_EXTENDED_FRAME_BOUNDS, out var windowRect);
-        User32.GetClientRect(_hWnd, out var clientRect);
+        User32.GetClientRect(hWnd, out var clientRect);
 
         region.Left = windowRect.Left - windowWithShadowRect.Left;
         // 标题栏 windowRect.Height - clientRect.Height 上阴影 windowRect.Top - windowWithShadowRect.Top
@@ -106,6 +106,9 @@ public partial class SharedSurfaceCapture : IGameCapture
                 if (_stagingTexture == null || _surfaceWidth != surfaceTexture.Description.Width ||
                     _surfaceHeight != surfaceTexture.Description.Height)
                 {
+                    if (User32.IsIconic(_hWnd))
+                        return null;
+
                     _stagingTexture?.Dispose();
                     _stagingTexture = null;
                     _surfaceWidth = surfaceTexture.Description.Width;


### PR DESCRIPTION
- [x] BitBlt 支持多显示器
窗口跨屏
- [x] DWM 不捕获最小化窗口
最小化可以捕获到很小的一个窗口，避免重建资源
- [x] WGC 优化窗口大小检测
异步有概率错过窗口大小变化的时机，改成和缓存下来的surface大小比较
为了减小心智负担，也不捕获最小化窗口
- [x] “选择捕获窗口”优化
  - [x] 原神置顶
  - [x] 根据 style 排除 UWP
  - [x] 云原神优化