### PR TITLE
修复Win10下WGC截图COM错误

### DIFF
--- a/Fischless.GameCapture/Graphics/GraphicsCapture.cs
+++ b/Fischless.GameCapture/Graphics/GraphicsCapture.cs
@@ -85,7 +85,7 @@ public class GraphicsCapture(bool captureHdr = false) : IGameCapture
             }
 
             _pixelFormat = DirectXPixelFormat.R16G16B16A16Float;
-            _captureFramePool = Direct3D11CaptureFramePool.CreateFreeThreaded(
+            _captureFramePool = Direct3D11CaptureFramePool.Create(
                 _d3dDevice,
                 _pixelFormat,
                 2,
@@ -95,7 +95,7 @@ public class GraphicsCapture(bool captureHdr = false) : IGameCapture
         {
             // Fallback
             _pixelFormat = DirectXPixelFormat.B8G8R8A8UIntNormalized;
-            _captureFramePool = Direct3D11CaptureFramePool.CreateFreeThreaded(
+            _captureFramePool = Direct3D11CaptureFramePool.Create(
                 _d3dDevice,
                 _pixelFormat,
                 2,


### PR DESCRIPTION
之前 OpenCV CPU 处理 HDR 图像时，`OnFrameArrived` 会抢占 CPU 导致 UI 卡死，当时改成多线程了。
Windows 10 会崩溃，回退。

Fix #1570