### PR TITLE
修复自动秘境的文案错误

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoDomain/AutoDomainTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoDomain/AutoDomainTask.cs
@@ -1143,7 +1143,7 @@ public class AutoDomainTask : ISoloTask
             fragileResinCount = StringUtils.TryParseInt(count);
         }
 
-        Logger.LogInformation("剩余：浓缩树脂 {CondensedResinCount} 脆弱树脂 {FragileResinCount}", condensedResinCount,
+        Logger.LogInformation("剩余：浓缩树脂 {CondensedResinCount} 原粹树脂 {FragileResinCount}", condensedResinCount,
             fragileResinCount);
         return (condensedResinCount, fragileResinCount);
     }


### PR DESCRIPTION
脆弱是体力药，原粹是体力，这俩图标是一样的