### PR TITLE
任务允许重复添加，配置组同步重名和删除

### DIFF
--- a/BetterGenshinImpact/Core/Config/OneDragonFlowConfig.cs
+++ b/BetterGenshinImpact/Core/Config/OneDragonFlowConfig.cs
@@ -14,8 +14,8 @@ public partial class OneDragonFlowConfig : ObservableObject
     /// <summary>
     /// 所有任务的开关状态
     /// </summary>
-    public Dictionary<string, bool> TaskEnabledList { get; set; } = new();
-   
+    public Dictionary<int,(bool,string)> TaskEnabledList { get; set; } = new();
+    
     // 合成树脂的国家
     [ObservableProperty]
     private string _craftingBenchCountry = "枫丹";

--- a/BetterGenshinImpact/Model/OneDragonTaskItem.cs
+++ b/BetterGenshinImpact/Model/OneDragonTaskItem.cs
@@ -16,12 +16,14 @@ namespace BetterGenshinImpact.Model;
 
 public partial class OneDragonTaskItem : ObservableObject
 {
+    [ObservableProperty] private int _index;
+    
     [ObservableProperty] private string _name;
 
     [ObservableProperty] private Brush _statusColor = Brushes.Gray;
 
     [ObservableProperty] private bool _isEnabled = true;
-
+    
     [ObservableProperty] private OneDragonBaseViewModel? _viewModel;
 
     public Func<Task>? Action { get; private set; }
@@ -30,7 +32,14 @@ public partial class OneDragonTaskItem : ObservableObject
     {
         Name = name;
     }
-
+    
+    public OneDragonTaskItem(int index,bool isEnabled,string name)
+    {
+        Name = name;
+        IsEnabled = isEnabled;
+        Index = index;
+    }
+    
     // public OneDragonTaskItem(Type viewModelType, Func<Task> action)
     // {
     //     ViewModel = App.GetService(viewModelType) as OneDragonBaseViewModel;
@@ -44,13 +53,13 @@ public partial class OneDragonTaskItem : ObservableObject
 
     public void InitAction(OneDragonFlowConfig config)
     {
-        if (config.TaskEnabledList.TryGetValue(Name, out _))
+        if (config.TaskEnabledList.TryGetValue(Index, out var taskStatus))
         {
-            config.TaskEnabledList[Name] = IsEnabled;
+            config.TaskEnabledList[Index] =  (IsEnabled, taskStatus.Item2);
         }
         else
         {
-            config.TaskEnabledList.Add(Name, IsEnabled);
+            config.TaskEnabledList.Add(Index, (IsEnabled, taskStatus.Item2));
         }
 
         switch (Name)

--- a/BetterGenshinImpact/Service/ApplicationHostService.cs
+++ b/BetterGenshinImpact/Service/ApplicationHostService.cs
@@ -47,6 +47,7 @@ public class ApplicationHostService(IServiceProvider serviceProvider) : IHostedS
         {
             _navigationWindow = (serviceProvider.GetService(typeof(INavigationWindow)) as INavigationWindow)!;
             _navigationWindow!.ShowWindow();
+            _ = _navigationWindow.Navigate(typeof(HomePage));//不进主页的话，快捷键会失效
             //
             var args = Environment.GetCommandLineArgs();
             if (args.Length > 1)


### PR DESCRIPTION
任务允许重复添加，配置组同步重名和删除
TaskEnabledList 类型修改为：
 public Dictionary<int,(bool,string)> TaskEnabledList { get; set; } = new();

1、配置文件和旧的不兼容，做了自动升级和备份配置文件。
2、支持任务列表重复添加，单独删除。
3、在配置组页面删除和修改会同步删除和修改所有任务列表中对应的配置信息。
