### PR TITLE
fix: 修复`AutoPathing`下的非顶层文件夹不显示图标的问题

### DIFF
--- a/BetterGenshinImpact/ViewModel/Pages/MapPathingViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/MapPathingViewModel.cs
@@ -57,17 +57,25 @@ public partial class MapPathingViewModel : ViewModel
         // 循环写入 root.Children
         foreach (var item in root.Children)
         {
-            // 补充图标
-            if (!string.IsNullOrEmpty(item.FilePath) && File.Exists(Path.Combine(item.FilePath, "icon.ico")))
-            {
-                item.IconFilePath = Path.Combine(item.FilePath, "icon.ico");
-            }
-            else
-            {
-                item.IconFilePath = item.FilePath;
-            }
-
+            SetIconForNodeAndChildren(item);
             TreeList.Add(item);
+        }
+    }
+
+    private void SetIconForNodeAndChildren(FileTreeNode<PathingTask> node)
+    {
+        if (!string.IsNullOrEmpty(node.FilePath) && File.Exists(Path.Combine(node.FilePath, "icon.ico")))
+        {
+            node.IconFilePath = Path.Combine(node.FilePath, "icon.ico");
+        }
+        else
+        {
+            node.IconFilePath = node.FilePath;
+        }
+
+        foreach (var child in node.Children)
+        {
+            SetIconForNodeAndChildren(child);
         }
     }
 


### PR DESCRIPTION
`bettergi-scripts-list`重新整理文件夹结构后方便查找了许多，不过由于追踪任务移动到了子文件夹内，地图追踪界面不显示它们的图标了。

此PR添加对子文件夹图标的支持：

![image](https://github.com/user-attachments/assets/65309fae-ccff-406a-be66-0fcf7eb76203)
