### PR TITLE
将路径追踪相关的日志改为debug级别 (#1645)

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
@@ -684,7 +684,7 @@ public class PathExecutor
         var screen = CaptureToRectArea();
         var position = await GetPosition(screen, waypoint);
         var targetOrientation = Navigation.GetTargetOrientation(waypoint, position);
-        Logger.LogInformation("朝向点，位置({x2},{y2})", $"{waypoint.GameX:F1}", $"{waypoint.GameY:F1}");
+        Logger.LogDebug("朝向点，位置({x2},{y2})", $"{waypoint.GameX:F1}", $"{waypoint.GameY:F1}");
         await _rotateTask.WaitUntilRotatedTo(targetOrientation, 2);
         await Delay(500, ct);
     }
@@ -699,7 +699,7 @@ public class PathExecutor
         var screen = CaptureToRectArea();
         var (position, additionalTimeInMs) = await GetPositionAndTime(screen, waypoint);
         var targetOrientation = Navigation.GetTargetOrientation(waypoint, position);
-        Logger.LogInformation("粗略接近途经点，位置({x2},{y2})", $"{waypoint.GameX:F1}", $"{waypoint.GameY:F1}");
+        Logger.LogDebug("粗略接近途经点，位置({x2},{y2})", $"{waypoint.GameX:F1}", $"{waypoint.GameY:F1}");
         await _rotateTask.WaitUntilRotatedTo(targetOrientation, 5);
         moveToStartTime = DateTime.UtcNow;
         var lastPositionRecord = DateTime.UtcNow;
@@ -743,7 +743,7 @@ public class PathExecutor
             Debug.WriteLine($"接近目标点中，距离为{distance}");
             if (distance < 4)
             {
-                Logger.LogInformation("到达路径点附近");
+                Logger.LogDebug("到达路径点附近");
                 break;
             }
 
@@ -943,7 +943,7 @@ public class PathExecutor
         ImageRegion screen;
         Point2f position;
         int targetOrientation;
-        Logger.LogInformation("精确接近目标点，位置({x2},{y2})", $"{waypoint.GameX:F1}", $"{waypoint.GameY:F1}");
+        Logger.LogDebug("精确接近目标点，位置({x2},{y2})", $"{waypoint.GameX:F1}", $"{waypoint.GameY:F1}");
 
         var stepsTaken = 0;
         while (!ct.IsCancellationRequested)
@@ -962,7 +962,7 @@ public class PathExecutor
             position = await GetPosition(screen, waypoint);
             if (Navigation.GetDistance(waypoint, position) < 2)
             {
-                Logger.LogInformation("已到达路径点");
+                Logger.LogDebug("已到达路径点");
                 break;
             }
 
@@ -1189,7 +1189,7 @@ public class PathExecutor
             preTime = DateTime.Now;
         }
 
-        //Logger.LogInformation("识别到路径："+position.X+","+position.Y);
+        //Logger.LogDebug("识别到路径："+position.X+","+position.Y);
         return (position,time);
     }
 

--- a/BetterGenshinImpact/GameTask/AutoTrackPath/TpTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoTrackPath/TpTask.cs
@@ -527,7 +527,7 @@ public class TpTask(CancellationToken ct)
             // 非常接近目标点，不再进一步调整
             if (mouseDistance < _tpConfig.Tolerance)
             {
-                Logger.LogInformation("移动 {I} 次鼠标后，已经接近目标点，不再移动地图。", iteration + 1);
+                Logger.LogDebug("移动 {I} 次鼠标后，已经接近目标点，不再移动地图。", iteration + 1);
                 break;
             }
 


### PR DESCRIPTION
#1645 的部分修改，只是将路径追踪相关的日志改为debug级别，不含日志筛选功能。

（和日志筛选不冲突，即使未来添加日志筛选，路径追踪相关的日志似乎也无需使用info级别，使用debug级别记录到文件中即可）

按功能需求合入，如无需此修改可直接关闭PR