### PR TITLE
任务允许重复添加，配置组同步重名和删除，尘歌壶优化

### DIFF
--- a/BetterGenshinImpact/Core/Config/OneDragonFlowConfig.cs
+++ b/BetterGenshinImpact/Core/Config/OneDragonFlowConfig.cs
@@ -7,6 +7,11 @@ namespace BetterGenshinImpact.Core.Config;
 [Serializable]
 public partial class OneDragonFlowConfig : ObservableObject
 {
+    
+    //版本号
+    [ObservableProperty]
+    private int _version = 1;
+    
     // 配置名
     [ObservableProperty]
     private string _name = string.Empty;
@@ -15,6 +20,13 @@ public partial class OneDragonFlowConfig : ObservableObject
     /// 所有任务的开关状态
     /// </summary>
     public Dictionary<int,(bool,string)> TaskEnabledList { get; set; } = new();
+    
+    // 定义旧版本的TaskEnabledList
+    [Serializable]
+    public class TaskEnabledListOld
+    {
+        public Dictionary<string, bool> TaskEnabledList { get; set; } = new();
+    }
     
     // 合成树脂的国家
     [ObservableProperty]

--- a/BetterGenshinImpact/Core/Config/OneDragonFlowConfig.cs
+++ b/BetterGenshinImpact/Core/Config/OneDragonFlowConfig.cs
@@ -14,8 +14,8 @@ public partial class OneDragonFlowConfig : ObservableObject
     /// <summary>
     /// 所有任务的开关状态
     /// </summary>
-    public Dictionary<string, bool> TaskEnabledList { get; set; } = new();
-   
+    public Dictionary<int,(bool,string)> TaskEnabledList { get; set; } = new();
+    
     // 合成树脂的国家
     [ObservableProperty]
     private string _craftingBenchCountry = "枫丹";

--- a/BetterGenshinImpact/GameTask/Common/Job/GoToSereniteaPotTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/GoToSereniteaPotTask.cs
@@ -297,17 +297,17 @@ internal class GoToSereniteaPotTask
         if (numberBtn.IsExist())
         {
             numberBtn.Move();
-            await Delay(300, ct);
+            await Delay(700, ct);//减慢速度，设备差异导致的延迟
             Simulation.SendInput.Mouse.LeftButtonDown();
-            await Delay(300, ct);
+            await Delay(700, ct);
             numberBtn.MoveTo(ra.Width/7,0);//moveby会超出边界，改用MoveTo
-            await Delay(300, ct);
+            await Delay(700, ct);
             Simulation.SendInput.Mouse.LeftButtonUp();
         }
 
-        await Delay(300, ct);
+        await Delay(700, ct);
         ra.Find(ElementAssets.Instance.BtnWhiteConfirm).Click();
-        await Delay(500, ct);
+        await Delay(700, ct);
         ra.Find(ElementAssets.Instance.BtnWhiteConfirm).Click();
     }
 

--- a/BetterGenshinImpact/GameTask/Common/Job/GoToSereniteaPotTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/GoToSereniteaPotTask.cs
@@ -82,35 +82,40 @@ internal class GoToSereniteaPotTask
         // 进入 壶
         await ChangeCountryForce("尘歌壶", ct);
         
-        
-
-        
         // 若未找到 ElementAssets.Instance.SereniteaPotRo 就是已经在尘歌壶了
-        var ra = CaptureToRectArea();
-        //确定洞天名称
-        var list = ra.FindMulti(new RecognitionObject
-        {
-            RecognitionType = RecognitionTypes.Ocr,
-            RegionOfInterest = new Rect((int)(ra.Width * 0.86), ra.Height*9/10, (int)(ra.Width * 0.073), (int)(ra.Height*0.04))
-        });
-        if (list.Count > 0)
-        {
-            dongTianName = list[0].Text;
-            Logger.LogInformation("领取尘歌壶奖励:{text}", "洞天名称：" + dongTianName);
+        var  ra = CaptureToRectArea();
+        for (int i = 0; i < 5; i++){
+            ra = CaptureToRectArea();
+            //确定洞天名称
+            var list = ra.FindMulti(new RecognitionObject
+            {
+                RecognitionType = RecognitionTypes.Ocr,
+                RegionOfInterest = new Rect((int)(ra.Width * 0.86), ra.Height*9/10, (int)(ra.Width * 0.073), (int)(ra.Height*0.04))
+            });
+            if (list.Count > 0)
+            {
+                dongTianName = list[0].Text;
+                Logger.LogInformation("领取尘歌壶奖励:{text}", "洞天名称：" + dongTianName);
+                await Task.Delay(100, ct);
+                break;
+            }
+            else
+            {
+                dongTianName = "";
+                Logger.LogInformation("领取尘歌壶奖励:{text}", "未识别到洞天名称");
+            }
+            await Task.Delay(100, ct);
         }
-        else
-        {
-            dongTianName = "";
-            Logger.LogInformation("领取尘歌壶奖励:{text}", "未识别到洞天名称");
-        }
-        
-        for (int i = 0; i < 3; i++)
+
+        for (int i = 0; i < 5; i++)
         {
             var sereniteaPotHomeIcon = ra.Find(ElementAssets.Instance.SereniteaPotHomeRo);
             if (!sereniteaPotHomeIcon.IsExist())
             {
-                Logger.LogInformation("领取尘歌壶奖励:{text}", "住宅图标未找到，调整地图缩放至3.0。");
-                await new Core.Script.Dependence.Genshin().SetBigMapZoomLevel(3.0);
+                Logger.LogInformation("领取尘歌壶奖励:{text}", "住宅图标未找到，调整地图缩放至2。");
+                await Task.Delay(1000, ct);
+                await new Core.Script.Dependence.Genshin().SetBigMapZoomLevel(2.5-i*0.2);//尝试缩放地图
+                await Task.Delay(1000, ct);
             }
             else
             {
@@ -140,8 +145,6 @@ internal class GoToSereniteaPotTask
 
         await NewRetry.WaitForAction(() => Bv.IsInMainUi(CaptureToRectArea()), ct);
     }
-
-    
 
     // 寻找阿圆并靠近
     private async Task FindAYuan(CancellationToken ct)
@@ -297,18 +300,18 @@ internal class GoToSereniteaPotTask
         if (numberBtn.IsExist())
         {
             numberBtn.Move();
-            await Delay(700, ct);//减慢速度，设备差异导致的延迟
+            await Delay(600, ct);//减慢速度，设备差异导致的延迟
             Simulation.SendInput.Mouse.LeftButtonDown();
-            await Delay(700, ct);
+            await Delay(600, ct);
             numberBtn.MoveTo(ra.Width/7,0);//moveby会超出边界，改用MoveTo
-            await Delay(700, ct);
+            await Delay(600, ct);
             Simulation.SendInput.Mouse.LeftButtonUp();
         }
 
-        await Delay(700, ct);
+        await Delay(600, ct);
         ra.Find(ElementAssets.Instance.BtnWhiteConfirm).Click();
-        await Delay(700, ct);
-        ra.Find(ElementAssets.Instance.BtnWhiteConfirm).Click();
+        await Delay(600, ct);
+        TaskContext.Instance().PostMessageSimulator.SimulateAction(GIActions.OpenPaimonMenu); // ESC 
     }
 
     private async Task GetReward(CancellationToken ct)
@@ -371,7 +374,6 @@ internal class GoToSereniteaPotTask
                 if (shopOption == TalkOptionRes.FoundAndClick)
                 {
                     Logger.LogInformation("领取尘歌壶奖励:{text}", "购买商店物品");
-                    
                     await Delay(500, ct);
                     // 购买的物品清单
                     var buy = new List<RecognitionObject>();
@@ -410,18 +412,39 @@ internal class GoToSereniteaPotTask
                                 break;
                         }
                     }
-
+                    
+                    //对比购买成功和buy的数量，如果不等，重试一次
+                    var buyCount = 0;
+                    var retryBuy= 0;
                     // 直接购买最大数量
-                    foreach (var item in buy)
+                    while (retryBuy < 2)
                     {
-                        var itemRo = CaptureToRectArea().Find(item);
-                        if (itemRo.IsExist())
+                        foreach (var item in buy)
                         {
-                            Logger.LogInformation("领取尘歌壶奖励:购买 {text} ", item.Name);
-                            itemRo.Click();
-                            await Delay(600, ct);
-                            await BuyMaxNumber(ct);
-                            await Delay(1200, ct);//等待购买动画结束
+                            var itemRo = CaptureToRectArea().Find(item);
+                            if (itemRo.IsExist())
+                            {
+                                buyCount++;
+                                Logger.LogInformation("领取尘歌壶奖励:购买 {text} ", item.Name);
+                                itemRo.Click();
+                                await Delay(600, ct);
+                                await BuyMaxNumber(ct);
+                                await Delay(1000, ct);//等待购买动画结束
+                            }
+                            else
+                            {
+                                await Delay(700, ct);
+                                Logger.LogInformation("领取尘歌壶奖励: {text} 未找到", item.Name);
+                            }
+                            await Delay(700, ct);
+                        }
+                        if (buyCount < buy.Count)
+                        {
+                            retryBuy++;
+                            await Delay(500, ct);
+                        }else
+                        {
+                            break;
                         }
                     }
                     await Delay(900, ct);

--- a/BetterGenshinImpact/Model/OneDragonTaskItem.cs
+++ b/BetterGenshinImpact/Model/OneDragonTaskItem.cs
@@ -16,12 +16,14 @@ namespace BetterGenshinImpact.Model;
 
 public partial class OneDragonTaskItem : ObservableObject
 {
+    [ObservableProperty] private int _index;
+    
     [ObservableProperty] private string _name;
 
     [ObservableProperty] private Brush _statusColor = Brushes.Gray;
 
     [ObservableProperty] private bool _isEnabled = true;
-
+    
     [ObservableProperty] private OneDragonBaseViewModel? _viewModel;
 
     public Func<Task>? Action { get; private set; }
@@ -30,7 +32,14 @@ public partial class OneDragonTaskItem : ObservableObject
     {
         Name = name;
     }
-
+    
+    public OneDragonTaskItem(int index,bool isEnabled,string name)
+    {
+        Name = name;
+        IsEnabled = isEnabled;
+        Index = index;
+    }
+    
     // public OneDragonTaskItem(Type viewModelType, Func<Task> action)
     // {
     //     ViewModel = App.GetService(viewModelType) as OneDragonBaseViewModel;
@@ -44,13 +53,13 @@ public partial class OneDragonTaskItem : ObservableObject
 
     public void InitAction(OneDragonFlowConfig config)
     {
-        if (config.TaskEnabledList.TryGetValue(Name, out _))
+        if (config.TaskEnabledList.TryGetValue(Index, out var taskStatus))
         {
-            config.TaskEnabledList[Name] = IsEnabled;
+            config.TaskEnabledList[Index] =  (IsEnabled, taskStatus.Item2);
         }
         else
         {
-            config.TaskEnabledList.Add(Name, IsEnabled);
+            config.TaskEnabledList.Add(Index, (IsEnabled, taskStatus.Item2));
         }
 
         switch (Name)

--- a/BetterGenshinImpact/Service/ApplicationHostService.cs
+++ b/BetterGenshinImpact/Service/ApplicationHostService.cs
@@ -49,6 +49,7 @@ public class ApplicationHostService(IServiceProvider serviceProvider) : IHostedS
         {
             _navigationWindow = (serviceProvider.GetService(typeof(INavigationWindow)) as INavigationWindow)!;
             _navigationWindow!.ShowWindow();
+            _ = _navigationWindow.Navigate(typeof(HomePage));//不进主页的话，快捷键会失效
             //
             var args = Environment.GetCommandLineArgs();
 

--- a/BetterGenshinImpact/ViewModel/Pages/ScriptControlViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/ScriptControlViewModel.cs
@@ -40,6 +40,7 @@ using Button = Wpf.Ui.Controls.Button;
 using MessageBoxButton = System.Windows.MessageBoxButton;
 using MessageBoxResult = Wpf.Ui.Controls.MessageBoxResult;
 using TextBlock = Wpf.Ui.Controls.TextBlock;
+using  Microsoft.Extensions.DependencyInjection;
 
 namespace BetterGenshinImpact.ViewModel.Pages;
 
@@ -592,6 +593,34 @@ public partial class ScriptControlViewModel : ViewModel
             }
             else
             {
+                var result = MessageBox.Show("所有配置单中名为 < " + item.Name + " > 配置组将重命名为 < " + str + " > ，是否继续？", 
+                    "重名配置组", System.Windows.MessageBoxButton.YesNo, MessageBoxImage.Question);
+                
+                if (result != System.Windows.MessageBoxResult.Yes)
+                {
+                    return;
+                }
+                
+                var ViewModel = new OneDragonFlowViewModel();
+                ViewModel.InitConfigList();
+                var configList = ViewModel.ConfigList;
+                
+               // 读取ConfigList中所有的配置单，检查每个配置单中的TaskEnabledList，如果含有和item.Name相同的配置组，则把这个TaskEnabledList中的配置组改为str
+                foreach (var config in configList)
+                {
+                    if (config.TaskEnabledList.Any(task => task.Value.Item2 == item.Name))
+                    {
+                        var oldName = item.Name;
+                        foreach (var task in config.TaskEnabledList)
+                        {
+                            if (task.Value.Item2 == oldName)
+                            {
+                                config.TaskEnabledList[task.Key] = (task.Value.Item1, str);
+                            }
+                        }
+                        ViewModel.WriteConfig(config);
+                    }
+                }
                 File.Move(Path.Combine(ScriptGroupPath, $"{item.Name}.json"), Path.Combine(ScriptGroupPath, $"{str}.json"));
                 item.Name = str;
                 if (item.NextFlag)
@@ -610,9 +639,41 @@ public partial class ScriptControlViewModel : ViewModel
         {
             return;
         }
-
+        
+        //弹窗提示"配置单中的所有同名配置组将被删除，是否继续？，取消退出，确认执行删除操作"
+        var result = MessageBox.Show("所有配置单中名为 < " + item.Name + " > 配置组将被删除，是否继续？", 
+            "删除配置组", System.Windows.MessageBoxButton.YesNo, MessageBoxImage.Question);
+        
+        if (result != System.Windows.MessageBoxResult.Yes)
+        {
+            return;
+        }
+        
         try
         {
+            var ViewModel = new OneDragonFlowViewModel();
+            ViewModel.InitConfigList();
+            var configList = ViewModel.ConfigList;
+            // 读取ConfigList中所有的配置单，检查每个配置单中的TaskEnabledList，如果含有和item.Name相同的配置组，则把这个TaskEnabledList中的配置组删除
+            foreach (var config in configList)
+            {
+                if (config.TaskEnabledList.Any(task => task.Value.Item2 == item.Name))
+                {
+                    var oldName = item.Name;
+                    foreach (var task in config.TaskEnabledList)
+                    {
+                        if (task.Value.Item2 == oldName)
+                        {
+                            config.TaskEnabledList.Remove(task.Key);
+                        }
+                    }
+                    ViewModel.WriteConfig(config);
+                }
+            }
+            
+            
+            
+            
             ScriptGroups.Remove(item);
             File.Delete(Path.Combine(ScriptGroupPath, $"{item.Name}.json"));
             _snackbarService.Show(
@@ -633,6 +694,13 @@ public partial class ScriptControlViewModel : ViewModel
                 null,
                 TimeSpan.FromSeconds(3)
             );
+        }
+        if (ScriptGroups.Count() != 0)//如果删除的是当前选中的配置组，则清空选中项
+        {
+            SelectedScriptGroup = ScriptGroups.First();
+        }else
+        {
+            SelectedScriptGroup = null;
         }
     }
 
@@ -1184,6 +1252,7 @@ public partial class ScriptControlViewModel : ViewModel
                     {
                         group.NextFlag = true;
                     }
+
                     groups.Add(group);
                 }
                 catch (Exception e)


### PR DESCRIPTION
任务允许重复添加，配置组同步重名和删除
TaskEnabledList 类型修改为：
public Dictionary<int,(bool,string)> TaskEnabledList { get; set; } = new();

1、配置文件和旧的不兼容，做了自动升级和备份配置文件。
2、支持任务列表重复添加，单独删除。
3、在配置组页面删除和修改会同步删除和修改所有任务列表中对应的配置信息。
4、尘歌壶购买逻辑优化，添加重试