### PR TITLE
bugfix: 挖矿从不识别捡掉落物

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoPathing/Handler/MiningHandler.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/Handler/MiningHandler.cs
@@ -56,7 +56,7 @@ public class MiningHandler : IActionHandler
 
 
         if (waypointForTrack is { ActionParams: not null }
-            && waypointForTrack.ActionParams.Contains("disablePickupAround",
+            && !waypointForTrack.ActionParams.Contains("disablePickupAround",
                 StringComparison.InvariantCultureIgnoreCase))
         {
             await Delay(1000, ct);


### PR DESCRIPTION
@Takaranoao 

`if ActionParams.Contains("disablePickupAround") then pick` 的逻辑感觉不是很对，不确定是否符合预期，提出来问一下

~水个commit~