### PR TITLE
一条龙尘歌壶进入添加重试/UI微调/一条龙快捷键修复 #1750 #1752

### DIFF
--- a/BetterGenshinImpact/GameTask/Common/Job/GoToSereniteaPotTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/GoToSereniteaPotTask.cs
@@ -379,8 +379,8 @@ internal class GoToSereniteaPotTask
             Logger.LogInformation("领取尘歌壶奖励:{text}", "未配置购买商店物品");
             return; 
         }
-        DateTime now = DateTime.Now;  
-        DayOfWeek currentDayOfWeek = now.DayOfWeek;
+        DateTime now = DateTime.Now;
+        DayOfWeek currentDayOfWeek = now.Hour >= 4 ? now.DayOfWeek : now.AddDays(-1).DayOfWeek;
         DayOfWeek? configDayOfWeek = GetDayOfWeekFromConfig(SelectedConfig.SecretTreasureObjects.First());
         if (configDayOfWeek.HasValue || SelectedConfig.SecretTreasureObjects.First() == "每天重复" && SelectedConfig.SecretTreasureObjects.Count > 1)
         {

--- a/BetterGenshinImpact/GameTask/Common/Job/GoToSereniteaPotTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/GoToSereniteaPotTask.cs
@@ -125,22 +125,39 @@ internal class GoToSereniteaPotTask
             }
         }
 
-        ra = CaptureToRectArea();
-        var teleportBtn = ra.Find(QuickTeleportAssets.Instance.TeleportButtonRo);
-        if (!teleportBtn.IsExist())
+        
+        for (int attempt = 0; attempt < 10; attempt++) // 尝试点击传送按钮
         {
+            ra = CaptureToRectArea();
+            var teleportBtn = ra.Find(QuickTeleportAssets.Instance.TeleportButtonRo);
+            if (teleportBtn.IsExist())
+            {
+                teleportBtn.Click();
+                break; // 找到并点击后退出循环
+            }
+
             var teleportSereniteaPotHome = ra.Find(ElementAssets.Instance.TeleportSereniteaPotHomeRo);
             if (teleportSereniteaPotHome.IsExist())
             {
                 teleportSereniteaPotHome.Click();
+                break; // 找到并点击后退出循环
             }
+            await Delay(500, ct);
         }
-
-        ra = CaptureToRectArea();
-        teleportBtn = ra.Find(QuickTeleportAssets.Instance.TeleportButtonRo);
-        if (teleportBtn.IsExist())
+        
+        for (int i = 0; i < 10; i++)//有传送图标，点击传送
         {
-            teleportBtn.Click();
+            ra = CaptureToRectArea();
+            var teleportBtn = ra.Find(QuickTeleportAssets.Instance.TeleportButtonRo);
+            if (teleportBtn.IsExist())
+            {
+                teleportBtn.Click();
+                await Delay(1000, ct);
+            }
+            else
+            {
+                break;
+            }
         }
 
         await NewRetry.WaitForAction(() => Bv.IsInMainUi(CaptureToRectArea()), ct);

--- a/BetterGenshinImpact/View/MainWindow.xaml
+++ b/BetterGenshinImpact/View/MainWindow.xaml
@@ -43,9 +43,15 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="Auto" />
+        </Grid.ColumnDefinitions>
 
         <ui:NavigationView x:Name="RootNavigation"
+                           Grid.Column="0"
                            Grid.Row="1"
+                           Margin="0,0,0,5"
                            IsBackButtonVisible="Collapsed"
                            IsPaneToggleVisible="True"
                            OpenPaneLength="160">

--- a/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml
+++ b/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml
@@ -476,7 +476,7 @@
                         </StackPanel>
                     </ui:CardExpander>
 
-                    <ui:CardExpander Margin="0,0,0,12" ContentPadding="0" IsExpanded="True">
+                    <ui:CardExpander Margin="0,0,0,12" ContentPadding="0">
                         <ui:CardExpander.Icon>
                             <ui:FontIcon Glyph="&#xf784;" Style="{StaticResource FaFontIconStyle}" />
                         </ui:CardExpander.Icon>
@@ -508,25 +508,20 @@
                             </Grid>
                         </ui:CardExpander.Header>
                         <StackPanel>
-                            <Grid Margin="52,16,16,16">
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="Auto" />
-                                </Grid.RowDefinitions>
+                            
+                                
+                     
                                 <ui:TextBlock Grid.Row="0"
                                               Grid.Column="0"
+                                                Margin="0,20,0,0"
+                                              HorizontalAlignment="Center"
                                               FontTypography="Body"
-                                              Text=""
-                                              TextWrapping="Wrap">
-                                    新的一天开始于 4:00
-                                </ui:TextBlock>
-                                <ui:TextBlock Grid.Row="1"
-                                              Grid.Column="0"
+                                              FontSize="12"
                                               Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                              Text="周期始于凌晨 4:00 ，如周一 4:00 至周二 3:59 刷取周一秘境" 
                                               TextWrapping="Wrap">
-                                    周一 4:00 至周二 3:59 执行周一配置，以此类推。
                                 </ui:TextBlock>
-                            </Grid>
+                           
                             <Grid Margin="16">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="Auto" />
@@ -847,6 +842,9 @@
                                               TextWrapping="Wrap" />
                                 <ui:TextBlock Grid.Row="1"
                                               Grid.Column="0"
+                                              TextAlignment="Center"
+                                              HorizontalAlignment="Center"
+                                              VerticalAlignment="Center"
                                               Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
                                               Text="用于给指定队伍加好感度"
                                               TextWrapping="Wrap" />
@@ -858,6 +856,9 @@
                             Margin="0,0,28,0"
                             Text="{Binding SelectedConfig.DailyRewardPartyName, Mode=TwoWay}"
                             PlaceholderText="填写好感队名称"
+                            TextAlignment="Center"
+                            VerticalAlignment="Center"
+                            HorizontalAlignment="Center"
                             TextWrapping="Wrap" />
                     </ui:CardControl>
 

--- a/BetterGenshinImpact/ViewModel/Pages/TaskSettingsPageViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/TaskSettingsPageViewModel.cs
@@ -163,13 +163,16 @@ public partial class TaskSettingsPageViewModel : ViewModel
     [RelayCommand]
     private async Task OnSOneDragonFlow()
     {   
-        if (OneDragonFlowViewModel == null || OneDragonFlowViewModel.SelectedConfig == null)
-        {
-            Toast.Warning("未设置任务!");
-            return;
-        }
-        OneDragonFlowViewModel.OnNavigatedTo();
-        await OneDragonFlowViewModel.OnOneKeyExecute();
+       if (OneDragonFlowViewModel == null || OneDragonFlowViewModel.SelectedConfig == null)
+       {
+            OneDragonFlowViewModel.OnNavigatedTo();
+            if (OneDragonFlowViewModel == null || OneDragonFlowViewModel.SelectedConfig == null)
+            {
+                Toast.Warning("未设置任务!");
+                return;
+            }
+       }
+       await OneDragonFlowViewModel.OnOneKeyExecute();
     }
 
     [RelayCommand]


### PR DESCRIPTION
#1752 #1750 
1、尘歌壶点击房屋图标后，会进行延时判断重试。
2、尘歌壶购买周期始于每天4点。
2、主页左侧菜单，在调度器展开后，设置按键会有几个像素的超出边框，修复。
3、一条龙每周秘境执行周期说明UI显示调整，UI微调。
4、一条龙快捷键修复。
