### PR TITLE
fix: 优化传送点点击的逻辑，增加退出重登的延时

### DIFF
--- a/BetterGenshinImpact/GameTask/Common/Job/ExitAndReloginJob.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/ExitAndReloginJob.cs
@@ -45,9 +45,11 @@ public class ExitAndReloginJob
         // 点击确认退出并等待确认弹窗消失
         await NewRetry.WaitForElementDisappear(
             _assets.ConfirmRo,
-            () => {
-                using var cr = CaptureToRectArea();
-                cr.Find(_assets.ConfirmRo, ra => { ra.Click(); ra.Dispose(); });
+            screen => {  // 接收当前截图作为参数
+                screen.Find(_assets.ConfirmRo, ra => { 
+                    ra.Click(); 
+                    ra.Dispose(); 
+                });
             },
             ct,
             5,
@@ -70,7 +72,7 @@ public class ExitAndReloginJob
             _assets.EnterGameRo,
             () => { },
             ct,
-            50,
+            120,
             1000
         );
         if (enterGameAppear)
@@ -94,7 +96,7 @@ public class ExitAndReloginJob
             ElementAssets.Instance.PaimonMenuRo,
             () => { },
             ct,
-            50,
+            120,
             1000
         );
         

--- a/BetterGenshinImpact/GameTask/Common/NewRetry.cs
+++ b/BetterGenshinImpact/GameTask/Common/NewRetry.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using BetterGenshinImpact.Core.Recognition;
+using BetterGenshinImpact.GameTask.Model.Area;
 using static BetterGenshinImpact.GameTask.Common.TaskControl;
 
 namespace BetterGenshinImpact.GameTask.Common;
@@ -161,6 +162,33 @@ public static class NewRetry
             {
                 return true;
             }
+        }
+        return false;
+    }
+    
+    public static async Task<bool> WaitForElementDisappear(
+        RecognitionObject recognitionObject,
+        Action<ImageRegion> retryAction,  // 接收截图的回调
+        CancellationToken ct,
+        int maxAttemptCount = 10,
+        int retryInterval = 1000)
+    {
+        for (int i = 0; i < maxAttemptCount; i++)
+        {
+            if (ct.IsCancellationRequested) return false;
+            
+            // 截图并查找元素
+            using var screen = CaptureToRectArea();
+            using var result = screen.Find(recognitionObject);
+            
+            // 元素已消失
+            if (result.IsEmpty()) return true;
+            
+            // 执行重试操作（传入当前截图）
+            retryAction?.Invoke(screen);
+            
+            // 等待指定时间
+            await Delay(retryInterval, ct);
         }
         return false;
     }


### PR DESCRIPTION
1. 300ms检测一次是否点击出了传送，最多检测1800ms；
2. 添加带截图的WaitForElementDisappear重载，避免重复截图；
3. 增加了退出重登的超时时间，避免部分低性能设备超出原设定的最长时间导致任务失败。