### PR TITLE
优先使用诺艾尔作为大剑挖矿角色

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoPathing/Handler/MiningHandler.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/Handler/MiningHandler.cs
@@ -17,6 +17,7 @@ namespace BetterGenshinImpact.GameTask.AutoPathing.Handler;
 public class MiningHandler : IActionHandler
 {
     private readonly CombatScript _miningCombatScript = CombatScriptParser.ParseContext("""
+        诺艾尔 attack(2.0)
         荒泷一斗 attack(2.0)
         迪希雅 attack(2.0)
         玛薇卡 attack(2.0)
@@ -24,7 +25,6 @@ public class MiningHandler : IActionHandler
         娜维娅 attack(2.0)
         菲米尼 attack(2.0)
         迪卢克 attack(2.0)
-        诺艾尔 attack(2.0)
         卡维 attack(2.0)
         雷泽 attack(2.0)
         优菈 attack(2.0)


### PR DESCRIPTION
提高诺艾尔在大剑挖矿角色选择列表中的优先级。

当前BetterGI建议的1号位角色位迪希雅，而迪希雅在此列表中排名靠前，导致玩家在运行大剑挖矿脚本中大概率选择迪希雅作为挖矿角色。迪希雅的问题是她的连续攻击第3段和第4段会向前冲刺一段距离，可能会使其超过矿石的位置，导致矿石只被攻击2下，进而挖不到矿。

诺艾尔的挖矿优势在于，她的四次攻击每次都会重新调整攻击方向，即使前两次攻击导致角色位移了一段距离，下一次攻击也会重新调整方向正对矿石，从而提高了挖矿的成功率。

并且诺艾尔作为新手祈愿必出角色，大部分玩家都应该持有。

基于以上原因，建议将诺艾尔作为优先选择。