### PR TITLE
延长换队失败的判断时间

### DIFF
--- a/BetterGenshinImpact/GameTask/Common/Job/SwitchPartyTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/SwitchPartyTask.cs
@@ -51,9 +51,9 @@ public class SwitchPartyTask
             {
                 Simulation.SendInput.SimulateAction(GIActions.OpenPartySetupScreen);
 
-                // 考虑加载时间 2s，共检查 3s，如果失败则抛出异常
+                // 考虑加载时间 2s，共检查 4.2s，如果失败则抛出异常
                 
-                for (int i = 0; i < 5; i++) // 检查 5 次
+                for (int i = 0; i < 7; i++) // 检查 7 次
                 {
                     await Delay(600, ct);
                     using var raCheck = CaptureToRectArea();


### PR DESCRIPTION
3s在低配电脑会超时，延长换队失败的判断时间
![1](https://github.com/user-attachments/assets/deb8477e-79a3-45ef-988e-d2bcc5dd96d0)
