### PR TITLE
修复goToAdventurersGuild如果从命令行启动或者连续执行配置组的情况下抛异常的问题

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
@@ -223,7 +223,10 @@ public class PathExecutor
                 catch (NormalEndException normalEndException)
                 {
                     Logger.LogInformation(normalEndException.Message);
-                    if (!RunnerContext.Instance.isAutoFetchDispatch && RunnerContext.Instance.IsContinuousRunGroup)
+                    if (normalEndException.Message == "达成结束条件，结束地图追踪")
+                    {
+                        break;
+                    } else if (!RunnerContext.Instance.isAutoFetchDispatch && RunnerContext.Instance.IsContinuousRunGroup)
                     {
                         throw;
                     }


### PR DESCRIPTION
fixed #1791, see details in the issue

从软件工程学的角度来讲似乎并不是最好的解决方案，应当引入一个新的Exception类型