### PR TITLE
JS图像识别模版匹配添加颜色遮罩

### DIFF
--- a/BetterGenshinImpact/Core/Recognition/RecognitionObject.cs
+++ b/BetterGenshinImpact/Core/Recognition/RecognitionObject.cs
@@ -101,6 +101,20 @@ public class RecognitionObject
         {
             RecognitionType = RecognitionTypes.TemplateMatch,
             TemplateImageMat = mat,
+            UseMask = false, 
+        };
+        
+        return ro.InitTemplate();
+    }
+
+    public static RecognitionObject TemplateMatch(Mat mat, bool useMask, Color maskColor = default)
+    {
+        var ro = new RecognitionObject
+        {
+            RecognitionType = RecognitionTypes.TemplateMatch,
+            TemplateImageMat = mat,
+            UseMask = useMask,
+            MaskColor = maskColor == default? Color.FromArgb(0, 255, 0) : maskColor
         };
         
         return ro.InitTemplate();


### PR DESCRIPTION
模版匹配添加颜色遮罩,有一些情况识别的模版差别很小，例如识别原粹树脂，脆弱树脂和须臾树脂，用一个模版全部都成功匹配成功，如果改用颜色遮罩，抠图把底色设置为纯绿色(0, 255, 0)，就可以正常区别进行匹配，我测了一下，效果可以，就看有没必要释放出来给JS。