### PR TITLE
精英拾取增加限制

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoPathing/Handler/AutoFightHandler.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/Handler/AutoFightHandler.cs
@@ -40,7 +40,7 @@ internal class AutoFightHandler : IActionHandler
         }
 
         //根据怪物标签，调整拾取配置
-        if (waypointForTrack!=null)
+        if (waypointForTrack!=null && waypointForTrack.EnableMonsterLootSplit)
         {
            // normal 小怪,elite 精英,legendary 传奇
            //不为精英或者小怪

--- a/BetterGenshinImpact/GameTask/AutoPathing/Model/PathingTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/Model/PathingTask.cs
@@ -64,7 +64,11 @@ public class PathingTask
         var task = JsonSerializer.Deserialize<PathingTask>(json, PathRecorder.JsonOptions) ?? throw new Exception("Failed to deserialize PathingTask");
         task.FileName = Path.GetFileName(filePath);
         task.FullPath = filePath;
-
+        //添加区分怪物拾取标志
+        foreach (var taskPosition in task.Positions)
+        {
+            taskPosition.PointExtParams.EnableMonsterLootSplit = task.Info.EnableMonsterLootSplit;
+        }
         // 比较版本号大小 BgiVersion
         if (!string.IsNullOrWhiteSpace(task.Info.BgiVersion) && Global.IsNewVersion(task.Info.BgiVersion))
         {

--- a/BetterGenshinImpact/GameTask/AutoPathing/Model/PathingTaskInfo.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/Model/PathingTaskInfo.cs
@@ -26,6 +26,11 @@ public class PathingTaskInfo
     /// </summary>
     public string Type { get; set; } = string.Empty;
 
+    /// <summary>
+    /// 区分怪物拾取
+    /// </summary>
+    public bool EnableMonsterLootSplit { get; set; } = false;
+
     [JsonIgnore]
     public string TypeDesc => PathingTaskType.GetMsgByCode(Type);
     

--- a/BetterGenshinImpact/GameTask/AutoPathing/Model/Waypoint.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/Model/Waypoint.cs
@@ -30,6 +30,7 @@ public class Waypoint
         public string Description { get; set; } = "";
         //normal 小怪,elite 精英,legendary 传奇
         public string MonsterTag { get; set; }
+        public bool EnableMonsterLootSplit { get; set; } = false;
     }
 
 

--- a/BetterGenshinImpact/GameTask/AutoPathing/Model/WaypointForTrack.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/Model/WaypointForTrack.cs
@@ -25,6 +25,8 @@ public class WaypointForTrack : Waypoint
     
     //怪物标签
     public string MonsterTag { get; set; } ="";
+    //区分怪物拾取，只有为true时怪物标签才生效
+    public bool EnableMonsterLootSplit{ get; set; } = false;
 
     /// <summary>
     /// 存在 combat_script 的 action 的话，这个值会存在

--- a/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
@@ -497,6 +497,7 @@ public class PathExecutor
             WaypointForTrack wft=new WaypointForTrack(waypoint, task.Info.MapName);
             wft.Misidentification=waypoint.PointExtParams.Misidentification;
             wft.MonsterTag = waypoint.PointExtParams.MonsterTag;
+            wft.EnableMonsterLootSplit = waypoint.PointExtParams.EnableMonsterLootSplit;
             return wft;
         }).ToList();
 


### PR DESCRIPTION
调整精英拾取功能，必须在追踪文件中勾选 区分怪物拾取 标志才会触发。