### PR TITLE
fix: 配置组部分配置处理逻辑修改

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
@@ -140,6 +140,11 @@ public class PathExecutor
             return;
         }
 
+        // 切换队伍
+        if (!await SwitchPartyBefore(task))
+        {
+            return;
+        }
         // 校验路径是否可以执行
         if (!await ValidateGameWithTask(task))
         {
@@ -278,6 +283,97 @@ public class PathExecutor
         return waypoint.Type == WaypointType.Target.Code;
     }
 
+    private async Task<bool> SwitchPartyBefore(PathingTask task)
+    {
+        var ra = CaptureToRectArea();
+
+        // 切换队伍前判断是否全队死亡 // 可能队伍切换失败导致的死亡
+        if (Bv.ClickIfInReviveModal(ra))
+        {
+            await Bv.WaitForMainUi(ct); // 等待主界面加载完成
+            Logger.LogInformation("复苏完成");
+            await Delay(4000, ct);
+            // 血量肯定不满，直接去七天神像回血
+            await TpStatueOfTheSeven();
+        }
+
+        var pRaList = ra.FindMulti(AutoFightAssets.Instance.PRa); // 判断是否联机
+        if (pRaList.Count > 0)
+        {
+            Logger.LogInformation("处于联机状态下，不切换队伍");
+        }
+        else
+        {
+            var partyName = FilterPartyNameByConditionConfig(task);
+            if (!await SwitchParty(partyName))
+            {
+                Logger.LogError("切换队伍失败，无法执行此路径！请检查地图追踪设置！");
+                return false;
+            }
+        }
+
+        return true;
+    }
+    
+    /// <summary>
+    /// 切换队伍
+    /// </summary>
+    /// <param name="partyName"></param>
+    /// <returns></returns>
+    private async Task<bool> SwitchParty(string? partyName)
+    {
+        bool success = true;
+        if (!string.IsNullOrEmpty(partyName))
+        {
+            if (RunnerContext.Instance.PartyName == partyName)
+            {
+                return success;
+            }
+
+            bool forceTp = PartyConfig.IsVisitStatueBeforeSwitchParty;
+
+            if (forceTp) // 强制传送模式
+            {
+                await new TpTask(ct).TpToStatueOfTheSeven(); // fix typos
+                success = await new SwitchPartyTask().Start(partyName, ct);
+            }
+            else // 优先原地切换模式
+            {
+                try
+                {
+                    success = await new SwitchPartyTask().Start(partyName, ct);
+                }
+                catch (PartySetupFailedException)
+                {
+                    await new TpTask(ct).TpToStatueOfTheSeven();
+                    success = await new SwitchPartyTask().Start(partyName, ct);
+                }
+            }
+
+            if (success)
+            {
+                RunnerContext.Instance.PartyName = partyName;
+                RunnerContext.Instance.ClearCombatScenes();
+            }
+        }
+
+        return success;
+    }
+
+
+    private static string? FilterPartyNameByConditionConfig(PathingTask task)
+    {
+        var pathingConditionConfig = TaskContext.Instance().Config.PathingConditionConfig;
+        var materialName = task.GetMaterialName();
+        var specialActions = task.Positions
+            .Select(p => p.Action)
+            .Where(action => !string.IsNullOrEmpty(action))
+            .Distinct()
+            .ToList();
+        var partyName = pathingConditionConfig.FilterPartyName(materialName, specialActions);
+        return partyName;
+    }
+    
     private void InitializePathing(PathingTask task)
     {
         LogScreenResolution();

--- a/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
@@ -286,17 +286,6 @@ public class PathExecutor
     private async Task<bool> SwitchPartyBefore(PathingTask task)
     {
         var ra = CaptureToRectArea();
-
-        // 切换队伍前判断是否全队死亡 // 可能队伍切换失败导致的死亡
-        if (Bv.ClickIfInReviveModal(ra))
-        {
-            await Bv.WaitForMainUi(ct); // 等待主界面加载完成
-            Logger.LogInformation("复苏完成");
-            await Delay(4000, ct);
-            // 血量肯定不满，直接去七天神像回血
-            await TpStatueOfTheSeven();
-        }
-
         var pRaList = ra.FindMulti(AutoFightAssets.Instance.PRa); // 判断是否联机
         if (pRaList.Count > 0)
         {

--- a/BetterGenshinImpact/Service/ScriptService.cs
+++ b/BetterGenshinImpact/Service/ScriptService.cs
@@ -125,6 +125,8 @@ public partial class ScriptService : IScriptService
             {
                 var stopwatch = new Stopwatch();
                 int projectIndex = -1;
+                // 在配置组开始执行前进行队伍切换
+                await SwitchPartyBeforeGroup(list, groupName);
                 foreach (var project in list)
                 {
                     projectIndex++;
@@ -158,10 +160,7 @@ public partial class ScriptService : IScriptService
                         _logger.LogInformation("执行被取消");
                         break;
                     }
-                    
-                    // 在配置组开始执行前进行队伍切换
-                    await SwitchPartyBeforeGroup(list, groupName);
-                    
+
                     if (fisrt)
                     {
                         fisrt = false;


### PR DESCRIPTION
1. 修改了切换队伍的时机
  - 配置组中切换队伍只在配置组最开始时执行 fix #1836 
  - 提高地图追踪设置的优先级，地图追踪设置的队伍切换不再受到配置组相关设置的影响
2. 移除了每次任务结束的固定两秒延时
3. 移动了全队阵亡检测的位置，目前在配置组中每个单独的任务进行之前都会进行一次全队阵亡的检查，以避免因为全队阵亡导致任务跳过（注：原来只会在需要切换队伍的时候会进行检查）

此次改动影响较大，需要进行严格的测试以验证以上修改没有其他不利影响