### PR TITLE
修复迷烟主成员非飞行状态下四叶印识别失败的Bug。模板匹配的置信度修改为数组。

### DIFF
--- a/BetterGenshinImpact/Core/Recognition/OpenCv/OpenCvCommonHelper.cs
+++ b/BetterGenshinImpact/Core/Recognition/OpenCv/OpenCvCommonHelper.cs
@@ -123,4 +123,46 @@ public class OpenCvCommonHelper
         Cv2.InRange(src, s, s, mask);
         return ~ mask;
     }
+    
+    /// <summary>
+    /// 检测多个点是否都在指定颜色范围内
+    /// </summary>
+    /// <param name="image">输入图像</param>
+    /// <param name="points">要检测的点集合</param>
+    /// <param name="lower">颜色下限</param>
+    /// <param name="upper">颜色上限</param>
+    /// <returns>所有点都在范围内返回 true，否则 false</returns>
+    public static bool CheckPointsInRange(Mat image, Point[] points, Scalar lower, Scalar upper)
+    {
+        if (image.Empty()) return false;
+        if (points.Length == 0) return true;
+        
+        var channels = image.Channels();
+        var isContinuous = image.IsContinuous();
+        var step = image.Step();
+        var width = image.Width;
+        var height = image.Height;
+        unsafe
+        {
+            var dataPtr = (byte*)image.Data;
+            foreach (var (x, y) in points)
+            {
+                if (x < 0 || x >= width || y < 0 || y >= height)
+                {
+                    Debug.WriteLine($"坐标({x}, {y}) 超过图片范围 ({width}, {height})");
+                    continue;
+                }
+                var index = isContinuous ? (y * width + x) * channels : y * step + x * channels;
+                for (var ch = 0; ch < channels; ch++)
+                {
+                    byte pixelValue = dataPtr[index + ch];
+                    if (pixelValue < lower[ch] || pixelValue > upper[ch])
+                    {
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
+    }
 }

--- a/BetterGenshinImpact/Core/Recognition/OpenCv/TemplateMatch/MiniMapMatchConfig.cs
+++ b/BetterGenshinImpact/Core/Recognition/OpenCv/TemplateMatch/MiniMapMatchConfig.cs
@@ -21,7 +21,6 @@ public static class MiniMapMatchConfig
     public const int ExactZoom = 1;
     public const int RoughSearchRadius = 50;
     public const int ExactSearchRadius = 20;
-    public static readonly float HighThreshold = 0.97f;
-    public static readonly float LowThreshold = 0.9f;
+    public static readonly float[] ConfidenceThresholds = { 0.99f, 0.97f, 0.95f };
     
 }

--- a/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
@@ -1000,6 +1000,7 @@ public class PathExecutor
         if (waypoint.Action == ActionEnum.UpDownGrabLeaf.Code)
         {
             Simulation.SendInput.Mouse.MiddleButtonClick();
+            await Delay(300, ct);
             var screen = CaptureToRectArea();
             var position = await GetPosition(screen, waypoint);
             var targetOrientation = Navigation.GetTargetOrientation(waypoint, position);


### PR DESCRIPTION
修复迷烟主成员非飞行状态下四叶印识别失败的Bug，给回正视角的添加300ms延迟，给四叶印识别失败添加回正视角。模板匹配的置信度修改为数组，可选不同等级的置信度。