### PR TITLE
选中的更新渠道URL写入配置文件并允许从自定义URL更新脚本仓库

### DIFF
--- a/BetterGenshinImpact/Core/Config/ScriptConfig.cs
+++ b/BetterGenshinImpact/Core/Config/ScriptConfig.cs
@@ -25,4 +25,7 @@ public partial class ScriptConfig : ObservableObject
     // 已订阅的脚本路径列表
     [ObservableProperty]
     private List<string> _subscribedScriptPaths = [];
+    
+    // 选择的更新渠道URL
+    [ObservableProperty] private string _selectedRepoUrl = "";
 }

--- a/BetterGenshinImpact/Core/Script/ScriptRepoUpdater.cs
+++ b/BetterGenshinImpact/Core/Script/ScriptRepoUpdater.cs
@@ -117,7 +117,7 @@ public class ScriptRepoUpdater : Singleton<ScriptRepoUpdater>
                     // 如果仓库不存在，执行浅克隆操作
                     _logger.LogInformation($"浅克隆仓库: {repoUrl} 到 {repoPath}");
 
-                    SimpleCloneRepository(repoUrl, repoPath, onCheckoutProgress);
+                    CloneRepository(repoUrl, repoPath, onCheckoutProgress);
 
                     // CloneRepository(repoUrl, repoPath);
                     updated = true;
@@ -211,8 +211,9 @@ public class ScriptRepoUpdater : Singleton<ScriptRepoUpdater>
     /// </summary>
     /// <param name="repoUrl"></param>
     /// <param name="repoPath"></param>
+    /// <param name="onCheckoutProgress"></param>
     /// <exception cref="Exception"></exception>
-    private void CloneRepository(string repoUrl, string repoPath)
+    private void CloneRepository(string repoUrl, string repoPath, CheckoutProgressHandler? onCheckoutProgress)
     {
         // 1. 创建目录
         Directory.CreateDirectory(repoPath);
@@ -229,9 +230,9 @@ public class ScriptRepoUpdater : Singleton<ScriptRepoUpdater>
         // 4. 获取数据（使用浅克隆选项）
         var fetchOptions = new FetchOptions
         {
-            Depth = 1, // 浅克隆，只获取最新的提交
             TagFetchMode = TagFetchMode.None // 不获取标签
         };
+        fetchOptions.ProxyOptions.ProxyType = ProxyType.None;
 
         // 5. 执行获取操作
         Commands.Fetch(repo, remote.Name, ["+refs/heads/*:refs/remotes/origin/*"], fetchOptions, "初始化拉取");
@@ -250,7 +251,11 @@ public class ScriptRepoUpdater : Singleton<ScriptRepoUpdater>
         repo.Branches.Update(localBranch, b => b.TrackedBranch = remoteBranch.CanonicalName);
 
         // 9. 检出分支
-        Commands.Checkout(repo, localBranch);
+        CheckoutOptions checkoutOptions = new CheckoutOptions
+        {
+            OnCheckoutProgress = onCheckoutProgress
+        };  
+        Commands.Checkout(repo, localBranch, checkoutOptions);
     }
 
     private void GitConfig(Repository repo)

--- a/BetterGenshinImpact/View/Windows/ScriptRepoWindow.xaml
+++ b/BetterGenshinImpact/View/Windows/ScriptRepoWindow.xaml
@@ -6,15 +6,14 @@
                  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
                  xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
                  xmlns:vio="http://schemas.lepo.co/wpfui/2022/xaml/violeta"
-                 xmlns:emoji="clr-namespace:Emoji.Wpf;assembly=Emoji.Wpf"
                  Title="脚本仓库"
-                 Width = "350"
+                 Width="350"
                  MinWidth="350"
                  MinHeight="50"
-                 SizeToContent="Height"
                  Background="#202020"
                  ExtendsContentIntoTitleBar="True"
                  FontFamily="{DynamicResource TextThemeFontFamily}"
+                 SizeToContent="Height"
                  WindowBackdropType="None"
                  WindowStartupLocation="CenterOwner"
                  mc:Ignorable="d">
@@ -28,58 +27,69 @@
                     CornerRadius="8">
                 <Grid Margin="8">
                     <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
-                    
-                    <!-- 第一行：更新渠道 -->
-                    <StackPanel Grid.Row="0" 
-                                Orientation="Horizontal" 
+
+                    <!--  第一行：更新渠道  -->
+                    <StackPanel Grid.Row="0"
+                                Margin="0,0,0,12"
                                 VerticalAlignment="Center"
-                                Margin="0,0,0,12">
-                        <ui:TextBlock
-                            Foreground="{ui:ThemeResource TextFillColorPrimaryBrush}"
-                            VerticalAlignment="Center"
-                            Margin="0,0,8,0"
-                            Text="更新渠道：" />
-                        <ComboBox
-                            Width="160"
-                            ItemsSource="{Binding RepoChannels}"
-                            DisplayMemberPath="Name"
-                            SelectedItem="{Binding SelectedRepoChannel}"
-                            VerticalAlignment="Center"/>
-                        
-  
-                    </StackPanel>
-                    
-                    <!-- 第二行：脚本仓库 -->
-                    <StackPanel Grid.Row="1" 
-                                Orientation="Horizontal" >
-                        <ui:Button
-                            Icon="{ui:SymbolIcon CloudSync24}"
-                            Content="更新仓库"
-                            Margin="0,0,8,0"
-                            Command="{Binding UpdateRepoCommand}" />
-                        <ui:Button
-                            Icon="{ui:SymbolIcon ArrowReset24}"
-                            Content="重置仓库"
-                            Margin="0,0,8,0"
-                            Command="{Binding ResetRepoCommand}" />
-                        <ui:Button
-                            Icon="{ui:SymbolIcon BookStar24}"
-                            Appearance="Primary"
-                            Content="打开仓库"
-                            Command="{Binding OpenLocalScriptRepoCommand}" />
-                    </StackPanel>
-                    
-                    <StackPanel Grid.Row="2"  Margin="0,8,0,4" Visibility="{Binding IsUpdating, Converter={StaticResource BooleanToVisibilityConverter}}">
-                        <ui:TextBlock Text="{Binding UpdateProgressText}" 
-                                      Foreground="{ui:ThemeResource TextFillColorSecondaryBrush}"
+                                Orientation="Horizontal">
+                        <ui:TextBlock Margin="0,0,8,0"
                                       VerticalAlignment="Center"
-                                      Margin="0,0,8,0" />
-                        <ProgressBar Value="{Binding UpdateProgressValue}" 
-                                     Maximum="100"   />
+                                      Foreground="{ui:ThemeResource TextFillColorPrimaryBrush}"
+                                      Text="更新渠道：" />
+                        <ComboBox Width="160"
+                                  VerticalAlignment="Center"
+                                  DisplayMemberPath="Name"
+                                  ItemsSource="{Binding RepoChannels}"
+                                  SelectedItem="{Binding SelectedRepoChannel}" />
+
+
+                    </StackPanel>
+                    <!--  第二行：脚本仓库URL  -->
+                    <StackPanel Grid.Row="1"
+                                Margin="0,0,0,12"
+                                VerticalAlignment="Center"
+                                Orientation="Horizontal">
+                        <ui:TextBlock Margin="0,0,8,0"
+                                      VerticalAlignment="Center"
+                                      Foreground="{ui:ThemeResource TextFillColorPrimaryBrush}"
+                                      Text="仓库地址：" />
+                        <TextBox MinWidth="160"
+                                 MaxWidth="200"
+                                 VerticalAlignment="Center"
+                                 IsReadOnly="False"
+                                 Text="{Binding Config.SelectedRepoUrl}" />
+                    </StackPanel>
+
+                    <!--  第三行：脚本仓库  -->
+                    <StackPanel Grid.Row="2" Orientation="Horizontal">
+                        <ui:Button Margin="0,0,8,0"
+                                   Command="{Binding UpdateRepoCommand}"
+                                   Content="更新仓库"
+                                   Icon="{ui:SymbolIcon CloudSync24}" />
+                        <ui:Button Margin="0,0,8,0"
+                                   Command="{Binding ResetRepoCommand}"
+                                   Content="重置仓库"
+                                   Icon="{ui:SymbolIcon ArrowReset24}" />
+                        <ui:Button Appearance="Primary"
+                                   Command="{Binding OpenLocalScriptRepoCommand}"
+                                   Content="打开仓库"
+                                   Icon="{ui:SymbolIcon BookStar24}" />
+                    </StackPanel>
+
+                    <StackPanel Grid.Row="3"
+                                Margin="0,8,0,4"
+                                Visibility="{Binding IsUpdating, Converter={StaticResource BooleanToVisibilityConverter}}">
+                        <ui:TextBlock Margin="0,0,8,0"
+                                      VerticalAlignment="Center"
+                                      Foreground="{ui:ThemeResource TextFillColorSecondaryBrush}"
+                                      Text="{Binding UpdateProgressText}" />
+                        <ProgressBar Maximum="100" Value="{Binding UpdateProgressValue}" />
                     </StackPanel>
                 </Grid>
             </Border>

--- a/BetterGenshinImpact/View/Windows/ScriptRepoWindow.xaml
+++ b/BetterGenshinImpact/View/Windows/ScriptRepoWindow.xaml
@@ -62,7 +62,8 @@
                         <TextBox MinWidth="160"
                                  MaxWidth="200"
                                  VerticalAlignment="Center"
-                                 IsReadOnly="False"
+                                 IsReadOnly="{Binding IsRepoUrlReadOnly}"
+                                 IsEnabled="{Binding IsRepoUrlReadOnly}"
                                  Text="{Binding Config.SelectedRepoUrl}" />
                     </StackPanel>
 

--- a/BetterGenshinImpact/View/Windows/ScriptRepoWindow.xaml.cs
+++ b/BetterGenshinImpact/View/Windows/ScriptRepoWindow.xaml.cs
@@ -1,7 +1,8 @@
 using System;
 using System.Collections.ObjectModel;
-using System.Diagnostics;
+using System.ComponentModel;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -35,35 +36,104 @@ public partial class ScriptRepoWindow
     public ObservableCollection<RepoChannel> RepoChannels => _repoChannels;
 
     // 选中的渠道
-    [ObservableProperty] private RepoChannel _selectedRepoChannel;
-    
+    [ObservableProperty] private RepoChannel? _selectedRepoChannel;
+
     // 添加进度相关的可观察属性
     [ObservableProperty] private bool _isUpdating;
     [ObservableProperty] private int _updateProgressValue;
     [ObservableProperty] private string _updateProgressText = "准备更新...";
+    [ObservableProperty] private ScriptConfig _config = TaskContext.Instance().Config.ScriptConfig;
 
     public ScriptRepoWindow()
     {
         InitializeRepoChannels();
         InitializeComponent();
         DataContext = this;
+        Config.PropertyChanged += OnConfigPropertyChanged;
+        PropertyChanged += OnPropertyChanged;
+    }
+
+    private void OnPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        //OnSelectedRepoChannelChanged
+        if (e.PropertyName == nameof(SelectedRepoChannel))
+        {
+            OnSelectedRepoChannelChanged();
+        }
+    }
+
+    ~ScriptRepoWindow()
+    {
+        Config.PropertyChanged -= OnConfigPropertyChanged;
+        PropertyChanged -= OnPropertyChanged;
+    }
+
+    private void OnConfigPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(ScriptConfig.SelectedRepoUrl))
+        {
+            OnConfigSelectedRepoUrlChanged();
+        }
     }
 
     private void InitializeRepoChannels()
     {
         _repoChannels = new ObservableCollection<RepoChannel>
         {
-            new RepoChannel("CNB", "https://cnb.cool/bettergi/bettergi-scripts-list"),
-            new RepoChannel("GitCode", "https://gitcode.com/huiyadanli/bettergi-scripts-list"),
-            new RepoChannel("Gitee", "https://gitee.com/babalae/bettergi-scripts-list"),
-            new RepoChannel("GitHub", "https://github.com/babalae/bettergi-scripts-list"),
+            new("CNB", "https://cnb.cool/bettergi/bettergi-scripts-list"),
+            new("GitCode", "https://gitcode.com/huiyadanli/bettergi-scripts-list"),
+            new("Gitee", "https://gitee.com/babalae/bettergi-scripts-list"),
+            new("GitHub", "https://github.com/babalae/bettergi-scripts-list"),
+            new("自定义", "https://example.com/custom-repo")
         };
-        SelectedRepoChannel = _repoChannels[0];
+
+        if (string.IsNullOrEmpty(Config.SelectedRepoUrl))
+        {
+            // 默认选中第一个渠道
+            SelectedRepoChannel = _repoChannels[0];
+            Config.SelectedRepoUrl = SelectedRepoChannel.Url;
+        }
+        else
+        {
+            // 尝试根据配置中的URL找到对应的渠道
+            OnConfigSelectedRepoUrlChanged();
+        }
+    }
+
+    // Config.SelectedRepoUrl 变化
+    private void OnConfigSelectedRepoUrlChanged()
+    {
+        // 如果配置中的URL与当前选中渠道不一致，更新选中渠道
+        if (string.IsNullOrEmpty(SelectedRepoChannel?.Url) || SelectedRepoChannel.Url != Config.SelectedRepoUrl)
+        {
+            SelectedRepoChannel = _repoChannels.FirstOrDefault(c => c.Url == Config.SelectedRepoUrl) ??
+                                  _repoChannels.FirstOrDefault(c => c.Name == "自定义") ?? _repoChannels[0];
+        }
+    }
+
+    private void OnSelectedRepoChannelChanged()
+    {
+        if (SelectedRepoChannel is null)
+        {
+            return;
+        }
+
+        // 更新配置中的选中仓库URL
+        if (SelectedRepoChannel.Name != "自定义")
+        {
+            // 如果不是自定义渠道，直接使用选中渠道的URL
+            Config.SelectedRepoUrl = SelectedRepoChannel.Url;
+        }
     }
 
     [RelayCommand]
     private async Task UpdateRepo()
     {
+        if (SelectedRepoChannel is null)
+        {
+            Toast.Warning("请选择一个脚本仓库更新渠道。");
+            return;
+        }
         try
         {
             // 使用选定渠道的URL进行更新
@@ -76,18 +146,17 @@ public partial class ScriptRepoWindow
             IsUpdating = true;
             UpdateProgressValue = 0;
             UpdateProgressText = "准备更新...";
-            // 执行更新
-            var (repoPath, updated) = await ScriptRepoUpdater.Instance.UpdateCenterRepoByGit(repoUrl, (path, steps, totalSteps) =>
-            {
-                // 更新进度显示
-                double progressPercentage = totalSteps > 0 ? Math.Min(100, (double)steps / totalSteps * 100) : 0;
-                UpdateProgressValue = (int)progressPercentage;
-                UpdateProgressText = $"{path}";
-            });
+            // 执行更新  (repoPath, updated) 
+            var (_, updated) = await ScriptRepoUpdater.Instance.UpdateCenterRepoByGit(repoUrl,
+                (path, steps, totalSteps) =>
+                {
+                    // 更新进度显示
+                    double progressPercentage = totalSteps > 0 ? Math.Min(100, (double)steps / totalSteps * 100) : 0;
+                    UpdateProgressValue = (int)progressPercentage;
+                    UpdateProgressText = $"{path}";
+                });
 
-            // 隐藏进度条
-            IsUpdating = false;
-            
+
             // 更新结果提示
             if (updated)
             {
@@ -101,6 +170,11 @@ public partial class ScriptRepoWindow
         catch (Exception ex)
         {
             await MessageBox.ErrorAsync($"更新失败，可尝试重置仓库后重新更新。失败原因：: {ex.Message}");
+        }
+        finally
+        {
+            // 隐藏进度条
+            IsUpdating = false;
         }
     }
 
@@ -120,14 +194,14 @@ public partial class ScriptRepoWindow
             Toast.Warning("请等待当前更新完成后再进行重置操作。");
             return;
         }
-        
+
         // 添加确认对话框
         var result = await MessageBox.ShowAsync(
             "确定要重置脚本仓库吗？无法正常更新时候可以使用本功能，重置后请重新更新脚本仓库。",
             "确认重置",
             MessageBoxButton.YesNo,
             MessageBoxImage.Warning);
-            
+
         if (result == MessageBoxResult.Yes)
         {
             try

--- a/BetterGenshinImpact/View/Windows/ScriptRepoWindow.xaml.cs
+++ b/BetterGenshinImpact/View/Windows/ScriptRepoWindow.xaml.cs
@@ -38,6 +38,9 @@ public partial class ScriptRepoWindow
     // 选中的渠道
     [ObservableProperty] private RepoChannel? _selectedRepoChannel;
 
+    // 控制仓库地址是否只读
+    [ObservableProperty] private bool _isRepoUrlReadOnly = true;
+
     // 添加进度相关的可观察属性
     [ObservableProperty] private bool _isUpdating;
     [ObservableProperty] private int _updateProgressValue;
@@ -117,6 +120,9 @@ public partial class ScriptRepoWindow
         {
             return;
         }
+
+        // 更新仓库地址只读状态
+        IsRepoUrlReadOnly = SelectedRepoChannel.Name != "自定义";
 
         // 更新配置中的选中仓库URL
         if (SelectedRepoChannel.Name != "自定义")


### PR DESCRIPTION
出于测试和奇奇怪怪的加速需求，有时候可能会从非官方源更新脚本仓库

以及选择项个人感觉应该写入配置文件

顺便修了更新出错时候进度条不重置的问题