### PR TITLE
自动秘境换队改到秘境页面/原粹识别优化

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoDomain/AutoDomainTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoDomain/AutoDomainTask.cs
@@ -99,6 +99,16 @@ public class AutoDomainTask : ISoloTask
         this.rapidformationString = stringLocalizer.WithCultureGet(cultureInfo, "快速编队");
         this.limitedFullyString = stringLocalizer.WithCultureGet(cultureInfo, "限时全开");
     }
+    
+    private static RecognitionObject GetConfirmRa(params string[] targetText)
+    {
+        var screenArea = CaptureToRectArea();
+        var x = (int)(screenArea.Width * 0.5);
+        var y = (int)(screenArea.Height * 0.5);
+        var width = (int)(screenArea.Width * 0.5);
+        var height = (int)(screenArea.Height * 0.5);
+        return RecognitionObject.OcrMatch(x, y, width, height, targetText);
+    }
 
     public async Task Start(CancellationToken ct)
     {
@@ -151,21 +161,24 @@ public class AutoDomainTask : ISoloTask
         // 传送到秘境
         await TpDomain();
         // 切换队伍
-        await SwitchParty(_taskParam.PartyName);
-
-        var combatScenes = new CombatScenes().InitializeTeam(CaptureToRectArea());
+        // await SwitchParty(_taskParam.PartyName);
 
         // 前置进入秘境
         await EnterDomain();
-
+        
+        var combatScenes = new CombatScenes();
         for (var i = 0; i < _taskParam.DomainRoundNum; i++)
         {
             // 0. 关闭秘境提示
             Logger.LogDebug("0. 关闭秘境提示");
             await CloseDomainTip();
-
-            // 队伍没初始化成功则重试
-            RetryTeamInit(combatScenes);
+            
+            //0.5. 初始化队伍，只执行一次
+            if (i == 0)
+            {
+                combatScenes = new CombatScenes().InitializeTeam(CaptureToRectArea());   
+            }
+            RetryTeamInit(combatScenes);// 队伍没初始化成功则重试
 
             // 0. 切换到第一个角色
             var combatCommands = FindCombatScriptAndSwitchAvatar(combatScenes);
@@ -253,12 +266,17 @@ public class AutoDomainTask : ISoloTask
                 await new TpTask(_ct).Tp(domainPosition.X, domainPosition.Y);
                 await Delay(1000, _ct);
                 await Bv.WaitForMainUi(_ct);
-                await Delay(1000, _ct);
 
+                var menuFound = false;
                 if ("芬德尼尔之顶".Equals(_taskParam.DomainName))
                 {
-                    Simulation.SendInput.SimulateAction(GIActions.MoveBackward, KeyType.KeyDown);
-                    Thread.Sleep(3000);
+                        menuFound = await NewRetry.WaitForElementAppear(
+                        AutoPickAssets.Instance.FRo,
+                        () => Simulation.SendInput.SimulateAction(GIActions.MoveBackward, KeyType.KeyDown),
+                        _ct,
+                        20,
+                        500
+                    );
                     Simulation.SendInput.SimulateAction(GIActions.MoveBackward, KeyType.KeyUp);
                 }
                 else if ("无妄引咎密宫".Equals(_taskParam.DomainName))
@@ -266,38 +284,56 @@ public class AutoDomainTask : ISoloTask
                     Simulation.SendInput.SimulateAction(GIActions.MoveForward, KeyType.KeyDown);
                     Thread.Sleep(500);
                     Simulation.SendInput.SimulateAction(GIActions.MoveForward, KeyType.KeyUp);
-                    Thread.Sleep(100);
-                    Simulation.SendInput.SimulateAction(GIActions.MoveLeft, KeyType.KeyDown);
-                    Thread.Sleep(1600);
+
+                    menuFound = await NewRetry.WaitForElementAppear(
+                        AutoPickAssets.Instance.FRo,
+                        () =>  Simulation.SendInput.SimulateAction(GIActions.MoveLeft, KeyType.KeyDown),
+                        _ct,
+                        20,
+                        500
+                    );
                     Simulation.SendInput.SimulateAction(GIActions.MoveLeft, KeyType.KeyUp);
-                }
-                else if ("苍白的遗荣".Equals(_taskParam.DomainName))
-                {
-                    Simulation.SendInput.SimulateAction(GIActions.MoveForward, KeyType.KeyDown);
-                    Thread.Sleep(2000);
-                    Simulation.SendInput.SimulateAction(GIActions.MoveForward, KeyType.KeyUp);
-                }
-                else if ("塞西莉亚苗圃".Equals(_taskParam.DomainName))
-                {
-                    Simulation.SendInput.SimulateAction(GIActions.MoveForward, KeyType.KeyDown);
-                    Thread.Sleep(2500);
-                    Simulation.SendInput.SimulateAction(GIActions.MoveForward, KeyType.KeyUp);
+                    
                 }
                 else if ("太山府".Equals(_taskParam.DomainName))
                 {
-                    // 直接F即可
-                    // nothing to do
+                    menuFound = await NewRetry.WaitForElementAppear(
+                        AutoPickAssets.Instance.FRo,
+                        () => { },
+                    _ct,
+                        20,
+                        500
+                    );
                 }
                 else
                 {
-                    Simulation.SendInput.SimulateAction(GIActions.MoveForward, KeyType.KeyDown);
-                    Thread.Sleep(2000);
+                    menuFound = await NewRetry.WaitForElementAppear(
+                    AutoPickAssets.Instance.FRo,
+                    () => Simulation.SendInput.SimulateAction(GIActions.MoveForward, KeyType.KeyDown),
+                    _ct,
+                    20,
+                    500
+                    );
                     Simulation.SendInput.SimulateAction(GIActions.MoveForward, KeyType.KeyUp);
                 }
-
-                await Delay(100, _ct);
-                Simulation.SendInput.SimulateAction(GIActions.Drop); // 可能爬上去了，X键下来
-                await Delay(3000, _ct); // 站稳
+                
+                if (!menuFound)
+                {
+                    throw new Exception("请检查是否在秘境门前");
+                }  
+                
+                var menu = await NewRetry.WaitForElementAppear(
+                    GetConfirmRa("单人挑战"),
+                    () => Simulation.SendInput.Keyboard.KeyPress(AutoPickAssets.Instance.PickVk),
+                    _ct,
+                    20,
+                    500
+                );
+                if (!menu)
+                {
+                    throw new Exception("请检查是否已进入秘境页面");
+                }
+                
             }
             else
             {
@@ -327,10 +363,9 @@ public class AutoDomainTask : ISoloTask
     private async Task EnterDomain()
     {
         var fightAssets = AutoFightAssets.Instance;
-        string[] targetText = { "单人挑战" }; //可以写成单个string，也可以写成数组进行多个匹配
-        // 等待F菜单界面文字出现--使用新增的OCR的方法
+        
         var menuFound = await NewRetry.WaitForElementAppear(
-            RecognitionObject.OcrMatch(CaptureToRectArea().Width * 0.5, CaptureToRectArea().Height * 0.5, CaptureToRectArea().Width * 0.5, CaptureToRectArea().Height * 0.5, targetText),
+            GetConfirmRa("单人挑战"),
             () => Simulation.SendInput.Keyboard.KeyPress(AutoPickAssets.Instance.PickVk),
             _ct,
             20,
@@ -338,17 +373,9 @@ public class AutoDomainTask : ISoloTask
         );
         if (!menuFound)
         {
-            throw new Exception(targetText + "未出现，请检查是否已进入秘境页面");
+            throw new Exception( "单人挑战 按键未出现，请检查是否已进入秘境页面");
         }
-        // // 等待F菜单界面出现---使用图像模板的方法
-        // await NewRetry.WaitForElementAppear(
-        //     fightAssets.ConfirmRa,
-        //     () => Simulation.SendInput.Keyboard.KeyPress(AutoPickAssets.Instance.PickVk),
-        //     _ct,
-        //     20,
-        //     500
-        // );
-
+        
         using var limitedFullyStringRa = CaptureToRectArea();
         var limitedFullyStringRaocrList =
             limitedFullyStringRa.FindMulti(RecognitionObject.Ocr(0, 0, limitedFullyStringRa.Width * 0.5,
@@ -360,7 +387,7 @@ public class AutoDomainTask : ISoloTask
         {
             Logger.LogInformation("自动秘境：{Text}", "检测到秘境限时全开");
         }
-
+        
         DateTime now = DateTime.Now;
         if ((now.DayOfWeek == DayOfWeek.Sunday && now.Hour >= 4 || now.DayOfWeek == DayOfWeek.Monday && now.Hour < 4) || limitedFullyStringRaocrListdone != null)
         {
@@ -374,7 +401,7 @@ public class AutoDomainTask : ISoloTask
                         Logger.LogInformation(limitedFullyStringRaocrListdone != null ? "自动秘境：限时全开秘境奖励序号 {sundaySelectedValue}" : "自动秘境：周日设置了秘境奖励序号 {sundaySelectedValue}", sundaySelectedValue);
                         using var abnormalscreenRa = CaptureToRectArea();
                         GlobalMethod.MoveMouseTo(abnormalscreenRa.Width / 4, abnormalscreenRa.Height / 2); //移到左侧
-                        for (var i = 0; i < 150; i++)
+                        for (var i = 0; i < 100; i++)
                         {
                             Simulation.SendInput.Mouse.VerticalScroll(-1);
                             await Delay(10, _ct);
@@ -409,7 +436,6 @@ public class AutoDomainTask : ISoloTask
                                     break;
                             }
                         }
-                        //await Delay(100000, _ct);//调试延时=========
                     }
                     else
                     {
@@ -418,7 +444,7 @@ public class AutoDomainTask : ISoloTask
                 }
                 else
                 {
-                    Logger.LogWarning("设置秘境奖励序号错误，请检查配置页面");
+                    Logger.LogWarning(_taskParam.SundaySelectedValue == "" ? "未设置秘境奖励序号" : "设置秘境奖励序号错误，请检查配置页面");
                 }
             }
 
@@ -434,12 +460,10 @@ public class AutoDomainTask : ISoloTask
                 var ra2 = ra.Find(fightAssets.ConfirmRa);
                 if (!ra2.IsEmpty())
                 {
-                    await Delay(50, _ct);
                     ra2.Click();
                     ra2.Dispose();
-                    Logger.LogInformation("自动秘境：点击 {Text}", "单人挑战"); //看LOG是否要显示
+                    Logger.LogInformation("自动秘境：点击 {Text}", "单人挑战");//看LOG是否要显示
                 }
-
                 using var confirmRectArea2 = ra.Find(RecognitionObject.Ocr(ra.Width * 0.263, ra.Height * 0.32,
                     ra.Width - ra.Width * 0.263 * 2, ra.Height - ra.Height * 0.32 - ra.Height * 0.353));
                 if (confirmRectArea2.IsExist() && confirmRectArea2.Text.Contains("是否仍要挑战该秘境"))
@@ -452,7 +476,7 @@ public class AutoDomainTask : ISoloTask
             20,
             500
         );
-
+        
         // 等待队伍选择界面出现
         var teamUiFound = await NewRetry.WaitForElementAppear(
             ElementAssets.Instance.PartyBtnChooseView,
@@ -468,17 +492,17 @@ public class AutoDomainTask : ISoloTask
         {
             throw new Exception("队伍选择界面未出现。");
         }
-
-        // 点击开始挑战确认并等待“快速编队”文字消失
+        
+        await SwitchParty(_taskParam.PartyName);//现在如果切换失败，抛出异常，停止运行，要不要继续进行？
+        
+        // 点击开始挑战确认并等待“开始挑战”文字消失
         var startFightFound = await NewRetry.WaitForElementDisappear(
-            RecognitionObject.OcrMatch(CaptureToRectArea().Width * 0.5, CaptureToRectArea().Height * 0.5, CaptureToRectArea().Width * 0.5, CaptureToRectArea().Height * 0.5, "快速编队"),
-            screen =>
-            {
-                screen.Find(fightAssets.ConfirmRa, ra =>
-                {
-                    ra.Click();
-                    ra.Dispose();
-                    Logger.LogInformation("自动秘境：点击 {Text}", "开始挑战"); //看LOG是否要显示
+            GetConfirmRa("开始挑战"),
+            screen => {
+                screen.Find(fightAssets.ConfirmRa, ra => { 
+                    ra.Click(); 
+                    ra.Dispose(); 
+                    Logger.LogInformation("自动秘境：点击 {Text}", "开始挑战");
                 });
             },
             _ct,
@@ -489,8 +513,7 @@ public class AutoDomainTask : ISoloTask
         {
             throw new Exception("开始挑战按钮未出现或未能点击。");
         }
-
-        // 载入动画
+        // 载入
         await Delay(1000, _ct);
     }
 
@@ -501,9 +524,10 @@ public class AutoDomainTask : ISoloTask
         {
             using var ra = CaptureToRectArea();
             var ocrList = ra.FindMulti(RecognitionObject.Ocr(0, ra.Height * 0.2, ra.Width, ra.Height * 0.6));
-            var ocrListLeft = ra.FindMulti(RecognitionObject.Ocr(0, CaptureToRectArea().Height * 0.9, CaptureToRectArea().Width * 0.1,
-                CaptureToRectArea().Height * 0.07));
-            return (ocrList.Any(t => t.Text.Contains(leyLineDisorderLocalizedString) || t.Text.Contains(clickanywheretocloseLocalizedString)) || ocrListLeft.Any(t => t.Text.Contains(enterString))); 
+            var ocrListLeft = ra.FindMulti(RecognitionObject.Ocr(0, ra.Height * 0.9, ra.Width * 0.1,
+                ra.Height * 0.07));
+            return (ocrList.Any(t => t.Text.Contains(leyLineDisorderLocalizedString) || 
+                                     t.Text.Contains(clickanywheretocloseLocalizedString)) || ocrListLeft.Any(t => t.Text.Contains(enterString))); 
         }, _ct, 20, 500);
         if (!domainTipFound)
         {
@@ -527,8 +551,8 @@ public class AutoDomainTask : ISoloTask
             }
             // 检查左下角区域是否还存在目标文字，消失则继续，存在则结束
             using var leftBottom = CaptureToRectArea();
-            var leftBottomOcr = leftBottom.FindMulti(RecognitionObject.Ocr(0, CaptureToRectArea().Height * 0.9, CaptureToRectArea().Width * 0.1,
-                CaptureToRectArea().Height * 0.07));
+            var leftBottomOcr = leftBottom.FindMulti(RecognitionObject.Ocr(0, leftBottom.Height * 0.9, leftBottom.Width * 0.1,
+                leftBottom.Height * 0.07));
             return leftBottomOcr.Any(t =>
                 t.Text.Contains(enterString));
         }, _ct, 20, 500);

--- a/BetterGenshinImpact/GameTask/AutoDomain/Model/ResinStatus.cs
+++ b/BetterGenshinImpact/GameTask/AutoDomain/Model/ResinStatus.cs
@@ -44,11 +44,15 @@ public class ResinStatus
             throw new Exception("未找到原粹树脂图标");
         }
 
-        // 找出 icon 的位置 + 30 ~ w-267 就是原粹树脂的数字
-        var originalResinCountRect = new Rect(originalResinRes.Right + 30, (int)(37 * assetScale),
-            captureArea.Width - (originalResinRes.Right + 30) - (int)(267 * assetScale), (int)(21 * assetScale));
+        var originalResinCountRect =  new Rect(originalResinRes.Right + 30, (int)(37 * assetScale),
+      captureArea.Width - (originalResinRes.Right + 30) - (int)(190 * assetScale), (int)(21 * assetScale));
         string cnt1 = OcrFactory.Paddle.OcrWithoutDetector(region.DeriveCrop(originalResinCountRect).SrcMat);
-        status.OriginalResinCount = StringUtils.TryExtractPositiveInt(cnt1, 0);
+        var match = System.Text.RegularExpressions.Regex.Match(cnt1, @"(\d+)\s*[/17]\s*(2|20|200)");
+        if (match.Success)
+        {
+            var numericPart = match.Groups[1].Value;
+            status.OriginalResinCount = StringUtils.TryExtractPositiveInt(numericPart, 0);
+        }
 
         // 2. 浓缩树脂
         var condensedResinRes = region.Find(AutoFightAssets.Instance.CondensedResinTopIconRa);

--- a/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
@@ -384,9 +384,9 @@ public partial class OneDragonFlowViewModel : ViewModel
 
     [ObservableProperty] private List<string> _completionActionList = ["无", "关闭游戏", "关闭游戏和软件", "关机"];
 
-    [ObservableProperty] private List<string> _sundayEverySelectedValueList = ["1", "2", "3"];
+    [ObservableProperty] private List<string> _sundayEverySelectedValueList = ["","1", "2", "3"];
     
-    [ObservableProperty] private List<string> _sundaySelectedValueList = ["1", "2", "3"];
+    [ObservableProperty] private List<string> _sundaySelectedValueList = ["","1", "2", "3"];
 
     [ObservableProperty] private List<string> _secretTreasureObjectList = ["布匹","须臾树脂","大英雄的经验","流浪者的经验","精锻用魔矿","摩拉","祝圣精华","祝圣油膏"];
     


### PR DESCRIPTION
自动秘境换队改到秘境页面/原粹识别优化

复用现在的切换队伍函数，加了标志位坐区分，省略几个步骤就可以了，测了几天还可以，目前没有发生影响其他情况的使用。

周末序号添加了一个空字符，用于不改变选择。

传送到秘境后，走到秘境过程进行了优化。

另外原粹树脂群里有反馈说存在不稳定，很多时候数字1的识别都不是很稳定，把后面的/200也截图下来，改用Match，这个方法好像挺稳定的，当识别都有其他数字，识别1的成功率就会更高。