### PR TITLE
调度器 - 名称 - 添加鼠标悬浮显示文件夹。

### DIFF
--- a/BetterGenshinImpact/View/Pages/ScriptControlPage.xaml
+++ b/BetterGenshinImpact/View/Pages/ScriptControlPage.xaml
@@ -299,7 +299,7 @@
                                             Header="名称" >
                                 <GridViewColumn.CellTemplate>
                                     <DataTemplate>
-                                        <TextBlock Text="{Binding Name}" FontSize="14">
+                                        <TextBlock Text="{Binding Name}" FontSize="14" ToolTip="{Binding FolderName}">
                                             <TextBlock.Style>
                                                 <Style TargetType="TextBlock">
                                                     <Setter Property="Foreground" Value="White" />


### PR DESCRIPTION
给调度器 - 名称 - 添加鼠标悬浮显示文件夹。

脚本与地图追踪任务命名没有统一标准，每个作者的命名方式不一样，想要删除或者禁用不太方便，所以想到添加路径的方式进行提示，使用起来更方便。