### PR TITLE
优化切换队伍点击队伍管理按键

### DIFF
--- a/BetterGenshinImpact/GameTask/Common/Job/SwitchPartyTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/SwitchPartyTask.cs
@@ -110,8 +110,8 @@ public class SwitchPartyTask
             ElementAssets.Instance.PartyBtnDelete,
             () => partyViewBtn.Click(),// 点击队伍选择按钮
             ct,
-            5,
-            1000
+            4,
+            500
         );
         if (!menu)
         {


### PR DESCRIPTION
原来直接点击队伍管理按键可能因为卡顿或延时，导致没点上，加上重试解决。