### PR TITLE
给telegramNotifier添加代理功能支持

### DIFF
--- a/BetterGenshinImpact/Service/Notification/NotificationConfig.cs
+++ b/BetterGenshinImpact/Service/Notification/NotificationConfig.cs
@@ -167,6 +167,16 @@ public partial class NotificationConfig : ObservableObject
     [ObservableProperty] private string _telegramApiBaseUrl = string.Empty;
 
     /// <summary>
+    ///     Telegram代理地址(可选，格式：http://127.0.0.1:7890)
+    /// </summary>
+    [ObservableProperty] private string _telegramProxyUrl = "http://127.0.0.1:10809";
+
+    /// <summary>
+    ///     是否启用Telegram代理
+    /// </summary>
+    [ObservableProperty] private bool _telegramProxyEnabled = false;
+
+    /// <summary>
     ///     Telegram机器人Token
     /// </summary>
     [ObservableProperty] private string _telegramBotToken = string.Empty;

--- a/BetterGenshinImpact/Service/Notification/NotificationService.cs
+++ b/BetterGenshinImpact/Service/Notification/NotificationService.cs
@@ -256,10 +256,12 @@ public class NotificationService : IHostedService, IDisposable
         if (_notificationConfig?.TelegramNotificationEnabled == true)
         {
             _notifierManager.RegisterNotifier(new TelegramNotifier(
-                _notifyHttpClient,
+                null,
                 _notificationConfig.TelegramBotToken,
                 _notificationConfig.TelegramChatId,
-                _notificationConfig.TelegramApiBaseUrl
+                _notificationConfig.TelegramApiBaseUrl,
+                _notificationConfig.TelegramProxyUrl,
+                _notificationConfig.TelegramProxyEnabled
             ));
         }
     }

--- a/BetterGenshinImpact/View/Pages/NotificationSettingsPage.xaml
+++ b/BetterGenshinImpact/View/Pages/NotificationSettingsPage.xaml
@@ -1456,6 +1456,61 @@
                                 TextWrapping="NoWrap" />
                 </Grid>
 
+                <Grid Margin="16">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="3*" />
+                        <ColumnDefinition Width="2*" />
+                    </Grid.ColumnDefinitions>
+                    <ui:TextBlock Grid.Row="0"
+                                  Grid.Column="0"
+                                  FontTypography="Body"
+                                  Text="启用代理"
+                                  TextWrapping="Wrap" />
+                    <ui:TextBlock Grid.Row="1"
+                                  Grid.Column="0"
+                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                  Text="是否启用代理连接"
+                                  TextWrapping="Wrap" />
+                    <ui:ToggleSwitch Grid.Row="0"
+                                     Grid.RowSpan="2"
+                                     Grid.Column="1"
+                                     Margin="0,0,36,0"
+                                     IsChecked="{Binding Config.NotificationConfig.TelegramProxyEnabled, Mode=TwoWay}" />
+                </Grid>
+
+                <Grid Margin="16">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="3*" />
+                        <ColumnDefinition Width="2*" />
+                    </Grid.ColumnDefinitions>
+                    <ui:TextBlock Grid.Row="0"
+                                  Grid.Column="0"
+                                  FontTypography="Body"
+                                  Text="代理地址"
+                                  TextWrapping="Wrap" />
+                    <ui:TextBlock Grid.Row="1"
+                                  Grid.Column="0"
+                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                  Text="格式：http://127.0.0.1:7890"
+                                  TextWrapping="Wrap" />
+                    <ui:TextBox Grid.Row="0"
+                                Grid.RowSpan="2"
+                                Grid.Column="1"
+                                MinWidth="180"
+                                MaxWidth="800"
+                                Margin="0,0,36,0"
+                                Text="{Binding Config.NotificationConfig.TelegramProxyUrl, Mode=TwoWay}"
+                                TextWrapping="NoWrap" />
+                </Grid>
+
                 <!-- 测试按钮 -->
                 <Grid Margin="16">
                     <Grid.RowDefinitions>


### PR DESCRIPTION
添加了代理支持功能，解决了 Telegram 通知无法通过代理的问题。详见 #1775
为了防止其他地方使用到代理，就在telegramNotifier中单独开启了httpClient单独判断是否需要代理环境
经测试，能够在代理环境情况下接收到消息