### PR TITLE
feat: Discord Webhook notification

### DIFF
--- a/BetterGenshinImpact/Service/Notification/NotificationConfig.cs
+++ b/BetterGenshinImpact/Service/Notification/NotificationConfig.cs
@@ -13,6 +13,7 @@ public partial class NotificationConfig : ObservableObject
     /// 是否允许 js 发送通知
     /// </summary>
     [ObservableProperty] private bool _jsNotificationEnabled = false;
+
     /// <summary>
     /// 传"none"时，点击推送不会弹窗
     /// </summary>
@@ -142,6 +143,7 @@ public partial class NotificationConfig : ObservableObject
     ///     飞书通知地址
     /// </summary>
     [ObservableProperty] private string _feishuWebhookUrl = string.Empty;
+
     [ObservableProperty] private string _feishuAppId = string.Empty;
     [ObservableProperty] private string _feishuAppSecret = string.Empty;
 
@@ -157,6 +159,7 @@ public partial class NotificationConfig : ObservableObject
     ///     OneBot通知地址
     /// </summary>
     [ObservableProperty] private string _OneBotEndpoint = string.Empty;
+
     [ObservableProperty] private string _OneBotUserId = string.Empty;
     [ObservableProperty] private string _OneBotGroupId = string.Empty;
     [ObservableProperty] private string _OneBotToken = string.Empty;
@@ -247,4 +250,30 @@ public partial class NotificationConfig : ObservableObject
     ///     信息推送通知是否启用
     /// </summary>
     [ObservableProperty] private bool _xxtuiNotificationEnabled;
+
+    /// <summary>
+    ///     Discord Webhook推送通知是否启用
+    /// </summary>
+    [ObservableProperty] private bool _discordWebhookNotificationEnabled;
+
+    /// <summary>
+    ///     Discord Webhook地址
+    /// </summary>
+    [ObservableProperty] private string _discordWebhookUrl = string.Empty;
+
+    /// <summary>
+    ///     Discord Webhook用户名
+    /// </summary>
+    [ObservableProperty] private string _discordWebhookUsername = "BetterGI·更好的原神";
+
+    /// <summary>
+    ///     Discord Webhook头像地址
+    ///     Default url from https://bettergi.com/
+    /// </summary>
+    [ObservableProperty] private string _discordWebhookAvatarUrl =
+        "https://img.alicdn.com/imgextra/i2/2042484851/O1CN01LQfLIG1lhoEZwz1Gt_!!2042484851.png";
+
+    ///     Discord Webhook 图像编码
+    /// </summary>
+    [ObservableProperty] private string _discordWebhookImageEncoder = "Jpeg";
 }

--- a/BetterGenshinImpact/Service/Notification/NotificationService.cs
+++ b/BetterGenshinImpact/Service/Notification/NotificationService.cs
@@ -106,6 +106,7 @@ public class NotificationService : IHostedService, IDisposable
         InitializeDingDingNotifier();
         InitializeTelegramNotifier();
         InitializeXxtuiNotifier();
+        InitializeDiscordWebhookNotifier();
 
         // 添加新通知渠道时，在此处添加对应的初始化方法调用
     }
@@ -279,6 +280,22 @@ public class NotificationService : IHostedService, IDisposable
             _notificationConfig.XxtuiApiKey,
             _notificationConfig.XxtuiFrom,
             channels
+        ));
+    }
+
+    /// <summary>
+    ///     初始化 Discord 通知器
+    /// </summary>
+    private void InitializeDiscordWebhookNotifier()
+    {
+        if (_notificationConfig?.DiscordWebhookNotificationEnabled != true) return;
+
+        _notifierManager.RegisterNotifier(new DiscordWebhookNotifier(
+            _notifyHttpClient,
+            _notificationConfig.DiscordWebhookUrl,
+            _notificationConfig.DiscordWebhookUsername,
+            _notificationConfig.DiscordWebhookAvatarUrl,
+            _notificationConfig.DiscordWebhookImageEncoder
         ));
     }
 

--- a/BetterGenshinImpact/Service/Notifier/DiscordWebhookNotifier.cs
+++ b/BetterGenshinImpact/Service/Notifier/DiscordWebhookNotifier.cs
@@ -1,0 +1,136 @@
+﻿using BetterGenshinImpact.Service.Notifier.Exception;
+using BetterGenshinImpact.Service.Notifier.Interface;
+using System.Net.Http;
+using System.Threading.Tasks;
+using BetterGenshinImpact.Service.Notification.Model;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using Microsoft.Extensions.Logging;
+using SixLabors.ImageSharp.Formats;
+using SixLabors.ImageSharp.Formats.Jpeg;
+using SixLabors.ImageSharp.Formats.Png;
+using SixLabors.ImageSharp.Formats.Webp;
+
+namespace BetterGenshinImpact.Service.Notifier;
+
+public class DiscordWebhookNotifier : INotifier
+{
+    private static readonly ILogger<DiscordWebhookNotifier> Logger = App.GetLogger<DiscordWebhookNotifier>();
+
+    private readonly HttpClient _httpClient;
+    private readonly string _webhookUrl;
+    private readonly string _username;
+    private readonly string _avatarUrl;
+    private readonly string _imageFormat;
+    private readonly IImageEncoder _imageEncoder;
+
+    public enum ImageEncoderEnum
+    {
+        Png,
+        Jpeg,
+        WebP
+    }
+
+    public DiscordWebhookNotifier(HttpClient httpClient, string webhookUrl, string username, string avatarUrl,
+        string imageFormat)
+    {
+        _httpClient = httpClient;
+        _webhookUrl = webhookUrl;
+        _username = username;
+        _avatarUrl = avatarUrl;
+        _imageFormat = imageFormat.ToLower();
+        _imageEncoder = imageFormat switch
+        {
+            nameof(ImageEncoderEnum.Png) => new PngEncoder(),
+            nameof(ImageEncoderEnum.WebP) => new WebpEncoder(),
+            _ => new JpegEncoder()
+        };
+    }
+
+    public string Name { get; set; } = "Discord Webhook";
+
+    public async Task SendAsync(BaseNotificationData content)
+    {
+        // ref: https://discord.com/developers/docs/resources/webhook#execute-webhook
+        if (string.IsNullOrEmpty(_webhookUrl)) throw new NotifierException("Discord webhook URL is not set");
+
+        var url = $"{_webhookUrl}?with_components=true";
+        var data = new MultipartFormDataContent("boundary");
+
+        var payloadJson = new
+        {
+            flags = 1 << 15,
+            components = new List<object>(),
+            username = _username,
+            avatar_url = _avatarUrl,
+            attachments = new List<object>(),
+        };
+
+        var components = new List<object>([
+            new
+            {
+                type = 10,
+                content = content.Message
+            },
+            new
+            {
+                type = 10,
+                content = $"-# {content.Event} | {content.Result}\n-# {content.Timestamp}"
+            }
+        ]);
+
+        if (content.Screenshot != null)
+        {
+            var fileName = $"screenshot.{_imageFormat}";
+            ;
+            payloadJson.attachments.Add(new
+            {
+                id = 0,
+                filename = fileName,
+            });
+            components = new List<object>([
+                new
+                {
+                    type = 9,
+                    components,
+                    accessory = new
+                    {
+                        type = 11,
+                        media = new { url = $"attachment://screenshot.{_imageFormat}" },
+                        description = "Screenshot"
+                    }
+                }
+            ]);
+
+            using (var ms = new MemoryStream())
+            {
+                await content.Screenshot.SaveAsync(ms, _imageEncoder);
+                var imageContent = new ByteArrayContent(ms.ToArray());
+                imageContent.Headers.ContentType =
+                    MediaTypeHeaderValue.Parse($"image/{_imageFormat}");
+                data.Add(imageContent, "files[0]", fileName);
+            }
+        }
+
+        payloadJson.components.Add(new
+        {
+            type = 17,
+            components
+        });
+
+        data.Add(JsonContent.Create(payloadJson), "payload_json");
+
+        try
+        {
+            var response = await _httpClient.PostAsync(url, data);
+            response.EnsureSuccessStatusCode();
+        }
+        catch (System.Exception ex)
+        {
+            Logger.LogDebug("Failed to send message to Discord: {ex}", ex.Message);
+            throw new System.Exception("Failed to send message to Discord", ex);
+        }
+    }
+}

--- a/BetterGenshinImpact/View/Pages/NotificationSettingsPage.xaml
+++ b/BetterGenshinImpact/View/Pages/NotificationSettingsPage.xaml
@@ -7,7 +7,7 @@
       xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
       Title="NotificationSettingsPage"
       d:DataContext="{d:DesignInstance Type=pages:NotificationSettingsPageViewModel}"
-      d:DesignHeight="950"
+      d:DesignHeight="1500"
       d:DesignWidth="600"
       ui:Design.Background="{DynamicResource ApplicationBackgroundBrush}"
       ui:Design.Foreground="{DynamicResource TextFillColorPrimaryBrush}"
@@ -1798,6 +1798,178 @@
                                Margin="0,0,36,0"
                                Command="{Binding TestDingDingWebhookNotificationCommand}"
                                CommandParameter="DingDingWebhook"
+                               Content="发送" />
+                </Grid>
+            </StackPanel>
+        </ui:CardExpander>
+        <!--  Discord Webhook  -->
+        <ui:CardExpander Margin="0,0,0,12"
+                         ContentPadding="0"
+                         Icon="{ui:SymbolIcon Bot24}">
+            <ui:CardExpander.Header>
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <ui:TextBlock Grid.Row="0"
+                                  Grid.Column="0"
+                                  FontTypography="Body"
+                                  Text="启用 Discord Webhook 通知"
+                                  TextWrapping="Wrap" />
+                    <ui:TextBlock Grid.Row="1"
+                                  Grid.Column="0"
+                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                  Text="Discord Webhook 通知相关设置"
+                                  TextWrapping="Wrap" />
+                    <ui:ToggleSwitch Grid.Row="0"
+                                     Grid.RowSpan="2"
+                                     Grid.Column="1"
+                                     Margin="0,0,24,0"
+                                     IsChecked="{Binding Config.NotificationConfig.DiscordWebhookNotificationEnabled, Mode=TwoWay}" />
+                </Grid>
+            </ui:CardExpander.Header>
+            <StackPanel>
+                <Grid Margin="16">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="3*" />
+                        <ColumnDefinition Width="2*" />
+                    </Grid.ColumnDefinitions>
+                    <ui:TextBlock Grid.Row="0"
+                                  Grid.Column="0"
+                                  FontTypography="Body"
+                                  Text="Webhook 网址"
+                                  TextWrapping="Wrap" />
+                    <ui:TextBlock Grid.Row="1"
+                                  Grid.Column="0"
+                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                  Text="填写 Discord 提供的 Webhook 网址"
+                                  TextWrapping="Wrap" />
+                    <ui:TextBox Grid.Row="0"
+                                Grid.RowSpan="2"
+                                Grid.Column="1"
+                                MinWidth="180"
+                                MaxWidth="800"
+                                Margin="0,0,36,0"
+                                Text="{Binding Config.NotificationConfig.DiscordWebhookUrl, Mode=TwoWay}"
+                                TextWrapping="NoWrap" />
+                </Grid>
+                <Grid Margin="16">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="3*" />
+                        <ColumnDefinition Width="2*" />
+                    </Grid.ColumnDefinitions>
+                    <ui:TextBlock Grid.Row="0"
+                                  Grid.Column="0"
+                                  FontTypography="Body"
+                                  Text="用户名"
+                                  TextWrapping="Wrap" />
+                    <ui:TextBlock Grid.Row="1"
+                                  Grid.Column="0"
+                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                  Text="讯息显示的名称，为空时使用 Discord 中预先设定的名字"
+                                  TextWrapping="Wrap" />
+                    <ui:TextBox Grid.Row="0"
+                                Grid.RowSpan="2"
+                                Grid.Column="1"
+                                MinWidth="180"
+                                MaxWidth="800"
+                                Margin="0,0,36,0"
+                                Text="{Binding Config.NotificationConfig.DiscordWebhookUsername, Mode=TwoWay}"
+                                TextWrapping="NoWrap" />
+                </Grid>
+                <Grid Margin="16">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="3*" />
+                        <ColumnDefinition Width="2*" />
+                    </Grid.ColumnDefinitions>
+                    <ui:TextBlock Grid.Row="0"
+                                  Grid.Column="0"
+                                  FontTypography="Body"
+                                  Text="头像网址"
+                                  TextWrapping="Wrap" />
+                    <ui:TextBlock Grid.Row="1"
+                                  Grid.Column="0"
+                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                  Text="讯息显示的头像，为空时使用 Discord 中预先设定的头像"
+                                  TextWrapping="Wrap" />
+                    <ui:TextBox Grid.Row="0"
+                                Grid.RowSpan="2"
+                                Grid.Column="1"
+                                MinWidth="180"
+                                MaxWidth="800"
+                                Margin="0,0,36,0"
+                                Text="{Binding Config.NotificationConfig.DiscordWebhookAvatarUrl, Mode=TwoWay}"
+                                TextWrapping="NoWrap" />
+                </Grid>
+                <Grid Margin="16">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <ui:TextBlock Grid.Row="0"
+                                  Grid.Column="0"
+                                  FontTypography="Body"
+                                  Text="截图编码"
+                                  TextWrapping="Wrap" />
+                    <ui:TextBlock Grid.Row="1"
+                                  Grid.Column="0"
+                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                  Text="PNG 无损，JPEG 快速压缩，WebP 档案小，按需选择"
+                                  TextWrapping="Wrap" />
+                    <ComboBox Grid.Row="0"
+                              Grid.RowSpan="2"
+                              Grid.Column="1"
+                              Width="100"
+                              Margin="0,0,36,0"
+                              ItemsSource="{Binding DiscordImageEncoderNames}"
+                              SelectedItem="{Binding Config.NotificationConfig.DiscordWebhookImageEncoder, Mode=TwoWay}" />
+                </Grid>
+                <Grid Margin="16">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <ui:TextBlock Grid.Row="0"
+                                  Grid.Column="0"
+                                  FontTypography="Body"
+                                  Text="测试 Discord Webhook 通知"
+                                  TextWrapping="Wrap" />
+                    <ui:TextBlock Grid.Row="1"
+                                  Grid.Column="0"
+                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                  Text="发送测试通知"
+                                  TextWrapping="Wrap" />
+                    <ui:Button Grid.Row="0"
+                               Grid.RowSpan="2"
+                               Grid.Column="1"
+                               Margin="0,0,36,0"
+                               Command="{Binding TestDiscordWebhookNotificationCommand}"
+                               CommandParameter="DiscordWebhook"
                                Content="发送" />
                 </Grid>
             </StackPanel>

--- a/BetterGenshinImpact/ViewModel/Pages/NotificationSettingsPageViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/NotificationSettingsPageViewModel.cs
@@ -40,6 +40,15 @@ public partial class NotificationSettingsPageViewModel : ObservableObject, IView
 
     [ObservableProperty] private string _xxtuiStatus = string.Empty;
 
+    [ObservableProperty] private string _discordStatus = string.Empty;
+
+    [ObservableProperty] private string[] _discordImageEncoderNames =
+    [
+        nameof(DiscordWebhookNotifier.ImageEncoderEnum.Png),
+        nameof(DiscordWebhookNotifier.ImageEncoderEnum.Jpeg),
+        nameof(DiscordWebhookNotifier.ImageEncoderEnum.WebP)
+    ];
+
     public NotificationSettingsPageViewModel(IConfigService configService, NotificationService notificationService)
     {
         Config = configService.Get();
@@ -247,6 +256,25 @@ public partial class NotificationSettingsPageViewModel : ObservableObject, IView
         var res = await _notificationService.TestNotifierAsync<DingDingWebhook>();
 
         DingDingStatus = res.Message;
+
+        // 添加Toast提示
+        if (res.IsSuccess)
+            Toast.Success(res.Message);
+        else
+            Toast.Error(res.Message);
+
+        IsLoading = false;
+    }
+
+    [RelayCommand]
+    private async Task OnTestDiscordWebhookNotification()
+    {
+        IsLoading = true;
+        DiscordStatus = string.Empty;
+
+        var res = await _notificationService.TestNotifierAsync<DiscordWebhookNotifier>();
+
+        DiscordStatus = res.Message;
 
         // 添加Toast提示
         if (res.IsSuccess)


### PR DESCRIPTION
related: #1632
ref: https://discord.com/developers/docs/resources/webhook#execute-webhook

<img width="533" height="396" alt="image" src="https://github.com/user-attachments/assets/603eb688-fe7e-43e9-8ddb-77844047edbf" />

右邊的 thumbnail 點進去會有全圖

可能要看看用不用把預設的頭像地址刪掉，我是在官網那邊拿的 URL