### PR TITLE
修复地图追踪配置中获取材料名称的问题

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoPathing/Model/PathingTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/Model/PathingTask.cs
@@ -72,8 +72,8 @@ public class PathingTask
         var conditionDefinition = ConditionDefinitions.Definitions["采集物"];
         var materialList = conditionDefinition.ObjectOptions?.ToList() ?? new List<string>();
         
-        //显示每一个采集物名称
-        for (var i = 0; i < level; i++)
+        //跳过第一个目录，i从1开始,（一级目录必定不是采集物），对比每一个采集物名称 
+        for (var i = 1; i < level; i++)
         {
             var materialName = fileNames[i];
             if (materialList.Contains(materialName))


### PR DESCRIPTION
#1914
采集物的名称获取，在仓库改版后获取材料名称就不是固定的第一个文件夹名称了，改为所有相对路径的目录名称和采集物的列表进行对比，从而活动材料名称