### PR TITLE
为脚本仓库节点提供“有更新”红点提示

### DIFF
--- a/BetterGenshinImpact/Core/Script/ScriptRepoUpdater.cs
+++ b/BetterGenshinImpact/Core/Script/ScriptRepoUpdater.cs
@@ -96,7 +96,6 @@ public class ScriptRepoUpdater : Singleton<ScriptRepoUpdater>
     //     }
     // }
 
-
     public async Task<(string, bool)> UpdateCenterRepoByGit(string repoUrl, CheckoutProgressHandler? onCheckoutProgress)
     {
         if (string.IsNullOrEmpty(repoUrl))
@@ -233,8 +232,6 @@ public class ScriptRepoUpdater : Singleton<ScriptRepoUpdater>
         return (repoPath, updated);
     }
 
-    
-
     /// <summary>
     /// 在新repo.json中添加更新标记
     /// </summary>
@@ -359,7 +356,6 @@ public class ScriptRepoUpdater : Singleton<ScriptRepoUpdater>
         }
     }
 
-
     private static void SimpleCloneRepository(string repoUrl, string repoPath,
         CheckoutProgressHandler? onCheckoutProgress)
     {
@@ -441,7 +437,6 @@ public class ScriptRepoUpdater : Singleton<ScriptRepoUpdater>
         repo.Config.Unset("http.proxy");
         repo.Config.Unset("https.proxy");
     }
-
 
     // [Obsolete]
     // public async Task<(string, bool)> UpdateCenterRepo()

--- a/BetterGenshinImpact/Core/Script/ScriptRepoUpdater.cs
+++ b/BetterGenshinImpact/Core/Script/ScriptRepoUpdater.cs
@@ -107,6 +107,9 @@ public class ScriptRepoUpdater : Singleton<ScriptRepoUpdater>
         var repoPath = Path.Combine(ReposPath, "bettergi-scripts-list-git");
         var updated = false;
 
+        // 备份相关变量
+        string? oldRepoJsonContent = null;
+
         await Task.Run(() =>
         {
             try
@@ -124,7 +127,27 @@ public class ScriptRepoUpdater : Singleton<ScriptRepoUpdater>
                 }
                 else
                 {
-                    // 仓库已经存在，执行拉取更新
+                    // 仓库已经存在，先备份repo.json再执行拉取更新
+                    try
+                    {
+                        // 检测repo.json是否存在，存在则备份
+                        var oldRepoJsonPath = Directory
+                            .GetFiles(CenterRepoPath, "repo.json", SearchOption.AllDirectories).FirstOrDefault();
+                        if (oldRepoJsonPath != null)
+                        {
+                            _logger.LogInformation($"找到上版repo.json: {oldRepoJsonPath}");
+                            oldRepoJsonContent = File.ReadAllText(oldRepoJsonPath);
+
+
+
+                            _logger.LogInformation("已备份repo.json内容");
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "备份repo.json失败，继续更新仓库");
+                    }
+
                     using var repo = new Repository(repoPath);
 
                     // 检查远程URL是否需要更新
@@ -187,11 +210,161 @@ public class ScriptRepoUpdater : Singleton<ScriptRepoUpdater>
                 throw;
             }
         });
+        // 如果仓库有更新且有备份内容，则标记新repo.json中的更新节点
+        if (updated && !string.IsNullOrEmpty(oldRepoJsonContent))
+        {
+            try
+            {
+                var newRepoJsonPath = Directory.GetFiles(CenterRepoPath, "repo.json", SearchOption.AllDirectories)
+                    .FirstOrDefault();
+                if (newRepoJsonPath != null)
+                {
+                    var newRepoJsonContent = await File.ReadAllTextAsync(newRepoJsonPath);
+                    var updatedContent = AddUpdateMarkersToNewRepo(oldRepoJsonContent, newRepoJsonContent);
+
+                    await File.WriteAllTextAsync(newRepoJsonPath, updatedContent);
+                    _logger.LogInformation("已标记repo.json中的更新节点");
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "标记repo.json更新节点失败");
+            }
+        }
 
         return (repoPath, updated);
     }
 
-    private static void SimpleCloneRepository(string repoUrl, string repoPath, CheckoutProgressHandler? onCheckoutProgress)
+    
+
+    /// <summary>
+    /// 在新repo.json中添加更新标记
+    /// </summary>
+    /// <param name="oldContent">旧版repo.json内容</param>
+    /// <param name="newContent">新版repo.json内容</param>
+    /// <returns>添加了hasUpdate标记的新repo.json内容</returns>
+    private string AddUpdateMarkersToNewRepo(string oldContent, string newContent)
+    {
+        try
+        {
+            var oldJson = JObject.Parse(oldContent);
+            var newJson = JObject.Parse(newContent);
+
+            if (oldJson["indexes"] is JArray oldIndexes && newJson["indexes"] is JArray newIndexes)
+            {
+                foreach (var newIndex in newIndexes)
+                {
+                    if (newIndex is JObject newIndexObj)
+                    {
+                        MarkNodeUpdates(newIndexObj, oldIndexes);
+                    }
+                }
+            }
+
+            return newJson.ToString(Newtonsoft.Json.Formatting.Indented);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "标记repo.json更新失败，返回原内容");
+            return newContent;
+        }
+    }
+
+    /// <summary>
+    /// 直接在新版节点上标记更新
+    /// </summary>
+    /// <param name="newNode">新版节点（会被直接修改）</param>
+    /// <param name="oldNodes">老版节点数组</param>
+    /// <returns>是否有更新（节点本身或子树）</returns>
+    private bool MarkNodeUpdates(JObject newNode, JArray oldNodes)
+    {
+        var newName = newNode["name"]?.ToString();
+        if (string.IsNullOrEmpty(newName))
+            return false;
+
+        // 在老版节点中查找对应的节点
+        var oldNode = oldNodes.FirstOrDefault(n => n is JObject obj && obj["name"]?.ToString() == newName) as JObject;
+
+        bool hasDirectUpdate = false;
+        bool hasChildUpdate = false;
+
+        // 检查节点本身是否有更新
+        if (oldNode != null)
+        {
+            // 对比时间戳
+            var oldTime = ParseLastUpdated(oldNode["lastUpdated"]?.ToString());
+            var newTime = ParseLastUpdated(newNode["lastUpdated"]?.ToString());
+
+            if (newTime > oldTime)
+            {
+                newNode["hasUpdate"] = true;
+                hasDirectUpdate = true;
+            }
+        }
+        else
+        {
+            // 新增节点
+            newNode["hasUpdate"] = true;
+            hasDirectUpdate = true;
+        }
+
+        // 处理子节点
+        if (newNode["children"] is JArray newChildren && newChildren.Count > 0)
+        {
+            var oldChildren = oldNode?["children"] as JArray ?? new JArray();
+
+            // 遍历新版的每个子节点
+            foreach (var newChild in newChildren)
+            {
+                if (newChild is JObject newChildObj)
+                {
+                    bool childHasUpdate = MarkNodeUpdates(newChildObj, oldChildren);
+                    if (childHasUpdate)
+                    {
+                        hasChildUpdate = true;
+
+                        // 如果是叶子节点更新，父节点也标记更新
+                        var isLeafChild = newChildObj["children"] == null ||
+                                          !((JArray?)newChildObj["children"])?.Any() == true;
+                        if (isLeafChild && !hasDirectUpdate && newChildObj["hasUpdate"] != null)
+                        {
+                            newNode["hasUpdate"] = true;
+                            hasDirectUpdate = true;
+                        }
+                    }
+                }
+            }
+        }
+
+        return hasDirectUpdate || hasChildUpdate;
+    }
+
+    /// <summary>
+    /// 解析lastUpdated时间戳
+    /// </summary>
+    /// <param name="timeString">时间字符串</param>
+    /// <returns>DateTime对象</returns>
+    private DateTime ParseLastUpdated(string? timeString)
+    {
+        if (string.IsNullOrEmpty(timeString))
+            return DateTime.MinValue;
+
+        try
+        {
+            if (DateTime.TryParse(timeString, out var result))
+                return result;
+
+            return DateTime.MinValue;
+        }
+        catch
+        {
+            return DateTime.MinValue;
+        }
+    }
+
+
+    private static void SimpleCloneRepository(string repoUrl, string repoPath,
+        CheckoutProgressHandler? onCheckoutProgress)
     {
         var options = new CloneOptions
         {
@@ -223,7 +396,7 @@ public class ScriptRepoUpdater : Singleton<ScriptRepoUpdater>
 
         using var repo = new Repository(repoPath);
         GitConfig(repo);
-        
+
         // 3. 添加远程源
         Remote remote = repo.Network.Remotes.Add("origin", repoUrl);
 
@@ -254,7 +427,7 @@ public class ScriptRepoUpdater : Singleton<ScriptRepoUpdater>
         CheckoutOptions checkoutOptions = new CheckoutOptions
         {
             OnCheckoutProgress = onCheckoutProgress
-        };  
+        };
         Commands.Checkout(repo, localBranch, checkoutOptions);
     }
 
@@ -263,10 +436,10 @@ public class ScriptRepoUpdater : Singleton<ScriptRepoUpdater>
         // 设置 Git 配置
         // 1. 设置 core.longpaths 为 true
         repo.Config.Set("core.longpaths", true);
-    
+
         // 2. 添加 safe.directory *
         repo.Config.Set("safe.directory", "*");
-    
+
         // 3. 移除 http.proxy 和 https.proxy 配置
         repo.Config.Unset("http.proxy");
         repo.Config.Unset("https.proxy");
@@ -570,7 +743,7 @@ public class ScriptRepoUpdater : Singleton<ScriptRepoUpdater>
         //         return;
         //     }
         // }
-        
+
         //顶层目录订阅时，不会删除其下，不在订阅中的文件夹
         List<string> newPaths = new List<string>();
         foreach (var path in paths)
@@ -585,7 +758,7 @@ public class ScriptRepoUpdater : Singleton<ScriptRepoUpdater>
                     string[] directories = Directory.GetDirectories(scriptPath, "*", SearchOption.TopDirectoryOnly);
                     foreach (var dir in directories)
                     {
-                        newPaths.Add("pathing"+"/"+Path.GetFileName(dir));
+                        newPaths.Add("pathing" + "/" + Path.GetFileName(dir));
                     }
                 }
                 else
@@ -597,9 +770,7 @@ public class ScriptRepoUpdater : Singleton<ScriptRepoUpdater>
             {
                 newPaths.Add(path);
             }
-
         }
-
 
         // 拷贝文件
         foreach (var path in newPaths)
@@ -672,9 +843,9 @@ public class ScriptRepoUpdater : Singleton<ScriptRepoUpdater>
                 continue;
 
             // 检查是否已被父路径覆盖
-            bool isCoveredByParent = pathsToKeep.Any(p => 
+            bool isCoveredByParent = pathsToKeep.Any(p =>
                 path.StartsWith(p + "/") || path == p);
-        
+
             if (!isCoveredByParent)
             {
                 pathsToKeep.Add(path);

--- a/BetterGenshinImpact/Core/Script/ScriptRepoUpdater.cs
+++ b/BetterGenshinImpact/Core/Script/ScriptRepoUpdater.cs
@@ -135,12 +135,7 @@ public class ScriptRepoUpdater : Singleton<ScriptRepoUpdater>
                             .GetFiles(CenterRepoPath, "repo.json", SearchOption.AllDirectories).FirstOrDefault();
                         if (oldRepoJsonPath != null)
                         {
-                            _logger.LogInformation($"找到上版repo.json: {oldRepoJsonPath}");
                             oldRepoJsonContent = File.ReadAllText(oldRepoJsonPath);
-
-
-
-                            _logger.LogInformation("已备份repo.json内容");
                         }
                     }
                     catch (Exception ex)
@@ -222,8 +217,12 @@ public class ScriptRepoUpdater : Singleton<ScriptRepoUpdater>
                     var newRepoJsonContent = await File.ReadAllTextAsync(newRepoJsonPath);
                     var updatedContent = AddUpdateMarkersToNewRepo(oldRepoJsonContent, newRepoJsonContent);
 
-                    await File.WriteAllTextAsync(newRepoJsonPath, updatedContent);
-                    _logger.LogInformation("已标记repo.json中的更新节点");
+                    // 保存到同级目录，而不是覆盖原文件
+                    var parentDir = Path.GetDirectoryName(repoPath);
+                    var updatedRepoJsonPath = Path.Combine(parentDir!, "repo_updated.json");
+                    
+                    await File.WriteAllTextAsync(updatedRepoJsonPath, updatedContent);
+                    _logger.LogInformation($"已标记repo.json中的更新节点并保存到: {updatedRepoJsonPath}");
                 }
             }
             catch (Exception ex)

--- a/BetterGenshinImpact/Core/Script/ScriptRepoUpdater.cs
+++ b/BetterGenshinImpact/Core/Script/ScriptRepoUpdater.cs
@@ -127,7 +127,6 @@ public class ScriptRepoUpdater : Singleton<ScriptRepoUpdater>
                 }
                 else
                 {
-                    // 仓库已经存在，先备份repo.json再执行拉取更新
                     try
                     {
                         // 检测repo.json是否存在，存在则备份
@@ -217,7 +216,7 @@ public class ScriptRepoUpdater : Singleton<ScriptRepoUpdater>
                     var newRepoJsonContent = await File.ReadAllTextAsync(newRepoJsonPath);
                     var updatedContent = AddUpdateMarkersToNewRepo(oldRepoJsonContent, newRepoJsonContent);
 
-                    // 保存到同级目录，而不是覆盖原文件
+                    // 保存到同级目录
                     var parentDir = Path.GetDirectoryName(repoPath);
                     var updatedRepoJsonPath = Path.Combine(parentDir!, "repo_updated.json");
                     
@@ -272,7 +271,7 @@ public class ScriptRepoUpdater : Singleton<ScriptRepoUpdater>
     /// <summary>
     /// 直接在新版节点上标记更新
     /// </summary>
-    /// <param name="newNode">新版节点（会被直接修改）</param>
+    /// <param name="newNode">新版节点</param>
     /// <param name="oldNodes">老版节点数组</param>
     /// <returns>是否有更新（节点本身或子树）</returns>
     private bool MarkNodeUpdates(JObject newNode, JArray oldNodes)
@@ -302,7 +301,6 @@ public class ScriptRepoUpdater : Singleton<ScriptRepoUpdater>
         }
         else
         {
-            // 新增节点
             newNode["hasUpdate"] = true;
             hasDirectUpdate = true;
         }

--- a/BetterGenshinImpact/Core/Script/WebView/RepoWebBridge.cs
+++ b/BetterGenshinImpact/Core/Script/WebView/RepoWebBridge.cs
@@ -1,46 +1,42 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Security.Policy;
 using System.Threading.Tasks;
 using BetterGenshinImpact.ViewModel.Message;
 using CommunityToolkit.Mvvm.Messaging;
-using Wpf.Ui.Violeta.Controls;
+using Newtonsoft.Json.Linq;
 
 namespace BetterGenshinImpact.Core.Script.WebView;
 
-/// <summary>
-/// 给 WebView 提供的桥接类
-/// 用于调用 C# 方法
-/// </summary>
 [ClassInterface(ClassInterfaceType.AutoDual)]
 [ComVisible(true)]
-public class RepoWebBridge
+public sealed class RepoWebBridge
 {
+    private static readonly HashSet<string> AllowedTextExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".txt", ".md", ".json", ".js", ".ts",
+        ".vue", ".css", ".html", ".csv", ".xml",
+        ".yaml", ".yml", ".ini", ".config"
+    };
+
     public async Task<string> GetRepoJson()
     {
         try
         {
             if (!Directory.Exists(ScriptRepoUpdater.CenterRepoPath))
             {
-                throw new Exception("仓库文件夹不存在，请至少成功更新一次仓库！");
+                throw new InvalidOperationException("仓库文件夹不存在，请至少成功更新一次仓库！");
             }
 
-            var localRepoJsonPath = Directory
-                .GetFiles(ScriptRepoUpdater.CenterRepoPath, "repo.json", SearchOption.AllDirectories).FirstOrDefault();
-            if (localRepoJsonPath is null)
-            {
-                throw new Exception("repo.json 仓库索引文件不存在，请至少成功更新一次仓库！");
-            }
-
-            var json = await File.ReadAllTextAsync(localRepoJsonPath);
-            return json;
+            string localRepoJsonPath = GetRepoJsonPath();
+            return await File.ReadAllTextAsync(localRepoJsonPath);
         }
-        catch (Exception e)
+        catch (Exception ex)
         {
-            await MessageBox.ShowAsync(e.Message, "获取仓库信息失败");
-            return "";
+            await MessageBox.ShowAsync(ex.Message, "获取仓库信息失败");
+            return string.Empty;
         }
     }
 
@@ -59,21 +55,15 @@ public class RepoWebBridge
 
     public async Task<string> GetUserConfigJson()
     {
-        try
+        string userConfigPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "User", "config.json");
+        
+        if (!File.Exists(userConfigPath))
         {
-            string userConfigPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "User", "config.json");
-            if (!File.Exists(userConfigPath))
-            {
-                throw new Exception("用户配置文件不存在: " + userConfigPath);
-            }
+            await MessageBox.ShowAsync($"用户配置文件不存在: {userConfigPath}", "获取用户配置失败");
+            return string.Empty;
+        }
 
-            return await File.ReadAllTextAsync(userConfigPath);
-        }
-        catch (Exception e)
-        {
-            await MessageBox.ShowAsync(e.Message, "获取用户配置失败");
-            return "";
-        }
+        return await File.ReadAllTextAsync(userConfigPath);
     }
 
     public async Task<string> GetFile(string relPath)
@@ -81,31 +71,134 @@ public class RepoWebBridge
         try
         {
             string filePath = Path.Combine(ScriptRepoUpdater.CenterRepoPath, "repo", relPath)
-                .Replace('/', Path.DirectorySeparatorChar);
-        
+                .Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+
             if (!File.Exists(filePath))
-                return "404";
-
-            // 允许返回内容的文本文件扩展名
-            string[] allowedTextExtensions = { 
-                ".txt", ".md", ".json", ".js", ".ts", 
-                ".vue", ".css", ".html", ".csv", ".xml",
-                ".yaml", ".yml", ".ini", ".config"
-            };
-
-            string ext = Path.GetExtension(filePath).ToLower();
-            
-            if (allowedTextExtensions.Contains(ext))
             {
-                return await File.ReadAllTextAsync(filePath);
+                return "404";
             }
 
-            // 其他所有文件类型返回404
-            return "404";
+            string extension = Path.GetExtension(filePath);
+            return AllowedTextExtensions.Contains(extension) 
+                ? await File.ReadAllTextAsync(filePath) 
+                : "404";
         }
         catch
         {
             return "404";
+        }
+    }
+
+    public async Task<bool> UpdateSubscribed(string path)
+    {
+        try
+        {
+            if (!Directory.Exists(ScriptRepoUpdater.CenterRepoPath))
+            {
+                throw new InvalidOperationException("仓库文件夹不存在，请至少成功更新一次仓库！");
+            }
+
+            string localRepoJsonPath = GetRepoJsonPath();
+            string json = await File.ReadAllTextAsync(localRepoJsonPath);
+            
+            var jsonObj = Newtonsoft.Json.JsonConvert.DeserializeObject<JObject>(json);
+            if (jsonObj?["indexes"] is not JArray indexes) return false;
+
+            string[] pathParts = path.Split('/');
+            ProcessPathRecursively(indexes, pathParts, 0);
+            
+            string modifiedJson = Newtonsoft.Json.JsonConvert.SerializeObject(jsonObj, Newtonsoft.Json.Formatting.Indented);
+            await File.WriteAllTextAsync(localRepoJsonPath, modifiedJson);
+            
+            return true;
+        }
+        catch (Exception ex)
+        {
+            await MessageBox.ShowAsync(ex.Message, "信息更新失败");
+            return false;
+        }
+    }
+    
+    public async Task<bool> ClearUpdate()
+    {
+        try
+        {
+            string? repoJsonPath = Directory
+                .GetFiles(ScriptRepoUpdater.CenterRepoPath, "repo.json", SearchOption.AllDirectories)
+                .FirstOrDefault();
+
+            if (string.IsNullOrEmpty(repoJsonPath))
+            {
+                throw new FileNotFoundException("找不到原始 repo.json 文件");
+            }
+
+            string repoDir = Path.GetDirectoryName(repoJsonPath) ?? 
+                             throw new DirectoryNotFoundException("无法确定仓库目录");
+            
+            string targetPath = Path.Combine(repoDir, "repo_updated.json");
+
+            File.Copy(repoJsonPath, targetPath, overwrite: true);
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            await MessageBox.ShowAsync($"清空更新标记失败: {ex.Message}", "操作失败");
+            return false;
+        }
+    }
+
+    private static string GetRepoJsonPath()
+    {
+        string updatedRepoJsonPath = Path.Combine(
+            Path.GetDirectoryName(Path.Combine(ScriptRepoUpdater.ReposPath, "bettergi-scripts-list-git"))!,
+            "repo_updated.json"
+        );
+
+        if (File.Exists(updatedRepoJsonPath))
+        {
+            return updatedRepoJsonPath;
+        }
+
+        string? repoJson = Directory
+            .GetFiles(ScriptRepoUpdater.CenterRepoPath, "repo.json", SearchOption.AllDirectories)
+            .FirstOrDefault();
+
+        return repoJson ?? throw new FileNotFoundException("repo.json 仓库索引文件不存在，请至少成功更新一次仓库！");
+    }
+
+    private static void ProcessPathRecursively(JArray array, string[] pathParts, int currentIndex)
+    {
+        foreach (JObject item in array.OfType<JObject>())
+        {
+            if (item["name"]?.ToString() != pathParts[currentIndex]) continue;
+            
+            if (currentIndex == pathParts.Length - 1)
+            {
+                ResetHasUpdateFlag(item);
+            }
+            else if (item["children"] is JArray children)
+            {
+                ProcessPathRecursively(children, pathParts, currentIndex + 1);
+            }
+            break;
+        }
+    }
+
+    private static void ResetHasUpdateFlag(JObject node)
+    {
+        if (node["hasUpdate"] is { Type: JTokenType.Boolean } hasUpdate && 
+            (bool)hasUpdate)
+        {
+            node["hasUpdate"] = false;
+        }
+        
+        if (node["children"] is JArray children)
+        {
+            foreach (JObject child in children.OfType<JObject>())
+            {
+                ResetHasUpdateFlag(child);
+            }
         }
     }
 }

--- a/BetterGenshinImpact/Core/Script/WebView/RepoWebBridge.cs
+++ b/BetterGenshinImpact/Core/Script/WebView/RepoWebBridge.cs
@@ -132,10 +132,7 @@ public sealed class RepoWebBridge
                 throw new FileNotFoundException("找不到原始 repo.json 文件");
             }
 
-            string repoDir = Path.GetDirectoryName(repoJsonPath) ?? 
-                             throw new DirectoryNotFoundException("无法确定仓库目录");
-            
-            string targetPath = Path.Combine(repoDir, "repo_updated.json");
+            string targetPath = Path.Combine(ScriptRepoUpdater.ReposPath, "repo_updated.json");
 
             File.Copy(repoJsonPath, targetPath, overwrite: true);
 


### PR DESCRIPTION
点击更新仓库后会将新的repo.json与旧版比较，有更新的部分将会添加一个新的hasUpdate=true的属性，随后将带有更新提示的repo_update.json添加到Repos路径下（放置在原处会引起git校验失败）
桥接方法新增UpdateSubscribed与ClearUpdate，能够提供单个有更新节点的“去红点”与覆盖式的全部清除