### PR TITLE
小优化及新增脚本仓库桥接支持

### DIFF
--- a/BetterGenshinImpact/Core/Script/WebView/RepoWebBridge.cs
+++ b/BetterGenshinImpact/Core/Script/WebView/RepoWebBridge.cs
@@ -10,6 +10,10 @@ using Newtonsoft.Json.Linq;
 
 namespace BetterGenshinImpact.Core.Script.WebView;
 
+/// <summary>
+/// 给 WebView 提供的桥接类
+/// 用于调用 C# 方法
+/// </summary>
 [ClassInterface(ClassInterfaceType.AutoDual)]
 [ComVisible(true)]
 public sealed class RepoWebBridge

--- a/BetterGenshinImpact/Core/Script/WebView/RepoWebBridge.cs
+++ b/BetterGenshinImpact/Core/Script/WebView/RepoWebBridge.cs
@@ -1,46 +1,42 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Security.Policy;
 using System.Threading.Tasks;
 using BetterGenshinImpact.ViewModel.Message;
 using CommunityToolkit.Mvvm.Messaging;
-using Wpf.Ui.Violeta.Controls;
+using Newtonsoft.Json.Linq;
 
 namespace BetterGenshinImpact.Core.Script.WebView;
 
-/// <summary>
-/// 给 WebView 提供的桥接类
-/// 用于调用 C# 方法
-/// </summary>
 [ClassInterface(ClassInterfaceType.AutoDual)]
 [ComVisible(true)]
-public class RepoWebBridge
+public sealed class RepoWebBridge
 {
+    private static readonly HashSet<string> AllowedTextExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".txt", ".md", ".json", ".js", ".ts",
+        ".vue", ".css", ".html", ".csv", ".xml",
+        ".yaml", ".yml", ".ini", ".config"
+    };
+
     public async Task<string> GetRepoJson()
     {
         try
         {
             if (!Directory.Exists(ScriptRepoUpdater.CenterRepoPath))
             {
-                throw new Exception("仓库文件夹不存在，请至少成功更新一次仓库！");
+                throw new InvalidOperationException("仓库文件夹不存在，请至少成功更新一次仓库！");
             }
 
-            var localRepoJsonPath = Directory
-                .GetFiles(ScriptRepoUpdater.CenterRepoPath, "repo.json", SearchOption.AllDirectories).FirstOrDefault();
-            if (localRepoJsonPath is null)
-            {
-                throw new Exception("repo.json 仓库索引文件不存在，请至少成功更新一次仓库！");
-            }
-
-            var json = await File.ReadAllTextAsync(localRepoJsonPath);
-            return json;
+            string localRepoJsonPath = GetRepoJsonPath();
+            return await File.ReadAllTextAsync(localRepoJsonPath);
         }
-        catch (Exception e)
+        catch (Exception ex)
         {
-            await MessageBox.ShowAsync(e.Message, "获取仓库信息失败");
-            return "";
+            await MessageBox.ShowAsync(ex.Message, "获取仓库信息失败");
+            return string.Empty;
         }
     }
 
@@ -59,21 +55,15 @@ public class RepoWebBridge
 
     public async Task<string> GetUserConfigJson()
     {
-        try
+        string userConfigPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "User", "config.json");
+        
+        if (!File.Exists(userConfigPath))
         {
-            string userConfigPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "User", "config.json");
-            if (!File.Exists(userConfigPath))
-            {
-                throw new Exception("用户配置文件不存在: " + userConfigPath);
-            }
+            await MessageBox.ShowAsync($"用户配置文件不存在: {userConfigPath}", "获取用户配置失败");
+            return string.Empty;
+        }
 
-            return await File.ReadAllTextAsync(userConfigPath);
-        }
-        catch (Exception e)
-        {
-            await MessageBox.ShowAsync(e.Message, "获取用户配置失败");
-            return "";
-        }
+        return await File.ReadAllTextAsync(userConfigPath);
     }
 
     public async Task<string> GetFile(string relPath)
@@ -81,31 +71,131 @@ public class RepoWebBridge
         try
         {
             string filePath = Path.Combine(ScriptRepoUpdater.CenterRepoPath, "repo", relPath)
-                .Replace('/', Path.DirectorySeparatorChar);
-        
+                .Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+
             if (!File.Exists(filePath))
-                return "404";
-
-            // 允许返回内容的文本文件扩展名
-            string[] allowedTextExtensions = { 
-                ".txt", ".md", ".json", ".js", ".ts", 
-                ".vue", ".css", ".html", ".csv", ".xml",
-                ".yaml", ".yml", ".ini", ".config"
-            };
-
-            string ext = Path.GetExtension(filePath).ToLower();
-            
-            if (allowedTextExtensions.Contains(ext))
             {
-                return await File.ReadAllTextAsync(filePath);
+                return "404";
             }
 
-            // 其他所有文件类型返回404
-            return "404";
+            string extension = Path.GetExtension(filePath);
+            return AllowedTextExtensions.Contains(extension) 
+                ? await File.ReadAllTextAsync(filePath) 
+                : "404";
         }
         catch
         {
             return "404";
+        }
+    }
+
+    public async Task<bool> UpdateSubscribed(string path)
+    {
+        try
+        {
+            if (!Directory.Exists(ScriptRepoUpdater.CenterRepoPath))
+            {
+                throw new InvalidOperationException("仓库文件夹不存在，请至少成功更新一次仓库！");
+            }
+
+            string localRepoJsonPath = GetRepoJsonPath();
+            string json = await File.ReadAllTextAsync(localRepoJsonPath);
+            
+            var jsonObj = Newtonsoft.Json.JsonConvert.DeserializeObject<JObject>(json);
+            if (jsonObj?["indexes"] is not JArray indexes) return false;
+
+            string[] pathParts = path.Split('/');
+            ProcessPathRecursively(indexes, pathParts, 0);
+            
+            string modifiedJson = Newtonsoft.Json.JsonConvert.SerializeObject(jsonObj, Newtonsoft.Json.Formatting.Indented);
+            await File.WriteAllTextAsync(localRepoJsonPath, modifiedJson);
+            
+            return true;
+        }
+        catch (Exception ex)
+        {
+            await MessageBox.ShowAsync(ex.Message, "信息更新失败");
+            return false;
+        }
+    }
+    
+    public async Task<bool> ClearUpdate()
+    {
+        try
+        {
+            string? repoJsonPath = Directory
+                .GetFiles(ScriptRepoUpdater.CenterRepoPath, "repo.json", SearchOption.AllDirectories)
+                .FirstOrDefault();
+
+            if (string.IsNullOrEmpty(repoJsonPath))
+            {
+                throw new FileNotFoundException("找不到原始 repo.json 文件");
+            }
+
+            string targetPath = Path.Combine(ScriptRepoUpdater.ReposPath, "repo_updated.json");
+
+            File.Copy(repoJsonPath, targetPath, overwrite: true);
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            await MessageBox.ShowAsync($"清空更新标记失败: {ex.Message}", "操作失败");
+            return false;
+        }
+    }
+
+    private static string GetRepoJsonPath()
+    {
+        string updatedRepoJsonPath = Path.Combine(
+            Path.GetDirectoryName(Path.Combine(ScriptRepoUpdater.ReposPath, "bettergi-scripts-list-git"))!,
+            "repo_updated.json"
+        );
+
+        if (File.Exists(updatedRepoJsonPath))
+        {
+            return updatedRepoJsonPath;
+        }
+
+        string? repoJson = Directory
+            .GetFiles(ScriptRepoUpdater.CenterRepoPath, "repo.json", SearchOption.AllDirectories)
+            .FirstOrDefault();
+
+        return repoJson ?? throw new FileNotFoundException("repo.json 仓库索引文件不存在，请至少成功更新一次仓库！");
+    }
+
+    private static void ProcessPathRecursively(JArray array, string[] pathParts, int currentIndex)
+    {
+        foreach (JObject item in array.OfType<JObject>())
+        {
+            if (item["name"]?.ToString() != pathParts[currentIndex]) continue;
+            
+            if (currentIndex == pathParts.Length - 1)
+            {
+                ResetHasUpdateFlag(item);
+            }
+            else if (item["children"] is JArray children)
+            {
+                ProcessPathRecursively(children, pathParts, currentIndex + 1);
+            }
+            break;
+        }
+    }
+
+    private static void ResetHasUpdateFlag(JObject node)
+    {
+        if (node["hasUpdate"] is { Type: JTokenType.Boolean } hasUpdate && 
+            (bool)hasUpdate)
+        {
+            node["hasUpdate"] = false;
+        }
+        
+        if (node["children"] is JArray children)
+        {
+            foreach (JObject child in children.OfType<JObject>())
+            {
+                ResetHasUpdateFlag(child);
+            }
         }
     }
 }

--- a/BetterGenshinImpact/GameTask/Common/Job/ExitAndReloginJob.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/ExitAndReloginJob.cs
@@ -82,7 +82,7 @@ public class ExitAndReloginJob
                 _assets.EnterGameRo,
                 () => GameCaptureRegion.GameRegion1080PPosClick(955, 666),
                 ct,
-                10,
+                120,
                 1000
             );
         }
@@ -111,4 +111,3 @@ public class ExitAndReloginJob
         await Delay(500, ct);
     }
 }
-

--- a/BetterGenshinImpact/View/Windows/PromptDialog.xaml.cs
+++ b/BetterGenshinImpact/View/Windows/PromptDialog.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System.Windows;
+using System.Windows;
 using System.Windows.Controls;
 
 namespace BetterGenshinImpact.View.Windows;
@@ -76,14 +76,14 @@ public partial class PromptDialog
     {
         var inst = new PromptDialog(question, title, new TextBox(), defaultValue, config);
         inst.ShowDialog();
-        return inst.DialogResult == true ? inst.ResponseText : defaultValue;
+        return inst.DialogResult == true ? inst.ResponseText : "";
     }
 
     public static string Prompt(string question, string title, UIElement uiElement, string defaultValue = "", PromptDialogConfig? config = null)
     {
         var inst = new PromptDialog(question, title, uiElement, defaultValue, config);
         inst.ShowDialog();
-        return inst.DialogResult == true ? inst.ResponseText : defaultValue;
+        return inst.DialogResult == true ? inst.ResponseText : "";
     }
 
     public static string Prompt(string question, string title, UIElement uiElement, Size size, PromptDialogConfig? config = null)

--- a/BetterGenshinImpact/ViewModel/Pages/ScriptControlViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/ScriptControlViewModel.cs
@@ -83,7 +83,16 @@ public partial class ScriptControlViewModel : ViewModel
     [RelayCommand]
     private void OnAddScriptGroup()
     {
-        var str = PromptDialog.Prompt("请输入配置组名称", "新增配置组");
+        var localizationService = App.GetService<ILocalizationService>();
+
+        // 创建一个TextBox并设置自动聚焦
+        var textBox = new System.Windows.Controls.TextBox();
+        textBox.Loaded += (sender, e) =>
+        {
+            textBox.Focus();
+            textBox.SelectAll();
+        };
+        var str = PromptDialog.Prompt(localizationService.GetString("dialog.enterConfigGroupName"), localizationService.GetString("dialog.addConfigGroup"), textBox);
         if (!string.IsNullOrEmpty(str))
         {
             // 检查是否已存在
@@ -596,7 +605,14 @@ public partial class ScriptControlViewModel : ViewModel
             return;
         }
 
-        var str = PromptDialog.Prompt("请输入配置组名称", "复制配置组", item.Name);
+        var textBox = new System.Windows.Controls.TextBox();
+        textBox.Loaded += (sender, e) =>
+        {
+            textBox.Focus();
+            textBox.SelectAll();
+        };
+
+        var str = PromptDialog.Prompt("请输入配置组名称", "复制配置组", textBox, item.Name);
         if (!string.IsNullOrEmpty(str))
         {
             // 检查是否已存在
@@ -632,7 +648,14 @@ public partial class ScriptControlViewModel : ViewModel
             return;
         }
 
-        var str = PromptDialog.Prompt("请输入配置组名称", "重命名配置组", item.Name);
+        var textBox = new System.Windows.Controls.TextBox();
+        textBox.Loaded += (sender, e) =>
+        {
+            textBox.Focus();
+            textBox.SelectAll();
+        };
+
+        var str = PromptDialog.Prompt("请输入配置组名称", "重命名配置组", textBox, item.Name);
         if (!string.IsNullOrEmpty(str))
         {
             if (item.Name == str)

--- a/BetterGenshinImpact/ViewModel/Pages/ScriptControlViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/ScriptControlViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
@@ -83,8 +83,6 @@ public partial class ScriptControlViewModel : ViewModel
     [RelayCommand]
     private void OnAddScriptGroup()
     {
-        var localizationService = App.GetService<ILocalizationService>();
-
         // 创建一个TextBox并设置自动聚焦
         var textBox = new System.Windows.Controls.TextBox();
         textBox.Loaded += (sender, e) =>
@@ -92,7 +90,7 @@ public partial class ScriptControlViewModel : ViewModel
             textBox.Focus();
             textBox.SelectAll();
         };
-        var str = PromptDialog.Prompt(localizationService.GetString("dialog.enterConfigGroupName"), localizationService.GetString("dialog.addConfigGroup"), textBox);
+        var str = PromptDialog.Prompt("请输入配置组名称", "新增配置组", textBox);
         if (!string.IsNullOrEmpty(str))
         {
             // 检查是否已存在


### PR DESCRIPTION
1、添加了一些文本框自动聚焦
2、修复调度器复制组点击取消后会有异常返回
3、点击更新仓库后会将新的repo.json与旧版比较，有更新的部分将会添加一个新的hasUpdate=true的属性，随后将带有更新提示的repo_update.json添加到Repos路径下（放置在原处会引起git校验失败）
4、桥接方法新增UpdateSubscribed与ClearUpdate，能够提供单个有更新节点的“去红点”与覆盖式的全部清除，后者采用将repo.json覆盖repo_update.json的方式