### PR TITLE
添加新角色临时假装识别功能

### DIFF
--- a/BetterGenshinImpact/Core/Config/OtherConfig.cs
+++ b/BetterGenshinImpact/Core/Config/OtherConfig.cs
@@ -22,8 +22,39 @@ public partial class OtherConfig : ObservableObject
     
     [ObservableProperty]
     private Miyoushe _miyousheConfig = new();
-    
 
+    // 自定义角色配置
+    [ObservableProperty]
+    private CustomAvatarConfig _customAvatarConfigOut = new CustomAvatarConfig();
+    
+    public partial class CustomAvatarConfig : ObservableObject
+    {
+        //自定义角色开关
+        public  bool CustomAvatarEnabled { set; get; } = false;
+        
+        // 自定义角色1名称,初始化用于举例
+        public string CustomAvatar1Name { get; set; } = "申鹤";
+        public string CustomAvatar1Name2 { get; set; } = "甘雨";
+        public string CustomAvatar1Name3 { get; set; } = "芭芭拉";
+    
+        // 自定义角色1假装名称
+        public string CustomAvatar1DisplayName { get; set; } = "琴";
+    
+        // 自定义角色2名称
+        public string CustomAvatar2Name { get; set; } = "凯亚";
+        public string CustomAvatar2Name2 { get; set; } = string.Empty;
+        public string CustomAvatar2Name3 { get; set; } = string.Empty;
+    
+        // 自定义角色2假装名称
+        public string CustomAvatar2DisplayName { get; set; } = "夜兰";
+    
+        // 自定义置信度1
+        public double CustomAvatar1Confidence { get; set; } = 0.7;
+    
+        // 自定义置信度2
+        public double CustomAvatar2Confidence { get; set; } = 0.7;
+    }
+    
     public partial class AutoRestart : ObservableObject
     {
         [ObservableProperty]

--- a/BetterGenshinImpact/GameTask/AutoFight/Config/DefaultAutoFightConfig.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Config/DefaultAutoFightConfig.cs
@@ -37,4 +37,22 @@ public class DefaultAutoFightConfig
 
         // return CombatAvatars.Find(x => x.Alias.Contains(alias))?.Name ?? throw new Exception($"角色名称校验失败：{alias}");
     }
+    
+    // //添加自定义角色-假装识别够用了，后续再考虑
+    // public static void AddCombatAvatar(CombatAvatar newAvatar)
+    // {
+    //     // 读取现有的 JSON 文件内容
+    //     var json = File.ReadAllText(Global.Absolute(@"GameTask\AutoFight\Assets\combat_avatar.json"));
+    //     var combatAvatars = Newtonsoft.Json.JsonConvert.DeserializeObject<List<CombatAvatar>>(json) ?? new List<CombatAvatar>();
+    //
+    //     // 添加新角色
+    //     combatAvatars.Add(newAvatar);
+    //
+    //     // 将更新后的角色列表序列化回 JSON 格式
+    //     var updatedJson = Newtonsoft.Json.JsonConvert.SerializeObject(combatAvatars, Newtonsoft.Json.Formatting.Indented);
+    //
+    //     // 将更新后的 JSON 写回到文件
+    //     File.WriteAllText(Global.Absolute(@"GameTask\AutoFight\Assets\combat_avatar.json"), updatedJson);
+    // }
+    
 }

--- a/BetterGenshinImpact/View/Pages/CommonSettingsPage.xaml
+++ b/BetterGenshinImpact/View/Pages/CommonSettingsPage.xaml
@@ -739,7 +739,7 @@
                 </Grid>
             </StackPanel>
         </ui:CardExpander>
-
+        
         <!--回血相关设置-->
         <ui:CardExpander Margin="0,0,0,12" ContentPadding="0">
             <ui:CardExpander.Icon>
@@ -876,38 +876,39 @@
                 </Grid>
             </StackPanel>
         </ui:CardExpander>
-        <!-- 新增手动导入本地脚本仓库功能 -->
-        <ui:CardControl Margin="0,0,0,12" Icon="{ui:SymbolIcon Folder24}">
-            <ui:CardControl.Header>
-                <Grid>
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                    </Grid.RowDefinitions>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*" />
-                        <ColumnDefinition Width="Auto" />
-                    </Grid.ColumnDefinitions>
-                    <ui:TextBlock Grid.Row="0"
-                                  Grid.Column="0"
-                                  FontTypography="Body"
-                                  Text="手动导入本地脚本仓库（zip格式）"
-                                  TextWrapping="Wrap" />
-                    <ui:TextBlock Grid.Row="1"
-                                  Grid.Column="0"
-                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
-                                  Text="脚本仓库无法在线更新时使用"
-                                  TextWrapping="Wrap" />
-                    <ui:Button Grid.Row="0"
-                               Grid.RowSpan="2"
-                               Grid.Column="1"
-                               Margin="0,0,36,0"
-                               Command="{Binding ImportLocalScriptsRepoZipCommand}"
-                               Content="导入" />
-                </Grid>
-
-            </ui:CardControl.Header>
-        </ui:CardControl>
+        
+        <!-- ~1~ 新增手动导入本地脚本仓库功能 @1@ --> 
+        <!-- <ui:CardControl Margin="0,0,0,12" Icon="{ui:SymbolIcon Folder24}"> -->
+        <!--     <ui:CardControl.Header> -->
+        <!--         <Grid> -->
+        <!--             <Grid.RowDefinitions> -->
+        <!--                 <RowDefinition Height="Auto" /> -->
+        <!--                 <RowDefinition Height="Auto" /> -->
+        <!--             </Grid.RowDefinitions> -->
+        <!--             <Grid.ColumnDefinitions> -->
+        <!--                 <ColumnDefinition Width="*" /> -->
+        <!--                 <ColumnDefinition Width="Auto" /> -->
+        <!--             </Grid.ColumnDefinitions> -->
+        <!--             <ui:TextBlock Grid.Row="0" -->
+        <!--                           Grid.Column="0" -->
+        <!--                           FontTypography="Body" -->
+        <!--                           Text="手动导入本地脚本仓库（zip格式）" -->
+        <!--                           TextWrapping="Wrap" /> -->
+        <!--             <ui:TextBlock Grid.Row="1" -->
+        <!--                           Grid.Column="0" -->
+        <!--                           Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}" -->
+        <!--                           Text="脚本仓库无法在线更新时使用" -->
+        <!--                           TextWrapping="Wrap" /> -->
+        <!--             <ui:Button Grid.Row="0" -->
+        <!--                        Grid.RowSpan="2" -->
+        <!--                        Grid.Column="1" -->
+        <!--                        Margin="0,0,36,0" -->
+        <!--                        Command="{Binding ImportLocalScriptsRepoZipCommand}" -->
+        <!--                        Content="导入" /> -->
+        <!--         </Grid> -->
+        <!-- -->
+        <!--     </ui:CardControl.Header> -->
+        <!-- </ui:CardControl> -->
 
 
         <!--  其他设置  -->
@@ -1373,6 +1374,218 @@
                         </StackPanel>
                     </StackPanel>
                 </ui:CardExpander>
+                
+                 <!--  假装识别相关设置  -->
+        <ui:CardExpander Margin="0,0,0,12" ContentPadding="0">
+            <ui:CardExpander.Icon>
+                <ui:FontIcon Glyph="&#xe533;" Style="{StaticResource FaFontIconStyle}" />
+            </ui:CardExpander.Icon>
+            <ui:CardExpander.Header>
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <ui:TextBlock Grid.Row="0"
+                                  Grid.Column="0"
+                                  FontTypography="Body"
+                                  Text="队伍角色假装识别设置"
+                                  TextWrapping="Wrap" />
+                    <ui:TextBlock Grid.Row="1"
+                                  Grid.Column="0"
+                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                  Text="在新角色实装后，新BGI版本发布前，临时用于识别队伍角色的设置"
+                                  TextWrapping="Wrap" />
+                </Grid>
+            </ui:CardExpander.Header>
+            <StackPanel>
+                <Grid Margin="16">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <ui:TextBlock Grid.Row="0"
+                                  Grid.Column="0"
+                                  FontTypography="Body"
+                                  Text="开启队伍角色假装识别功能"
+                                  TextWrapping="Wrap" />
+                    <ui:TextBlock Grid.Row="1"
+                                  Grid.Column="0"
+                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                  Text="注意本功能仅用于临时使用，请多次尝试设置，以确保识别准确"
+                                  TextWrapping="Wrap" />
+                    <ui:ToggleSwitch Grid.Row="0"
+                                     Grid.RowSpan="2"
+                                     Grid.Column="1"
+                                     Margin="0,0,36,0"
+                                     IsChecked="{Binding Config.OtherConfig.CustomAvatarConfigOut.CustomAvatarEnabled, Mode=TwoWay}" />
+                </Grid>
+                
+                <StackPanel>
+                    <Grid Margin="16,-15,16,16">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <ui:TextBlock Grid.Row="0"
+                                      Grid.Column="0"
+                                      Grid.ColumnSpan="7"
+                                      Margin="0,0,10,10"
+                                      FontTypography="Body"
+                                      Text="新角色可能识别成的角色(可填3个)，填写完整角色名称 (运行自动战斗可以查看)"
+                                      TextWrapping="Wrap" />
+                        <ui:TextBlock Grid.Row="1"
+                                      Grid.Column="0"
+                                      Grid.ColumnSpan="7"
+                                      Margin="0,0,25,10"
+                                      FontTypography="Body"
+                                      Text="请固定新角色在队伍中的位置(建议4号位），地图追踪时不要用作行走位，置信度可填0至1，越高越容易识别为指定角色(填老角色)，识别不到请逐步提高置信度。"
+                                      TextWrapping="Wrap" />
+                        <ui:TextBox Grid.Row="2"
+                                    Grid.Column="0"
+                                    MinWidth="80"
+                                    HorizontalAlignment="Left"
+                                    HorizontalContentAlignment="Center"
+                                    Margin="0,0,10,0"
+                                    Text="{Binding Config.OtherConfig.CustomAvatarConfigOut.CustomAvatar1Name, Mode=TwoWay, ValidatesOnNotifyDataErrors=True}" />
+                        <ui:TextBox Grid.Row="2"
+                                    Grid.Column="1"
+                                    MinWidth="80"
+                                    HorizontalAlignment="Left"
+                                    HorizontalContentAlignment="Center"
+                                    Margin="0,0,10,0"
+                                    Text="{Binding Config.OtherConfig.CustomAvatarConfigOut.CustomAvatar1Name2, Mode=TwoWay, ValidatesOnNotifyDataErrors=True}" />
+                        <ui:TextBox Grid.Row="2"
+                                    Grid.Column="2"
+                                    MinWidth="80"
+                                    HorizontalAlignment="Left"
+                                    HorizontalContentAlignment="Center"
+                                    Margin="0,0,10,0"
+                                    Text="{Binding Config.OtherConfig.CustomAvatarConfigOut.CustomAvatar1Name3, Mode=TwoWay, ValidatesOnNotifyDataErrors=True}" />
+                        <ui:TextBlock Grid.Row="2"
+                                      Grid.Column="3"
+                                      VerticalAlignment="Center"
+                                      HorizontalAlignment="Center"
+                                      Margin="0,0,5,0"
+                                      FontTypography="Body"
+                                      Text="置信度低于："
+                                      TextWrapping="Wrap" />
+                        <ui:TextBox Grid.Row="2"
+                                    Grid.Column="4"
+                                    MinWidth="70"
+                                    HorizontalAlignment="Left"
+                                    HorizontalContentAlignment="Center"
+                                    Margin="0,0,10,0"
+                                    Text="{Binding Config.OtherConfig.CustomAvatarConfigOut.CustomAvatar1Confidence, Mode=TwoWay, ValidatesOnNotifyDataErrors=True}" />
+                        <ui:TextBlock Grid.Row="2"
+                                      Grid.Column="5"
+                                      VerticalAlignment="Center"
+                                      HorizontalAlignment="Center"
+                                      Margin="0,0,5,0"
+                                      FontTypography="Body"
+                                      Text="识别为："
+                                      TextWrapping="Wrap" />
+                        <ui:TextBox Grid.Row="2"
+                                    Grid.Column="6"
+                                    MinWidth="80"
+                                    HorizontalAlignment="Left"
+                                    HorizontalContentAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    Margin="0,0,10,0"
+                                    Text="{Binding Config.OtherConfig.CustomAvatarConfigOut.CustomAvatar1DisplayName, Mode=TwoWay, ValidatesOnNotifyDataErrors=True}" />
+                        
+                    </Grid>
+                    
+                    <Grid Margin="16,0,16,16">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <ui:TextBox Grid.Row="1"
+                                    Grid.Column="0"
+                                    MinWidth="80"
+                                    HorizontalAlignment="Left"
+                                    HorizontalContentAlignment="Center"
+                                    Margin="0,0,10,0"
+                                    Text="{Binding Config.OtherConfig.CustomAvatarConfigOut.CustomAvatar2Name, Mode=TwoWay, ValidatesOnNotifyDataErrors=True}" />
+                        <ui:TextBox Grid.Row="1"
+                                    Grid.Column="1"
+                                    MinWidth="80"
+                                    HorizontalAlignment="Left"
+                                    HorizontalContentAlignment="Center"
+                                    Margin="0,0,10,0"
+                                    Text="{Binding Config.OtherConfig.CustomAvatarConfigOut.CustomAvatar2Name2, Mode=TwoWay, ValidatesOnNotifyDataErrors=True}" />
+                        <ui:TextBox Grid.Row="1"
+                                    Grid.Column="2"
+                                    MinWidth="80"
+                                    HorizontalAlignment="Left"
+                                    HorizontalContentAlignment="Center"
+                                    Margin="0,0,10,0"
+                                    Text="{Binding Config.OtherConfig.CustomAvatarConfigOut.CustomAvatar2Name3, Mode=TwoWay, ValidatesOnNotifyDataErrors=True}" />
+                        <ui:TextBlock Grid.Row="1"
+                                      Grid.Column="3"
+                                      VerticalAlignment="Center"
+                                      HorizontalAlignment="Center"
+                                      Margin="0,0,5,0"
+                                      FontTypography="Body"
+                                      Text="置信度低于："
+                                      TextWrapping="Wrap" />
+                        <ui:TextBox Grid.Row="1"
+                                    Grid.Column="4"
+                                    MinWidth="70"
+                                    HorizontalAlignment="Left"
+                                    HorizontalContentAlignment="Center"
+                                    Margin="0,0,10,0"
+                                    Text="{Binding Config.OtherConfig.CustomAvatarConfigOut.CustomAvatar2Confidence, Mode=TwoWay, ValidatesOnNotifyDataErrors=True}" />
+                        <ui:TextBlock Grid.Row="1"
+                                      Grid.Column="5"
+                                      VerticalAlignment="Center"
+                                      HorizontalAlignment="Center"
+                                      Margin="0,0,5,0"
+                                      FontTypography="Body"
+                                      Text="识别为："
+                                      TextWrapping="Wrap" />
+                        <ui:TextBox Grid.Row="1"
+                                    Grid.Column="6"
+                                    MinWidth="80"
+                                    HorizontalAlignment="Left"
+                                    HorizontalContentAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    Margin="0,0,10,0"
+                                    Text="{Binding Config.OtherConfig.CustomAvatarConfigOut.CustomAvatar2DisplayName, Mode=TwoWay, ValidatesOnNotifyDataErrors=True}" />
+                        
+                    </Grid>
+                </StackPanel>
+            </StackPanel>
+        </ui:CardExpander>
+                
                 <!--米游社相关 -->
                                 <ui:CardExpander Margin="0,0,0,12"
                                  ContentPadding="0"


### PR DESCRIPTION
#1968
- 新增假装识别队伍角色功能。（默认关闭，在设置->其他设置，中进行启用）
  1、新角色实装后，可启用该功能，将把新角色临时识别成指定老角色，避免领取好感和锄地时报错退出。
  2、该功能为临时用，在新版BGI支持新角色后，请关闭。
- 手动导入仓库已经不可用，群里躁动的氨气让顺手注释掉。