### PR TITLE
增加JS保存文件支持

### DIFF
--- a/BetterGenshinImpact/Core/Script/Project/Manifest.cs
+++ b/BetterGenshinImpact/Core/Script/Project/Manifest.cs
@@ -1,4 +1,4 @@
-﻿using BetterGenshinImpact.Service;
+using BetterGenshinImpact.Service;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -23,6 +23,7 @@ public class Manifest
     public string SettingsUi { get; set; } = string.Empty;
     public string[] Scripts { get; set; } = [];
     public string[] Library { get; set; } = [];
+    public string[] SavedFiles { get; set; } = [];
 
     public static Manifest FromJson(string json)
     {


### PR DESCRIPTION
在JS脚本的manifest.json中添加saved_files字段（数组），可保存指定的文件（支持通配符与正则表达式）
示例：
<img width="279" height="155" alt="image" src="https://github.com/user-attachments/assets/2c84a4c5-b9dc-4d9f-93f1-2b8db7d8e58d" />
