### PR TITLE
CUDA路径嗅探默认关闭

### DIFF
--- a/BetterGenshinImpact/Core/Config/HardwareAccelerationConfig.cs
+++ b/BetterGenshinImpact/Core/Config/HardwareAccelerationConfig.cs
@@ -50,10 +50,10 @@ public partial class HardwareAccelerationConfig : ObservableObject
     private int _cudaDevice = 0;
 
     /// <summary>
-    /// 自动附加cuda的path。一般情况下用这个就足够了。默认开启。
+    /// 自动附加cuda的path。一般情况下用这个就足够了。默认关闭。
     /// </summary>
     [ObservableProperty]
-    private bool _autoAppendCudaPath = true;
+    private bool _autoAppendCudaPath = false;
 
     #endregion
 

--- a/BetterGenshinImpact/Core/Recognition/ONNX/BgiOnnxFactory.cs
+++ b/BetterGenshinImpact/Core/Recognition/ONNX/BgiOnnxFactory.cs
@@ -244,14 +244,32 @@ public class BgiOnnxFactory
             .Distinct()
 
             //确定路径是否真的存在
-            .Where(Directory.Exists)
+            .Where(d =>
+            {
+                try
+                {
+                    return Directory.Exists(d);
+                }
+                catch (Exception)
+                {
+                    return false;
+                }
+            })
             .SelectMany(s =>
                 //确定需要的文件是否存在
                 filePrefix.SelectMany(se =>
-                    Directory.GetFiles(s, $"{se}*.dll").Select(Path.GetDirectoryName).WhereNotNull()))
+                {
+                    try
+                    {
+                        return Directory.GetFiles(s, $"{se}*.dll").Select(Path.GetDirectoryName).WhereNotNull();
+                    }
+                    catch (Exception)
+                    {
+                        return [];
+                    }
+                }))
             //去重
             .Distinct();
-
         AppendPath(validPaths.ToArray());
     }
 
@@ -506,6 +524,7 @@ public class BgiOnnxFactory
                 result.Remove("trt_timing_cache_path");
             }
         }
+
         return result;
     }
 
@@ -521,11 +540,12 @@ public class BgiOnnxFactory
         };
         return result;
     }
-/// <summary>
-/// 
-/// </summary>
-/// <param name="cacheFolder"></param>
-/// <returns></returns>
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="cacheFolder"></param>
+    /// <returns></returns>
     private Dictionary<string, string> GetOpenVinoProviderConfig(string? cacheFolder)
     {
         var result = new Dictionary<string, string>();

--- a/BetterGenshinImpact/View/Pages/View/HardwareAccelerationView.xaml
+++ b/BetterGenshinImpact/View/Pages/View/HardwareAccelerationView.xaml
@@ -266,7 +266,7 @@
                         <ui:TextBlock Grid.Row="1"
                                       Grid.Column="0"
                                       Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
-                                      Text="自动添加系统CUDA环境路径 默认开启" />
+                                      Text="自动添加系统CUDA环境路径 默认关闭" />
                     </Grid>
                     <!--  _additionalPath  -->
                     <Separator Margin="-18,0" BorderThickness="0,1,0,0" />


### PR DESCRIPTION
有些PC在奇奇怪怪环境下嗅探PATH会导致异常
异常处理了
默认这个功能关闭，小白一般也用不上