### PR TITLE
优化尘歌壶购买弹窗显示/旋转寻敌优化

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoFight/AutoFightSeek.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/AutoFightSeek.cs
@@ -51,10 +51,10 @@ namespace BetterGenshinImpact.GameTask.AutoFight
                     Point firstPixel = new Point(x, y);
                     logger.LogInformation("敌人位置: ({firstPixel.X}, {firstPixel.Y})，血量高度: {height}", firstPixel.X, firstPixel.Y, height);
                     
-                    if (firstPixel.X < 500 || firstPixel.X > 1200 || firstPixel.Y < 300 || firstPixel.Y > 920)
+                    if (firstPixel.X < 580 || firstPixel.X > 1315 || firstPixel.Y > 800)
                     {
                         // 非中心区域的处理逻辑
-                        if (firstPixel.X < 500 && firstPixel.Y < 300)
+                        if (firstPixel.X < 500 && firstPixel.Y < 800)
                         {
                             // 左上区域
                             if (height <= 6)
@@ -70,7 +70,7 @@ namespace BetterGenshinImpact.GameTask.AutoFight
                                 }, ct);
                             }
                         }
-                        else if (firstPixel.X > 1200 && firstPixel.Y < 300)
+                        else if (firstPixel.X > 1315 && firstPixel.Y < 800)
                         {
                             // 右上区域
                             if (height <= 6)
@@ -86,7 +86,7 @@ namespace BetterGenshinImpact.GameTask.AutoFight
                                 }, ct);
                             }
                         }
-                        else if (firstPixel.X < 500 && firstPixel.Y > 920)
+                        else if (firstPixel.X < 500 && firstPixel.Y > 800)
                         {
                             // 左下区域
                             if (height <= 6)
@@ -102,7 +102,7 @@ namespace BetterGenshinImpact.GameTask.AutoFight
                                 }, ct);
                             }
                         }
-                        else if (firstPixel.X > 1200 && firstPixel.Y > 920)
+                        else if (firstPixel.X > 1315 && firstPixel.Y > 800)
                         {
                             // 右下区域
                             if (height <= 6)
@@ -118,7 +118,7 @@ namespace BetterGenshinImpact.GameTask.AutoFight
                                 }, ct);
                             }
                         }
-                        else if (firstPixel.Y < 300)
+                        else if (firstPixel.Y < 800)
                         {
                             // 上方区域
                             if (height <= 6)
@@ -132,7 +132,7 @@ namespace BetterGenshinImpact.GameTask.AutoFight
                                 }, ct);
                             }
                         }
-                        else if (firstPixel.Y > 920)
+                        else if (firstPixel.Y > 800)
                         {
                             // 下方区域
                             if (height <= 6)
@@ -165,7 +165,7 @@ namespace BetterGenshinImpact.GameTask.AutoFight
                         {
                             logger.LogInformation("敌人在中心且高度大于6，不移动");
                         }
-                        else if (firstPixel.X < 1200 && firstPixel.X > 500 && firstPixel.Y < 800 && height > 2)
+                        else if (firstPixel.X < 1315 && firstPixel.X > 500 && firstPixel.Y < 800 && height > 2)
                         {
                             logger.LogInformation("敌人在上方，向前移动");
                             Task.Run(() =>
@@ -175,7 +175,7 @@ namespace BetterGenshinImpact.GameTask.AutoFight
                                 Simulation.SendInput.SimulateAction(GIActions.MoveForward, KeyType.KeyUp);
                             }, ct);
                         }
-                        else if (firstPixel.X < 1200 && firstPixel.X > 500 && firstPixel.Y > 800 && height > 2)
+                        else if (firstPixel.X < 1315 && firstPixel.X > 500 && firstPixel.Y > 800 && height > 2)
                         {
                             logger.LogInformation("敌人在下方，向后移动");
                             Task.Run(() =>
@@ -184,6 +184,10 @@ namespace BetterGenshinImpact.GameTask.AutoFight
                                 Task.Delay(1000, ct).Wait();
                                 Simulation.SendInput.SimulateAction(GIActions.MoveBackward, KeyType.KeyUp);
                             }, ct);
+                        }
+                        else if (height < 3)
+                        {
+                            logger.LogInformation("敌人血量高度小于3，不移动");
                         }
                         else
                         {

--- a/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml
+++ b/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml
@@ -25,9 +25,6 @@
         </b:EventTrigger>
     </b:Interaction.Triggers>
     
-    
-    
-    
     <Grid Margin="22,16,8,12">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*" MaxWidth="300" />
@@ -229,7 +226,8 @@
                                FontSize="16"
                                FontWeight="Bold"
                                VerticalAlignment="Center"
-                               Text="配置" />
+                               Text="配置" 
+                               x:Name="ConfigListGrid"/>
                     <ComboBox Grid.Column="1"
                               MinWidth="200"
                               Height="34"
@@ -1043,12 +1041,268 @@
                             <ComboBox MinWidth="90"
                                       Margin="0,0,10,0"
                                       SelectedItem="{Binding SelectedConfig.SereniteaPotTpType, Mode=TwoWay}"
-                                      ItemsSource="{Binding SereniteaPotTpTypes}" />
-                            <Button MinWidth="90"
-                                    Height="36"
-                                    Margin="0,0,28,0"
-                                    Content="购买选择"
-                                    Command="{Binding AddPotBuyItemCommand}" />
+                                      ItemsSource="{Binding SniteaPotTypes}" />
+                            <ToggleButton                                         
+                                Margin="0,0,28,0"
+                                VerticalAlignment="Center"
+                                HorizontalAlignment="Right"
+                                HorizontalContentAlignment="Center"
+                                MinWidth="100"
+                                Height="36"
+                                Padding="0"
+                                ClickMode="Press"
+                                Content="购买选择"
+                                Click="SereniteaPotTpType_Clicked"
+                                x:Name="PotButton">
+                            </ToggleButton>
+                            
+                            <!-- 弹窗 -->
+                                <Popup Grid.Row="0" Grid.Column="0" x:Name="Popup"
+                                       Placement="Bottom"
+                                       PlacementTarget="{Binding ElementName=ConfigListGrid}"
+                                       IsOpen="{Binding IsChecked,ElementName=PotButton}"
+                                       AllowsTransparency="True"
+                                       PopupAnimation="Fade"
+                                       HorizontalAlignment="Center"
+                                       Focusable="False" 
+                                       StaysOpen="False"
+                                       Margin="12">
+                                    <Border CornerRadius="12"
+                                            HorizontalAlignment="Left"
+                                            VerticalAlignment="Top"
+                                            Background="{DynamicResource  ApplicationBackgroundBrush}"
+                                            BorderBrush="{DynamicResource SystemAccentColorPrimaryBrush}"
+                                            BorderThickness="1"
+                                            MaxWidth="300"
+                                            Margin="12">
+                                    
+                                        <StackPanel Margin="12">
+                                            <Grid>
+                                                <Grid.RowDefinitions>
+                                                    <RowDefinition Height="Auto" />
+                                                    <RowDefinition Height="Auto" />
+                                                    <RowDefinition Height="Auto" />
+                                                    <RowDefinition Height="Auto" />
+                                                    <RowDefinition Height="Auto" />
+                                                    <RowDefinition Height="Auto" />
+                                                    <RowDefinition Height="Auto" />
+                                                    <RowDefinition Height="Auto" />
+                                                    <RowDefinition Height="Auto" />
+                                                    <RowDefinition Height="Auto" />
+                                                    <RowDefinition Height="Auto" />
+                                                </Grid.RowDefinitions>
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="Auto" />
+                                                    <ColumnDefinition Width="*" />
+                                                </Grid.ColumnDefinitions>
+                                                <ui:TextBlock Grid.Row="0" 
+                                                              Grid.Column="0"
+                                                              Grid.ColumnSpan="2"
+                                                              Margin="5,5,5,5"
+                                                              FontSize="14"
+                                                              HorizontalAlignment="Left"
+                                                              VerticalAlignment="Center"
+                                                              Text="日期不影响领取好感和钱币"
+                                                              Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                                              TextWrapping="Wrap"/>
+                                                <ComboBox Grid.Row="1" 
+                                                          Grid.Column="0"
+                                                          Grid.ColumnSpan="2" 
+                                                          MinWidth="150"
+                                                          Margin="5,5,5,5"
+                                                          ItemsSource="{Binding SereniteaPotTypes}"
+                                                          x:Name="SereniteaPotComboBox" />
+                                                
+                                                <Separator Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2"  Margin="5,3,5,3" BorderThickness="0,1,0,0" />
+                                                
+                                                <CheckBox
+                                                          Grid.Row="3" 
+                                                          Grid.Column="0"
+                                                          Margin="5,0,5,5"
+                                                          Background="Transparent"
+                                                          Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                                          HorizontalAlignment="Left"
+                                                          VerticalAlignment="Center"
+                                                          IsEnabled="{Binding SelectedConfig.SecretTreasureObjects[1], Mode=TwoWay}"
+                                                          x:Name="ClothCheckBox"/>
+                                                <ui:TextBlock Grid.Row="3" 
+                                                              Grid.Column="1"
+                                                              Margin="5,0,5,5"
+                                                              FontSize="14"
+                                                              HorizontalAlignment="Left"
+                                                              VerticalAlignment="Center"
+                                                              Text="布匹"
+                                                              Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                                              TextWrapping="Wrap"/>
+                                                
+                                                <CheckBox
+                                                    Grid.Row="4" 
+                                                    Grid.Column="0"
+                                                    Margin="5,0,5,5"
+                                                    Background="Transparent"
+                                                    Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                                    HorizontalAlignment="Left"
+                                                    VerticalAlignment="Center"
+                                                    x:Name="MomentResinCheckBox"/>
+                                                <ui:TextBlock Grid.Row="4" 
+                                                              Grid.Column="1"
+                                                              Margin="5,0,5,5"
+                                                              FontSize="14"
+                                                              HorizontalAlignment="Left"
+                                                              VerticalAlignment="Center"
+                                                              Text="须臾树脂"
+                                                              Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                                              TextWrapping="Wrap"/>
+                                                
+                                                <CheckBox
+                                                    Grid.Row="5" 
+                                                    Grid.Column="0"
+                                                    Margin="5,0,5,5"
+                                                    Background="Transparent"
+                                                    Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                                    HorizontalAlignment="Left"
+                                                    VerticalAlignment="Center"
+                                                    x:Name="SereniteapotExpBookCheckBox"/>
+                                                <ui:TextBlock Grid.Row="5" 
+                                                              Grid.Column="1"
+                                                              Margin="5,0,5,5"
+                                                              FontSize="14"
+                                                              HorizontalAlignment="Left"
+                                                              VerticalAlignment="Center"
+                                                              Text="大英雄的经验"
+                                                              Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                                              TextWrapping="Wrap"/>
+                                                
+                                                <CheckBox
+                                                    Grid.Row="6" 
+                                                    Grid.Column="0"
+                                                    Margin="5,0,5,5"
+                                                    Background="Transparent"
+                                                    Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                                    HorizontalAlignment="Left"
+                                                    VerticalAlignment="Center"
+                                                    x:Name="SereniteapotExpBookSmallCheckBox"/>
+                                                <ui:TextBlock Grid.Row="6" 
+                                                              Grid.Column="1"
+                                                              Margin="5,0,5,5"
+                                                              FontSize="14"
+                                                              HorizontalAlignment="Left"
+                                                              VerticalAlignment="Center"
+                                                              Text="流浪者的经验"
+                                                              Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                                              TextWrapping="Wrap"/>
+                                                
+                                                <CheckBox
+                                                    Grid.Row="7" 
+                                                    Grid.Column="0"
+                                                    Margin="5,0,5,5"
+                                                    Background="Transparent"
+                                                    Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                                    HorizontalAlignment="Left"
+                                                    VerticalAlignment="Center"
+                                                    x:Name="MagicmineralprecisionCheckBox"/>
+                                                <ui:TextBlock Grid.Row="7" 
+                                                              Grid.Column="1"
+                                                              Margin="5,0,5,5"
+                                                              FontSize="14"
+                                                              HorizontalAlignment="Left"
+                                                              VerticalAlignment="Center"
+                                                              Text="精锻用魔矿"
+                                                              Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                                              TextWrapping="Wrap"/>
+                                                
+                                                <CheckBox
+                                                    Grid.Row="8" 
+                                                    Grid.Column="0"
+                                                    Margin="5,0,5,5"
+                                                    Background="Transparent"
+                                                    Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                                    HorizontalAlignment="Left"
+                                                    VerticalAlignment="Center"
+                                                    x:Name="MOlaCheckBox"/>
+                                                <ui:TextBlock Grid.Row="8" 
+                                                              Grid.Column="1"
+                                                              Margin="5,0,5,5"
+                                                              FontSize="14"
+                                                              HorizontalAlignment="Left"
+                                                              VerticalAlignment="Center"
+                                                              Text="摩拉"
+                                                              Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                                              TextWrapping="Wrap"/>
+                                                
+                                                <CheckBox
+                                                    Grid.Row="9" 
+                                                    Grid.Column="0"
+                                                    Margin="5,0,5,5"
+                                                    Background="Transparent"
+                                                    Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                                    HorizontalAlignment="Left"
+                                                    VerticalAlignment="Center"
+                                                    x:Name="ExpBottleBigCheckBox"/>
+                                                <ui:TextBlock Grid.Row="9" 
+                                                              Grid.Column="1"
+                                                              Margin="5,0,5,5"
+                                                              FontSize="14"
+                                                              HorizontalAlignment="Left"
+                                                              VerticalAlignment="Center"
+                                                              Text="祝圣精华"
+                                                              Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                                              TextWrapping="Wrap"/>
+                                                
+                                                <CheckBox
+                                                    Grid.Row="10" 
+                                                    Grid.Column="0"
+                                                    Margin="5,0,5,5"
+                                                    Background="Transparent"
+                                                    Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                                    HorizontalAlignment="Left"
+                                                    VerticalAlignment="Center"
+                                                    x:Name="ExpBottleSmallCheckBox"/>
+                                                <ui:TextBlock Grid.Row="10" 
+                                                              Grid.Column="1"
+                                                              Margin="5,0,5,5"
+                                                              FontSize="14"
+                                                              HorizontalAlignment="Left"
+                                                              VerticalAlignment="Center"
+                                                              Text="祝圣油膏"
+                                                              Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                                              TextWrapping="Wrap"/>
+                                            </Grid>  
+                                            
+                                            <Separator  Margin="5,0,5,5" BorderThickness="0,1,0,0" />
+                                            
+                                            <Grid>
+                                                <Grid.RowDefinitions>
+                                                    <RowDefinition Height="Auto" />
+                                                </Grid.RowDefinitions>
+                                                <Grid.ColumnDefinitions>
+                                                    <ColumnDefinition Width="Auto" />
+                                                    <ColumnDefinition Width="Auto" />
+                                                </Grid.ColumnDefinitions>
+                                                <Button
+                                                    Grid.Row="0"
+                                                    Grid.Column="0"
+                                                    HorizontalAlignment="Center"
+                                                    VerticalContentAlignment="Center"
+                                                    Width="70"
+                                                    Margin="15,0,5,5"
+                                                    Content="确定" 
+                                                    Click="BuySereniteaPotClick"/>
+                                                <Button
+                                                    Grid.Row="0"
+                                                    Grid.Column="1"
+                                                    HorizontalAlignment="Center"
+                                                    VerticalContentAlignment="Center"
+                                                    Width="70"
+                                                    Margin="5,0,5,5"
+                                                    Content="取消" 
+                                                    Click="PopupCloseButtonClick"/>
+                                            </Grid>
+                                        </StackPanel>
+                                    </Border>
+                                </Popup>
+                            
+                            
                         </StackPanel>
                     </ui:CardControl>
                     

--- a/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml
+++ b/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml
@@ -1110,7 +1110,7 @@
                                                           Grid.ColumnSpan="2" 
                                                           MinWidth="150"
                                                           Margin="5,5,5,5"
-                                                          ItemsSource="{Binding SereniteaPotTypes}"
+                                                          ItemsSource="{x:Static local:OneDragonFlowPage.SereniteaPotTypes}"
                                                           x:Name="SereniteaPotComboBox" />
                                                 
                                                 <Separator Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2"  Margin="5,3,5,3" BorderThickness="0,1,0,0" />
@@ -1287,7 +1287,8 @@
                                                     Width="70"
                                                     Margin="15,0,5,5"
                                                     Content="确定" 
-                                                    Click="BuySereniteaPotClick"/>
+                                                    x:Name="PopupConfirmButton"
+                                                    Click="SereniteaPotTpType_Clicked"/>
                                                 <Button
                                                     Grid.Row="0"
                                                     Grid.Column="1"
@@ -1296,7 +1297,8 @@
                                                     Width="70"
                                                     Margin="5,0,5,5"
                                                     Content="取消" 
-                                                    Click="PopupCloseButtonClick"/>
+                                                    x:Name="PopupCloseButton"
+                                                    Click="SereniteaPotTpType_Clicked"/>
                                             </Grid>
                                         </StackPanel>
                                     </Border>

--- a/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml.cs
+++ b/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml.cs
@@ -14,11 +14,14 @@ public partial class OneDragonFlowPage
     public OneDragonFlowViewModel ViewModel { get; }
     
     private readonly Dictionary<CheckBox, string> _checkBoxMappings;
+    
+    public static readonly List<string> SereniteaPotTypes = new List<string> { "每天重复", "星期一", "星期二", "星期三", "星期四", "星期五", "星期六", "星期日" };
 
     public OneDragonFlowPage(OneDragonFlowViewModel viewModel)
     {
         DataContext = ViewModel = viewModel;
         InitializeComponent();
+        
         _checkBoxMappings = new Dictionary<CheckBox, string>
         {
             { ClothCheckBox, "布匹" },
@@ -30,11 +33,34 @@ public partial class OneDragonFlowPage
             { ExpBottleBigCheckBox, "祝圣精华" },
             { ExpBottleSmallCheckBox, "祝圣油膏" }
         };
+        
     }
     
     private async void SereniteaPotTpType_Clicked(object sender, RoutedEventArgs e)
     {
-        if (ViewModel.SelectedConfig != null)
+        if (ViewModel.SelectedConfig == null)
+        {
+            Toast.Warning("初始化失败，请先选择配置单");
+            return;
+        }
+        
+        if (sender.Equals(PopupCloseButton)) //关闭弹窗
+        {
+            Popup.IsOpen = false;
+        }
+        
+        else if (sender.Equals(PopupConfirmButton)) //确认选择
+        {
+            var selectedObjects = new List<string>(SereniteaPotComboBox.SelectedItem.ToString().Split('/'))
+                .Concat(_checkBoxMappings.Where(pair => pair.Key.IsChecked == true).Select(pair => pair.Value)).ToList();
+
+            ViewModel.SelectedConfig.SecretTreasureObjects = selectedObjects;
+            ViewModel.SaveConfig();
+            
+            Popup.IsOpen = false;
+        }
+        
+        else if (sender.Equals(PotButton)) //打开初始化显示购买信息
         {
             if (ViewModel.SelectedConfig.SecretTreasureObjects.Count == 0)
             {
@@ -42,7 +68,6 @@ public partial class OneDragonFlowPage
                 ViewModel.SaveConfig();
                 return;
             }
-            
             SereniteaPotComboBox.SelectedItem = ViewModel.SelectedConfig.SecretTreasureObjects[0];
 
             foreach (var pair in _checkBoxMappings)
@@ -50,29 +75,7 @@ public partial class OneDragonFlowPage
                 pair.Key.IsChecked = ViewModel.SelectedConfig.SecretTreasureObjects.Contains(pair.Value);
             }
         }
-    }
-    
-    private void BuySereniteaPotClick(object sender, RoutedEventArgs e)
-    {
-        if (ViewModel.SelectedConfig == null || ViewModel.SelectedConfig.SecretTreasureObjects == null)
-        {
-            Toast.Warning("初始化失败，请先选择配置单");
-            return;
-        }
         
-        var selectedObjects = new List<string>(SereniteaPotComboBox.SelectedItem.ToString().Split('/'))
-            .Concat(_checkBoxMappings.Where(pair => pair.Key.IsChecked == true).Select(pair => pair.Value)).ToList();
-
-        ViewModel.SelectedConfig.SecretTreasureObjects = selectedObjects;
-        ViewModel.SaveConfig();
-
-        Toast.Success("添加购买成功");
-        Popup.IsOpen = false;
-    }
-    
-    private void PopupCloseButtonClick(object sender, RoutedEventArgs e)
-    {
-        Popup.IsOpen = false;
     }
     
 }

--- a/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml.cs
+++ b/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml.cs
@@ -1,14 +1,78 @@
 ﻿using BetterGenshinImpact.ViewModel.Pages;
+using BetterGenshinImpact.ViewModel.Pages;
+using System.Windows;
+using System.Windows.Controls;
+using Wpf.Ui.Violeta.Controls;
+using System.Linq; 
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace BetterGenshinImpact.View.Pages;
 
 public partial class OneDragonFlowPage
 {
     public OneDragonFlowViewModel ViewModel { get; }
+    
+    private readonly Dictionary<CheckBox, string> _checkBoxMappings;
 
     public OneDragonFlowPage(OneDragonFlowViewModel viewModel)
     {
         DataContext = ViewModel = viewModel;
         InitializeComponent();
+        _checkBoxMappings = new Dictionary<CheckBox, string>
+        {
+            { ClothCheckBox, "布匹" },
+            { MomentResinCheckBox, "须臾树脂" },
+            { SereniteapotExpBookCheckBox, "大英雄的经验" },
+            { SereniteapotExpBookSmallCheckBox, "流浪者的经验" },
+            { MagicmineralprecisionCheckBox, "精锻用魔矿" },
+            { MOlaCheckBox, "摩拉" },
+            { ExpBottleBigCheckBox, "祝圣精华" },
+            { ExpBottleSmallCheckBox, "祝圣油膏" }
+        };
     }
+    
+    private async void SereniteaPotTpType_Clicked(object sender, RoutedEventArgs e)
+    {
+        if (ViewModel.SelectedConfig != null)
+        {
+            if (ViewModel.SelectedConfig.SecretTreasureObjects.Count == 0)
+            {
+                SereniteaPotComboBox.SelectedItem = new List<string> { "每天重复" };
+                ViewModel.SaveConfig();
+                return;
+            }
+            
+            SereniteaPotComboBox.SelectedItem = ViewModel.SelectedConfig.SecretTreasureObjects[0];
+
+            foreach (var pair in _checkBoxMappings)
+            {
+                pair.Key.IsChecked = ViewModel.SelectedConfig.SecretTreasureObjects.Contains(pair.Value);
+            }
+        }
+    }
+    
+    private void BuySereniteaPotClick(object sender, RoutedEventArgs e)
+    {
+        if (ViewModel.SelectedConfig == null || ViewModel.SelectedConfig.SecretTreasureObjects == null)
+        {
+            Toast.Warning("初始化失败，请先选择配置单");
+            return;
+        }
+        
+        var selectedObjects = new List<string>(SereniteaPotComboBox.SelectedItem.ToString().Split('/'))
+            .Concat(_checkBoxMappings.Where(pair => pair.Key.IsChecked == true).Select(pair => pair.Value)).ToList();
+
+        ViewModel.SelectedConfig.SecretTreasureObjects = selectedObjects;
+        ViewModel.SaveConfig();
+
+        Toast.Success("添加购买成功");
+        Popup.IsOpen = false;
+    }
+    
+    private void PopupCloseButtonClick(object sender, RoutedEventArgs e)
+    {
+        Popup.IsOpen = false;
+    }
+    
 }

--- a/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
@@ -293,8 +293,6 @@ public partial class OneDragonFlowViewModel : ViewModel
     
     [ObservableProperty] private List<string> _sereniteaPotTpTypes = ["地图传送", "尘歌壶道具"];
     
-     [ObservableProperty] private List<string> _sereniteaPotTypes = ["每天重复", "星期一", "星期二", "星期三", "星期四", "星期五", "星期六", "星期日"];
-    
     public AllConfig Config { get; set; } = TaskContext.Instance().Config;
 
     public OneDragonFlowViewModel()

--- a/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
@@ -270,105 +270,6 @@ public partial class OneDragonFlowViewModel : ViewModel
         }
         return null;
     }
-
-    public async Task<string?> OnPotBuyItemAsync()
-    {
-        var stackPanel = new StackPanel
-        {
-            Orientation = Orientation.Vertical,
-            VerticalAlignment = VerticalAlignment.Center,
-            HorizontalAlignment = HorizontalAlignment.Center
-        };
-        var checkBoxes = new Dictionary<string, CheckBox>(); 
-        CheckBox selectedCheckBox = null;
-        
-        if (SelectedConfig.SecretTreasureObjects == null || SelectedConfig.SecretTreasureObjects.Count == 0)
-        {
-            Toast.Warning("未配置洞天百宝购买配置，请先设置");
-            SelectedConfig.SecretTreasureObjects.Add("每天重复");
-        }
-        var infoTextBlock = new TextBlock
-        {
-            Text = "日期不影响领取好感和钱币",
-            HorizontalAlignment = HorizontalAlignment.Center,
-            FontSize = 12,
-            Margin = new Thickness(0, 0, 0, 10)
-        };
-
-        stackPanel.Children.Add(infoTextBlock);
-        // 添加下拉选择框
-        var dayComboBox = new ComboBox
-        {
-            ItemsSource = new List<string> { "星期一", "星期二", "星期三", "星期四", "星期五", "星期六", "星期日", "每天重复" },
-            SelectedItem = SelectedConfig.SecretTreasureObjects.First(),
-            FontSize = 12,
-            Margin = new Thickness(0, 0, 0, 10)
-        };
-        stackPanel.Children.Add(dayComboBox);
-        
-        foreach (var potBuyItem in SecretTreasureObjectList)
-        {
-            var checkBox = new CheckBox
-            {
-                Content = potBuyItem,
-                Tag = potBuyItem,
-                MinWidth = 180,
-                IsChecked = SelectedConfig.SecretTreasureObjects.Contains(potBuyItem) 
-            };
-            checkBoxes[potBuyItem] = checkBox; 
-            stackPanel.Children.Add(checkBox);
-        }
-        
-        var uiMessageBox = new Wpf.Ui.Controls.MessageBox
-        {
-            Title = "洞天百宝购买选择",
-            Content = new ScrollViewer
-            {
-                Content = stackPanel,
-                VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
-            },
-            CloseButtonText = "关闭",
-            PrimaryButtonText = "确认",
-            Owner = Application.Current.ShutdownMode == ShutdownMode.OnMainWindowClose ? null : Application.Current.MainWindow,
-            WindowStartupLocation = WindowStartupLocation.CenterOwner,
-            SizeToContent = SizeToContent.Width, // 确保弹窗根据内容自动调整大小
-            MinWidth = 200,
-            MaxHeight = 500,
-        };
-
-        var result = await uiMessageBox.ShowDialogAsync();
-        if (result == Wpf.Ui.Controls.MessageBoxResult.Primary)
-        {
-            SelectedConfig.SecretTreasureObjects.Clear();
-            SelectedConfig.SecretTreasureObjects.Add(dayComboBox.SelectedItem.ToString());
-            List<string> selectedItems = new List<string>(); // 用于存储所有选中的项
-            foreach (var checkBox in checkBoxes.Values)
-            {
-                if (checkBox.IsChecked == true)
-                {
-                    var potBuyItem = checkBox.Tag as string;
-                    if (potBuyItem != null)
-                    {
-                        selectedItems.Add(potBuyItem);
-                        SelectedConfig.SecretTreasureObjects.Add(potBuyItem);
-                    }
-                    else
-                    {
-                        Toast.Error("加载失败");
-                    }
-                }
-            }
-            if (selectedItems.Count > 0)
-            {
-                return string.Join(",", selectedItems); // 返回所有选中的项
-            }
-            else
-            {
-                Toast.Warning("选择为空，请选择购买的宝物");
-            }
-        }
-        return null;
-    }
     
     [ObservableProperty] private ObservableCollection<OneDragonFlowConfig> _configList = [];
     /// <summary>
@@ -391,6 +292,8 @@ public partial class OneDragonFlowViewModel : ViewModel
     [ObservableProperty] private List<string> _secretTreasureObjectList = ["布匹","须臾树脂","大英雄的经验","流浪者的经验","精锻用魔矿","摩拉","祝圣精华","祝圣油膏"];
     
     [ObservableProperty] private List<string> _sereniteaPotTpTypes = ["地图传送", "尘歌壶道具"];
+    
+     [ObservableProperty] private List<string> _sereniteaPotTypes = ["每天重复", "星期一", "星期二", "星期三", "星期四", "星期五", "星期六", "星期日"];
     
     public AllConfig Config { get; set; } = TaskContext.Instance().Config;
 
@@ -561,14 +464,6 @@ public partial class OneDragonFlowViewModel : ViewModel
         }
 
         WriteConfig(SelectedConfig);
-    }
-
-    [RelayCommand]
-    private async void AddPotBuyItem()
-    {
-        await OnPotBuyItemAsync();
-        SaveConfig();
-        SelectedTask = null;
     }
     
     [RelayCommand]


### PR DESCRIPTION
优化尘歌壶购买弹窗显示/旋转寻敌优化
1、把目前在OneDragonFlowViewModel.cs中的尘歌壶购买弹窗删除，显示部分做到XAML，逻辑出来部分做到OneDragonFlowPage.xaml.cs，提高后的可续维护性和代码可读性。
2、旋转寻敌目前效果还是不错的，配合更快结束战斗，能减少开队伍检测的次数。