### PR TITLE
提高领取纪行奖励的鲁棒性

### DIFF
--- a/BetterGenshinImpact/GameTask/Common/Job/ClaimBattlePassRewardsTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/ClaimBattlePassRewardsTask.cs
@@ -25,13 +25,13 @@ public class ClaimBattlePassRewardsTask
 {
     private readonly ReturnMainUiTask _returnMainUiTask = new();
 
-    private readonly string claimAllLocalizedString;
+    private readonly string[] claimAllLocalizedStrings;
 
     public ClaimBattlePassRewardsTask()
     {
         IStringLocalizer<ClaimBattlePassRewardsTask> stringLocalizer = App.GetService<IStringLocalizer<ClaimBattlePassRewardsTask>>() ?? throw new NullReferenceException();
         CultureInfo cultureInfo = new CultureInfo(TaskContext.Instance().Config.OtherConfig.GameCultureInfoName);
-        this.claimAllLocalizedString = stringLocalizer.WithCultureGet(cultureInfo, "一键");
+        this.claimAllLocalizedStrings = ((string[])["一键", "领取"]).Select(i => stringLocalizer.WithCultureGet(cultureInfo, i)).ToArray();
     }
 
     public async Task Start(CancellationToken ct)
@@ -88,8 +88,8 @@ public class ClaimBattlePassRewardsTask
     {
         using var ra = CaptureToRectArea();
         var ocrList = ra.FindMulti(RecognitionObject.Ocr(ra.ToRect().CutRightBottom(0.3, 0.2)));
-        var wt = ocrList.FirstOrDefault(txt => Regex.IsMatch(txt.Text, this.claimAllLocalizedString));
-        Debug.WriteLine(this.claimAllLocalizedString);
+        var wt = ocrList.FirstOrDefault(txt => this.claimAllLocalizedStrings.Any(i => Regex.IsMatch(txt.Text, i)));
+        Debug.WriteLine(this.claimAllLocalizedStrings);
         if (wt != null)
         {
             wt.Click();

--- a/BetterGenshinImpact/GameTask/Common/Job/ClaimBattlePassRewardsTask.en.resx
+++ b/BetterGenshinImpact/GameTask/Common/Job/ClaimBattlePassRewardsTask.en.resx
@@ -120,4 +120,7 @@
   <data name="一键" xml:space="preserve">
     <value>All</value>
   </data>
+  <data name="领取" xml:space="preserve">
+    <value>Claim</value>
+  </data>
 </root>

--- a/BetterGenshinImpact/GameTask/Common/Job/ClaimBattlePassRewardsTask.fr.resx
+++ b/BetterGenshinImpact/GameTask/Common/Job/ClaimBattlePassRewardsTask.fr.resx
@@ -120,4 +120,7 @@
   <data name="一键" xml:space="preserve">
     <value>Tout</value>
   </data>
+  <data name="领取" xml:space="preserve">
+    <value>récupérer</value>
+  </data>
 </root>

--- a/BetterGenshinImpact/GameTask/Common/Job/ClaimBattlePassRewardsTask.zh-Hans.resx
+++ b/BetterGenshinImpact/GameTask/Common/Job/ClaimBattlePassRewardsTask.zh-Hans.resx
@@ -120,4 +120,7 @@
   <data name="一键" xml:space="preserve">
     <value>一键</value>
   </data>
+  <data name="领取" xml:space="preserve">
+    <value>领取</value>
+  </data>
 </root>

--- a/BetterGenshinImpact/GameTask/Common/Job/ClaimBattlePassRewardsTask.zh-Hant.resx
+++ b/BetterGenshinImpact/GameTask/Common/Job/ClaimBattlePassRewardsTask.zh-Hant.resx
@@ -120,4 +120,7 @@
   <data name="一键" xml:space="preserve">
     <value>一鍵</value>
   </data>
+  <data name="领取" xml:space="preserve">
+    <value>領取</value>
+  </data>
 </root>


### PR DESCRIPTION
当前最新的代码领取纪行奖励仍然会失败，经过调试发现是OCR识别不准确导致的。部分log如下，使用"键"作为关键字匹配效果不甚理想，因为这个字复杂容易出错，所以在本PR中增加一个关键字，只要有一个匹配成功即认为成功

```
[19:10:31.419] [INF] BetterGenshinImpact.GameTask.Common.TaskControl
"—钧"

[19:10:31.419] [INF] BetterGenshinImpact.GameTask.Common.TaskControl
"解锁珍珠纪行"

[19:10:31.419] [INF] BetterGenshinImpact.GameTask.Common.TaskControl
"键领取"

[19:10:31.419] [INF] BetterGenshinImpact.GameTask.Common.TaskControl
"UID: xxxxxxxxx"

[19:10:31.421] [INF] BetterGenshinImpact.GameTask.Common.TaskControl
纪行："无需领取"
```