### PR TITLE
修复自定义的交互按键未对自动秘境生效的问题

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoDomain/AutoDomainTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoDomain/AutoDomainTask.cs
@@ -269,7 +269,7 @@ public class AutoDomainTask : ISoloTask
                 if ("芬德尼尔之顶".Equals(_taskParam.DomainName))
                 {
                         menuFound = await NewRetry.WaitForElementAppear(
-                        AutoPickAssets.Instance.FRo,
+                        AutoPickAssets.Instance.PickRo,
                         () => Simulation.SendInput.SimulateAction(GIActions.MoveBackward, KeyType.KeyDown),
                         _ct,
                         20,
@@ -284,7 +284,7 @@ public class AutoDomainTask : ISoloTask
                     Simulation.SendInput.SimulateAction(GIActions.MoveForward, KeyType.KeyUp);
 
                     menuFound = await NewRetry.WaitForElementAppear(
-                        AutoPickAssets.Instance.FRo,
+                        AutoPickAssets.Instance.PickRo,
                         () =>  Simulation.SendInput.SimulateAction(GIActions.MoveLeft, KeyType.KeyDown),
                         _ct,
                         20,
@@ -296,7 +296,7 @@ public class AutoDomainTask : ISoloTask
                 else if ("太山府".Equals(_taskParam.DomainName))
                 {
                     menuFound = await NewRetry.WaitForElementAppear(
-                        AutoPickAssets.Instance.FRo,
+                        AutoPickAssets.Instance.PickRo,
                         () => { },
                     _ct,
                         20,
@@ -306,7 +306,7 @@ public class AutoDomainTask : ISoloTask
                 else
                 {
                     menuFound = await NewRetry.WaitForElementAppear(
-                    AutoPickAssets.Instance.FRo,
+                    AutoPickAssets.Instance.PickRo,
                     () => Simulation.SendInput.SimulateAction(GIActions.MoveForward, KeyType.KeyDown),
                     _ct,
                     20,

--- a/BetterGenshinImpact/View/Pages/TriggerSettingsPage.xaml
+++ b/BetterGenshinImpact/View/Pages/TriggerSettingsPage.xaml
@@ -189,7 +189,7 @@
                     <ui:TextBlock Grid.Row="1"
                                   Grid.Column="0"
                                   Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
-                                  Text="默认为 F，自带了 E 按键，需要改成其他键的请阅读文档"
+                                  Text="默认为 F，自带了 E 和 G 按键，需要改成其他键的请阅读文档"
                                   TextWrapping="Wrap" />
                     <ComboBox Grid.Row="0"
                               Grid.RowSpan="2"


### PR DESCRIPTION
修复后默认的`F`和自定义按键都能正常工作


https://github.com/user-attachments/assets/c6f851c0-91d8-44d7-b191-e5146adcaa8f

https://github.com/user-attachments/assets/9435a6e8-be48-4a35-8714-10be8be96ce2

