### PR TITLE
尘歌壶领取好感角色为空时不领好感

### DIFF
--- a/BetterGenshinImpact/GameTask/Common/Job/GoToSereniteaPotTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/GoToSereniteaPotTask.cs
@@ -22,6 +22,7 @@ using System.Collections.ObjectModel;
 using System.IO;
 using Newtonsoft.Json;
 using BetterGenshinImpact.GameTask.QuickSereniteaPot;
+using BetterGenshinImpact.Core.Recognition.OCR;
 
 namespace BetterGenshinImpact.GameTask.Common.Job;
 
@@ -419,7 +420,28 @@ internal class GoToSereniteaPotTask
         {
             Logger.LogInformation("领取尘歌壶奖励:{text}", "领取好感和宝钱");
             await Delay(1000, ct);
-            CaptureToRectArea().Find(ElementAssets.Instance.SereniteaPotLoveRo, a => a.Click());
+
+            var getAare = CaptureToRectArea();
+            var count = OcrFactory.Paddle.OcrWithoutDetector(getAare.DeriveCrop(getAare.Width* 1801 / 1920,
+                getAare.Height* 609 / 1080,getAare.Width * 75 / 1920,getAare.Width * 46 / 1920).SrcMat);
+            
+            var match = System.Text.RegularExpressions.Regex.Match(count, @"(\d+)\s*[/17]\s*(8)");
+            var shouldClick = true;
+            if (match.Success)
+            {
+                var numericPart = StringUtils.TryParseInt(match.Groups[1].Value);
+                if (numericPart == 0)
+                {
+                    Logger.LogWarning("领取尘歌壶奖励:{text}", "没有角色可领取好感"); //存好感
+                    shouldClick = false;
+                }
+            }
+            
+            if (shouldClick)
+            {
+                getAare.Find(ElementAssets.Instance.SereniteaPotLoveRo, a => a.Click());
+            }
+            
             await Delay(500, ct);
             var ra = CaptureToRectArea();
             var list = ra.FindMulti(new RecognitionObject


### PR DESCRIPTION
尘歌壶领取好感角色为空时不领好感
1、目前领取尘歌壶好感时不管是否有放入角色的，考虑到有人全好感度，会存一管好感给后续新角色。