### PR TITLE
角色短E技能cd的OCR加入重试/新增中E的cd计算

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
@@ -424,10 +424,18 @@ public class Avatar
             }
 
             Sleep(200, Ct);
-
             var region = CaptureToRectArea();
-            ThrowWhenDefeated(region, Ct); // 检测是不是要跑神像
-            var cd = AfterUseSkill(region);
+            ThrowWhenDefeated(region, Ct);
+
+            double cd = 0;
+            for (var attempt = 0; attempt < 2; attempt++)
+            {
+                if (attempt > 0) region = CaptureToRectArea(); // 非首次尝试时重新截图
+                cd = AfterUseSkill(region);
+                if (cd > 0) break;
+                Thread.Sleep(100);
+            }
+            
             if (cd > 0)
             {
                 Logger.LogInformation(hold ? "{Name} 长按元素战技，cd:{Cd} 秒" : "{Name} 点按元素战技，cd:{Cd} 秒", Name,
@@ -885,6 +893,39 @@ public class Avatar
                 break;
             default:
                 Simulation.SendInput.Keyboard.KeyUp(vk);
+                if (vk == User32.VK.VK_E)
+                {
+                    Thread.Sleep(200);
+                    double cd = 0;
+                    var cooldownDetected = false;
+    
+                    for (var attempt = 0; attempt < 2; attempt++)
+                    {
+                        var region = CaptureToRectArea();
+                        cd = AfterUseSkill(region);
+        
+                        if (cd > 0)
+                        {
+                            cooldownDetected = true;
+                            break;
+                        }
+        
+                        if (attempt < 2 - 1)
+                        {
+                            Thread.Sleep(100);
+                        }
+                    }
+
+                    if (cooldownDetected)
+                    {
+                        Logger.LogInformation("{Name} 元素战技，cd:{Cooldown} 秒", 
+                            Name, Math.Round(cd, 2));
+                    }
+                    else
+                    {
+                        Logger.LogWarning("{Name} 战技cd未更新", Name);
+                    }
+                }
                 break;
         }
     }


### PR DESCRIPTION
逻辑改为FOR

1、原来短E会偶发读不到OCR的CD，加入100ms重试多一次
2、一些战斗脚本的中E写法，特别是万叶，不能ocr进行CD识别，添加E按键的keyup后OCR(改为对所有角色)