### PR TITLE
七圣召唤配置文件中可以设置骰子数量增减

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoGeniusInvokation/Model/ActionCommand.cs
+++ b/BetterGenshinImpact/GameTask/AutoGeniusInvokation/Model/ActionCommand.cs
@@ -15,6 +15,11 @@ namespace BetterGenshinImpact.GameTask.AutoGeniusInvokation.Model
         /// 目标编号（技能编号，从右往左）
         /// </summary>
         public int TargetIndex { get; set; }
+        
+        /// <summary>
+        /// 灵活改变骰子的数量（因为在不同的牌局中或者角色技能中会发生骰子实际需要的数量增加或减少）
+        /// </summary>
+        public int DiceDelta { get; set; } = 0;
 
         public override string? ToString()
         {

--- a/BetterGenshinImpact/GameTask/AutoGeniusInvokation/Model/Duel.cs
+++ b/BetterGenshinImpact/GameTask/AutoGeniusInvokation/Model/Duel.cs
@@ -203,7 +203,7 @@ public class Duel
                         }
 
                         // 2. 判断使用技能
-                        if (actionCommand.GetAllDiceUseCount() > CurrentDiceCount)
+                        if (actionCommand.GetAllDiceUseCount() + actionCommand.DiceDelta > CurrentDiceCount)// 判断条件加上 DiceDelta 骰子变化
                         {
                             _logger.LogInformation("骰子不足以进行下一步：{Action}", actionCommand);
                             break;
@@ -213,7 +213,10 @@ public class Duel
                             bool useSkillRes = actionCommand.UseSkill(this);
                             if (useSkillRes)
                             {
-                                CurrentDiceCount -= actionCommand.GetAllDiceUseCount();
+                                // 实际扣除骰子的地方增加用户的 DiceDelta
+                                int realCost = actionCommand.GetAllDiceUseCount() + actionCommand.DiceDelta;
+                                realCost = Math.Max(realCost, 0);
+                                CurrentDiceCount -= realCost;
                                 alreadyExecutedActionIndex.Add(i);
                                 alreadyExecutedActionCommand.Add(actionCommand);
                                 _logger.LogInformation("→指令执行完成：{Action}", actionCommand);

--- a/BetterGenshinImpact/GameTask/AutoGeniusInvokation/ScriptParser.cs
+++ b/BetterGenshinImpact/GameTask/AutoGeniusInvokation/ScriptParser.cs
@@ -59,7 +59,7 @@ public class ScriptParser
                     MyAssert(duel.Characters[3] != null, "角色未定义");
 
                     string[] actionParts = line.Split(" ", StringSplitOptions.RemoveEmptyEntries);
-                    MyAssert(actionParts.Length == 3, "策略中的行动命令解析错误");
+                    MyAssert(actionParts.Length >= 3, "策略中的行动命令解析错误");
                     MyAssert(actionParts[1] == "使用", "策略中的行动命令解析错误");
 
                     var actionCommand = new ActionCommand();
@@ -82,6 +82,23 @@ public class ScriptParser
                     int skillNum = int.Parse(RegexHelper.ExcludeNumberRegex().Replace(actionParts[2], ""));
                     MyAssert(skillNum < 5, "策略中的行动命令解析错误：技能编号错误");
                     actionCommand.TargetIndex = skillNum;
+                    
+                    // 解析骰子增减
+                    actionCommand.DiceDelta = 0;
+                    if (actionParts.Length >= 4)
+                    {
+                        if (actionParts[3].StartsWith("骰子增加"))
+                        {
+                            int delta = int.Parse(RegexHelper.ExcludeNumberRegex().Replace(actionParts[3], ""));
+                            actionCommand.DiceDelta = delta;
+                        }
+                        else if (actionParts[3].StartsWith("骰子减少"))
+                        {
+                            int delta = int.Parse(RegexHelper.ExcludeNumberRegex().Replace(actionParts[3], ""));
+                            actionCommand.DiceDelta = -delta;
+                        }
+                    }
+                    
                     duel.ActionCommandQueue.Add(actionCommand);
                 }
                 else


### PR DESCRIPTION
配置文件可以这么写：

---
角色定义:
角色1=可莉
角色2=柯莱
角色3=刻晴

策略定义:
可莉 使用 技能2 
可莉 使用 技能3
可莉 使用 技能3 骰子减少1

---
角色定义:
角色1=可莉
角色2=柯莱
角色3=刻晴

策略定义:
可莉 使用 技能2 骰子增加10
可莉 使用 技能3
可莉 使用 技能3 

---

因为在某些情况下，比如可莉的重击
首先是e技能8-3=5
再一次平a是5-3=2（这个时候会出现特殊效果下一次是重击，骰子需求-1）
但是实际上它计算的还是2-3=-1不够
现在可以增加语句“骰子减少”，来应对这种情况了
同时也会有特殊情况导致角色需要的骰子数量增加1，也就是 酒馆挑战26深渊咏者紫电.txt
里面有我讲解
第4回合，莫娜使用技能2因为特殊效果变成了4颗元素骰子，但是它只会帮你烧牌到3个骰子，导致以为打出牌了，或者错误