### PR TITLE
feat: 自动拾取支持纯白名单

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoPick/AutoPickConfig.cs
+++ b/BetterGenshinImpact/GameTask/AutoPick/AutoPickConfig.cs
@@ -4,6 +4,22 @@ using System;
 namespace BetterGenshinImpact.GameTask.AutoPick
 {
     /// <summary>
+    /// 拾取模式枚举
+    /// </summary>
+    public enum AutoPickMode
+    {
+        /// <summary>
+        /// 黑白名单混合模式（默认）
+        /// </summary>
+        Mixed,
+        
+        /// <summary>
+        /// 纯白名单模式
+        /// </summary>
+        WhitelistOnly
+    }
+
+    /// <summary>
     /// 非16:9分辨率下可能无法正常工作
     /// </summary>
     [Serializable]
@@ -57,5 +73,9 @@ namespace BetterGenshinImpact.GameTask.AutoPick
         // 白名单启用状态
         [ObservableProperty]
         private bool _whiteListEnabled= false;
+        
+        // 拾取模式
+        [ObservableProperty]
+        private AutoPickMode _pickMode = AutoPickMode.Mixed;
     }
 }

--- a/BetterGenshinImpact/GameTask/AutoPick/AutoPickTrigger.cs
+++ b/BetterGenshinImpact/GameTask/AutoPick/AutoPickTrigger.cs
@@ -289,6 +289,7 @@ public partial class AutoPickTrigger : ITaskTrigger
                 return;
             }
 
+            // 检查白名单
             if (config.WhiteListEnabled && (_whiteList.Contains(text) || _whiteList.Contains(simpleText)))
             {
                 LogPick(content, text);
@@ -298,27 +299,37 @@ public partial class AutoPickTrigger : ITaskTrigger
 
             speedTimer.Record("白名单判断");
 
-            if (isExcludeIcon)
+            // 根据拾取模式处理
+            if (config.PickMode == AutoPickMode.WhitelistOnly)
             {
-                //Debug.WriteLine("AutoPickTrigger: 物品图标是聊天气泡，一般是NPC对话，不拾取");
+                // 纯白名单模式：只有在白名单中的物品才会被拾取
                 return;
             }
-
-            // 如果黑名单中有通配符*，表示仅支持白名单自动拾取，不认识的选项都不拾取
-            if (config.BlackListEnabled && _blackList.Contains("*"))
+            else
             {
-                return;
+                // 混合模式（默认）：保持原有逻辑
+                if (isExcludeIcon)
+                {
+                    //Debug.WriteLine("AutoPickTrigger: 物品图标是聊天气泡，一般是NPC对话，不拾取");
+                    return;
+                }
+
+                // 如果黑名单中有通配符*，表示仅支持白名单自动拾取，不认识的选项都不拾取
+                if (config.BlackListEnabled && _blackList.Contains("*"))
+                {
+                    return;
+                }
+
+                if (config.BlackListEnabled && (_blackList.Contains(text) || _blackList.Contains(simpleText)))
+                {
+                    return;
+                }
+
+                speedTimer.Record("黑名单判断");
+
+                LogPick(content, text);
+                Simulation.SendInput.Keyboard.KeyPress(AutoPickAssets.Instance.PickVk);
             }
-
-            if (config.BlackListEnabled && (_blackList.Contains(text) || _blackList.Contains(simpleText)))
-            {
-                return;
-            }
-
-            speedTimer.Record("黑名单判断");
-
-            LogPick(content, text);
-            Simulation.SendInput.Keyboard.KeyPress(AutoPickAssets.Instance.PickVk);
         }
 
         speedTimer.DebugPrint();

--- a/BetterGenshinImpact/GameTask/AutoPick/AutoPickTrigger.cs
+++ b/BetterGenshinImpact/GameTask/AutoPick/AutoPickTrigger.cs
@@ -304,6 +304,12 @@ public partial class AutoPickTrigger : ITaskTrigger
                 return;
             }
 
+            // 如果黑名单中有通配符*，表示仅支持白名单自动拾取，不认识的选项都不拾取
+            if (config.BlackListEnabled && _blackList.Contains("*"))
+            {
+                return;
+            }
+
             if (config.BlackListEnabled && (_blackList.Contains(text) || _blackList.Contains(simpleText)))
             {
                 return;

--- a/BetterGenshinImpact/View/Pages/TriggerSettingsPage.xaml
+++ b/BetterGenshinImpact/View/Pages/TriggerSettingsPage.xaml
@@ -119,6 +119,33 @@
                     <ui:TextBlock Grid.Row="0"
                                   Grid.Column="0"
                                   FontTypography="Body"
+                                  Text="拾取模式"
+                                  TextWrapping="Wrap" />
+                    <ui:TextBlock Grid.Row="1"
+                                  Grid.Column="0"
+                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                  Text="选择自动拾取的模式：混合模式或纯白名单模式"
+                                  TextWrapping="Wrap" />
+                    <ComboBox Grid.Row="0"
+                              Grid.RowSpan="2"
+                              Grid.Column="1"
+                              Width="140"
+                              Margin="0,0,36,0"
+                              ItemsSource="{Binding AutoPickModeNames}"
+                              SelectedIndex="{Binding Config.AutoPickConfig.PickMode, Mode=TwoWay}" />
+                </Grid>
+                <Grid Margin="16">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <ui:TextBlock Grid.Row="0"
+                                  Grid.Column="0"
+                                  FontTypography="Body"
                                   Text="黑名单"
                                   TextWrapping="Wrap" />
                     <ui:TextBlock Grid.Row="1"

--- a/BetterGenshinImpact/ViewModel/Pages/TriggerSettingsPageViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/TriggerSettingsPageViewModel.cs
@@ -26,6 +26,8 @@ public partial class TriggerSettingsPageViewModel : ViewModel
 
     [ObservableProperty] private string[] _pickOcrEngineNames = [PickOcrEngineEnum.Paddle.ToString(), PickOcrEngineEnum.Yap.ToString()];
 
+    [ObservableProperty] private string[] _autoPickModeNames = ["黑白名单混合模式", "纯白名单模式"];
+
     [ObservableProperty] private List<string> _pickButtonNames;
 
     public AllConfig Config { get; set; }


### PR DESCRIPTION
- 背景
  - 锄地时间长了，很多材料都达到上限
  - 核心诉求：锄地过程只拾取掉落的圣遗物
- 方案
  - 目前自动拾取的文本识别经常出现异常，导致黑名单无效
  - 比较合理的实现方式是增加一个纯白名单模式的配置，不过这块逻辑还没太盘清楚怎么写
  - 因此先简单处理，在黑名单中支持通配符*作为黑名单过滤所有选项的方式
- 其他
  - 目前使用AutoHotKey配合自动触发滚轮上下滚动，来解决选中不拾取物品后，无法继续拾取问题，这个建议后续考虑能不能在万叶自动拾取逻辑里面一起实现