### PR TITLE
add JS环境下对C#带out参数方法的支持

### DIFF
--- a/BetterGenshinImpact/Core/Script/EngineExtend.cs
+++ b/BetterGenshinImpact/Core/Script/EngineExtend.cs
@@ -61,7 +61,8 @@ public class EngineExtend
         
         
         engine.AddHostObject("OpenCvSharp", new HostTypeCollection("OpenCvSharp"));
-
+        // 调用带out参数的方法
+        engine.AddHostObject("host", new HostFunctions());
 
 
 


### PR DESCRIPTION
https://microsoft.github.io/ClearScript/Tutorial/FAQtorial.html

OpenCvSharp中部分方法带有out参数，目前还无法调用。
但我对C#和ClearScript不了解，大佬评估下风险

测试了OpenCvSharp中Mat.LocateROI方法，方法是有效的

**Mat.LocateROI方法：**
·https://github.com/shimat/opencvsharp/blob/4b7e1345bdc8229293c9ebaea37ef900ff2fbff4/src/OpenCvSharp/Modules/core/Mat/Mat.cs#L2415

**JS调用示例**
```
        let cap = captureGameRegion();
        let roiMat = cap.SrcMat;

        var wholeSizeVar = host.newVar(OpenCvSharp.OpenCvSharp.Size);
        var ofsVar = host.newVar(OpenCvSharp.OpenCvSharp.Point);

        roiMat.LocateROI(wholeSizeVar.out, ofsVar.out);

        var wholeSize = wholeSizeVar.value;
        var offset = ofsVar.value;

        log.info("🔍 LocateROI 结果：");
        log.info("   整体图像大小: {0} x {1}", wholeSize.Width, wholeSize.Height);
        log.info("   当前ROI偏移: X={0}, Y={1}", offset.X, offset.Y);
```

**运行结果：**
<img width="387" height="212" alt="image" src="https://github.com/user-attachments/assets/44d5c443-bffc-4df4-8742-388433d29339" />
