### PR TITLE
菈乌玛入队相关情况修复

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
@@ -290,11 +290,14 @@ public class Avatar
 
     private void Offset60Fix(int i)
     {
-        // 6.0 特殊逻辑
-        if (i > 3 && CombatScenes.IndexRectOffset60Fix)
+        // 3次失败考虑是否偏移出现问题，修改偏移位置
+        if (i <= 2)
         {
-            // 3次失败考虑是否偏移出现问题，修改偏移位置
-            // 只有 草露 角色离队，然后跨地图传送后，会出现这个场景。也就是只有 偏移 -> 原始 的场景
+            return;
+        }
+        
+        if (CombatScenes.IndexRectOffset60Fix)
+        {
             foreach (var avatar in CombatScenes.GetAvatars())
             {
                 var rect1 = avatar.IndexRect;
@@ -304,6 +307,18 @@ public class Avatar
 
             CombatScenes.IndexRectOffset60Fix = false;
         }
+        else
+        {
+            foreach (var avatar in CombatScenes.GetAvatars())
+            {
+                var rect1 = avatar.IndexRect;
+                rect1.Y -= 14;
+                avatar.IndexRect = rect1;
+            }
+
+            CombatScenes.IndexRectOffset60Fix = true;
+        }
+        
     }
 
     /// <summary>

--- a/BetterGenshinImpact/GameTask/AutoFight/Model/CombatScenes.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Model/CombatScenes.cs
@@ -156,42 +156,6 @@ public class CombatScenes : IDisposable
     /// <param name="avatarIndexRectList"></param>
     public bool AvatarSideFixOffset(ImageRegion imageRegion, List<Rect> avatarSideIconRectList, List<Rect> avatarIndexRectList)
     {
-        List<Rect> avatarSideIconRectListOffset;
-        List<Rect> avatarIndexRectListOffset;
-        // 直接重新进行初始化，以这个为基准进行修改
-        var pRaList = imageRegion.FindMulti(AutoFightAssets.Instance.PRa);
-        if (pRaList.Count > 0)
-        {
-            var num = pRaList.Count + 1;
-            if (num > 4)
-            {
-                throw new Exception("当前处于联机状态，但是队伍人数超过4人，无法识别");
-            }
-
-            // 联机状态下判断
-            var onePRa = imageRegion.Find(AutoFightAssets.Instance.OnePRa);
-            var p = "p";
-            if (!onePRa.IsEmpty())
-            {
-                Logger.LogInformation("当前处于联机状态，且当前账号是房主，联机人数{Num}人", num);
-                p = "1p";
-            }
-            else
-            {
-                Logger.LogInformation("当前处于联机状态，且在别人世界中，联机人数{Num}人", num);
-            }
-
-            avatarSideIconRectListOffset = AutoFightAssets.Instance.AvatarSideIconRectListMap[$"{p}_{num}"];
-            avatarIndexRectListOffset = AutoFightAssets.Instance.AvatarIndexRectListMap[$"{p}_{num}"];
-
-            ExpectedTeamAvatarNum = avatarSideIconRectList.Count;
-        }
-        else
-        {
-            avatarSideIconRectListOffset = AutoFightAssets.Instance.AvatarSideIconRectList;
-            avatarIndexRectListOffset = AutoFightAssets.Instance.AvatarIndexRectList;
-        }
-        
         // 角色序号 左上角 坐标偏移（+2, -5）后存在3个白色点，则认为存在 草露 进度条
         // 存在 草露 进度条时候整体上移 14 个像素
         int whitePointCount = 0;
@@ -212,14 +176,14 @@ public class CombatScenes : IDisposable
 
             for (int i = 0; i < avatarSideIconRectList.Count; i++)
             {
-                var rect = avatarSideIconRectListOffset[i];
+                var rect = avatarSideIconRectList[i];
                 rect.Y -= 14;
                 avatarSideIconRectList[i] = rect;
             }
 
             for (int i = 0; i < avatarIndexRectList.Count; i++)
             {
-                var rect = avatarIndexRectListOffset[i];
+                var rect = avatarIndexRectList[i];
                 rect.Y -= 14;
                 avatarIndexRectList[i] = rect;
             }
@@ -232,14 +196,14 @@ public class CombatScenes : IDisposable
             Logger.LogInformation("检测到右侧队伍下偏移，进行位置位置");
             for (int i = 0; i < avatarSideIconRectList.Count; i++)
             {
-                var rect = avatarSideIconRectListOffset[i];
+                var rect = avatarSideIconRectList[i];
                 rect.Y += 14;
                 avatarSideIconRectList[i] = rect;
             }
 
             for (int i = 0; i < avatarIndexRectList.Count; i++)
             {
-                var rect = avatarIndexRectListOffset[i];
+                var rect = avatarIndexRectList[i];
                 rect.Y += 14;
                 avatarIndexRectList[i] = rect;
             }


### PR DESCRIPTION
菈乌玛的修正问题有三个：

一、TrySwitch默认重试4次，传入Offset60Fix的最大为3，所以涉及的切人（行走位和战斗）都不会触发修正，解决方法：Offset60Fix中把改为if (i > 2)。

二、相关rect如重新启动任务会重置，导致切人那边不知道现在的真实状态，例如用菈乌玛跑了一个地图追踪，目前-14后的rect，跑完我停止任务，重新执行一个任务，rect会重置为非-14，那么状态就会出错，默认的rect是初始值，触发切人修正的基准应该为-14，导致修正出错。解决办法：每次触发纠正以初始为基准进行-14或+14。

三、正常任务中，因为卡地形，出招卡切换等，可能会导致切换失败超过3次，在非需要修正下触发多次+14的操作，所以，切人修正得正反修正以纠正可能的修正错误。