### PR TITLE
修复菈乌玛UI问题的卡顿等问题

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
@@ -40,6 +40,8 @@ public class AutoFightTask : ISoloTask
     private readonly double _dpi = TaskContext.Instance().DpiScale;
 
     public static OtherConfig Config { get; set; } = TaskContext.Instance().Config.OtherConfig;
+    
+    public static bool FightStatusFlag { get; set; } = false;
 
     private class TaskFightFinishDetectConfig
     {
@@ -287,6 +289,8 @@ public class AutoFightTask : ISoloTask
         {
             try
             {
+                FightStatusFlag = true;
+                
                 while (!cts2.Token.IsCancellationRequested)
                 {
                     // 所有战斗角色都可以被取消
@@ -442,6 +446,7 @@ public class AutoFightTask : ISoloTask
             finally
             {
                 Simulation.ReleaseAllKey();
+                FightStatusFlag = false;
             }
         }, cts2.Token);
 

--- a/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
@@ -94,6 +94,7 @@ public class Avatar
         NameRect = nameRect;
         CombatAvatar = DefaultAutoFightConfig.CombatAvatarMap[name];
         ManualSkillCd = manualSkillCd;
+        AutoFightTask.FightStatusFlag = false;
     }
 
 
@@ -291,7 +292,7 @@ public class Avatar
     private void Offset60Fix(int i)
     {
         // 3次失败考虑是否偏移出现问题，修改偏移位置
-        if (i <= 2)
+        if (i <= 2 || AutoFightTask.FightStatusFlag)
         {
             return;
         }
@@ -300,18 +301,18 @@ public class Avatar
         {
             foreach (var avatar in CombatScenes.GetAvatars())
             {
-                var rect1 = avatar.IndexRect;
-                rect1.Y += 14;
+                var originalRect = AutoFightAssets.Instance.AvatarIndexRectList[avatar.Index - 1];
+                var rect1 = new Rect(originalRect.X, originalRect.Y, originalRect.Width, originalRect.Height);
                 avatar.IndexRect = rect1;
             }
-
             CombatScenes.IndexRectOffset60Fix = false;
         }
         else
         {
             foreach (var avatar in CombatScenes.GetAvatars())
             {
-                var rect1 = avatar.IndexRect;
+                var originalRect = AutoFightAssets.Instance.AvatarIndexRectList[avatar.Index - 1];
+                var rect1 = new Rect(originalRect.X, originalRect.Y, originalRect.Width, originalRect.Height);
                 rect1.Y -= 14;
                 avatar.IndexRect = rect1;
             }

--- a/BetterGenshinImpact/GameTask/AutoFight/Model/CombatScenes.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Model/CombatScenes.cs
@@ -96,15 +96,15 @@ public class CombatScenes : IDisposable
                 Logger.LogInformation("当前处于联机状态，且在别人世界中，联机人数{Num}人", num);
             }
 
-            avatarSideIconRectList = AutoFightAssets.Instance.AvatarSideIconRectListMap[$"{p}_{num}"];
-            avatarIndexRectList = AutoFightAssets.Instance.AvatarIndexRectListMap[$"{p}_{num}"];
+            avatarSideIconRectList = new List<Rect>(AutoFightAssets.Instance.AvatarSideIconRectListMap[$"{p}_{num}"]);
+            avatarIndexRectList = new List<Rect>(AutoFightAssets.Instance.AvatarIndexRectListMap[$"{p}_{num}"]);
 
             ExpectedTeamAvatarNum = avatarSideIconRectList.Count;
         }
         else
         {
-            avatarSideIconRectList = AutoFightAssets.Instance.AvatarSideIconRectList;
-            avatarIndexRectList = AutoFightAssets.Instance.AvatarIndexRectList;
+            avatarSideIconRectList = new List<Rect>(AutoFightAssets.Instance.AvatarSideIconRectList);
+            avatarIndexRectList = new List<Rect>(AutoFightAssets.Instance.AvatarIndexRectList);
         }
         
         // 6.0 版本 队伍下的 草露 进度条 导致位置偏移
@@ -158,7 +158,7 @@ public class CombatScenes : IDisposable
     {
         // 角色序号 左上角 坐标偏移（+2, -5）后存在3个白色点，则认为存在 草露 进度条
         // 存在 草露 进度条时候整体上移 14 个像素
-        int whitePointCount = 0;
+        var whitePointCount = 0;
         foreach (var rectIndex in avatarIndexRectList)
         {
             int x = rectIndex.X + 2;
@@ -170,47 +170,28 @@ public class CombatScenes : IDisposable
             }
         }
 
-        if (whitePointCount >= 3)
+        if (whitePointCount < 3)
         {
-            Logger.LogInformation("检测到右侧队伍上偏移，进行位置偏移");
-
-            for (int i = 0; i < avatarSideIconRectList.Count; i++)
-            {
-                var rect = avatarSideIconRectList[i];
-                rect.Y -= 14;
-                avatarSideIconRectList[i] = rect;
-            }
-
-            for (int i = 0; i < avatarIndexRectList.Count; i++)
-            {
-                var rect = avatarIndexRectList[i];
-                rect.Y -= 14;
-                avatarIndexRectList[i] = rect;
-            }
-
-            return true;
-        }
-        else if (whitePointCount <= 1) //发现有时候识别到一个白点
-        {
-            Logger.LogInformation("检测到右侧队伍下偏移，进行位置偏移");
-            for (int i = 0; i < avatarSideIconRectList.Count; i++)
-            {
-                var rect = avatarSideIconRectList[i];
-                rect.Y += 14;
-                avatarSideIconRectList[i] = rect;
-            }
-
-            for (int i = 0; i < avatarIndexRectList.Count; i++)
-            {
-                var rect = avatarIndexRectList[i];
-                rect.Y += 14;
-                avatarIndexRectList[i] = rect;
-            }
-
             return false;
-        }   
-        
-        return false;
+        }
+
+        Logger.LogInformation("检测到右侧队伍上偏移，进行位置偏移");
+
+        for (var i = 0; i < avatarSideIconRectList.Count; i++)
+        {
+            var rect = avatarSideIconRectList[i];
+            rect.Y -= 14;
+            avatarSideIconRectList[i] = rect;
+        }
+
+        for (var i = 0; i < avatarIndexRectList.Count; i++)
+        {
+            var rect = avatarIndexRectList[i];
+            rect.Y -= 14;
+            avatarIndexRectList[i] = rect;
+        }
+
+        return true;
     }
     
 

--- a/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
@@ -1101,7 +1101,7 @@ public class PathExecutor
             return null;
         }
 
-        var success = avatar.TrySwitch();
+        var success = avatar.TrySwitch(5);//多切换一次，否则如果切人纠正要等下一个循环
         if (success)
         {
             await Delay(100, ct);


### PR DESCRIPTION
问题一，构建队伍问题：
avatarSideIconRectList = AutoFightAssets.Instance.AvatarSideIconRectList;
avatarIndexRectList = AutoFightAssets.Instance.AvatarIndexRectList;
以上赋值会导致avatarIndexRectList和avatarSideIconRectList的改变会直接影响改变原始参数AutoFightAssets.Instance.AvatarSideIconRectList和AutoFightAssets.Instance.AvatarIndexRectList;的值，在连续任务重会导致基准值变化，复现步骤举例为：菈乌玛队伍执行幽境JS，在进入秘境前已经进行了-14纠正，原始AutoFightAssets.Instance.AvatarIndexRectList也改变了，进入用非菈乌玛队伍，导致非菈乌玛队伍在构建队伍时机基准为已经-14纠正得值，又不进行纠正（秘境中UI恢复了），所以导致需要通过切人检测，这样会导致要通过切人检测进行纠正，但基础值错误，导致可能的多次和错误纠正次数，也可能一直错误，导致战斗卡顿。

解决方案：
1、使用NEW去赋值，保证初始值参数不变
 avatarSideIconRectList = new List<Rect>(AutoFightAssets.Instance.AvatarSideIconRectList);
 avatarIndexRectList = new List<Rect>(AutoFightAssets.Instance.AvatarIndexRectList);
2、在进行构建时检测上移就纠正，不上移保持不变即可。

问题二，切人修正问题：
1、因为只可能存在两种情况，CombatScenes.IndexRectOffset60Fix为TRUE(构建队伍时上移)，就直接回复初始值，如果为false,进行-14纠正，减少可能的纠正错误重复纠正，
2、因为目前战斗战斗逻辑可能存在战略性的提前切人，例如在放Q过程的动画时间，可能就已经在执行切人，或者万叶E下落会提前执行切人，存在一定合理的切换失败范围，建议加入在战斗过程不进行纠正的机制，因为战斗过程UI不会改变。如果保留战斗过程的纠正，可能出现一定的卡顿，例如触发一次纠正后是错误的，又要纠正一次恢复，那么就会有500毫秒的卡顿，因为切换函数的重试延时是250毫秒。切人纠正一般用于地图追踪等其他会变化游戏场景触发的UI改变（对纠正延时有容错高的场景），战斗场景的队伍和场景都不会变化。
