### PR TITLE
修复传送至渊下宫的地图时有概率识别不出来的问题

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoTrackPath/TpTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoTrackPath/TpTask.cs
@@ -878,7 +878,11 @@ public class TpTask
         var list = ra.FindMulti(new RecognitionObject
         {
             RecognitionType = RecognitionTypes.Ocr,
-            RegionOfInterest = new Rect(ra.Width / 2, 0, ra.Width / 2, ra.Height)
+            RegionOfInterest = new Rect(ra.Width / 2, 0, ra.Width / 2, ra.Height),
+            ReplaceDictionary = new Dictionary<string, string[]>
+            {
+                ["渊下宫"] = ["渊下宮"],
+            },
         });
         string minCountryLocalized = this.stringLocalizer.WithCultureGet(this.cultureInfo, areaName);
         Region? matchRect = list.OrderByDescending(r => r.Y).FirstOrDefault(r => r.Text.Contains(minCountryLocalized));

--- a/BetterGenshinImpact/GameTask/Model/Area/ImageRegion.cs
+++ b/BetterGenshinImpact/GameTask/Model/Area/ImageRegion.cs
@@ -193,7 +193,7 @@ public class ImageRegion : Region
             {
                 foreach (var replaceStr in entry.Value)
                 {
-                    text = text.Replace(entry.Key, replaceStr);
+                    text = text.Replace(replaceStr, entry.Key);
                 }
             }
 

--- a/BetterGenshinImpact/GameTask/Model/RectArea.cs
+++ b/BetterGenshinImpact/GameTask/Model/RectArea.cs
@@ -305,7 +305,7 @@
 //             {
 //                 foreach (var replaceStr in entry.Value)
 //                 {
-//                     text = text.Replace(entry.Key, replaceStr);
+//                     text = text.Replace(replaceStr, entry.Key);
 //                 }
 //             }
 //


### PR DESCRIPTION
BetterGI长时间运行之后传送至渊下宫地图有概率触发此问题。经过研究发现是OCR的时候把`宫`(Unicode U+5BAB)识别成`宮`(Unicode U+5BAE)。且会连续识别错误，重试无效。

log如下

```
[03:35:56.793] [INF] BetterGenshinImpact.Service.ScriptService
→ 开始执行地图追踪任务: "G06-紫晶块-渊下宫-蛇心之地左上03(有战斗,火免,精英200x1,小怪)-4个.json"

[03:35:56.845] [DBG] BetterGenshinImpact.GameTask.Common.TaskControl
战斗脚本解析完成，共1条指令，涉及角色："当前角色"

[03:35:56.845] [DBG] BetterGenshinImpact.GameTask.Common.TaskControl
战斗脚本解析完成，共1条指令，涉及角色："当前角色"

[03:35:56.845] [DBG] BetterGenshinImpact.GameTask.Common.TaskControl
战斗脚本解析完成，共1条指令，涉及角色："当前角色"

[03:35:58.583] [WRN] BetterGenshinImpact.GameTask.Common.TaskControl
切换区域失败："渊下宫"

[03:35:58.583] [INF] BetterGenshinImpact.GameTask.Common.TaskControl
识别结果："地图,X,蒙德,璃月,稻妻,由,须弥,纳塔,枫丹,挪德卡莱,层岩巨渊·地下矿区,渊下宮,旧日之海,远古圣山,尘歌壶,蛇心之地,UID: 33543xxxx"

[03:35:58.584] [ERR] BetterGenshinImpact.GameTask.Common.TaskControl
传送失败，重试 1 次

[03:35:58.584] [DBG] BetterGenshinImpact.GameTask.Common.TaskControl
传送失败，重试 1 次
System.Exception: 切换独立地图区域[渊下宫]失败
   at BetterGenshinImpact.GameTask.AutoTrackPath.TpTask.SwitchArea(String areaName) in C:\wd\better-genshin-impact\BetterGenshinImpact\GameTask\AutoTrackPath\TpTask.cs:line 892
   at BetterGenshinImpact.GameTask.AutoTrackPath.TpTask.TpOnce(Double tpX, Double tpY, String mapName, Boolean force) in C:\wd\better-genshin-impact\BetterGenshinImpact\GameTask\AutoTrackPath\TpTask.cs:line 243
   at BetterGenshinImpact.GameTask.AutoTrackPath.TpTask.Tp(Double tpX, Double tpY, String mapName, Boolean force) in C:\wd\better-genshin-impact\BetterGenshinImpact\GameTask\AutoTrackPath\TpTask.cs:line 448

[03:35:59.138] [WRN] BetterGenshinImpact.GameTask.Common.TaskControl
切换区域失败："渊下宫"

[03:35:59.138] [INF] BetterGenshinImpact.GameTask.Common.TaskControl
识别结果："地图,X,蒙德,璃月,稻妻,由,须弥,纳塔,枫丹,挪德卡莱,层岩巨渊·地下矿区,渊下宮,旧日之海,远古圣山,尘歌壶,蛇心之地,UID: 33543xxxx"

[03:35:59.138] [ERR] BetterGenshinImpact.GameTask.Common.TaskControl
传送失败，重试 2 次

[03:35:59.138] [DBG] BetterGenshinImpact.GameTask.Common.TaskControl
传送失败，重试 2 次
System.Exception: 切换独立地图区域[渊下宫]失败
   at BetterGenshinImpact.GameTask.AutoTrackPath.TpTask.SwitchArea(String areaName) in C:\wd\better-genshin-impact\BetterGenshinImpact\GameTask\AutoTrackPath\TpTask.cs:line 892
   at BetterGenshinImpact.GameTask.AutoTrackPath.TpTask.TpOnce(Double tpX, Double tpY, String mapName, Boolean force) in C:\wd\better-genshin-impact\BetterGenshinImpact\GameTask\AutoTrackPath\TpTask.cs:line 243
   at BetterGenshinImpact.GameTask.AutoTrackPath.TpTask.Tp(Double tpX, Double tpY, String mapName, Boolean force) in C:\wd\better-genshin-impact\BetterGenshinImpact\GameTask\AutoTrackPath\TpTask.cs:line 448

[03:35:59.684] [WRN] BetterGenshinImpact.GameTask.Common.TaskControl
切换区域失败："渊下宫"

[03:35:59.684] [INF] BetterGenshinImpact.GameTask.Common.TaskControl
识别结果："地图,X,蒙德,璃月,稻妻,由,须弥,纳塔,枫丹,挪德卡莱,层岩巨渊·地下矿区,渊下宮,旧日之海,远古圣山,尘歌壶,蛇心之地,UID: 33543xxxx"

[03:35:59.684] [ERR] BetterGenshinImpact.GameTask.Common.TaskControl
传送失败，重试 3 次

[03:35:59.684] [DBG] BetterGenshinImpact.GameTask.Common.TaskControl
传送失败，重试 3 次
System.Exception: 切换独立地图区域[渊下宫]失败
   at BetterGenshinImpact.GameTask.AutoTrackPath.TpTask.SwitchArea(String areaName) in C:\wd\better-genshin-impact\BetterGenshinImpact\GameTask\AutoTrackPath\TpTask.cs:line 892
   at BetterGenshinImpact.GameTask.AutoTrackPath.TpTask.TpOnce(Double tpX, Double tpY, String mapName, Boolean force) in C:\wd\better-genshin-impact\BetterGenshinImpact\GameTask\AutoTrackPath\TpTask.cs:line 243
   at BetterGenshinImpact.GameTask.AutoTrackPath.TpTask.Tp(Double tpX, Double tpY, String mapName, Boolean force) in C:\wd\better-genshin-impact\BetterGenshinImpact\GameTask\AutoTrackPath\TpTask.cs:line 448

[03:35:59.685] [DBG] BetterGenshinImpact.Service.ScriptService
执行脚本时发生异常
System.InvalidOperationException: 传送失败
   at BetterGenshinImpact.GameTask.AutoTrackPath.TpTask.Tp(Double tpX, Double tpY, String mapName, Boolean force) in C:\wd\better-genshin-impact\BetterGenshinImpact\GameTask\AutoTrackPath\TpTask.cs:line 469
   at BetterGenshinImpact.GameTask.AutoPathing.PathExecutor.HandleTeleportWaypoint(WaypointForTrack waypoint) in C:\wd\better-genshin-impact\BetterGenshinImpact\GameTask\AutoPathing\PathExecutor.cs:line 687
   at BetterGenshinImpact.GameTask.AutoPathing.PathExecutor.Pathing(PathingTask task) in C:\wd\better-genshin-impact\BetterGenshinImpact\GameTask\AutoPathing\PathExecutor.cs:line 188
   at BetterGenshinImpact.Core.Script.Group.ScriptGroupProject.Run() in C:\wd\better-genshin-impact\BetterGenshinImpact\Core\Script\Group\ScriptGroupProject.cs:line 208
   at BetterGenshinImpact.Service.ScriptService.ExecuteProject(ScriptGroupProject project) in C:\wd\better-genshin-impact\BetterGenshinImpact\Service\ScriptService.cs:line 536
   at BetterGenshinImpact.Service.ScriptService.<>c__DisplayClass5_0.<<RunMulti>b__0>d.MoveNext() in C:\wd\better-genshin-impact\BetterGenshinImpact\Service\ScriptService.cs:line 337

[03:35:59.685] [ERR] BetterGenshinImpact.Service.ScriptService
执行脚本时发生异常: "传送失败"

[03:35:59.686] [INF] BetterGenshinImpact.Service.ScriptService
→ 脚本执行结束: "G06-紫晶块-渊下宫-蛇心之地左上03(有战斗,火免,精英200x1,小怪)-4个.json", 耗时: 0分2.892秒

[03:35:59.686] [INF] BetterGenshinImpact.Service.ScriptService
------------------------------
```