### PR TITLE
修复传送至渊下宫的地图时有概率识别不出来的问题 2

### DIFF
--- a/BetterGenshinImpact/GameTask/Model/Area/ImageRegion.cs
+++ b/BetterGenshinImpact/GameTask/Model/Area/ImageRegion.cs
@@ -417,6 +417,13 @@ public class ImageRegion : Region
                 {
                     var newRa = this.Derive(r.Rect.BoundingRect() + ro.RegionOfInterest.Location);
                     newRa.Text = r.Text;
+                    foreach (var entry in ro.ReplaceDictionary)
+                    {
+                        foreach (var replaceStr in entry.Value)
+                        {
+                            newRa.Text = newRa.Text.Replace(replaceStr, entry.Key);
+                        }
+                    }
                     return newRa;
                 }).ToList();
                 if (ro.DrawOnWindow && !string.IsNullOrEmpty(ro.Name))


### PR DESCRIPTION
在PR [#2249](https://github.com/babalae/better-genshin-impact/pull/2249)中我们只修改了`Find()`，在此补充修改`FindMulti()`