### PR TITLE
CountInventoryItem支持一次数多个物品

### DIFF
--- a/BetterGenshinImpact/Core/Script/Project/ScriptProject.cs
+++ b/BetterGenshinImpact/Core/Script/Project/ScriptProject.cs
@@ -1,4 +1,4 @@
-﻿using BetterGenshinImpact.Core.Config;
+using BetterGenshinImpact.Core.Config;
 using Microsoft.ClearScript;
 using Microsoft.ClearScript.V8;
 using System;

--- a/BetterGenshinImpact/GameTask/Common/Job/CountInventoryItem.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/CountInventoryItem.cs
@@ -10,13 +10,14 @@ using Microsoft.ML.OnnxRuntime;
 using OpenCvSharp;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace BetterGenshinImpact.GameTask.Common.Job
 {
-    internal class CountInventoryItem : ISoloTask<int>
+    internal class CountInventoryItem : ISoloTask<object>
     {
         public string Name => "背包数物品";
 
@@ -24,33 +25,74 @@ namespace BetterGenshinImpact.GameTask.Common.Job
         private readonly InputSimulator input = Simulation.SendInput;
         private CancellationToken ct;
         private readonly GridScreenName gridScreenName;
-        private readonly string itemName;
+        private readonly string? itemName;
+        private readonly IEnumerable<string>? itemNames;
 
-        public CountInventoryItem(GridScreenName gridScreenName, string itemName)
+        public CountInventoryItem(GridScreenName gridScreenName, string? itemName = null, IEnumerable<string>? itemNames = null)
         {
             this.gridScreenName = gridScreenName;
+            if (itemName != null && itemNames != null)
+            {
+                throw new ArgumentException($"参数{nameof(itemName)}和{nameof(itemNames)}不能同时使用");
+            }
+            if (itemName == null && itemNames == null)
+            {
+                throw new ArgumentException($"参数{nameof(itemName)}和{nameof(itemNames)}不能同时为空");
+            }
+            if (itemNames != null && !itemNames.Any())
+            {
+                throw new ArgumentException($"参数{nameof(itemNames)}不能为空序列");
+            }
             this.itemName = itemName;
+            this.itemNames = itemNames;
         }
 
-        public async Task<int> Start(CancellationToken ct)
+        public async Task<object> Start(CancellationToken ct)
         {
             this.ct = ct;
 
-            logger.LogInformation("打开背包并在{grid}寻找{name}……", this.gridScreenName, this.itemName);
+            if (this.itemName != null)
+            {
+                logger.LogInformation("打开背包并在{grid}寻找{name}……", this.gridScreenName, this.itemName!);
+            }
+            else
+            {
+                logger.LogInformation("打开背包并在{grid}寻找{first}等{count}类物品……", this.gridScreenName, this.itemNames!.First(), this.itemNames!.Count());
+            }
             await new ReturnMainUiTask().Start(ct);
             await AutoArtifactSalvageTask.OpenInventory(this.gridScreenName, input, logger, this.ct);
 
             using InferenceSession session = GridIconsAccuracyTestTask.LoadModel(out Dictionary<string, float[]> prototypes);
 
-            using var ra = TaskControl.CaptureToRectArea();
+            object result;
+            if (this.itemName != null)
+            {
+                result = await FindOne(session, prototypes);
+            }
+            else
+            {
+                result = await FindMulti(session, prototypes);
+            }
+
+            await new ReturnMainUiTask().Start(ct);
+
+            return result;
+        }
+
+        private async Task<int> FindOne(InferenceSession session, Dictionary<string, float[]> prototypes)
+        {
             GridScreen gridScreen = new GridScreen(GridParams.Templates[this.gridScreenName], logger, ct);
             int? count = null;
             await foreach (ImageRegion itemRegion in gridScreen)
             {
                 using Mat icon = itemRegion.SrcMat.GetGridIcon();
                 var result = GridIconsAccuracyTestTask.Infer(icon, session, prototypes);
+                if (result.Item1 == null)
+                {
+                    continue;
+                }
                 string predName = result.Item1;
-                if (predName == this.itemName)
+                if (predName == this.itemName!)
                 {
                     string numStr = itemRegion.SrcMat.GetGridItemIconText(OcrFactory.Paddle);
                     if (int.TryParse(numStr, out int num))
@@ -59,21 +101,68 @@ namespace BetterGenshinImpact.GameTask.Common.Job
                     }
                     else
                     {
-                        count = -2;
                         logger.LogWarning("无法识别数量：{text}", numStr);
+                        count = -2;
                     }
-
                     break;
                 }
             }
             if (count == null)
             {
                 count = -1;
-                logger.LogInformation("没有找到{name}", this.itemName);
+                logger.LogInformation("没有找到{name}", this.itemName!);
             }
-            await new ReturnMainUiTask().Start(ct);
-
             return count.Value;
+        }
+
+        private async Task<Dictionary<string, int>> FindMulti(InferenceSession session, Dictionary<string, float[]> prototypes)
+        {
+            Dictionary<string, int> itemsCountDic = new Dictionary<string, int>();
+            List<string> notFoundItemNames = this.itemNames!.ToList();
+
+            GridScreen gridScreen = new GridScreen(GridParams.Templates[this.gridScreenName], logger, ct);
+            await foreach (ImageRegion itemRegion in gridScreen)
+            {
+                using Mat icon = itemRegion.SrcMat.GetGridIcon();
+                var result = GridIconsAccuracyTestTask.Infer(icon, session, prototypes);
+                if (result.Item1 == null)
+                {
+                    continue;
+                }
+                string predName = result.Item1;
+                if (this.itemNames!.Contains(predName) && !itemsCountDic!.ContainsKey(predName))
+                {
+                    int count;
+                    string numStr = itemRegion.SrcMat.GetGridItemIconText(OcrFactory.Paddle);
+                    if (int.TryParse(numStr, out int num))
+                    {
+                        count = num;
+                    }
+                    else
+                    {
+                        logger.LogWarning("无法识别数量：{text}", numStr);
+                        count = -2;
+                    }
+
+                    if (!itemsCountDic!.TryAdd(predName, count))
+                    {
+                        logger.LogWarning("重复的名称：{name}", predName);
+                    }
+
+                    notFoundItemNames.RemoveAll(n => n == predName);
+
+                    if (notFoundItemNames.Count <= 0)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            if (notFoundItemNames.Count > 0)
+            {
+                logger.LogInformation("没有找到{name}", String.Join(", ", notFoundItemNames));
+            }
+            return itemsCountDic;
         }
 
         async Task ISoloTask.Start(CancellationToken ct)

--- a/BetterGenshinImpact/Helpers/ScriptObjectConverter.cs
+++ b/BetterGenshinImpact/Helpers/ScriptObjectConverter.cs
@@ -1,5 +1,6 @@
 using Microsoft.ClearScript;
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 
 namespace BetterGenshinImpact.Helpers;
@@ -44,41 +45,108 @@ public class ScriptObjectConverter
     {
         if (source[propertyName] is not Undefined && source[propertyName] != null)
         {
-            object value = source.GetProperty(propertyName);
+            object v8Value = source.GetProperty(propertyName);
 
-            Type type = typeof(T);
-            type = Nullable.GetUnderlyingType(type) ?? type;
-
-            if (type.IsEnum)
+            if (TryMap(v8Value, out T value))
             {
-                // 处理数字
-                if (value is int intValue)
-                {
-                    if (Enum.IsDefined(type, intValue))
-                    {
-                        return (T)Enum.ToObject(type, intValue);
-                    }
-                    else
-                    {
-                        return defaultValue;
-                    }
-                }
-                // 处理字符串
-                else if (value is string strValue)
-                {
-                    if (Enum.TryParse(type, strValue, ignoreCase: true, out object? parsedEnum))
-                    {
-                        return (T)parsedEnum;
-                    }
-                    else
-                    {
-                        return defaultValue;
-                    }
-                }
+                return value;
             }
-
-            return (T)value;
         }
         return defaultValue;
+    }
+
+    /// <summary>
+    /// <para>适用集合的重载</para>
+    /// 如果<paramref name="propertyName"/>解析失败，默认返回一个空集合；
+    /// 如果集合元素解析失败，将跳过该元素
+    /// <para>仅支持一层集合，<typeparamref name="T"/>不能再是集合</para>
+    /// <para>避开反射，享受健康生活</para>
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="source"></param>
+    /// <param name="propertyName"></param>
+    /// <returns></returns>
+    public static IEnumerable<T> GetValue<T>(ScriptObject source, string propertyName)
+    {
+        if (source[propertyName] is not Undefined && source[propertyName] != null)
+        {
+            object v8Value = source.GetProperty(propertyName);
+
+            return TryMap<T>(v8Value);
+        }
+        return new T[0];
+    }
+
+    /// <summary>
+    /// 尝试将ClearScript的类型转换成常用类型
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="v8Value"></param>
+    /// <param name="value"></param>
+    /// <returns></returns>
+    private static bool TryMap<T>(object v8Value, out T value)
+    {
+        Type type = typeof(T);
+        type = Nullable.GetUnderlyingType(type) ?? type;
+
+        if (type.IsEnum)
+        {
+            // 处理数字
+            if (v8Value is int intValue)
+            {
+                if (Enum.IsDefined(type, intValue))
+                {
+                    value = (T)Enum.ToObject(type, intValue);
+                    return true;
+                }
+                else
+                {
+                    value = default!;
+                    return false;
+                }
+            }
+            // 处理字符串
+            else if (v8Value is string strValue)
+            {
+                if (Enum.TryParse(type, strValue, ignoreCase: true, out object? parsedEnum))
+                {
+                    value = (T)parsedEnum;
+                    return true;
+                }
+                else
+                {
+                    value = default!;
+                    return false;
+                }
+            }
+        }
+
+        value = (T)v8Value;
+        return true;
+    }
+
+    /// <summary>
+    /// 尝试将ClearScript的V8Array类型转换成常用泛型集合类型
+    /// 如果集合元素解析失败，将跳过该元素，如此始终能返回一个集合
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="v8Value"></param>
+    /// <returns></returns>
+    private static IEnumerable<T> TryMap<T>(object v8Value)
+    {
+        Type elementType = typeof(T);
+        var iList = (System.Collections.IList)v8Value;  // V8Array虽然是私有类型无法获取，但其实现IList，可根据此接口操作
+
+        Type listType = typeof(List<>).MakeGenericType(elementType);
+        System.Collections.IList list = (System.Collections.IList)Activator.CreateInstance(listType)!;
+        foreach (var elementV8Value in iList)
+        {
+            if (TryMap(elementV8Value, out T elementValue))
+            {
+                list.Add(elementValue);
+            }
+        }
+
+        return (IEnumerable<T>)list;
     }
 }

--- a/Test/BetterGenshinImpact.UnitTest/GameTaskTests/GetGridIconsTests/GridIconsAccuracyTestTaskTests.cs
+++ b/Test/BetterGenshinImpact.UnitTest/GameTaskTests/GetGridIconsTests/GridIconsAccuracyTestTaskTests.cs
@@ -46,7 +46,7 @@ namespace BetterGenshinImpact.UnitTest.GameTaskTests.GetGridIconsTests
             var rows = GridScreen.GridEnumerator.ClusterRows(gridItems, 10);
 
             //
-            var result = new List<(string, int)>();
+            var result = new List<(string?, int)>();
             foreach (var row in rows)
             {
                 foreach (Rect rect in row)


### PR DESCRIPTION
#2261 
给ClearScript引擎增加集合参数解析时差点掉进反射的深坑了，，，out参数的反射让我直接放弃，，，现在就马马虎虎支持一下单层IEnumerable<T>的参数就好啦。

JS这边把返回值当字典来解析就好了，示例如下，回头更新到文档上去：
```
const result = await dispatcher.runTask(new SoloTask("CountInventoryItem", { "gridScreenName": "Food", "itemNames": ["鸡豆花", "超级至尊披萨"] }));
log.Info(`C# 方法返回鸡豆花数量: ${JSON.stringify(result["鸡豆花"])}`);
log.Info(`C# 方法返回超级至尊披萨数量: ${JSON.stringify(result["超级至尊披萨"])}`);
```

请注意目前这个方案的短处是，物品的定位效果不稳定，受背景干扰严重。请尝试自行面朝黑色场景进行降噪、多次调整视角尝试等手段