### PR TITLE
挪德卡莱中心点更新/地图追踪不执行自动派遣

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
@@ -637,9 +637,9 @@ public class PathExecutor
         {
             tpTask = new TpTask(ct);
         }
-
+        
         // 最小5分钟间隔
-        if ((DateTime.UtcNow - _lastGetExpeditionRewardsTime).TotalMinutes < 5)
+        if ( _combatScenes?.CurrentMultiGameStatus?.IsInMultiGame == true && (DateTime.UtcNow - _lastGetExpeditionRewardsTime).TotalMinutes < 5)
         {
             return false;
         }
@@ -652,7 +652,6 @@ public class PathExecutor
         if (!RunnerContext.Instance.isAutoFetchDispatch && adventurersGuildCountry != "无")
         {
             var ra1 = CaptureToRectArea();
-
             var textRect = new Rect(60, 20, 160, 260);
             var textMat = new Mat(ra1.SrcMat, textRect);
             string text = OcrFactory.Paddle.Ocr(textMat);

--- a/BetterGenshinImpact/GameTask/Common/Element/Assets/MapLazyAssets.cs
+++ b/BetterGenshinImpact/GameTask/Common/Element/Assets/MapLazyAssets.cs
@@ -25,6 +25,7 @@ public class MapLazyAssets : Singleton<MapLazyAssets>
         { "须弥", [2877, -374] },
         { "枫丹", [4515, 3631] },
         { "纳塔", [8973.5, -1879.1] },
+        { "挪德卡莱", [9542.25, 1661.84] },
     };
 
     public readonly Dictionary<string, GiTpPosition> DomainPositionMap = new();


### PR DESCRIPTION
1、挪德卡莱没中心点，如果在枫丹活纳塔传送到挪德卡莱，就会直接拖动过去。
2、联机中派遣是无法正常执行自动派遣的，联机狗粮，联机锄地等会造成错误。#2155
_combatScenes?.CurrentMultiGameStatus?.IsInMultiGame在队伍构建时就进行了联机检测，可以直接使用。