### PR TITLE
feat: 改进http，返回header和status_code，并实现url级别细粒度控制和ui提示

### DIFF
--- a/BetterGenshinImpact/Core/Script/Dependence/Http.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/Http.cs
@@ -9,37 +9,61 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
 using BetterGenshinImpact.GameTask;
+using Microsoft.Extensions.Logging;
 
 namespace BetterGenshinImpact.Core.Script.Dependence;
 
 public class Http
 {
-    private bool CheckHttpPermission()
+    private readonly ILogger<Http> _logger = App.GetLogger<Http>();
+
+    private void CheckHttpPermission(string url)
     {
-        try
+        var currentProject = TaskContext.Instance().CurrentScriptProject;
+        if (!currentProject?.AllowJsHTTP ?? false)
         {
-            var currentProject = TaskContext.Instance().CurrentScriptProject;
-            return currentProject?.AllowJsHTTP ?? false;
+            throw new UnauthorizedAccessException("当前JS脚本不允许使用HTTP请求，请在调度器通用设置中启用“JS HTTP权限”");
         }
-        catch
+        var allowedUrls = currentProject?.Project?.Manifest.HttpAllowedUrls ?? [];
+        if (allowedUrls.Length == 0)
         {
-            return false;
+            throw new UnauthorizedAccessException("当前JS脚本没有配置允许请求的URL，请在脚本的manifest.json中配置http_allowed_urls");
         }
+        if (allowedUrls.Any(allowedUrl =>
+        {
+            // fuzzy match
+            var pattern = "^" + System.Text.RegularExpressions.Regex.Escape(allowedUrl).Replace("\\*", ".*") + "$";
+            _logger.LogDebug($"[HTTP] 检查URL {url} 是否符合: {pattern}");
+            var regex = new System.Text.RegularExpressions.Regex(pattern);
+            return regex.IsMatch(url);
+        }))
+        {
+            return;
+        }
+        throw new UnauthorizedAccessException($"当前JS脚本不允许请求此URL: {url}，请在脚本的manifest.json中配置http_allowed_urls，当前允许的URL列表: [{string.Join(", ", allowedUrls)}]");
     }
+
+    public class HttpReponse
+    {
+        public int status_code { get; set; }
+        public Dictionary<string, string> headers { get; set; } = new();
+        public string body { get; set; } = "";
+    }
+
 
     /// <summary>
     /// 执行HTTP请求
     /// </summary>
     /// <param name="method">HTTP方法</param>
     /// <param name="url">请求URL</param>
-    /// <param name="body">请求体</param
+    /// <param name="body">请求体</param>
+    /// <param name="headersJson">请求头，JSON格式</param>
     /// <returns></returns>
-    public async Task<string> Request(string method, string url, string? body, string? headersJson)
+    public async Task<HttpReponse> Request(string method, string url, string? body, string? headersJson)
     {
-        if (!CheckHttpPermission())
-        {
-            throw new UnauthorizedAccessException("当前JS脚本不允许使用HTTP请求，请在调度器通用设置中启用“JS HTTP权限”");
-        }
+        _logger.LogDebug($"[HTTP] 发送HTTP请求: {method} {url} Body: {(body != null ? body : "null")} Headers: {(headersJson != null ? headersJson : "null")}");
+        CheckHttpPermission(url);
+
         var dictHeaders = new Dictionary<string, string>();
         if (!string.IsNullOrWhiteSpace(headersJson))
         {
@@ -59,7 +83,7 @@ public class Http
 
         // header全部小写
         dictHeaders = dictHeaders.ToDictionary(kvp => kvp.Key.ToLowerInvariant(), kvp => kvp.Value);
-        
+
         // 提前取出来Content-Type，防止被覆盖
         string contentType = "application/json";
         if (dictHeaders.TryGetValue("content-type", out var ct))
@@ -67,7 +91,7 @@ public class Http
             contentType = ct;
             dictHeaders.Remove("content-type");
         }
-        
+
         // 使用HttpClient发送请求
         using var httpClient = new HttpClient();
         httpClient.DefaultRequestHeaders.Clear();
@@ -79,6 +103,14 @@ public class Http
         var content = body == null ? null : new StringContent(body, Encoding.UTF8, contentType);
         var response = await httpClient.SendAsync(new HttpRequestMessage(new HttpMethod(method), url) { Content = content });
 
-        return await response.Content.ReadAsStringAsync();
+        var responseCode = (int)response.StatusCode;
+        var responseHeaders = response.Headers.ToDictionary(h => h.Key, h => h.Value.First()); // 只取第一个值
+        var responseBody = await response.Content.ReadAsStringAsync();
+        return new HttpReponse
+        {
+            status_code = responseCode,
+            headers = responseHeaders,
+            body = responseBody,
+        };
     }
 }

--- a/BetterGenshinImpact/Core/Script/Group/ScriptGroupProject.cs
+++ b/BetterGenshinImpact/Core/Script/Group/ScriptGroupProject.cs
@@ -107,7 +107,19 @@ public partial class ScriptGroupProject : ObservableObject
     private bool? _allowJsNotification = true;
 
     [ObservableProperty]
-    private bool? _allowJsHTTP = false;
+    private string? _allowJsHTTPHash = "";
+
+    /// <summary>
+    /// 是否允许JS脚本发送HTTP请求，通过验证Hash来控制
+    /// </summary>
+    [JsonIgnore]
+    public bool AllowJsHTTP
+    {
+        get
+        {
+            return GetHttpAllowedUrlsHash() == AllowJsHTTPHash;
+        }
+    }
 
 
     public ScriptGroupProject()
@@ -165,6 +177,19 @@ public partial class ScriptGroupProject : ObservableObject
             throw new Exception("FolderName 为空");
         }
         Project = new ScriptProject(FolderName);
+    }
+
+    public string GetHttpAllowedUrlsHash()
+    {
+        if (Project == null)
+        {
+            BuildScriptProjectRelation();
+        }
+        if (Project == null)
+        {
+            return "";
+        }
+        return string.Join("|", Project.Manifest.HttpAllowedUrls);
     }
 
     public async Task Run()

--- a/BetterGenshinImpact/Core/Script/Project/Manifest.cs
+++ b/BetterGenshinImpact/Core/Script/Project/Manifest.cs
@@ -26,6 +26,7 @@ public class Manifest
     public string[] Scripts { get; set; } = [];
     public string[] Library { get; set; } = [];
     public string[] SavedFiles { get; set; } = [];
+    public string[] HttpAllowedUrls { get; set; } = [];
 
     public static Manifest FromJson(string json)
     {

--- a/BetterGenshinImpact/Service/ScriptService.cs
+++ b/BetterGenshinImpact/Service/ScriptService.cs
@@ -486,7 +486,7 @@ public partial class ScriptService : IScriptService
         target.JsScriptSettingsObject = source.JsScriptSettingsObject;
         target.GroupInfo = source.GroupInfo;
         target.AllowJsNotification = source.AllowJsNotification;
-        target.AllowJsHTTP = source.AllowJsHTTP;
+        target.AllowJsHTTPHash = source.AllowJsHTTPHash;
         target.SkipFlag = source.SkipFlag;
     }
 

--- a/BetterGenshinImpact/View/Windows/Editable/ScriptGroupProjectEditor.xaml
+++ b/BetterGenshinImpact/View/Windows/Editable/ScriptGroupProjectEditor.xaml
@@ -6,10 +6,10 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:editable="clr-namespace:BetterGenshinImpact.ViewModel.Windows.Editable"
              xmlns:sys="clr-namespace:System;assembly=System.Runtime"
-             Width="200"
-             Height="300"
+             MinWidth="350"
+             MinHeight="300"
              d:DesignHeight="200"
-             d:DesignWidth="300"
+             d:DesignWidth="350"
              mc:Ignorable="d">
     <UserControl.Resources>
         <ObjectDataProvider x:Key="StatusDescriptionsProvider"
@@ -49,8 +49,41 @@
                       SelectedValue="{Binding AllowJsNotification, Mode=TwoWay}"
                       Visibility="{Binding IsJsScript, Converter={StaticResource BoolToVisConverter}}">
             </ComboBox>
+
             <TextBlock Margin="0,10,0,5" Text="JS HTTP权限"
                        Visibility="{Binding IsJsScript, Converter={StaticResource BoolToVisConverter}}"/>
+            <TextBlock Margin="0,0,0,5"
+                       Text="允许脚本发送HTTP请求，可能会带来安全风险，请谨慎开启。"
+                       Foreground="Orange"
+                       Visibility="{Binding IsJsScript, Converter={StaticResource BoolToVisConverter}}"/>
+            <TextBlock Margin="0,0,0,5"
+                       Text="注意：脚本更新http_allowed_urls后，需手动重新启用权限。"
+                       Foreground="Orange"
+                       Visibility="{Binding IsJsScript, Converter={StaticResource BoolToVisConverter}}"/>
+            <ItemsControl Margin="0,0,0,0" ItemsSource="{Binding JsHTTPInfoText}"
+                          Visibility="{Binding IsJsScript, Converter={StaticResource BoolToVisConverter}}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <TextBlock Text="{Binding Text}"
+                                Foreground="{Binding Color}"
+                                FontSize="11"
+                                TextWrapping="NoWrap"/>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+            <ItemsControl Margin="0,0,0,10" ItemsSource="{Binding JsHTTPInfo}"
+                          Visibility="{Binding IsJsScript, Converter={StaticResource BoolToVisConverter}}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <TextBox Text="{Binding Text}"
+                                IsReadOnly="True"
+                                Foreground="{Binding Color}"
+                                FontSize="11"
+                                FontFamily="Consolas"
+                                TextWrapping="NoWrap"/>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
             <ComboBox DisplayMemberPath="Value"
                       ItemsSource="{Binding JsNotificationOptions}"
                       SelectedValue="{Binding AllowJsHTTP, Mode=TwoWay}"

--- a/BetterGenshinImpact/ViewModel/Windows/Editable/ScriptGroupProjectEditorViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Windows/Editable/ScriptGroupProjectEditorViewModel.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Text.Json.Serialization;
+using System.Windows.Documents;
+using System.Windows.Media;
 using BetterGenshinImpact.Core.Script.Group;
 using BetterGenshinImpact.GameTask;
 using BetterGenshinImpact.Service.Notification;
@@ -37,11 +39,74 @@ public class ScriptGroupProjectEditorViewModel : ObservableObject
     
     public bool? AllowJsHTTP
     {
-        get => _project.AllowJsHTTP;
+        get
+        {
+            return _project.AllowJsHTTP;
+        }
         set
         {
-            _project.AllowJsHTTP = value;
+            // 为了避免误用，AllowJsHTTP禁止set，通过更新Hash来控制
+            // 脚本作者更新时，如果Hash变更会自动禁用http权限，避免安全风险
+            if (value == null || value == false)
+            {
+                _project.AllowJsHTTPHash = null;
+            }
+            else
+            {
+                _project.AllowJsHTTPHash = _project.GetHttpAllowedUrlsHash();
+            }
             OnPropertyChanged();
+        }
+    }
+
+    public record JsText(string Text, Brush Color);
+    public List<JsText> JsHTTPInfoText
+    {
+        get
+        {
+            if (_project.Project == null)
+            {
+                _project.BuildScriptProjectRelation();
+            }
+            if (_project.Project == null)
+            {
+                return new List<JsText>
+                {
+                    new JsText("当前脚本项目未加载", Brushes.Red)
+                };
+            }
+            var urls = _project.Project.Manifest?.HttpAllowedUrls ?? [];
+            if (urls.Length == 0)
+            {
+                return new List<JsText>
+                {
+                    new JsText("当前脚本无需使用HTTP资源", Brushes.Green)
+                };
+            }
+            return new List<JsText>
+            {
+                new JsText($"当前脚本使用 {urls.Length} 个HTTP资源", Brushes.OrangeRed)
+            };
+        }
+    }
+
+    public record JsLine(string Text, Brush Color);
+
+    public List<JsLine> JsHTTPInfo
+    {
+        get
+        {
+            if (_project.Project == null)
+            {
+                _project.BuildScriptProjectRelation();
+            }
+            var urls = _project.Project?.Manifest?.HttpAllowedUrls ?? [];
+            var blocks = new List<JsLine>();
+            foreach (var url in urls)
+            {
+                blocks.Add(new JsLine(url, Brushes.OrangeRed));
+            }
+            return blocks;
         }
     }
     
@@ -68,7 +133,7 @@ public class ScriptGroupProjectEditorViewModel : ObservableObject
             {
                 OnPropertyChanged(nameof(AllowJsNotification));
             }
-            if (e.PropertyName == nameof(ScriptGroupProject.AllowJsHTTP))
+            if (e.PropertyName == nameof(ScriptGroupProject.AllowJsHTTPHash))
             {
                 OnPropertyChanged(nameof(AllowJsHTTP));
             }


### PR DESCRIPTION
在manifest.json中增加http_allowed_urls字段，定义脚本能够访问url的白名单，支持`*`作为通配符。
同时在通用配置显著提示用户安全风险，同时显示脚本使用的url列表供用户审查。

为了避免更新被劫持偷偷插入用户未同意的url，通过记录url hash并比对来确定是否启用权限。url列表更新后，权限将自动禁用。
<img width="562" height="570" alt="image" src="https://github.com/user-attachments/assets/cd83aa2e-1215-456c-80b9-0df2a0853572" />
<img width="522" height="197" alt="image" src="https://github.com/user-attachments/assets/7abbe75f-e2e1-41f9-9f7a-f33348d83fd6" />


