### PR TITLE
typo: 修复 `AutoDomainParam` 泛型定义

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoDomain/AutoDomainParam.cs
+++ b/BetterGenshinImpact/GameTask/AutoDomain/AutoDomainParam.cs
@@ -1,11 +1,10 @@
 using System.Collections.Generic;
 using BetterGenshinImpact.GameTask.Model;
-using System.Threading;
 using BetterGenshinImpact.Core.Config;
 
 namespace BetterGenshinImpact.GameTask.AutoDomain;
 
-public class AutoDomainParam : BaseTaskParam<AutoDomainParam>
+public class AutoDomainParam : BaseTaskParam<AutoDomainTask>
 {
     public int DomainRoundNum { get; set; }
 


### PR DESCRIPTION
项目中貌似没有对 `BaseTaskParam` 进行反射以获得其泛型类型的地方，或者是我没注意到，姑且算捉虫

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **代码重构**
  * 优化了内部代码结构和依赖关系，提升代码维护性

<!-- end of auto-generated comment: release notes by coderabbit.ai -->