### PR TITLE
修复遮罩窗口小概率消失的bug

### DIFF
--- a/BetterGenshinImpact/GameTask/TaskTriggerDispatcher.cs
+++ b/BetterGenshinImpact/GameTask/TaskTriggerDispatcher.cs
@@ -262,6 +262,10 @@ namespace BetterGenshinImpact.GameTask
                             if (maskWindow.IsExist())
                             {
                                 maskWindow.Show();
+                                if (!_prevGameActive)
+                                {
+                                    maskWindow.BringToTop();
+                                }
                             }
                         });
                         // }

--- a/BetterGenshinImpact/View/MaskWindow.xaml.cs
+++ b/BetterGenshinImpact/View/MaskWindow.xaml.cs
@@ -68,6 +68,11 @@ public partial class MaskWindow : Window
         return _maskWindow != null && PresentationSource.FromVisual(_maskWindow) != null;
     }
 
+    public void BringToTop()
+    {
+        User32.BringWindowToTop(new WindowInteropHelper(this).Handle);
+    }
+
     public void RefreshPosition()
     {
         if (TaskContext.Instance().Config.MaskWindowConfig.UseSubform)
@@ -92,6 +97,7 @@ public partial class MaskWindow : Window
             Top = currentRect.Top / dpiScale;
             Width = currentRect.Width / dpiScale;
             Height = currentRect.Height / dpiScale;
+            BringToTop();
         });
     }
 


### PR DESCRIPTION
主要修复了两种可复现场景：

1. Alt+Enter切换全屏/窗口模式时遮罩窗口消失
2. 顺序执行：运行BetterGI->启动->最小化GI->启动配置组 的时候遮罩窗口消失

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- 改进了掩码窗口的显示管理，游戏窗口从非活跃切换为活跃状态时，掩码窗口现在会自动置于最前面显示。
- 优化了窗口位置调整后的显示层级处理，确保窗口显示顺序正确。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->