### PR TITLE
feat(js): 全局方法暴露 `getGameMetrics` 方法

### DIFF
--- a/BetterGenshinImpact/Core/Script/Dependence/GlobalMethod.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/GlobalMethod.cs
@@ -161,6 +161,11 @@ public class GlobalMethod
         _dpi = dpi;
     }
 
+    public static double[] GetGameMetrics()
+    {
+        return [_gameWidth, _gameHeight, _dpi];
+    }
+
     public static void MoveMouseBy(int x, int y)
     {
         var realDpi = TaskContext.Instance().DpiScale;

--- a/BetterGenshinImpact/Core/Script/EngineExtend.cs
+++ b/BetterGenshinImpact/Core/Script/EngineExtend.cs
@@ -103,6 +103,7 @@ public class EngineExtend
         engine.AddHostObject("keyUp", GlobalMethod.KeyUp);
         engine.AddHostObject("keyPress", GlobalMethod.KeyPress);
         engine.AddHostObject("setGameMetrics", GlobalMethod.SetGameMetrics);
+        engine.AddHostObject("getGameMetrics", GlobalMethod.GetGameMetrics);
         engine.AddHostObject("moveMouseBy", GlobalMethod.MoveMouseBy);
         engine.AddHostObject("moveMouseTo", GlobalMethod.MoveMouseTo);
         engine.AddHostObject("click", GlobalMethod.Click);


### PR DESCRIPTION
在封装游戏操作函数时，考虑到封装后的通用性，常规来说一般是如下逻辑。

问题：目前js暂无暴露类似方法提供获取当前GameMetrics，故暴露该方法使得开发者可以获取当前的分辨率、DPI。
目的：开发者可随意拷贝、复用、分享封装的操作函数轮子，而不用担心对使用者的Metrics上下文产生影响，导致后续由于分辨率、DPI被修改逻辑出现混乱。

```js
  function doSomething() {
    try {
      // 1.保存当前的分辨率、DPI
      const [width, height, dpi]= getGameMetrics();
      // 2.设置成开发者的分辨率、DPI
      setGameMetrics(1920, 1080, 1.25);
      // 3.执行一系列操作（与开发者的分辨率、DPI有关）
      doSomethingElse();
    } finally {
       // 4.恢复之前的分辨率、DPI
      setGameMetrics(width, height, dpi);
    }
  }
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新功能
- 新增游戏指标获取功能，脚本现可访问当前游戏的屏幕分辨率和DPI等显示信息。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->