### PR TITLE
路径追踪中异常处理增加一种场景

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
@@ -1268,7 +1268,8 @@ public class PathExecutor
         var cookRa = imageRegion.Find(AutoSkipAssets.Instance.CookRo);
         var closeRa = imageRegion.Find(AutoSkipAssets.Instance.PageCloseMainRo);
         var closeRa2 = imageRegion.Find(ElementAssets.Instance.PageCloseWhiteRo);
-        if (cookRa.IsExist() || closeRa.IsExist() || closeRa2.IsExist())
+        var closeRa3 = imageRegion.Find(AutoSkipAssets.Instance.PageCloseRo);
+        if (cookRa.IsExist() || closeRa.IsExist() || closeRa2.IsExist() || closeRa3.IsExist())
         {
             // 排除大地图
             if (Bv.IsInBigMapUi(imageRegion))


### PR DESCRIPTION
目前无法处理发光点误触打开的阅读页面（如下图），解决方法是增加检测右上角的❌

<img width="960" height="498" alt="out" src="https://github.com/user-attachments/assets/46adf479-ecb9-4cda-807d-874e0eb04a00" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug 修复**
  * 改进了对话框关闭逻辑，扩展了用户界面状态识别范围，使系统能够更准确地处理特定界面元素，从而优化了异常情况下的控制流程。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->