### PR TITLE
fixbug - 修复指定次数模式下树脂消耗完毕的识别问题

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoDomain/AutoDomainTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoDomain/AutoDomainTask.cs
@@ -1090,7 +1090,7 @@ public class AutoDomainTask : ISoloTask
         // 再 OCR 一次，弹出框，确认当前是否有原粹树脂
         using var ra2 = CaptureToRectArea();
         var textListInPrompt = ra2.FindMulti(RecognitionObject.Ocr(ra2.Width * 0.25, ra2.Height * 0.2, ra2.Width * 0.5, ra2.Height * 0.6));
-        if (textListInPrompt.Any(t => t.Text.Contains("数量不足") || t.Text.Contains("补充原粹树脂")))
+        if (textListInPrompt.Any(t => t.Text.Contains("数量不足") || t.Text.Contains("补充")))
         {
             // 没有原粹树脂，直接退出秘境
             Logger.LogInformation("自动秘境：原粹树脂已用尽，退出秘境");


### PR DESCRIPTION
将OCR识别的 补充原粹树脂 切换为 补充 。
树脂打完可以正常识别并退出。
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/e968f225-0538-4390-9d02-985639fe01cb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 改进了副本任务中对原粹树脂不足提示的识别逻辑，使检测更加可靠，能更准确地捕获树脂补充相关提示信息。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->