### PR TITLE
fix: 遮罩匹配颜色没有容差

### DIFF
--- a/BetterGenshinImpact/Core/Recognition/OpenCv/OpenCvCommonHelper.cs
+++ b/BetterGenshinImpact/Core/Recognition/OpenCv/OpenCvCommonHelper.cs
@@ -114,14 +114,23 @@ public class OpenCvCommonHelper
     /// <summary>
     ///     和二值化的颜色刚好相反
     /// </summary>
-    /// <param name="src"></param>
-    /// <param name="s"></param>
+    /// <param name="src">源图像</param>
+    /// <param name="s">遮罩颜色</param>
+    /// <param name="tolerance">容差</param>
     /// <returns></returns>
-    public static Mat CreateMask(Mat src, Scalar s)
+    public static Mat CreateMask(Mat src, Scalar s, int tolerance = 0)
     {
+        var lower = new Scalar(
+            Math.Max(0, s.Val0 - tolerance),
+            Math.Max(0, s.Val1 - tolerance),
+            Math.Max(0, s.Val2 - tolerance));
+        var upper = new Scalar(
+            Math.Min(255, s.Val0 + tolerance),
+            Math.Min(255, s.Val1 + tolerance),
+            Math.Min(255, s.Val2 + tolerance));
         var mask = new Mat();
-        Cv2.InRange(src, s, s, mask);
-        return ~ mask;
+        Cv2.InRange(src, lower, upper, mask);
+        return ~mask;
     }
     
     /// <summary>

--- a/BetterGenshinImpact/Core/Recognition/RecognitionObject.cs
+++ b/BetterGenshinImpact/Core/Recognition/RecognitionObject.cs
@@ -66,6 +66,12 @@ public class RecognitionObject
     /// </summary>
     public Color MaskColor { get; set; } = Color.FromArgb(0, 255, 0);
 
+    /// <summary>
+    ///     模板遮罩的颜色容差，默认零容差
+    ///     UseMask = true 的时候有用
+    /// </summary>
+    public int MaskColorTolerance { get; set; } = 0;
+
     public Mat? MaskMat { get; set; }
 
     /// <summary>
@@ -102,20 +108,21 @@ public class RecognitionObject
             Cv2.CvtColor(TemplateImageMat, TemplateImageGreyMat, ColorConversionCodes.BGR2GRAY);
         }
 
-        if (UseMask && TemplateImageMat != null && MaskMat == null) MaskMat = OpenCvCommonHelper.CreateMask(TemplateImageMat, MaskColor.ToScalar());
+        if (UseMask && TemplateImageMat != null && MaskMat == null)
+            MaskMat = OpenCvCommonHelper.CreateMask(TemplateImageMat, MaskColor.ToScalar(), MaskColorTolerance);
         return this;
     }
 
-    
+
     public static RecognitionObject TemplateMatch(Mat mat)
     {
         var ro = new RecognitionObject
         {
             RecognitionType = RecognitionTypes.TemplateMatch,
             TemplateImageMat = mat,
-            UseMask = false, 
+            UseMask = false,
         };
-        
+
         return ro.InitTemplate();
     }
 
@@ -126,12 +133,12 @@ public class RecognitionObject
             RecognitionType = RecognitionTypes.TemplateMatch,
             TemplateImageMat = mat,
             UseMask = useMask,
-            MaskColor = maskColor == default? Color.FromArgb(0, 255, 0) : maskColor
+            MaskColor = maskColor == default ? Color.FromArgb(0, 255, 0) : maskColor
         };
-        
+
         return ro.InitTemplate();
     }
-    
+
     public static RecognitionObject TemplateMatch(Mat mat, double x, double y, double w, double h)
     {
         var ro = new RecognitionObject
@@ -140,7 +147,7 @@ public class RecognitionObject
             TemplateImageMat = mat,
             RegionOfInterest = new Rect((int)Math.Round(x), (int)Math.Round(y), (int)Math.Round(w), (int)Math.Round(h))
         };
-        
+
         return ro.InitTemplate();
     }
 
@@ -195,12 +202,12 @@ public class RecognitionObject
     ///     多个值全匹配的情况下才算成功
     /// </summary>
     public List<string> RegexMatchText { get; set; } = [];
-    
+
     /// <summary>
     /// 用于多个OCR结果的匹配
     /// </summary>
     public string Text { get; set; } = string.Empty;
-    
+
     public static RecognitionObject Ocr(double x, double y, double w, double h)
     {
         return new RecognitionObject
@@ -209,7 +216,7 @@ public class RecognitionObject
             RegionOfInterest = new Rect((int)Math.Round(x), (int)Math.Round(y), (int)Math.Round(w), (int)Math.Round(h))
         };
     }
-    
+
     public static RecognitionObject OcrMatch(double x, double y, double w, double h, params string[] matchTexts)
     {
         return new RecognitionObject
@@ -235,9 +242,8 @@ public class RecognitionObject
     };
 
     #endregion OCR文字识别
-    
-    
-    
+
+
     /// <summary>
     /// 克隆当前 RecognitionObject 实例
     /// </summary>
@@ -249,7 +255,7 @@ public class RecognitionObject
             RecognitionType = this.RecognitionType,
             RegionOfInterest = this.RegionOfInterest,
             Name = this.Name,
-            
+
             // 模板匹配相关属性
             TemplateImageMat = this.TemplateImageMat, // 注意：Mat 是引用类型，克隆后仍然指向同一内存
             TemplateImageGreyMat = this.TemplateImageGreyMat, // 注意：Mat 是引用类型，克隆后仍然指向同一内存
@@ -262,22 +268,22 @@ public class RecognitionObject
             DrawOnWindow = this.DrawOnWindow,
             DrawOnWindowPen = new Pen(this.DrawOnWindowPen.Color, this.DrawOnWindowPen.Width),
             MaxMatchCount = this.MaxMatchCount,
-            
+
             // 颜色匹配相关属性
             ColorConversionCode = this.ColorConversionCode,
             LowerColor = this.LowerColor,
             UpperColor = this.UpperColor,
             MatchCount = this.MatchCount,
-            
+
             // OCR相关属性
             OcrEngine = this.OcrEngine,
-            ReplaceDictionary = this.ReplaceDictionary,  // 不克隆字典，因为字典通常是不可变的
+            ReplaceDictionary = this.ReplaceDictionary, // 不克隆字典，因为字典通常是不可变的
             AllContainMatchText = this.AllContainMatchText, // 不克隆
             OneContainMatchText = this.OneContainMatchText, // 不克隆
             RegexMatchText = this.RegexMatchText, // 不克隆
             Text = this.Text
         };
-        
+
         return cloned;
     }
 }


### PR DESCRIPTION
问题：遮罩指定的纯色（例如 (0, 255, 0)）可能因修图软件有损压缩、优化等操作发生轻微变化（例如变为 (0, 254, 0)）。此色差会导致最终创建的遮罩 Mat 对象几乎为纯白色，使得模板匹配无法正确进行。

解决方案：在创建遮罩时，默认引入一个微小的容差范围。现在，像素颜色只要处于目标颜色的容差范围内，即被视为有效，从而提升了遮罩匹配在真实场景下的健壮性。

影响范围： 仅影响 `RecognitionObject.InitTemplate` 单个方法。

~~查了半天还以为ps坏了，调试半天输出遮罩Mat到本地文件一看发现是纯白的,吸管一吸发现颜色变了一丢丢😅~~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 增强了颜色识别：由精确匹配改为基于可调颜色容差的范围匹配，提升识别灵活性与鲁棒性；新增可配置的“掩码颜色容差”设置（默认 0），保持最终掩码的反转行为不变。  
* **文档**
  * 更新了注释与说明，明确容差参数及其作用。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->