### PR TITLE
稍微优化遮罩窗口内log的展示方式

### DIFF
--- a/BetterGenshinImpact/View/MaskWindow.xaml.cs
+++ b/BetterGenshinImpact/View/MaskWindow.xaml.cs
@@ -205,6 +205,10 @@ public partial class MaskWindow : Window
 
     private void LogTextBoxTextChanged(object sender, TextChangedEventArgs e)
     {
+        if (LogTextBox.Document.Blocks.FirstBlock is Paragraph p && p.Inlines.Count > 100)
+        {
+            (p.Inlines as System.Collections.IList).RemoveAt(0);
+        }
         var textRange = new TextRange(LogTextBox.Document.ContentStart, LogTextBox.Document.ContentEnd);
         if (textRange.Text.Length > 10000)
         {


### PR DESCRIPTION
要解决的问题：当日志积累到一定的量后会被清空。用户看起来日志突然消失，让人不明所以。并且清空前的最后一条log展示不出来。如下视频所示

https://github.com/user-attachments/assets/0003843f-a201-452d-8ddd-2100c826e689



解决方法是最多只保留100行log，超过的话就清空最前面的一行。这样用户看到的log是连续无间断滚动的。
如果以后要改遮罩窗口的大小、字号，100行应该也足够，或可容易地增加。
如果以后日志文档结构改变，原逻辑仍然能起作用，以保持兼容性和稳定性。