### PR TITLE
F文字菜单UI区域适配

### DIFF
--- a/BetterGenshinImpact/GameTask/Common/Job/ChooseTalkOptionTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/ChooseTalkOptionTask.cs
@@ -157,7 +157,7 @@ public partial class ChooseTalkOptionTask
 
             // 通过最下面的气泡框来文字识别
             var lowest = chatOptionResultList[0];
-            var ocrRect = new Rect((int)(lowest.X + lowest.Width + 8 * assetScale), region.Height / 12,
+            var ocrRect = new Rect((int)(lowest.X + lowest.Width + 8 * assetScale), region.Height / 8,
                 (int)(535 * assetScale), (int)(lowest.Y + lowest.Height + 30 * assetScale - region.Height / 12d));
             var ocrResList = region.FindMulti(RecognitionObject.Ocr(ocrRect));
 


### PR DESCRIPTION
F文字菜单的气泡识别后，如果有退出或再见选项在气泡下方，可能会识别不到，例如尘歌壶中使用，会识别不到“再见”选项，导致失败，还有凯瑟琳也是，向下多寻一点就可以，修改了寻找区域即可解决。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **问题修复**
  * 优化了对话选项识别的检测区域位置，以提高识别准确性和可靠性。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->