### PR TITLE
修复路径追踪过程中各种打断导致的路径追踪失败

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
@@ -721,6 +721,7 @@ public class PathExecutor
         var fastMode = false;
         var prevPositions = new List<Point2f>();
         var fastModeColdTime = DateTime.MinValue;
+        var prevNotTooFarPosition = position;
         int num = 0, distanceTooFarRetryCount = 0, consecutiveRotationCountBeyondAngle = 0;
 
         // 按下w，一直走
@@ -790,10 +791,22 @@ public class PathExecutor
                         {
                             Logger.LogWarning($"距离过远（{position.X},{position.Y}）->（{waypoint.X},{waypoint.Y}）={distance}，重试");
                         }
+                        // 取余减少判断频率
+                        if (distanceTooFarRetryCount % 10 == 0)
+                        {
+                            await ResolveAnomalies(screen);
+                            Logger.LogInformation($"重置到上次正确识别的坐标 ({prevNotTooFarPosition.X},{prevNotTooFarPosition.Y})");
+                            Navigation.SetPrevPosition(prevNotTooFarPosition.X, prevNotTooFarPosition.Y);
+                            // 淡入淡出特效
+                            await Delay(500, ct);
+                        }
                         await Delay(50, ct);
                         continue;
                     }
                 }
+            } else
+            {
+                prevNotTooFarPosition = position;
             }
 
             // 非攀爬状态下，检测是否卡死（脱困触发器）


### PR DESCRIPTION
这是PR https://github.com/babalae/better-genshin-impact/pull/2425 的一个follow-up，主要优化了情况`1`中的子情况`ii`的场景。

场景描述：在路径追踪的过程中，如果被其他弹出窗口打断，会导致截图中看不到左上角的小地图，进而在识别坐标的时候很可能得到错误的结果，这个错误的坐标距离真实的目标距离往往很远，连续错误50次后会导致当前路径失败。在这个过程中异常处理函数没有被调用。

在这个PR中我们增加了异常处理函数的检测点，但这仍不足以修复这个问题。因为坐标识别会记录上次识别的结果，后续识别会优先在其附近匹配，导致连续得到错误的结果。尝试使用`Navigation.GetPositionStable()`函数，效果并不理想。

我们在此提出的解决方法是在路径追踪过程中记录上次识别到的，距离正确目标点“不太远“的坐标，在异常处理结束后，把坐标重置到这个”不太远“的坐标附近，强制在这个正确的坐标附近匹配。

附：发生错误的场景示例

https://github.com/user-attachments/assets/eddc3659-b76a-4be8-9bd5-3d26fa0f95d4

https://github.com/user-attachments/assets/ae934c30-b78d-4995-be99-8adfcb8ab9fb




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* 自动寻路体验优化：引入周期性异常检测和恢复机制，在导航遇到问题时自动调整参考位置。
* 增强了位置追踪逻辑，改进复杂场景下的寻路准确性。
* 添加了路径重置的视觉反馈效果。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->