### PR TITLE
修复错误的Pen生命周期导致绘制失败的问题；单元测试鱼的名字的入参更新

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoFishing/Behaviours.cs
+++ b/BetterGenshinImpact/GameTask/AutoFishing/Behaviours.cs
@@ -859,10 +859,8 @@ namespace BetterGenshinImpact.GameTask.AutoFishing
                 int hExtra = _cur.Height, vExtra = _cur.Height / 4;
                 blackboard.fishBoxRect = new Rect(_cur.X - hExtra, _cur.Y - vExtra,
                      (topMat.Width / 2 - _cur.X) * 2 + hExtra * 2, _cur.Height + vExtra * 2);
-                // VisionContext.Instance().DrawContent.PutRect("FishBox", _fishBoxRect.ToRectDrawable(new Pen(Color.LightPink, 2)));
                 using var boxRa = imageRegion.Derive(blackboard.fishBoxRect);
-                using var pen = new System.Drawing.Pen(Color.LightPink, 2);
-                boxRa.DrawSelf("FishBox", pen);
+                boxRa.DrawSelf("FishBox", System.Drawing.Pens.LightPink);
                 logger.LogInformation("  识别到钓鱼框");
                 return BehaviourStatus.Succeeded;
             }

--- a/Test/BetterGenshinImpact.UnitTest/GameTaskTests/AutoFishingTests/BehavioursTests.ChooseBait.cs
+++ b/Test/BetterGenshinImpact.UnitTest/GameTaskTests/AutoFishingTests/BehavioursTests.ChooseBait.cs
@@ -44,7 +44,7 @@ namespace BetterGenshinImpact.UnitTest.GameTaskTests.AutoFishingTests
         [InlineData(@"20250225101300361_ChooseBait_Succeeded.png", new string[] { "medaka", "butterflyfish", "butterflyfish", "pufferfish" })]
         [InlineData(@"20250226161354285_ChooseBait_Succeeded.png", new string[] { "medaka" })]  // 不稳定的测试用例，因未学习被照亮的场景
         [InlineData(@"202503160917566615@900p.png", new string[] { "pufferfish" })]
-        [InlineData(@"202509141339218213_ChooseBait.png", new string[] { "axehead fish" })]
+        [InlineData(@"202509141339218213_ChooseBait.png", new string[] { "axehead" })]
         [InlineData(@"202509141339218213_ChooseBait.png", new string[] { "mauler shark", "crystal eye", "medaka", "medaka", "medaka" })]
         /// <summary>
         /// 测试各种选取鱼饵，结果为成功


### PR DESCRIPTION
瞅了一下钓鱼，发现上次改出来的小bug，拉条的框框显示不出来了。。。遮罩层render似乎不是即时的，所以不能把Pen提前释放

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 优化了自动钓鱼功能的检测框渲染方式。

* **Tests**
  * 更新了自动钓鱼功能的相关测试数据以确保准确性。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->