### PR TITLE
稍微优化空月祝福检测的逻辑

### DIFF
--- a/BetterGenshinImpact/GameTask/Common/Job/BlessingOfTheWelkinMoonTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/BlessingOfTheWelkinMoonTask.cs
@@ -25,7 +25,7 @@ public class BlessingOfTheWelkinMoonTask
             if (t.Hour == 4 && t.Minute < 10)
             {
                 using var ra = CaptureToRectArea();
-                if (Bv.IsInBlessingOfTheWelkinMoon(ra))
+                if (Bv.IsInBlessingOfTheWelkinMoon(ra) || ra.Find(ElementAssets.Instance.PrimogemRo).IsExist())
                 {
                     Logger.LogInformation("检测到空月祝福界面，自动点击");
                     GameCaptureRegion.GameRegion1080PPosMove(100, 100);


### PR DESCRIPTION
要解决的问题：空月祝福可能在简易策略脚本或者战斗过程中弹出，策略执行的时候的点击操作可能导致跳过了新月少女的页面，直接进入了第二阶段的90个原石页面，此时月卡检测函数再执行就会因为检测不到新月少女页面而不生效。

这个问题遇到过两次，又有用户在此https://github.com/babalae/bettergi-scripts-list/issues/2486 反馈了一次，所以还是修掉比较好。

<img width="953" height="651" alt="image" src="https://github.com/user-attachments/assets/34f21b8f-1524-40d9-950d-1a94a5d36bf1" />

还有一种更刁钻的情况是策略执行的时候点击了原石的图标进入了如下的第三阶段页面。这个等有用户反馈的时候再修吧。

除此之外应该没有其他已知情形了。

<img width="1622" height="1304" alt="image" src="https://github.com/user-attachments/assets/13794874-50cd-458d-8e60-bdd3a08fff2f" />



closes https://github.com/babalae/bettergi-scripts-list/issues/2486

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **改进**
  * 优化了祝福月卡自动点击功能的触发检测机制，增强了界面识别能力，提升了功能的可靠性。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->