### PR TITLE
优化路径追踪过程中传送的逻辑

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
@@ -186,6 +186,10 @@ public class PathExecutor
 
                         if (waypoint.Type == WaypointType.Teleport.Code)
                         {
+                            if (CurWaypoints.Item1 > 0)
+                            {
+                                await Delay(1000, ct);
+                            }
                             await HandleTeleportWaypoint(waypoint);
                         }
                         else


### PR DESCRIPTION
要解决的问题：

当一个路径追踪json文件中包含多个传送类型的路径点时，除第一个以外的传送点会在角色到达上一个路径点坐标之后立即触发，这会导致大概率拾取不到上一个路径点附近的资源。如下视频所示，角色要拾取树莓，到达树莓的时候，拾取按钮还没有显示清晰就开地图传送走了。所以很多有经验的脚本作者往往在传送点前面增加一个wait简易策略来规避这个问题。


https://github.com/user-attachments/assets/12c852c8-46cc-42e8-a0f0-1d0367ccc1f6



但是这个问题随着PR https://github.com/babalae/better-genshin-impact/pull/2544 的引入变得更突出了。https://github.com/babalae/better-genshin-impact/pull/2544 将挖矿策略执行时间压缩至最短，挖矿操作执行完毕的时候，角色的挖矿后摇其实并没有完成，矿石也没有拾取。其出发点是为下一个路径点导航节省启动时间。但如果下一个路径点是传送类型，就会导致角色没有时间拾取矿石，反而降低了挖矿的效率，综合来看得不偿失。

因此为了提高资源拾取效率，我们建议在每个路径追踪的第二个传送点开始，传送之前等待1秒钟来解决这个问题。实际测试1秒钟时间大约恰好够拾取3～4个资源，这能涵盖大部分采集资源类型（绝云椒椒为4个，矿石最多3个）。