### PR TITLE
添加虚拟域名情况下README内图片获取支持

### DIFF
--- a/BetterGenshinImpact/Core/Script/WebView/RepoWebBridge.cs
+++ b/BetterGenshinImpact/Core/Script/WebView/RepoWebBridge.cs
@@ -8,6 +8,7 @@ using BetterGenshinImpact.View.Windows;
 using BetterGenshinImpact.ViewModel.Message;
 using CommunityToolkit.Mvvm.Messaging;
 using Newtonsoft.Json.Linq;
+using System.Net;
 
 namespace BetterGenshinImpact.Core.Script.WebView;
 
@@ -81,7 +82,7 @@ public sealed class RepoWebBridge
         try
         {
             // URL 解码路径（处理中文文件名）
-            relPath = System.Web.HttpUtility.UrlDecode(relPath);
+            relPath = WebUtility.UrlDecode(relPath);
         
             string filePath = Path.Combine(ScriptRepoUpdater.CenterRepoPath, "repo", relPath)
                 .Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 改进Web视图文件加载，新增对常见图片格式的支持并以适当方式返回图片内容
  * 优化路径与URL处理，加入解码与路径校验以避免非法路径访问并提升扩展名识别准确性
  * 对不被支持或验证失败的文件类型返回404，提升安全性与稳定性

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->