### PR TITLE
改进`GetGridItemIconText`获得全角数字字符时的处理

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoEat/AutoEatTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoEat/AutoEatTask.cs
@@ -9,6 +9,7 @@ using BetterGenshinImpact.GameTask.GetGridIcons;
 using BetterGenshinImpact.GameTask.Model;
 using BetterGenshinImpact.GameTask.Model.Area;
 using BetterGenshinImpact.GameTask.Model.GameUI;
+using BetterGenshinImpact.Helpers;
 using BetterGenshinImpact.View.Drawable;
 using Fischless.WindowsInput;
 using Microsoft.Extensions.Logging;
@@ -104,7 +105,8 @@ public class AutoEatTask : BaseIndependentTask, ISoloTask<int?>
                         itemRegion.Click();
 
                         #region 识别数量
-                        string numStr = itemRegion.SrcMat.GetGridItemIconText(OcrFactory.Paddle);
+                        string ocrText = itemRegion.SrcMat.GetGridItemIconText(OcrFactory.Paddle);
+                        string numStr = StringUtils.ConvertFullWidthNumToHalfWidth(ocrText);
                         if (int.TryParse(numStr, out int num))
                         {
                             count = num - 1;    // 算上吃掉的1个

--- a/BetterGenshinImpact/GameTask/Common/Job/CountInventoryItem.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/CountInventoryItem.cs
@@ -5,6 +5,7 @@ using BetterGenshinImpact.GameTask.GetGridIcons;
 using BetterGenshinImpact.GameTask.Model.Area;
 using BetterGenshinImpact.GameTask.Model.GameUI;
 using BetterGenshinImpact.View.Drawable;
+using BetterGenshinImpact.Helpers;
 using Fischless.WindowsInput;
 using Microsoft.Extensions.Logging;
 using Microsoft.ML.OnnxRuntime;
@@ -100,7 +101,8 @@ namespace BetterGenshinImpact.GameTask.Common.Job
                     string predName = result.Item1;
                     if (predName == this.itemName!)
                     {
-                        string numStr = itemRegion.SrcMat.GetGridItemIconText(OcrFactory.Paddle);
+                        string ocrText = itemRegion.SrcMat.GetGridItemIconText(OcrFactory.Paddle);
+                        string numStr = StringUtils.ConvertFullWidthNumToHalfWidth(ocrText);
                         if (int.TryParse(numStr, out int num))
                         {
                             count = num;
@@ -149,7 +151,8 @@ namespace BetterGenshinImpact.GameTask.Common.Job
                     if (this.itemNames!.Contains(predName) && !itemsCountDic!.ContainsKey(predName))
                     {
                         int count;
-                        string numStr = itemRegion.SrcMat.GetGridItemIconText(OcrFactory.Paddle);
+                        string ocrText = itemRegion.SrcMat.GetGridItemIconText(OcrFactory.Paddle);
+                        string numStr = StringUtils.ConvertFullWidthNumToHalfWidth(ocrText);
                         if (int.TryParse(numStr, out int num))
                         {
                             count = num;

--- a/BetterGenshinImpact/Helpers/StringUtils.cs
+++ b/BetterGenshinImpact/Helpers/StringUtils.cs
@@ -71,6 +71,24 @@ public partial class StringUtils
         return chineseString;
     }
 
+    /// <summary>
+    /// 将全角数字转换为半角数字
+    /// </summary>
+    /// <param name="text">需要转换的文本</param>
+    /// <returns>转换后的文本，全角数字被替换为半角数字</returns>
+    public static string ConvertFullWidthNumToHalfWidth(string text)
+    {
+        StringBuilder sb = new StringBuilder(text.Length);
+        foreach (char c in text)
+        {
+            if (c >= 0xFF10 && c <= 0xFF19) // 全角数字 ０-９
+                sb.Append((char)(c - 0xFF10 + '0'));
+            else
+                sb.Append(c);
+        }
+        return sb.ToString();
+    }
+
     public static double TryParseDouble(string text)
     {
         _ = double.TryParse(text, out double result);


### PR DESCRIPTION
`GetGridItemIconText` 在遇到单个数字字符时，可能会识别为全角字符返回，导致无法parse int。
<img width="516" height="123" alt="image" src="https://github.com/user-attachments/assets/f0317ffb-d830-4985-9240-18de4a04db80" />

此PR添加简单的全角转半角函数，细微提升这种情况下的可用性：
<img width="516" height="107" alt="image" src="https://github.com/user-attachments/assets/8e25d1b7-664b-49a0-ab8a-0adbf5ae1886" />
