### PR TITLE
精简日志，注释掉过多的`解析战斗脚本命令`

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoFight/Script/CombatScriptParser.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Script/CombatScriptParser.cs
@@ -187,10 +187,10 @@ public class CombatScriptParser
             }
             fullCombatCommands.AddRange(combatCommands);
         }
-        foreach (var combatCommand in fullCombatCommands)
-        {
-            Logger.LogDebug("解析战斗脚本命令：{cmd}", combatCommand.ToString());
-        }
+        // foreach (var combatCommand in fullCombatCommands)
+        // {
+        //     Logger.LogDebug("解析战斗脚本命令：{cmd}", combatCommand.ToString());
+        // }
         return fullCombatCommands;
     }
 


### PR DESCRIPTION
从 0.54.1-alpha.4 升级到 0.54.2-alpha.2 后，如下形式的日志
```
解析战斗脚本命令："<CombatCommand 爱可菲, BetterGenshinImpact.GameTask.AutoFight.Script.Method(System.Collections.Generic.List`1[System.String]) (rounds )>"
```
大量重复出现，淹没了整个日志文件(昨晚锄地，81%的行都是这个)

<img width="1450" height="434" alt="image" src="https://github.com/user-attachments/assets/97f7e12b-cfc5-4fec-bb02-8eb6aa93b084" />

这日志的信息量非常有限，而且看起来像是开发过程中调试用的日志，先把它在主分支注释掉

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **杂项修改**
  * 移除了战斗脚本命令解析过程中的运行时日志记录输出。此改动不影响战斗脚本的任何功能性行为、命令处理或执行结果。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->