### PR TITLE
fix: 修复模糊黑名单读取错误的文件路径

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoPick/AutoPickTrigger.cs
+++ b/BetterGenshinImpact/GameTask/AutoPick/AutoPickTrigger.cs
@@ -79,7 +79,7 @@ public partial class AutoPickTrigger : ITaskTrigger
                 _blackList.UnionWith(userBlackList);
             }
 
-            _fuzzyBlackList = ReadTextList(@"User\pick_black_lists.txt");
+            _fuzzyBlackList = ReadTextList(@"User\pick_fuzzy_black_lists.txt");
         }
 
         if (config.WhiteListEnabled)


### PR DESCRIPTION
## 问题
UI 设置的模糊匹配黑名单保存到 `User\pick_fuzzy_black_lists.txt`，但 `AutoPickTrigger` 读取时却读的是 `User\pick_black_lists.txt`，导致用户设置的模糊黑名单从未生效。

## 修复
将 `AutoPickTrigger.cs` 第 82 行的文件路径从 `pick_black_lists.txt` 改为 `pick_fuzzy_black_lists.txt`。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug修复**
  * 修正了自动拾取功能的黑名单配置读取路径。现在能够正确加载用户自定义的模糊黑名单设置，进一步提升了拾取功能的个性化定制能力。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->