### PR TITLE
使用Nullable作为游戏坐标系的坐标数据类型

### DIFF
--- a/BetterGenshinImpact/Core/Script/Dependence/Genshin.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/Genshin.cs
@@ -182,7 +182,7 @@ public class Genshin
     /// 获取当前在大地图上的位置坐标
     /// </summary>
     /// <returns>包含X和Y坐标的Point2f结构体</returns>
-    public Point2f GetPositionFromBigMap()
+    public Point2f? GetPositionFromBigMap()
     {
         TpTask tpTask = new TpTask(CancellationContext.Instance.Cts.Token);
         return tpTask.GetPositionFromBigMap(MapTypes.Teyvat.ToString());
@@ -193,7 +193,7 @@ public class Genshin
     /// </summary>
     /// <param name="mapName">大地图名称</param>
     /// <returns>包含X和Y坐标的Point2f结构体</returns>
-    public Point2f GetPositionFromBigMap(string mapName)
+    public Point2f? GetPositionFromBigMap(string mapName)
     {
         TpTask tpTask = new TpTask(CancellationContext.Instance.Cts.Token);
         return tpTask.GetPositionFromBigMap(mapName);
@@ -203,7 +203,7 @@ public class Genshin
     /// 获取当前在小地图上的位置坐标
     /// </summary>
     /// <returns>包含X和Y坐标的Point2f结构体</returns>
-    public Point2f GetPositionFromMap()
+    public Point2f? GetPositionFromMap()
     {
         return GetPositionFromMap(MapTypes.Teyvat.ToString());
     }
@@ -220,7 +220,7 @@ public class Genshin
     /// <param name="mapName">大地图名称</param>
     /// <param name="cacheTimeMs">缓存时间，单位毫秒，默认900ms</param>
     /// <returns>包含X和Y坐标的Point2f结构体</returns>
-    public Point2f GetPositionFromMap(string mapName, int cacheTimeMs = 900)
+    public Point2f? GetPositionFromMap(string mapName, int cacheTimeMs = 900)
     {
         var imageRegion = CaptureToRectArea();
         if (!Bv.IsInMainUi(imageRegion))
@@ -241,7 +241,7 @@ public class Genshin
     /// <param name="x">世界坐标x</param>
     /// <param name="y">世界坐标y</param>
     /// <returns>包含X和Y坐标的Point2f结构体</returns>
-    public Point2f GetPositionFromMap(string mapName, float x, float y)
+    public Point2f? GetPositionFromMap(string mapName, float x, float y)
     {
         var imageRegion = CaptureToRectArea();
         if (!Bv.IsInMainUi(imageRegion))

--- a/BetterGenshinImpact/GameTask/AutoPathing/Model/WaypointForTrack.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/Model/WaypointForTrack.cs
@@ -53,7 +53,9 @@ public class WaypointForTrack : Waypoint
         // 坐标系转换
         mapMatchMethod ??= TaskContext.Instance().Config.PathingConditionConfig.MapMatchingMethod;
         MapMatchMethod = mapMatchMethod;
-        (MatX, MatY) = MapManager.GetMap(mapName, MapMatchMethod).ConvertGenshinMapCoordinatesToImageCoordinates((float)waypoint.X, (float)waypoint.Y);
+        var MatP = MapManager.GetMap(mapName, MapMatchMethod).ConvertGenshinMapCoordinatesToImageCoordinates(new OpenCvSharp.Point2f((float)waypoint.X, (float)waypoint.Y));
+        MatX = MatP.X;
+        MatY = MatP.Y;
         X = MatX;
         Y = MatY;
         if (waypoint.Action == ActionEnum.CombatScript.Code)

--- a/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
@@ -693,7 +693,7 @@ public class PathExecutor
         await TryGetExpeditionRewardsDispatch(tpTask);
         var (tpX, tpY) = await tpTask.Tp(waypoint.GameX, waypoint.GameY, waypoint.MapName, forceTp);
         var (tprX, tprY) = MapManager.GetMap(waypoint.MapName, waypoint.MapMatchMethod)
-            .ConvertGenshinMapCoordinatesToImageCoordinates((float)tpX, (float)tpY);
+            .ConvertGenshinMapCoordinatesToImageCoordinates(new Point2f((float)tpX, (float)tpY));
         Navigation.SetPrevPosition(tprX, tprY); // 通过上一个位置直接进行局部特征匹配
         await Delay(500, ct); // 多等一会
     }

--- a/BetterGenshinImpact/GameTask/AutoPathing/PathRecorder.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/PathRecorder.cs
@@ -62,13 +62,16 @@ public class PathRecorder : Singleton<PathRecorder>
         var waypoint = new Waypoint();
         var screen = TaskControl.CaptureToRectArea();
         var position = Navigation.GetPositionStable(screen, GetMapName(), matchingMethod);
-        if (position == default)
+        var nullablePosition = MapManager.GetMap(GetMapName(), matchingMethod).ConvertImageCoordinatesToGenshinMapCoordinates(position);
+        if (nullablePosition == null)
         {
             TaskControl.Logger.LogWarning("未识别到当前位置！");
             return;
         }
-
-        position = MapManager.GetMap(GetMapName(), matchingMethod).ConvertImageCoordinatesToGenshinMapCoordinates(position);
+        else
+        {
+            position = nullablePosition.Value;
+        }
         waypoint.X = position.X;
         waypoint.Y = position.Y;
         waypoint.Type = WaypointType.Teleport.Code;
@@ -91,11 +94,15 @@ public class PathRecorder : Singleton<PathRecorder>
         var screen = TaskControl.CaptureToRectArea();
         var matchingMethod = TaskContext.Instance().Config.PathingConditionConfig.MapMatchingMethod;
         var position = Navigation.GetPositionStable(screen, GetMapName(), matchingMethod);
-        position = MapManager.GetMap(GetMapName(), matchingMethod).ConvertImageCoordinatesToGenshinMapCoordinates(position);
-        if (position == default)
+        var nullablePosition = MapManager.GetMap(GetMapName(), matchingMethod).ConvertImageCoordinatesToGenshinMapCoordinates(position);
+        if (nullablePosition == null)
         {
             TaskControl.Logger.LogWarning("未识别到当前位置！");
             return;
+        }
+        else
+        {
+            position = nullablePosition.Value;
         }
 
         waypoint.X = position.X;

--- a/BetterGenshinImpact/GameTask/AutoTrackPath/Model/GiPathPoint.cs
+++ b/BetterGenshinImpact/GameTask/AutoTrackPath/Model/GiPathPoint.cs
@@ -29,7 +29,8 @@ public class GiPathPoint
         var pt = MapManager.GetMap(MapTypes.Teyvat, matchingMethod).ConvertImageCoordinatesToGenshinMapCoordinates(point);
         return new GiPathPoint
         {
-            Pt = pt,
+            // pt will not be null
+            Pt = pt ?? new Point2f(0, 0),
             MatchPt = point,
             Index = index,
             Time = DateTime.Now

--- a/BetterGenshinImpact/GameTask/AutoTrackPath/TpTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoTrackPath/TpTask.cs
@@ -389,7 +389,7 @@ public class TpTask
     /// <returns></returns>
     private (double clickX, double clickY) ConvertToGameRegionPosition(string mapName, Rect bigMapInAllMapRect, double x, double y)
     {
-        var (picX, picY) = MapManager.GetMap(mapName, _mapMatchingMethod).ConvertGenshinMapCoordinatesToImageCoordinates((float)x, (float)y);
+        var (picX, picY) = MapManager.GetMap(mapName, _mapMatchingMethod).ConvertGenshinMapCoordinatesToImageCoordinates(new Point2f((float)x, (float)y));
         var picRect = MapManager.GetMap(mapName, _mapMatchingMethod).ConvertGenshinMapCoordinatesToImageCoordinates(bigMapInAllMapRect);
         Debug.WriteLine($"({picX},{picY}) 在 {picRect} 内，计算它在窗体内的位置");
         var clickX = (picX - picRect.X) / picRect.Width * _captureRect.Width;
@@ -769,7 +769,7 @@ public class TpTask
             rect = new Rect(rect.X * s, rect.Y * s, rect.Width * s, rect.Height * s);
         }
 
-        return MapManager.GetMap(mapName, _mapMatchingMethod).ConvertImageCoordinatesToGenshinMapCoordinates(rect);
+        return MapManager.GetMap(mapName, _mapMatchingMethod).ConvertImageCoordinatesToGenshinMapCoordinates(rect)!.Value;
     }
 
     public Point2f GetBigMapCenterPoint(string mapName)
@@ -793,7 +793,7 @@ public class TpTask
                 (x, y) = (p.X * TeyvatMap.BigMap256ScaleTo2048, p.Y * TeyvatMap.BigMap256ScaleTo2048);
             }
 
-            return MapManager.GetMap(mapName, _mapMatchingMethod).ConvertImageCoordinatesToGenshinMapCoordinates(new Point2f(x, y));
+            return MapManager.GetMap(mapName, _mapMatchingMethod).ConvertImageCoordinatesToGenshinMapCoordinates(new Point2f(x, y))!.Value;
         }
         else
         {

--- a/BetterGenshinImpact/GameTask/Common/Map/Maps/Base/ISceneMap.cs
+++ b/BetterGenshinImpact/GameTask/Common/Map/Maps/Base/ISceneMap.cs
@@ -47,22 +47,18 @@ public interface ISceneMap
     /// </summary>
     /// <param name="imageCoordinates"></param>
     /// <returns></returns>
-    Point2f ConvertImageCoordinatesToGenshinMapCoordinates(Point2f imageCoordinates);
+    Point2f? ConvertImageCoordinatesToGenshinMapCoordinates(Point2f imageCoordinates);
     
-    (float x, float y) ConvertImageCoordinatesToGenshinMapCoordinates(float x, float y);
-    
-    Rect ConvertImageCoordinatesToGenshinMapCoordinates(Rect rect);
+    Rect? ConvertImageCoordinatesToGenshinMapCoordinates(Rect rect);
 
     /// <summary>
     /// 原神游戏坐标系 -> 地图图像坐标系
     /// </summary>
     /// <param name="genshinMapCoordinates"></param>
     /// <returns></returns>
-    Point2f ConvertGenshinMapCoordinatesToImageCoordinates(Point2f genshinMapCoordinates);
-
-    (float x, float y) ConvertGenshinMapCoordinatesToImageCoordinates(float c, float a);
+    Point2f ConvertGenshinMapCoordinatesToImageCoordinates(Point2f? genshinMapCoordinates);
     
-    Rect ConvertGenshinMapCoordinatesToImageCoordinates(Rect rect);
+    Rect ConvertGenshinMapCoordinatesToImageCoordinates(Rect? rect);
 
     #endregion
 }

--- a/BetterGenshinImpact/GameTask/Common/Map/Maps/Base/SceneBaseMap.cs
+++ b/BetterGenshinImpact/GameTask/Common/Map/Maps/Base/SceneBaseMap.cs
@@ -151,47 +151,54 @@ public abstract class SceneBaseMap : ISceneMap
 
     #region 坐标系转换
 
-    public Point2f ConvertImageCoordinatesToGenshinMapCoordinates(Point2f imageCoordinates)
+    public Point2f? ConvertImageCoordinatesToGenshinMapCoordinates(Point2f imageCoordinates)
     {
+        if (imageCoordinates.X == 0 && imageCoordinates.Y == 0)
+        {
+            return null;
+        }
         // 原神坐标系是 1024 级别的，当图像坐标系不是 1024 级别的时候要做转换
         return new Point2f((MapOriginInImageCoordinate.X - imageCoordinates.X) / _mapImageBlockWidthScale,
             (MapOriginInImageCoordinate.Y - imageCoordinates.Y) / _mapImageBlockWidthScale);
     }
 
-    public (float x, float y) ConvertImageCoordinatesToGenshinMapCoordinates(float x, float y)
+    public Rect? ConvertImageCoordinatesToGenshinMapCoordinates(Rect rect)
     {
-        return new((MapOriginInImageCoordinate.X - x) / _mapImageBlockWidthScale,
-            (MapOriginInImageCoordinate.Y - y) / _mapImageBlockWidthScale);
-    }
-
-    public Rect ConvertImageCoordinatesToGenshinMapCoordinates(Rect rect)
-    {
+        if (rect.X == 0 && rect.Y == 0 && rect.Width == 0 && rect.Height == 0)
+        {
+            return null;
+        }
         var center = rect.GetCenterPoint();
-        var (x, y) = ConvertImageCoordinatesToGenshinMapCoordinates(center.X, center.Y);
-        return new Rect((int)(x - rect.Width / 2f / _mapImageBlockWidthScale), (int)(y - rect.Height / 2f / _mapImageBlockWidthScale),
-            (int)(rect.Width / _mapImageBlockWidthScale), (int)(rect.Height / _mapImageBlockWidthScale));
+        var nullablePoint = ConvertImageCoordinatesToGenshinMapCoordinates(new Point2f(center.X, center.Y));
+        if (nullablePoint is Point2f p)
+        {
+            return new Rect((int)(p.X - rect.Width / 2f / _mapImageBlockWidthScale), (int)(p.Y - rect.Height / 2f / _mapImageBlockWidthScale),
+                (int)(rect.Width / _mapImageBlockWidthScale), (int)(rect.Height / _mapImageBlockWidthScale));
+        }
+        return null;
     }
 
-    public Point2f ConvertGenshinMapCoordinatesToImageCoordinates(Point2f genshinMapCoordinates)
+    public Point2f ConvertGenshinMapCoordinatesToImageCoordinates(Point2f? genshinMapCoordinates)
     {
-        return new Point2f(MapOriginInImageCoordinate.X - genshinMapCoordinates.X * _mapImageBlockWidthScale,
-            MapOriginInImageCoordinate.Y - genshinMapCoordinates.Y * _mapImageBlockWidthScale);
+        if (genshinMapCoordinates is Point2f p)
+        {
+            return new Point2f(MapOriginInImageCoordinate.X - p.X * _mapImageBlockWidthScale,
+           MapOriginInImageCoordinate.Y - p.Y * _mapImageBlockWidthScale);
+        }
+        return default;
     }
 
-    public (float x, float y) ConvertGenshinMapCoordinatesToImageCoordinates(float c, float a)
+    public Rect ConvertGenshinMapCoordinatesToImageCoordinates(Rect? genshinMapRect)
     {
-        return new(MapOriginInImageCoordinate.X - c * _mapImageBlockWidthScale,
-            MapOriginInImageCoordinate.Y - a * _mapImageBlockWidthScale);
-    }
-
-    public Rect ConvertGenshinMapCoordinatesToImageCoordinates(Rect rect)
-    {
-        var center = rect.GetCenterPoint();
-        var (x, y) = ConvertGenshinMapCoordinatesToImageCoordinates(center.X, center.Y);
-        return new Rect((int)Math.Round(x - rect.Width / 2f * _mapImageBlockWidthScale),
-            (int)Math.Round(y - rect.Height / 2f * _mapImageBlockWidthScale),
-            (int)Math.Round(rect.Width * _mapImageBlockWidthScale),
-            (int)Math.Round(rect.Height * _mapImageBlockWidthScale));
+        if (genshinMapRect is Rect rect)
+        {
+            var (x, y) = ConvertGenshinMapCoordinatesToImageCoordinates(rect.GetCenterPoint());
+            return new Rect((int)Math.Round(x - rect.Width / 2f * _mapImageBlockWidthScale),
+             (int)Math.Round(y - rect.Height / 2f * _mapImageBlockWidthScale),
+             (int)Math.Round(rect.Width * _mapImageBlockWidthScale),
+             (int)Math.Round(rect.Height * _mapImageBlockWidthScale));
+        }
+        return default;
     }
 
     #endregion

--- a/BetterGenshinImpact/GameTask/Common/Map/Maps/Base/SceneBaseMapByTemplateMatch.cs
+++ b/BetterGenshinImpact/GameTask/Common/Map/Maps/Base/SceneBaseMapByTemplateMatch.cs
@@ -84,7 +84,7 @@ public abstract class SceneBaseMapByTemplateMatch : SceneBaseMap
         using (miniMap)
         using (mask)
         {
-            LocalMatch(miniMap, mask, ConvertImageCoordinatesToGenshinMapCoordinates(new Point2f(prevX, prevY)), ref curResult);
+            LocalMatch(miniMap, mask, ConvertImageCoordinatesToGenshinMapCoordinates(new Point2f(prevX, prevY))!.Value, ref curResult);
             return UpdateResult(curResult, rank);
         }
     }

--- a/BetterGenshinImpact/GameTask/Common/Map/Maps/SeaOfBygoneErasMap.cs
+++ b/BetterGenshinImpact/GameTask/Common/Map/Maps/SeaOfBygoneErasMap.cs
@@ -71,7 +71,7 @@ public class SeaOfBygoneErasMap : SceneBaseMap
                     }
                     var x = (float)p["position"]![2]!;
                     var y = (float)p["position"]![0]!;
-                    var (x1, y1) = ConvertGenshinMapCoordinatesToImageCoordinates(x, y);
+                    var (x1, y1) = ConvertGenshinMapCoordinatesToImageCoordinates(new Point2f (x, y));
                     mapTeleports.Add(new Point(x1, y1));
                 }
             }

--- a/BetterGenshinImpact/ViewModel/Windows/MapViewerViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Windows/MapViewerViewModel.cs
@@ -50,8 +50,8 @@ public partial class MapViewerViewModel : ObservableObject
         _mapName = mapName;
         Init(mapName);
         var matchingMethod = TaskContext.Instance().Config.PathingConditionConfig.MapMatchingMethod;
-        var center = MapManager.GetMap(_mapName, matchingMethod).ConvertGenshinMapCoordinatesToImageCoordinates(512, 512);
-        _mapBitmap = ClipMat(new Point2f(center.x, center.y)).ToWriteableBitmap();
+        var center = MapManager.GetMap(_mapName, matchingMethod).ConvertGenshinMapCoordinatesToImageCoordinates(new Point2f(512, 512));
+        _mapBitmap = ClipMat(new Point2f(center.X, center.Y)).ToWriteableBitmap();
         WeakReferenceMessenger.Default.Register<PropertyChangedMessage<object>>(this, (sender, msg) =>
         {
             if (msg.PropertyName == "SendCurrentPosition")
@@ -219,7 +219,7 @@ public partial class MapViewerViewModel : ObservableObject
     private Point ConvertToMapPoint(Waypoint point)
     {
         var matchingMethod = TaskContext.Instance().Config.PathingConditionConfig.MapMatchingMethod;
-        var (x, y) = MapManager.GetMap(_mapName, matchingMethod).ConvertGenshinMapCoordinatesToImageCoordinates((float)point.X, (float)point.Y);
+        var (x, y) = MapManager.GetMap(_mapName, matchingMethod).ConvertGenshinMapCoordinatesToImageCoordinates(new Point2f((float)point.X, (float)point.Y));
         return new Point(x, y);
     }
 


### PR DESCRIPTION
图片坐标系下的`(0, 0)`坐标被用来表示未匹配到，这个做法本身没有问题。但是这个特殊的坐标被映射到游戏坐标系之后，在不同的地图中会得到一个不同的值，往往令人一头雾水，且在js脚本的逻辑中无法简单判断一个结果是有效的坐标，还是识别失败。

这个PR主要达到了以下效果：

1. 录制编辑器识别不到坐标时，会打一条warning log说识别不到坐标，而不是在编辑器里增加一个极大的坐标
2. 寻路的时候识别不到坐标时，不会当成一个极大的坐标报路径过远
3. js脚本调用`genshin.getPositionFromMap`识别不到坐标的时候会返回`null`，而不是一个极大的坐标