### PR TITLE
修复旧日之海点击传送点有偏差的问题

### DIFF
--- a/BetterGenshinImpact/GameTask/Common/Map/Maps/SeaOfBygoneErasMap.cs
+++ b/BetterGenshinImpact/GameTask/Common/Map/Maps/SeaOfBygoneErasMap.cs
@@ -133,7 +133,8 @@ public class SeaOfBygoneErasMap : SceneBaseMap
         {
             return default;
         }
-        teleportPoints = teleportPoints.OrderBy(i => i.X).ThenBy(i => i.Y).ToList();
+        teleportPoints = teleportPoints.Select(i => new Point(i.X + 12, i.Y + 12)).
+            OrderBy(i => i.X).ThenBy(i => i.Y).ToList();
         /*
         foreach (var p in teleportPoints) {
             Logger.LogInformation("Teleport point: {a}", p);


### PR DESCRIPTION
因旧日之海大地图识别方法中需要查找传送锚点作为参考，其结果是包含传送锚点矩形图片的左上角。经过一系列计算后，点击传送锚点时的点击位置同样是其左上角（下图中的绿色位置），这会导致有些时候点击不到。改进方法是人工加上一个offset，将点击位置移动到传送锚点中央（下图中红色位置）。

<img width="286" height="267" alt="20260119_172604-0001" src="https://github.com/user-attachments/assets/397ff542-277b-499a-8d54-de9c588d89b1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 修复

* **Bug 修复**
  * 改进了传送点地图位置的处理精度。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->