### PR TITLE
fix: 修复自动剧情有时无法完成对话的问题

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
@@ -1350,6 +1350,7 @@ public class PathExecutor
                 if (disabledUiButtonRa.IsExist())
                 {
                     _autoSkipTrigger.OnCapture(new CaptureContent(ra));
+                    noDisabledUiButtonTimes = 0;
                 }
                 else
                 {


### PR DESCRIPTION
## 问题
在各种任务中，拾取有时候会触发NPC或物品对话，可以在窗口看到“进入剧情，自动点击剧情直到结束”，有时会直接卡死在这一步。

## 分析
在 `PathExecutor.AutoSkip()` 中，`noDisabledUiButtonTimes` 计数器在检测到对话 UI 时没有重置为 0。这导致计数器累计所有未检测到 UI 的帧数，而不是连续未检测的帧数。

## 修复
当检测到对话 UI 时，重置 `noDisabledUiButtonTimes` 为 0，确保只有在连续 10 次未检测到 UI（约 2.1 秒）后才退出循环。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复了自动寻路功能中的一个问题：当检测到禁用的UI按钮时，计数器不会再继续累积，从而避免路径执行循环意外退出，提高了自动寻路的稳定性和可靠性。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->