### PR TITLE
优化换队拾取和切换队伍

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
@@ -498,13 +498,13 @@ public class AutoFightTask : ISoloTask
             {
                 oldPartyName = RunnerContext.Instance.PartyName;
             }
-            else if (picker is null)
+            else if(picker is null && !string.IsNullOrEmpty(_taskParam.KazuhaPartyName))
             {
                 Logger.LogWarning("换队拾取：当前队伍名称为空，尝试读取！");
                 await Delay(1000, ct);
                 await _returnMainUiTask.Start(ct);
 
-                for (int attempt = 0; attempt < 3; attempt++)
+                for (int attempt = 0; attempt < 6; attempt++)
                 {
                     Simulation.SendInput.SimulateAction(GIActions.OpenPartySetupScreen);
                     var enterGameAppear = await NewRetry.WaitForElementAppear(
@@ -514,13 +514,15 @@ public class AutoFightTask : ISoloTask
                         15,
                         500
                     );
-                    if (attempt == 2)
+                    if(attempt == 5 && !enterGameAppear)
                     {
-                        Logger.LogWarning("换队拾取：读取队伍名称失败！");
+                        Logger.LogWarning("换队拾取：读取队伍名称失败，跳过换队拾取步骤");
                     }
                 }
             }
             
+            await Delay(1000, ct);
+                
             //等待寻找2秒队伍按钮出现
             var timeWaitStart = 0;
             while(timeWaitStart < 6000)
@@ -530,14 +532,43 @@ public class AutoFightTask : ISoloTask
                 if (partyViewBtn.IsExist())
                 {
                     // OCR 当前队伍名称（无法单字，中间禁止空格）
-                    oldPartyName = ra.Find(new RecognitionObject
-                    {
-                        RecognitionType = RecognitionTypes.Ocr,
-                        RegionOfInterest = new Rect(partyViewBtn.Right, partyViewBtn.Top, (int)(350 * _assetScale),
-                            partyViewBtn.Height)
-                    }).Text;
-                    Logger.LogInformation("换队拾取：当前队伍名称读取为：{oldPartyName}",oldPartyName);
-                    RunnerContext.Instance.PartyName = oldPartyName;
+                  // 读取OCR原始识别文本
+                  var rawPartyName = ra.Find(new RecognitionObject
+                  {
+                      RecognitionType = RecognitionTypes.Ocr,
+                      RegionOfInterest = new Rect(partyViewBtn.Right, partyViewBtn.Top, (int)(350 * _assetScale),
+                          partyViewBtn.Height)
+                  }).Text;
+                  
+                  // 核心处理逻辑：1.空值兜底 2.去首尾空白 3.移除末尾的“口”字（仅最后一个是口才删）
+                  if (string.IsNullOrWhiteSpace(rawPartyName))
+                  {
+                      oldPartyName = string.Empty;
+                  }
+                  else
+                  {
+                      //有概率把编辑图标识别为字符，并且含有空格或换行符，需要过滤
+                      var tempName = rawPartyName
+                          .Replace("\"", "")        // 移除所有双引号（核心新增，解决日志里的""问题）
+                          .Replace("\r\n", "")      // 清理Windows换行符
+                          .Replace("\r", "");   // 先清理所有双引号，避免引号干扰后续处理
+                          
+                          // 核心逻辑：找到第一个换行符(\n)的位置，截断并删除换行+后面所有字符
+                          int firstNewLineIndex = tempName.IndexOf('\n');
+                          if (firstNewLineIndex != -1) // 存在换行符，截取到换行符前
+                          {
+                              tempName = tempName.Substring(0, firstNewLineIndex);
+                          }
+                      
+                          // 最后统一去首尾所有空白（空格、制表符、回车符\r等），得到纯净队伍名
+                          oldPartyName = tempName.Trim();
+                  }
+                  
+                  // 后续原有逻辑不变
+                  Logger.LogInformation("换队拾取：当前队伍名称读取为：{oldPartyName}", oldPartyName);
+                  // 加在rawPartyName赋值后，打印原始文本的“原始形态”（转义符会显示）
+                  Logger.LogDebug("OCR原始识别文本（含转义）：{rawPartyName}", rawPartyName);
+                  RunnerContext.Instance.PartyName = oldPartyName;
                     // await _returnMainUiTask.Start(ct);
                     break;
                 }

--- a/BetterGenshinImpact/GameTask/Common/Job/SwitchPartyTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/SwitchPartyTask.cs
@@ -92,6 +92,21 @@ public class SwitchPartyTask
             RegionOfInterest = new Rect(partyViewBtn.Right, partyViewBtn.Top, (int)(350 * _assetScale),
                 partyViewBtn.Height)
         }).Text;
+        
+        var tempName = currTeamName
+            .Replace("\"", "")        // 移除所有双引号（核心新增，解决日志里的""问题）
+            .Replace("\r\n", "")      // 清理Windows换行符
+            .Replace("\r", "");   // 先清理所有双引号，避免引号干扰后续处理
+                              
+        // 核心逻辑：找到第一个换行符(\n)的位置，截断并删除换行+后面所有字符
+        int firstNewLineIndex = tempName.IndexOf('\n');
+        if (firstNewLineIndex != -1) // 存在换行符，截取到换行符前
+        {
+            tempName = tempName.Substring(0, firstNewLineIndex);
+        }
+                          
+        // 最后统一去首尾所有空白（空格、制表符、回车符\r等），得到纯净队伍名
+        currTeamName = tempName.Trim();
 
         Logger.LogInformation("切换队伍，当前队伍名称: {Text}，使用正则表达式规则进行模糊匹配", currTeamName);
         if (Regex.IsMatch(currTeamName, partyName))


### PR DESCRIPTION
1.换队拾取判断加入判断是否启用
2.有概率把编辑图标识别为字符，并且含有空格或换行符，需要过滤

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **错误修复**
  * 优化了队伍识别流程，提高了匹配准确性
  * 增强了OCR文本处理的鲁棒性，改进了规范化处理
  * 改进了队伍切换的同步机制，增加了UI状态协调延迟
  * 提升了故障场景的处理和日志记录

<!-- end of auto-generated comment: release notes by coderabbit.ai -->