### PR TITLE
背包计数任务更快定位到武器经验材料

### DIFF
--- a/BetterGenshinImpact/GameTask/Common/Job/CountInventoryItem.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/CountInventoryItem.cs
@@ -82,6 +82,26 @@ namespace BetterGenshinImpact.GameTask.Common.Job
             return result;
         }
 
+        private async Task PreScrollToBottomForWeaponOre()
+        {
+            // 长按滑动栏底部，快速翻页到底部后，再继续滚动确保在最后一页
+            GameCaptureRegion.GameRegion1080PPosMove(1289, 936);
+            try
+            {
+                GlobalMethod.LeftButtonDown();
+                await TaskControl.Delay(2000, ct);
+            }
+            finally
+            {
+                GlobalMethod.LeftButtonUp();
+            }
+            var gridScroller = new GridScroller(GridParams.Templates[gridScreenName], logger, input, ct);
+            while (await gridScroller.TryVerticalScollDown((src, columns) => GridScreen.GridEnumerator.GetGridItems(src, columns)))
+            {
+                await TaskControl.Delay(300, ct);
+            }
+        }
+
         private async Task<int> FindOne(InferenceSession session, Dictionary<string, float[]> prototypes)
         {
             GridScreen gridScreen = new GridScreen(GridParams.Templates[this.gridScreenName], logger, ct);
@@ -91,18 +111,9 @@ namespace BetterGenshinImpact.GameTask.Common.Job
             try
             {
                 //如果是武器页的武器经验道具，直接翻页到最底部
-                if (this.gridScreenName! == GridScreenName.Weapons && this.itemName!.Contains("精锻用"))
+                if (gridScreenName == GridScreenName.Weapons && itemName!.StartsWith("精锻用"))
                 {
-                    //长按滑动栏底部，快速翻页到底部后，再继续滚动确保在最后一页
-                    GameCaptureRegion.GameRegion1080PPosMove(1289, 936);
-                    GlobalMethod.LeftButtonDown();  
-                    await TaskControl.Delay(2000, ct); 
-                    GlobalMethod.LeftButtonUp();
-                    var gridScroller = new GridScroller(GridParams.Templates[this.gridScreenName!], logger, Simulation.SendInput, ct);  
-                    while (await gridScroller.TryVerticalScollDown((src, columns) => GridScreen.GridEnumerator.GetGridItems(src, columns)))  
-                    {
-                        await TaskControl.Delay(300, ct); 
-                    }  
+                    await PreScrollToBottomForWeaponOre();
                 }
                 
                 //开始识别
@@ -156,19 +167,10 @@ namespace BetterGenshinImpact.GameTask.Common.Job
             try
             {
                 //如果包含武器页的武器经验道具，直接翻页到最底部
-                bool hasOre = this.itemNames!.Any(name => name.StartsWith("精锻用"));
-                if (this.gridScreenName! == GridScreenName.Weapons && hasOre)
+                bool hasOre = itemNames!.Any(name => name.StartsWith("精锻用"));
+                if (gridScreenName == GridScreenName.Weapons && hasOre)
                 {
-                    //长按滑动栏底部，快速翻页到底部后，再继续滚动确保在最后一页
-                    GameCaptureRegion.GameRegion1080PPosMove(1289, 936);
-                    GlobalMethod.LeftButtonDown();  
-                    await TaskControl.Delay(2000, ct); 
-                    GlobalMethod.LeftButtonUp();
-                    var gridScroller = new GridScroller(GridParams.Templates[this.gridScreenName!], logger, Simulation.SendInput, ct);  
-                    while (await gridScroller.TryVerticalScollDown((src, columns) => GridScreen.GridEnumerator.GetGridItems(src, columns)))  
-                    {
-                        await TaskControl.Delay(300, ct); 
-                    }  
+                    await PreScrollToBottomForWeaponOre();
                 }
                 await foreach ((ImageRegion pageRegion, Rect itemRect) in gridScreen)
                 {


### PR DESCRIPTION
武器的计数逻辑跟材料不同，在武器页直接拉到底应该没有负面影响。
武器页滑动到底的方式在1920x1080和2560x1440分辨率下测试没问题。

预期更快的识别：精锻用魔矿、精锻用良矿、精锻用杂矿
材料图片还没炼

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## 发行说明

* **Bug 修复**
  * 优化了武器库存识别流程：在检测到特定精锻用材料时，界面会预先滚动至武器网格底部再开始识别，确保所有项目加载完成并提升识别准确率。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->