### PR TITLE
fix:自动拾取黑名单配置文本框复制剪切时UI短暂无响应

### DIFF
--- a/BetterGenshinImpact/ViewModel/Pages/TriggerSettingsPageViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/TriggerSettingsPageViewModel.cs
@@ -82,7 +82,6 @@ public partial class TriggerSettingsPageViewModel : ViewModel
             TextWrapping = TextWrapping.Wrap,
             AcceptsReturn = true,
             VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
-            HorizontalScrollBarVisibility = ScrollBarVisibility.Auto,
             PlaceholderText = "每行一条记录",
             Text = exactText
         };
@@ -94,7 +93,6 @@ public partial class TriggerSettingsPageViewModel : ViewModel
             TextWrapping = TextWrapping.Wrap,
             AcceptsReturn = true,
             VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
-            HorizontalScrollBarVisibility = ScrollBarVisibility.Auto,
             PlaceholderText = "每行一条记录",
             Text = fuzzyText
         };
@@ -136,8 +134,8 @@ public partial class TriggerSettingsPageViewModel : ViewModel
 
         if (p.DialogResult == true)
         {
-            File.WriteAllText(Global.Absolute(exactPath), exactTextBox.Text);
-            File.WriteAllText(Global.Absolute(fuzzyPath), fuzzyTextBox.Text);
+            Global.WriteAllText(exactPath, exactTextBox.Text);
+            Global.WriteAllText(fuzzyPath, fuzzyTextBox.Text);
             GameTaskManager.RefreshTriggerConfigs();
         }
     }


### PR DESCRIPTION
<img width="992" height="554" alt="image" src="https://github.com/user-attachments/assets/a392d802-c94a-4e1a-8bdd-47069ae535fd" />
解决这两个文本框按剪切和复制快捷键时，UI有一个短暂的未响应且剪切不生效的问题，。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **用户界面改进**
  * 重新设计了黑名单管理界面，替换为更简洁的纯文本输入控件。
  * 增加文本换行、回车多行输入及占位提示，改善编辑体验与默认内容显示。
* **修复与稳定性**
  * 简化保存与加载流程，确保黑名单内容在保存和显示时一致，减少格式问题。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->