### PR TITLE
Revert "优化路径追踪过程中传送的逻辑"

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
@@ -186,10 +186,6 @@ public class PathExecutor
 
                         if (waypoint.Type == WaypointType.Teleport.Code)
                         {
-                            if (CurWaypoints.Item1 > 0)
-                            {
-                                await Delay(1000, ct);
-                            }
                             await HandleTeleportWaypoint(waypoint);
                         }
                         else


### PR DESCRIPTION
Reverts babalae/better-genshin-impact#2550
直接每一个传送前强制等待过于武断，并不是所有情况下都需要进行这个等待，针对所提到的挖矿的场景，应该由地图追踪那边添加等待的简易策略
该方法还会导致提及的有经验的作者制作的路线已经添加了等待时，进行了双倍的等待

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* 优化了自动寻路系统中传送路点的处理机制，移除了导致操作延迟的不必要等待时间，使传送操作更加迅速，显著改善游戏的响应速度和用户体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->