### PR TITLE
修复七圣召唤月之五伊涅芙会导致手牌不可调和的死循环

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoGeniusInvokation/GeniusInvokationControl.cs
+++ b/BetterGenshinImpact/GameTask/AutoGeniusInvokation/GeniusInvokationControl.cs
@@ -600,6 +600,10 @@ public class GeniusInvokationControl
 
         var (startX, spacing) = table[currentCardCount];
 
+        // 先点中间位置，确保牌是展开状态
+        ClickExtension.Click(rect.X + rect.Width / 2d, rect.Y + rect.Height - 50);
+        Sleep(1500);
+
         // 从左往右尝试
         for (int idx = 0; idx < currentCardCount; idx++)
         {


### PR DESCRIPTION
改为从左往右一张张调和，无法调和的就跳过，所有牌都无法调和才会放弃尝试
#2845 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug修复**
  * 优化了天才招聘模式中元素调谐的自动化流程，改进了卡牌选择策略，提高了自动操作的成功率和稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->