### PR TITLE
fix:适配秘境限时全开的UI改动

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoDomain/AutoDomainTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoDomain/AutoDomainTask.cs
@@ -95,7 +95,7 @@ public class AutoDomainTask : ISoloTask
         this.clickanywheretocloseLocalizedString = stringLocalizer.WithCultureGet(cultureInfo, "点击任意位置关闭");
         this.matchingChallengeString = stringLocalizer.WithCultureGet(cultureInfo, "匹配挑战");
         this.rapidformationString = stringLocalizer.WithCultureGet(cultureInfo, "快速编队");
-        this.limitedFullyString = stringLocalizer.WithCultureGet(cultureInfo, "限时全开");
+        this.limitedFullyString = stringLocalizer.WithCultureGet(cultureInfo, "限时全部开放");
         this.limitedFullyAllString = stringLocalizer.WithCultureGet(cultureInfo, "限时开放");
     }
 
@@ -382,7 +382,7 @@ public class AutoDomainTask : ISoloTask
         using var limitedFullyStringRa = CaptureToRectArea();
         var limitedFullyStringRaocrList =
             limitedFullyStringRa.FindMulti(RecognitionObject.Ocr(0, 0, limitedFullyStringRa.Width * 0.5,
-                limitedFullyStringRa.Height));
+                limitedFullyStringRa.Height * 0.5));
         var limitedFullyStringRaocrListdone = limitedFullyStringRaocrList.LastOrDefault(t =>
             Regex.IsMatch(t.Text, this.limitedFullyString) || Regex.IsMatch(t.Text, this.limitedFullyAllString));
         // 检测是否为限时全开秘境


### PR DESCRIPTION
fix:#2853
改为识别左上角文字
<img width="768" height="1052" alt="image" src="https://github.com/user-attachments/assets/7198a702-e6b2-4b53-8c41-32de9c8ae22e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* 更新了秘境限时开放状态的本地化文本显示，确保信息准确传达。
* 优化了秘境限时开放状态的识别算法，改进了文本检测精度，使自动秘境功能识别更加可靠。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->