### PR TITLE
fix(AutoLeyLineOutcrop): 修正冒险之证配置逻辑歧义

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoLeyLineOutcrop/AutoLeyLineOutcropParam.cs
+++ b/BetterGenshinImpact/GameTask/AutoLeyLineOutcrop/AutoLeyLineOutcropParam.cs
@@ -44,7 +44,8 @@ public class AutoLeyLineOutcropParam:BaseTaskParam<AutoLeyLineOutcropTask>
     {
         OpenModeCountMin= config.OpenModeCountMin;
         IsResinExhaustionMode= config.IsResinExhaustionMode;
-        UseAdventurerHandbook= config.UseAdventurerHandbook;
+        //最小修正歧义
+        UseAdventurerHandbook= !config.UseAdventurerHandbook;
         FriendshipTeam= config.FriendshipTeam;
         Team= config.Team;
         Timeout= config.Timeout;

--- a/BetterGenshinImpact/GameTask/AutoLeyLineOutcrop/AutoLeyLineOutcropTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoLeyLineOutcrop/AutoLeyLineOutcropTask.cs
@@ -326,7 +326,7 @@ public class AutoLeyLineOutcropTask : ISoloTask
             await _switchPartyTask.Start(_taskParam.Team, _ct);
         }
 
-        if (_taskParam.UseAdventurerHandbook)
+        if (!_taskParam.UseAdventurerHandbook)
         {
             // The config flag means "do NOT use handbook"; close custom marks for manual navigation.
             await CloseCustomMarks();
@@ -339,7 +339,7 @@ public class AutoLeyLineOutcropTask : ISoloTask
     {
         while (_currentRunTimes < _taskParam.Count)
         {
-            if (!_taskParam.UseAdventurerHandbook)
+            if (_taskParam.UseAdventurerHandbook)
             {
                 // Handbook flow: open the book and track a ley line target.
                 await FindLeyLineOutcropByBook(_taskParam.Country, _taskParam.LeyLineOutcropType);
@@ -796,7 +796,7 @@ public class AutoLeyLineOutcropTask : ISoloTask
         }
 
         await EnsureExitRewardPage();
-        if (_taskParam.UseAdventurerHandbook)
+        if (!_taskParam.UseAdventurerHandbook)
         {
             _logger.LogWarning("寻找地脉花失败：当前已勾选“不使用冒险之证寻路”，可尝试关闭该选项后重试！");
             throw new Exception("寻找地脉花失败：未在地图上识别到地脉花图标。当前已勾选“不使用冒险之证寻路”，可尝试关闭该选项后重试！");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 修复

- 修复了自动秘境探宝中冒险家手册选项的逻辑错误。该功能现在可以正确地根据选项状态来控制秘境初始化、挑战执行和失败处理的流程。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->