### PR TITLE
添加check动作

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
@@ -418,7 +418,14 @@ public class AutoFightTask : ISoloTask
                             fightEndFlag = await CheckFightFinish(delayTime, detectDelayTime);
                         }
                         #endregion
-                        
+
+                        #region check动作触发战斗结束检测
+                        if (command.Method == Method.Check)
+                        {
+                            fightEndFlag = await CheckFightFinish(delayTime, detectDelayTime);
+                        }
+                        #endregion
+
                         command.Execute(combatScenes, lastCommand);
                         //统计战斗人次
                         if (i == combatCommands.Count - 1 || command.Name != combatCommands[i + 1].Name)

--- a/BetterGenshinImpact/GameTask/AutoFight/Script/CombatCommand.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Script/CombatCommand.cs
@@ -202,6 +202,10 @@ public class CombatCommand
         {
             avatar.Ready();
         }
+        else if (Method == Method.Check)
+        {
+            // check动作在AutoFightTask主循环中处理，此处不做任何操作
+        }
         else if (Method == Method.Aim)
         {
             throw new NotImplementedException();

--- a/BetterGenshinImpact/GameTask/AutoFight/Script/Method.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Script/Method.cs
@@ -13,6 +13,7 @@ public class Method
     public static readonly Method Charge = new(["charge", "重击"]);
     public static readonly Method Wait = new(["wait", "after", "等待"]);
     public static readonly Method Ready = new(["ready", "完成"]);
+    public static readonly Method Check = new(["check", "检测"]);
 
     public static readonly Method Walk = new(["walk", "行走"]);
     public static readonly Method W = new(["w"]);
@@ -45,6 +46,7 @@ public class Method
             yield return Charge;
             yield return Wait;
             yield return Ready;
+            yield return Check;
 
             yield return Walk;
             yield return W;


### PR DESCRIPTION
允许如那维莱特 q,charge(3),check,charge(3)的写法以额外检测战斗结束，从而节省战斗时间或资源

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增检测命令，优化自动战斗的战斗结束判定逻辑
  * 改进了自动战斗任务的命令处理流程，增强了战斗状态检测的可靠性

<!-- end of auto-generated comment: release notes by coderabbit.ai -->