### PR TITLE
对传送前的Delay增加更细致的条件控制

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
@@ -188,7 +188,19 @@ public class PathExecutor
                         {
                             if (CurWaypoints.Item1 > 0)
                             {
-                                await Delay(1000, ct);
+                                var prevWaypoints = waypointsList[CurWaypoints.Item1 - 1];
+                                var prevWaypoint = prevWaypoints[prevWaypoints.Count - 1];
+                                if (prevWaypoint.Type == WaypointType.Teleport.Code
+                                    || prevWaypoint.Action == ActionEnum.Fight.Code
+                                    || prevWaypoint.Action == ActionEnum.NahidaCollect.Code
+                                    || prevWaypoint.Action == ActionEnum.PickAround.Code)
+                                {
+                                    // No delay
+                                }
+                                else
+                                {
+                                    await Delay(1000, ct);
+                                }
                             }
                             await HandleTeleportWaypoint(waypoint);
                         }


### PR DESCRIPTION
经过对脚本仓库所有路径追踪文件的分析，共找到“在路径追踪文件中间的传送类型路径点”约`2183`个，对其上一个路径点进行分类，得到数据如下。

若上一个路径点类型/操作为战斗、纳西妲收集、传送、转圈拾取，传送前的sleep操作并无必要。所以我们在此PR中增加了若干条件限制，并以方便扩展的方式实现出来。

```
(614, 'target,')
(307, 'path,fight')
(300, 'path,combat_script')
(203, 'target,combat_script')
(161, 'path,')
(149, 'orientation,combat_script')
(101, 'target,mining')
(97, 'path,nahida_collect')
(51, 'target,pyro_collect')
(37, 'target,nahida_collect')
(36, 'path,pyro_collect')
(29, 'target,stop_flying')
(26, 'teleport,')
(19, 'target,fight')
(16, 'path,pick_around')
(10, 'path,use_gadget')
(7, 'target,electro_collect')
(6, 'path,stop_flying')
(4, 'orientation,fight')
(3, 'teleport,force_tp')
(1, 'teleport,pyro_collect')
(1, 'teleport,nahida_collect')
(1, 'target,hydro_collect')
(1, 'path,mining')
(1, 'orientation,nahida_collect')
(1, 'path,electro_collect')
(1, 'orientation,')
```

closes: https://github.com/babalae/better-genshin-impact/issues/2844

related to: https://github.com/babalae/better-genshin-impact/pull/2550 https://github.com/babalae/better-genshin-impact/pull/2831

next step: 批量分析脚本仓库中所有传送点前有sleep的操作，删除不必要的sleep操作。

cc @Bedrockx

