### PR TITLE
增加关闭自动领取派遣的设置按钮

### DIFF
--- a/BetterGenshinImpact/Core/Config/PathingPartyConfig.cs
+++ b/BetterGenshinImpact/Core/Config/PathingPartyConfig.cs
@@ -104,6 +104,12 @@ public partial class PathingPartyConfig : ObservableObject
     [ObservableProperty]
     private AutoEatConfig _autoEatConfig = new();
 
+    /// <summary>
+    /// 关闭地图追踪过程中的自动领取派遣奖励
+    /// </summary>
+    [ObservableProperty]
+    private bool _disableAutoFetchDispatch = false;  // 默认关闭
+
     //在连续执行时是否隐藏
     [ObservableProperty]
     private bool _hideOnRepeat = false;

--- a/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
@@ -637,6 +637,12 @@ public class PathExecutor
     /// <returns>是否可以领取派遣奖励</returns>
     private async Task<bool> TryGetExpeditionRewardsDispatch(TpTask? tpTask = null)
     {
+        // 检查配置组设置：是否禁用自动领取派遣奖励
+        if (PartyConfig?.DisableAutoFetchDispatch == true)
+        {
+            return false;
+        }
+
         if (tpTask == null)
         {
             tpTask = new TpTask(ct);

--- a/BetterGenshinImpact/View/Pages/View/ScriptGroupConfigView.xaml
+++ b/BetterGenshinImpact/View/Pages/View/ScriptGroupConfigView.xaml
@@ -314,8 +314,32 @@
                                          Grid.RowSpan="2"
                                          Grid.Column="1"
                                          IsChecked="{Binding PathingConfig.OnlyInTeleportRecover, Mode=TwoWay}" />
-
                     </Grid>
+
+                    <Grid Margin="16">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <ui:TextBlock Grid.Row="0"
+                                          Grid.Column="0"
+                                          FontTypography="Body"
+                                          Text="关闭地图追踪过程中的自动领取派遣奖励"
+                                          TextWrapping="Wrap" />
+                            <ui:TextBlock Grid.Row="1"
+                                          Grid.Column="0"
+                                          Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                          Text="开启后，在大地图传送中，不会自动领取派遣奖励"
+                                          TextWrapping="Wrap" />
+                            <ui:ToggleSwitch Grid.Row="0"
+                                             Grid.RowSpan="2"
+                                             Grid.Column="1"
+                                             IsChecked="{Binding PathingConfig.DisableAutoFetchDispatch, Mode=TwoWay}" />
+                        </Grid>
                     <Grid Margin="16">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />


### PR DESCRIPTION
主要是跑狗粮超限点的时候使用，如果跑的时候传送了，调查点会消失

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 在地图追踪功能中新增自动派遣奖励获取的开关控制，用户现可根据需要在设置中启用或禁用自动领取派遣奖励。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->