### PR TITLE
选择鱼饵增加等待时间，以降低鱼饵尚未出现时执行动作的频率

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoFishing/Behaviours.cs
+++ b/BetterGenshinImpact/GameTask/AutoFishing/Behaviours.cs
@@ -151,7 +151,7 @@ namespace BetterGenshinImpact.GameTask.AutoFishing
 
             // 寻找鱼饵
             var boxAndBaits = FindBait(imageRegion);
-            ;
+            
             foreach ((Rect box, string? predName) in boxAndBaits)
             {
                 if (predName == blackboard.selectedBait.GetDescription())
@@ -201,6 +201,7 @@ namespace BetterGenshinImpact.GameTask.AutoFishing
             }
             else
             {
+                blackboard.Sleep(200);
                 return BehaviourStatus.Running;
             }
         }


### PR DESCRIPTION
针对 #2856，可能解决这个问题
虽然我测试通过了无限执行选取鱼饵动作的情况，但有可能是我的cpu太慢了所以没有暴露问题。issue中“2.36秒内累计输出396次选择鱼饵”是个很高的频率了，确实应该控制一下。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **错误修复**
  * 改进自动钓鱼功能中鱼饵界面的加载时序，提升界面响应稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->