### PR TITLE
修改check触发检查的时机

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
@@ -426,14 +426,14 @@ public class AutoFightTask : ISoloTask
                             countFight++;
                         }
 
-                        lastFightName = command.Name;
-
                         #region check动作触发战斗结束检测
                         if (command.Method == Method.Check)
                         {
                             fightEndFlag = await CheckFightFinish(delayTime, detectDelayTime);
                         }
                         #endregion
+
+                        lastFightName = command.Name;
                         if (!fightEndFlag && _taskParam is { FightFinishDetectEnabled: true })
                         {
                             //处于最后一个位置，或者当前执行人和下一个人名字不一样的情况，满足一定条件(开启快速检查，并且检查时间大于0或人名存在配置)检查战斗


### PR DESCRIPTION
将check触发检查的时机改为command.Execute之后，实现以下效果
1.一行策略动作之间进行检查时，无其他影响，会通过同角色切换的机制确保角色编号块可见
2.策略开头使用check时，触发跨角色切换后再检查战斗结束，避免上一个角色的技能前后摇影响按l判定
例如以下场景
芙宁娜 e
那维莱特 check,e
在关闭更快检测战斗结束的情况下可以由check主动触发检测，可以将检测前延时降至0以节约原默认的1.5秒时间（通常使用的是0.4）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 调整了自动战斗中检测“战斗已结束”信号的时机，改进了战斗完成识别逻辑，减少误判并保证在指令执行流程中更可靠地捕获战斗结束，从而改善早退判定行为和战斗流程稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->