### PR TITLE
fix: 避免自动地脉花路径追踪时再次自动切队

### DIFF
--- a/BetterGenshinImpact/Core/Config/PathingPartyConfig.cs
+++ b/BetterGenshinImpact/Core/Config/PathingPartyConfig.cs
@@ -21,6 +21,9 @@ public partial class PathingPartyConfig : ObservableObject
     // 切换到队伍的名称
     [ObservableProperty]
     private string _partyName = string.Empty;
+
+    [JsonIgnore]
+    public bool SkipPartySwitch { get; set; }
     
     // 切换队伍前是否前往须弥七天神像
     [ObservableProperty]

--- a/BetterGenshinImpact/GameTask/AutoLeyLineOutcrop/AutoLeyLineOutcropTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoLeyLineOutcrop/AutoLeyLineOutcropTask.cs
@@ -327,8 +327,7 @@ public class AutoLeyLineOutcropTask : ISoloTask
 
         if (!string.IsNullOrWhiteSpace(_taskParam.Team))
         {
-            _switchPartyTask ??= new SwitchPartyTask();
-            await _switchPartyTask.Start(_taskParam.Team, _ct);
+            await TrySwitchPartyAndSync(_taskParam.Team);
         }
 
         if (_taskParam.UseAdventurerHandbook)
@@ -727,7 +726,15 @@ public class AutoLeyLineOutcropTask : ISoloTask
 
         var task = PathingTask.BuildFromFilePath(fullPath) ?? throw new Exception("路径文件解析失败");
         var executor = new PathExecutor(_ct);
+        executor.PartyConfig = BuildLeyLinePathingPartyConfig();
         await executor.Pathing(task);
+    }
+
+    private static PathingPartyConfig BuildLeyLinePathingPartyConfig()
+    {
+        var partyConfig = PathingPartyConfig.BuildDefault();
+        partyConfig.SkipPartySwitch = true;
+        return partyConfig;
     }
 
     private async Task<NodeData> LoadNodeData()
@@ -1489,8 +1496,7 @@ public class AutoLeyLineOutcropTask : ISoloTask
         Simulation.SendInput.SimulateAction(GIActions.MoveForward, KeyType.KeyUp);
         try
         {
-            _switchPartyTask ??= new SwitchPartyTask();
-            await _switchPartyTask.Start(_taskParam.FriendshipTeam, _ct);
+            await TrySwitchPartyAndSync(_taskParam.FriendshipTeam);
         }
         catch (Exception ex)
         {
@@ -1506,8 +1512,24 @@ public class AutoLeyLineOutcropTask : ISoloTask
         }
 
         Simulation.SendInput.SimulateAction(GIActions.MoveForward, KeyType.KeyUp);
+        await TrySwitchPartyAndSync(_taskParam.Team);
+    }
+
+    private async Task<bool> TrySwitchPartyAndSync(string partyName)
+    {
+        if (string.IsNullOrWhiteSpace(partyName))
+        {
+            return false;
+        }
+
         _switchPartyTask ??= new SwitchPartyTask();
-        await _switchPartyTask.Start(_taskParam.Team, _ct);
+        var success = await _switchPartyTask.Start(partyName, _ct);
+        if (success)
+        {
+            RunnerContext.Instance.PartyName = partyName;
+        }
+
+        return success;
     }
 
     private async Task<bool> AttemptReward(int retryCount = 0)

--- a/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
@@ -330,6 +330,11 @@ public class PathExecutor
             await TpStatueOfTheSeven();
         }
 
+        if (PartyConfig.SkipPartySwitch)
+        {
+            return true;
+        }
+
         var pRaList = ra.FindMulti(AutoFightAssets.Instance.PRa); // 判断是否联机
         if (pRaList.Count > 0)
         {
@@ -460,9 +465,11 @@ public class PathExecutor
         // 没有强制配置的情况下，使用地图追踪内的条件配置
         // 必须放在这里，因为要通过队伍识别来得到最终结果
         var pathingConditionConfig = TaskContext.Instance().Config.PathingConditionConfig;
+        var skipPartySwitch = PartyConfig.SkipPartySwitch;
         if (PartyConfig is { Enabled: false })
         {
             PartyConfig = pathingConditionConfig.BuildPartyConfigByCondition(_combatScenes);
+            PartyConfig.SkipPartySwitch = skipPartySwitch;
         }
 
         // 校验角色是否存在


### PR DESCRIPTION
Fixes #2929

## 变更摘要

修复自动地脉花在执行路径文件时，可能被路径追踪流程再次切换队伍的问题。

## 修改内容

- 在 PathingPartyConfig 中新增运行时标记 SkipPartySwitch
- 自动地脉花执行 RunPathingFile() 前，显式为 PathExecutor 设置专用 PartyConfig
- PathExecutor 在检测到 SkipPartySwitch 后，跳过路径开始前的自动切队逻辑
- PathExecutor 在重新构造 PartyConfig 时保留该标记，避免被覆盖
- 自动地脉花内部的显式换队统一通过 helper 执行，并同步 RunnerContext.Instance.PartyName

## 影响范围

仅影响自动地脉花任务中的路径执行流程，不修改全局地图追踪条件匹配逻辑

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增队伍切换跳过选项，允许在特定任务执行期间保持当前队伍不变。

* **重构**
  * 优化了队伍切换逻辑的实现方式。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->