### PR TITLE
feat: 为js提供html遮罩

### DIFF
--- a/BetterGenshinImpact/Core/Script/Dependence/HtmlMask.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/HtmlMask.cs
@@ -87,7 +87,7 @@ public class HtmlMask : IDisposable
         catch (Exception ex)
         {
             TaskControl.Logger.LogError(ex, "打开HTML遮罩失败: {Url}", url);
-            return null!;
+            throw;
         }
     }
 
@@ -218,7 +218,8 @@ public class HtmlMask : IDisposable
         if (string.IsNullOrWhiteSpace(json)) return null;
         try
         {
-            return JsonDocument.Parse(json).RootElement;
+            using var doc = JsonDocument.Parse(json);
+            return doc.RootElement.Clone();
         }
         catch
         {

--- a/BetterGenshinImpact/Core/Script/Dependence/HtmlMask.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/HtmlMask.cs
@@ -1,0 +1,244 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using BetterGenshinImpact.Core.Script.Utils;
+using BetterGenshinImpact.GameTask.Common;
+using BetterGenshinImpact.View;
+using Microsoft.Extensions.Logging;
+
+namespace BetterGenshinImpact.Core.Script.Dependence;
+
+/// <summary>
+/// HTML遮罩层 - JS脚本依赖类
+/// 提供窗口管理与消息通信功能
+/// </summary>
+public class HtmlMask : IDisposable
+{
+    private static readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false
+    };
+
+    /// <summary>
+    /// 通信消息结构
+    /// </summary>
+    public class Message
+    {
+        public string Url { get; set; } = "";
+        public JsonElement? Data { get; set; }
+    }
+
+    /// <summary>
+    /// 脚本到HTML的待推送队列
+    /// </summary>
+    private static readonly ConcurrentDictionary<string, ConcurrentQueue<Message>> _toHtmlQueues = new();
+
+    /// <summary>
+    /// HTML到脚本的消息队列
+    /// </summary>
+    private static readonly ConcurrentDictionary<string, ConcurrentQueue<Message>> _fromHtmlQueues = new();
+
+    private readonly string _workDir;
+    private readonly List<string> _openedWindows = [];
+    private bool _disposed;
+
+    public HtmlMask(string workDir)
+    {
+        _workDir = workDir;
+    }
+
+    #region 窗口管理
+
+    /// <summary>
+    /// 显示HTML遮罩窗口
+    /// </summary>
+    public string Show(string url, string? id = null)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(url))
+                throw new ArgumentException("URL不能为空");
+
+            string finalUrl;
+
+            if (url.StartsWith("http", StringComparison.OrdinalIgnoreCase))
+            {
+                finalUrl = url;
+            }
+            else
+            {
+                // 禁止 file:// 绝对路径，仅允许脚本目录下的相对路径
+                string absPath = ScriptUtils.NormalizePath(_workDir, url);
+                finalUrl = new Uri(absPath).AbsoluteUri;
+            }
+
+            string windowId = HtmlMaskWindow.Show(finalUrl, id, _workDir);
+
+            _toHtmlQueues[windowId] = new ConcurrentQueue<Message>();
+            _fromHtmlQueues[windowId] = new ConcurrentQueue<Message>();
+            _openedWindows.Add(windowId);
+
+            return windowId;
+        }
+        catch (Exception ex)
+        {
+            TaskControl.Logger.LogError(ex, "打开HTML遮罩失败: {Url}", url);
+            return null!;
+        }
+    }
+
+    /// <summary>
+    /// 关闭指定窗口
+    /// </summary>
+    public bool Close(string id)
+    {
+        _openedWindows.Remove(id);
+        CleanupQueues(id);
+        return HtmlMaskWindow.Close(id);
+    }
+
+    /// <summary>
+    /// 关闭所有由本实例打开的窗口
+    /// </summary>
+    public void CloseAll()
+    {
+        foreach (var windowId in _openedWindows)
+        {
+            CleanupQueues(windowId);
+            HtmlMaskWindow.Close(windowId);
+        }
+        _openedWindows.Clear();
+    }
+
+    /// <summary>
+    /// 获取所有窗口ID
+    /// </summary>
+    public string[] GetWindowIds() => HtmlMaskWindow.GetWindowIds();
+
+    /// <summary>
+    /// 窗口是否存在
+    /// </summary>
+    public bool Exists(string id) => HtmlMaskWindow.Exists(id);
+
+    #endregion
+
+    #region 消息通信
+
+    /// <summary>
+    /// 发送消息到HTML
+    /// </summary>
+    /// <param name="windowId">目标窗口ID</param>
+    /// <param name="url">接口路径，如 /data/update</param>
+    /// <param name="jsonData">JSON数据</param>
+    public void Send(string windowId, string url, string jsonData)
+    {
+        if (!_toHtmlQueues.TryGetValue(windowId, out var queue))
+        {
+            _toHtmlQueues[windowId] = queue = new ConcurrentQueue<Message>();
+        }
+
+        queue.Enqueue(new Message
+        {
+            Url = url,
+            Data = ParseData(jsonData)
+        });
+
+        // 通知WebView2推送
+        HtmlMaskWindow.NotifyFlush(windowId);
+    }
+
+    /// <summary>
+    /// 轮询来自HTML的消息
+    /// </summary>
+    public string? Poll(string windowId)
+    {
+        if (_fromHtmlQueues.TryGetValue(windowId, out var queue) &&
+            queue.TryDequeue(out var message))
+        {
+            return JsonSerializer.Serialize(message, _jsonOptions);
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// 批量获取来自HTML的所有消息
+    /// </summary>
+    public string PollAll(string windowId)
+    {
+        var messages = new List<Message>();
+        if (_fromHtmlQueues.TryGetValue(windowId, out var queue))
+        {
+            while (queue.TryDequeue(out var message))
+            {
+                messages.Add(message);
+            }
+        }
+        return JsonSerializer.Serialize(messages, _jsonOptions);
+    }
+
+    #endregion
+
+    #region 内部方法
+
+    /// <summary>
+    /// 将待推送队列中的消息通过回调逐一发出
+    /// </summary>
+    internal static void FlushPendingMessages(string windowId, Action<string> postAction)
+    {
+        if (_toHtmlQueues.TryGetValue(windowId, out var queue))
+        {
+            while (queue.TryDequeue(out var msg))
+            {
+                postAction(JsonSerializer.Serialize(msg, _jsonOptions));
+            }
+        }
+    }
+
+    /// <summary>
+    /// HTML端发来的消息入队
+    /// </summary>
+    internal static void SendFromHtml(string windowId, string url, string data)
+    {
+        if (_fromHtmlQueues.TryGetValue(windowId, out var queue))
+        {
+            queue.Enqueue(new Message
+            {
+                Url = url,
+                Data = ParseData(data)
+            });
+        }
+    }
+
+    private static JsonElement? ParseData(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return null;
+        try
+        {
+            return JsonDocument.Parse(json).RootElement;
+        }
+        catch
+        {
+            // 不是合法JSON，作为纯文本包装
+            return JsonSerializer.SerializeToElement(json, _jsonOptions);
+        }
+    }
+
+    private static void CleanupQueues(string windowId)
+    {
+        _toHtmlQueues.TryRemove(windowId, out _);
+        _fromHtmlQueues.TryRemove(windowId, out _);
+    }
+
+    #endregion
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        CloseAll();
+    }
+}

--- a/BetterGenshinImpact/Core/Script/Dependence/HtmlMask.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/HtmlMask.cs
@@ -52,8 +52,14 @@ public class HtmlMask : IDisposable
     /// </summary>
     private static readonly ConcurrentDictionary<string, TaskCompletionSource<string>> _jsPendingRequests = new();
 
+    /// <summary>
+    /// requestId到windowId的映射，用于窗口关闭时取消对应的pending请求
+    /// </summary>
+    private static readonly ConcurrentDictionary<string, string> _requestWindowMap = new();
+
     private readonly string _workDir;
     private readonly List<string> _openedWindows = [];
+    private readonly object _openedWindowsLock = new();
     private bool _disposed;
 
     public HtmlMask(string workDir)
@@ -90,7 +96,7 @@ public class HtmlMask : IDisposable
 
             _toHtmlQueues[windowId] = new ConcurrentQueue<Message>();
             _fromHtmlQueues[windowId] = new ConcurrentQueue<Message>();
-            _openedWindows.Add(windowId);
+            lock (_openedWindowsLock) { _openedWindows.Add(windowId); }
 
             return windowId;
         }
@@ -106,7 +112,7 @@ public class HtmlMask : IDisposable
     /// </summary>
     public bool Close(string id)
     {
-        _openedWindows.Remove(id);
+        lock (_openedWindowsLock) { _openedWindows.Remove(id); }
         CleanupQueues(id);
         return HtmlMaskWindow.Close(id);
     }
@@ -116,12 +122,17 @@ public class HtmlMask : IDisposable
     /// </summary>
     public void CloseAll()
     {
-        foreach (var windowId in _openedWindows)
+        List<string> windows;
+        lock (_openedWindowsLock)
+        {
+            windows = [.. _openedWindows];
+            _openedWindows.Clear();
+        }
+        foreach (var windowId in windows)
         {
             CleanupQueues(windowId);
             HtmlMaskWindow.Close(windowId);
         }
-        _openedWindows.Clear();
     }
 
     /// <summary>
@@ -167,6 +178,7 @@ public class HtmlMask : IDisposable
         var requestId = Guid.NewGuid().ToString("N");
         var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
         _jsPendingRequests[requestId] = tcs;
+        _requestWindowMap[requestId] = windowId;
 
         try
         {
@@ -195,9 +207,14 @@ public class HtmlMask : IDisposable
 
             return await tcs.Task;
         }
+        catch (OperationCanceledException)
+        {
+            return null;
+        }
         finally
         {
             _jsPendingRequests.TryRemove(requestId, out _);
+            _requestWindowMap.TryRemove(requestId, out _);
         }
     }
 
@@ -216,6 +233,9 @@ public class HtmlMask : IDisposable
         {
             if (queue.TryDequeue(out var message))
                 return JsonSerializer.Serialize(message, _jsonOptions);
+
+            if (!HtmlMaskWindow.Exists(windowId))
+                return null;
 
             if (timeoutMs > 0 && sw.ElapsedMilliseconds > timeoutMs)
                 return null;
@@ -280,7 +300,7 @@ public class HtmlMask : IDisposable
         if (requestId != null && _jsPendingRequests.TryRemove(requestId, out var tcs))
         {
             var parsed = ParseData(data);
-            tcs.SetResult(parsed != null ? parsed.Value.GetRawText() : "null");
+            tcs.TrySetResult(parsed != null ? parsed.Value.GetRawText() : "null");
             return;
         }
 
@@ -315,6 +335,15 @@ public class HtmlMask : IDisposable
     {
         _toHtmlQueues.TryRemove(windowId, out _);
         _fromHtmlQueues.TryRemove(windowId, out _);
+
+        // 取消该窗口关联的待响应请求
+        foreach (var kvp in _requestWindowMap)
+        {
+            if (kvp.Value == windowId && _jsPendingRequests.TryRemove(kvp.Key, out var tcs))
+            {
+                tcs.TrySetCanceled();
+            }
+        }
     }
 
     #endregion

--- a/BetterGenshinImpact/Core/Script/Dependence/HtmlMask.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/HtmlMask.cs
@@ -234,7 +234,7 @@ public class HtmlMask : IDisposable
             if (queue.TryDequeue(out var message))
                 return JsonSerializer.Serialize(message, _jsonOptions);
 
-            if (!HtmlMaskWindow.Exists(windowId))
+            if (_disposed || !_fromHtmlQueues.ContainsKey(windowId) || !HtmlMaskWindow.Exists(windowId))
                 return null;
 
             if (timeoutMs > 0 && sw.ElapsedMilliseconds > timeoutMs)

--- a/BetterGenshinImpact/Core/Script/Dependence/HtmlMask.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/HtmlMask.cs
@@ -143,10 +143,8 @@ public class HtmlMask : IDisposable
     /// </summary>
     public void Send(string windowId, string url, string jsonData)
     {
-        if (!_toHtmlQueues.TryGetValue(windowId, out var queue))
-        {
-            _toHtmlQueues[windowId] = queue = new ConcurrentQueue<Message>();
-        }
+        if (!HtmlMaskWindow.Exists(windowId) || !_toHtmlQueues.TryGetValue(windowId, out var queue))
+            throw new InvalidOperationException($"HTML遮罩窗口不存在或已关闭: {windowId}");
 
         queue.Enqueue(new Message
         {
@@ -167,15 +165,13 @@ public class HtmlMask : IDisposable
     public async Task<string?> Request(string windowId, string url, string jsonData, int timeoutMs = 0)
     {
         var requestId = Guid.NewGuid().ToString("N");
-        var tcs = new TaskCompletionSource<string>();
+        var tcs = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
         _jsPendingRequests[requestId] = tcs;
 
         try
         {
-            if (!_toHtmlQueues.TryGetValue(windowId, out var queue))
-            {
-                _toHtmlQueues[windowId] = queue = new ConcurrentQueue<Message>();
-            }
+            if (!HtmlMaskWindow.Exists(windowId) || !_toHtmlQueues.TryGetValue(windowId, out var queue))
+                throw new InvalidOperationException($"HTML遮罩窗口不存在或已关闭: {windowId}");
 
             queue.Enqueue(new Message
             {
@@ -189,7 +185,11 @@ public class HtmlMask : IDisposable
             if (timeoutMs > 0)
             {
                 using var cts = new System.Threading.CancellationTokenSource(timeoutMs);
-                cts.Token.Register(() => tcs.TrySetResult(null!));
+                await using var registration = cts.Token.Register(() =>
+                {
+                    if (_jsPendingRequests.TryRemove(requestId, out var pending))
+                        pending.TrySetResult(null!);
+                });
                 return await tcs.Task;
             }
 

--- a/BetterGenshinImpact/Core/Script/Dependence/HtmlMask.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/HtmlMask.cs
@@ -3,6 +3,8 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
 using BetterGenshinImpact.Core.Script.Utils;
 using BetterGenshinImpact.GameTask.Common;
 using BetterGenshinImpact.View;
@@ -30,6 +32,9 @@ public class HtmlMask : IDisposable
     {
         public string Url { get; set; } = "";
         public JsonElement? Data { get; set; }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? RequestId { get; set; }
     }
 
     /// <summary>
@@ -41,6 +46,11 @@ public class HtmlMask : IDisposable
     /// HTML到脚本的消息队列
     /// </summary>
     private static readonly ConcurrentDictionary<string, ConcurrentQueue<Message>> _fromHtmlQueues = new();
+
+    /// <summary>
+    /// JS到HTML请求的等待句柄，用于request-response匹配
+    /// </summary>
+    private static readonly ConcurrentDictionary<string, TaskCompletionSource<string>> _jsPendingRequests = new();
 
     private readonly string _workDir;
     private readonly List<string> _openedWindows = [];
@@ -129,11 +139,8 @@ public class HtmlMask : IDisposable
     #region 消息通信
 
     /// <summary>
-    /// 发送消息到HTML
+    /// 发送消息到HTML（单向推送）
     /// </summary>
-    /// <param name="windowId">目标窗口ID</param>
-    /// <param name="url">接口路径，如 /data/update</param>
-    /// <param name="jsonData">JSON数据</param>
     public void Send(string windowId, string url, string jsonData)
     {
         if (!_toHtmlQueues.TryGetValue(windowId, out var queue))
@@ -147,12 +154,78 @@ public class HtmlMask : IDisposable
             Data = ParseData(jsonData)
         });
 
-        // 通知WebView2推送
         HtmlMaskWindow.NotifyFlush(windowId);
     }
 
     /// <summary>
-    /// 轮询来自HTML的消息
+    /// 发送请求到HTML并等待响应
+    /// </summary>
+    /// <param name="windowId">目标窗口ID</param>
+    /// <param name="url">接口路径</param>
+    /// <param name="jsonData">JSON数据</param>
+    /// <param name="timeoutMs">超时毫秒，0表示无限等待</param>
+    public async Task<string?> Request(string windowId, string url, string jsonData, int timeoutMs = 0)
+    {
+        var requestId = Guid.NewGuid().ToString("N");
+        var tcs = new TaskCompletionSource<string>();
+        _jsPendingRequests[requestId] = tcs;
+
+        try
+        {
+            if (!_toHtmlQueues.TryGetValue(windowId, out var queue))
+            {
+                _toHtmlQueues[windowId] = queue = new ConcurrentQueue<Message>();
+            }
+
+            queue.Enqueue(new Message
+            {
+                Url = url,
+                Data = ParseData(jsonData),
+                RequestId = requestId
+            });
+
+            HtmlMaskWindow.NotifyFlush(windowId);
+
+            if (timeoutMs > 0)
+            {
+                using var cts = new System.Threading.CancellationTokenSource(timeoutMs);
+                cts.Token.Register(() => tcs.TrySetResult(null!));
+                return await tcs.Task;
+            }
+
+            return await tcs.Task;
+        }
+        finally
+        {
+            _jsPendingRequests.TryRemove(requestId, out _);
+        }
+    }
+
+    /// <summary>
+    /// 等待接收来自HTML的一条消息
+    /// </summary>
+    /// <param name="windowId">窗口ID</param>
+    /// <param name="timeoutMs">超时毫秒，0表示无限等待</param>
+    public async Task<string?> Receive(string windowId, int timeoutMs = 0)
+    {
+        if (!_fromHtmlQueues.TryGetValue(windowId, out var queue))
+            return null;
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (true)
+        {
+            if (queue.TryDequeue(out var message))
+                return JsonSerializer.Serialize(message, _jsonOptions);
+
+            if (timeoutMs > 0 && sw.ElapsedMilliseconds > timeoutMs)
+                return null;
+
+            await Task.Delay(50);
+        }
+    }
+
+    /// <summary>
+    /// 轮询来自HTML的消息（非阻塞）
     /// </summary>
     public string? Poll(string windowId)
     {
@@ -199,16 +272,26 @@ public class HtmlMask : IDisposable
     }
 
     /// <summary>
-    /// HTML端发来的消息入队
+    /// HTML端发来的消息入队，如果是JS请求的响应则直接resolve
     /// </summary>
-    internal static void SendFromHtml(string windowId, string url, string data)
+    internal static void SendFromHtml(string windowId, string url, string data, string? requestId = null)
     {
+        // 匹配JS端pending的request
+        if (requestId != null && _jsPendingRequests.TryRemove(requestId, out var tcs))
+        {
+            var parsed = ParseData(data);
+            tcs.SetResult(parsed != null ? parsed.Value.GetRawText() : "null");
+            return;
+        }
+
+        // 普通消息入队
         if (_fromHtmlQueues.TryGetValue(windowId, out var queue))
         {
             queue.Enqueue(new Message
             {
                 Url = url,
-                Data = ParseData(data)
+                Data = ParseData(data),
+                RequestId = requestId
             });
         }
     }

--- a/BetterGenshinImpact/Core/Script/EngineExtend.cs
+++ b/BetterGenshinImpact/Core/Script/EngineExtend.cs
@@ -89,6 +89,9 @@ public class EngineExtend
 
         engine.AddHostObject("host", new CustomHostFunctions());
 
+        // HTML 遮罩
+        engine.AddHostObject("htmlMask", new HtmlMask(workDir));
+
         // 导入 JavaScript 模块
         // https://microsoft.github.io/ClearScript/2023/01/24/module-interop.html
         // https://github.com/microsoft/ClearScript/blob/master/ClearScriptTest/V8ModuleTest.cs

--- a/BetterGenshinImpact/Core/Script/Project/ScriptProject.cs
+++ b/BetterGenshinImpact/Core/Script/Project/ScriptProject.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using BetterGenshinImpact.Core.Script.Dependence;
+using BetterGenshinImpact.View;
 using Microsoft.ClearScript.JavaScript;
 
 namespace BetterGenshinImpact.Core.Script.Project;
@@ -138,6 +139,7 @@ public class ScriptProject
         }
         finally
         {
+            HtmlMaskWindow.CloseAll();
             engine.Dispose();
         }
     }

--- a/BetterGenshinImpact/GameTask/TaskTriggerDispatcher.cs
+++ b/BetterGenshinImpact/GameTask/TaskTriggerDispatcher.cs
@@ -171,6 +171,7 @@ namespace BetterGenshinImpact.GameTask
             _gameRect = RECT.Empty;
             _prevGameActive = false;
             PictureInPictureService.Hide(resetManual: true);
+            HtmlMaskWindow.CloseAll();
             if (_winEventHookMoveSize != default)
             {
                 User32.UnhookWinEvent(_winEventHookMoveSize);
@@ -233,6 +234,7 @@ namespace BetterGenshinImpact.GameTask
                     PictureInPictureService.Hide(resetManual: true);
                     UiTaskStopTickEvent?.Invoke(sender, e);
                     maskWindow.Invoke(maskWindow.HideSelf);
+                    HtmlMaskWindow.HideAll();
                     return;
                 }
                 
@@ -271,6 +273,7 @@ namespace BetterGenshinImpact.GameTask
                     {
                         // Debug.WriteLine(pName + "：hide mask window");
                         maskWindow.Invoke(() => { maskWindow.HideSelf(); });
+                        HtmlMaskWindow.HideAll();
                     }
 
                     _prevGameActive = active;
@@ -319,6 +322,7 @@ namespace BetterGenshinImpact.GameTask
                             }
                         }
                     });
+                    HtmlMaskWindow.ShowAll();
                     // }
 
                     _prevGameActive = active;
@@ -449,6 +453,7 @@ namespace BetterGenshinImpact.GameTask
                 _gameRect = new RECT(currentRect);
                 TaskContext.Instance().SystemInfo.CaptureAreaRect = currentRect;
                 MaskWindow.Instance().RefreshPosition();
+                HtmlMaskWindow.UpdateAllPositions();
                 return true;
             }
 

--- a/BetterGenshinImpact/View/HtmlMaskWindow.xaml
+++ b/BetterGenshinImpact/View/HtmlMaskWindow.xaml
@@ -1,0 +1,15 @@
+<Window x:Class="BetterGenshinImpact.View.HtmlMaskWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:wv2="clr-namespace:Microsoft.Web.WebView2.Wpf;assembly=Microsoft.Web.WebView2.Wpf"
+        Title="HtmlMaskWindow"
+        WindowStyle="None"
+        AllowsTransparency="True"
+        Background="Transparent"
+        WindowStartupLocation="Manual"
+        ShowInTaskbar="False"
+        Topmost="True">
+    <Grid>
+        <wv2:WebView2 x:Name="WebView" DefaultBackgroundColor="Transparent"/>
+    </Grid>
+</Window>

--- a/BetterGenshinImpact/View/HtmlMaskWindow.xaml.cs
+++ b/BetterGenshinImpact/View/HtmlMaskWindow.xaml.cs
@@ -319,28 +319,38 @@ public partial class HtmlMaskWindow : Window
                 var fullDir = Path.GetFullPath(_workDir);
                 var fullFile = Path.GetFullPath(localPath);
                 if (fullFile.StartsWith(fullDir, StringComparison.OrdinalIgnoreCase)) return;
+                TaskControl.Logger.LogWarning("拦截HTML遮罩越级文件访问: {Uri}", e.Request.Uri);
                 e.Response = WebView.CoreWebView2.Environment.CreateWebResourceResponse(null, 403, "Blocked", "");
                 return;
             }
 
-            // 允许页面自身的初始导航及同源请求
+            // 仅允许页面自身的初始导航
             if (string.Equals(uri.AbsoluteUri, _pageUrl, StringComparison.OrdinalIgnoreCase)) return;
-            try
-            {
-                var pageUri = new Uri(_pageUrl);
-                if (string.Equals(uri.Host, pageUri.Host, StringComparison.OrdinalIgnoreCase)) return;
-            }
-            catch { }
 
-            // 检查是否匹配 manifest 中注册的允许URL
-            var allowedUrls = TaskContext.Instance().CurrentScriptProject?.Project?.Manifest.HttpAllowedUrls ?? [];
-            if (allowedUrls.Length > 0 && allowedUrls.Any(allowedUrl =>
+            // HTTP/HTTPS 请求：与 JS 脚本使用完全一致的权限校验
+            var currentProject = TaskContext.Instance().CurrentScriptProject;
+            if (currentProject?.AllowJsHTTP != true)
+            {
+                TaskControl.Logger.LogWarning("未启用JS HTTP权限，拦截HTML遮罩网络请求: {Uri}", e.Request.Uri);
+                e.Response = WebView.CoreWebView2.Environment.CreateWebResourceResponse(null, 403, "Blocked", "");
+                return;
+            }
+
+            var allowedUrls = currentProject?.Project?.Manifest.HttpAllowedUrls ?? [];
+            if (allowedUrls.Length == 0)
+            {
+                TaskControl.Logger.LogWarning("未配置 http_allowed_urls，拦截HTML遮罩网络请求: {Uri}", e.Request.Uri);
+                e.Response = WebView.CoreWebView2.Environment.CreateWebResourceResponse(null, 403, "Blocked", "");
+                return;
+            }
+
+            if (allowedUrls.Any(allowedUrl =>
             {
                 var pattern = "^" + Regex.Escape(allowedUrl).Replace("\\*", ".*") + "$";
                 return Regex.IsMatch(e.Request.Uri, pattern, RegexOptions.IgnoreCase);
             })) return;
 
-            // 阻止请求
+            TaskControl.Logger.LogWarning("URL不在允许列表中，拦截HTML遮罩网络请求: {Uri}", e.Request.Uri);
             e.Response = WebView.CoreWebView2.Environment.CreateWebResourceResponse(null, 403, "Blocked", "");
         }
         catch (Exception ex)

--- a/BetterGenshinImpact/View/HtmlMaskWindow.xaml.cs
+++ b/BetterGenshinImpact/View/HtmlMaskWindow.xaml.cs
@@ -54,19 +54,19 @@ public partial class HtmlMaskWindow : Window
     /// </summary>
     public static string Show(string url, string? id, string workDir)
     {
-        // 指定ID时先关闭已有窗口
-        if (id != null && _windows.TryGetValue(id, out var existing))
-        {
-            existing.Dispatcher.Invoke(() => existing.Close());
-        }
-
-        if (_windows.Count >= MaxWindows)
-        {
-            throw new InvalidOperationException($"最多同时打开 {MaxWindows} 个HTML遮罩窗口");
-        }
-
         return Application.Current.Dispatcher.Invoke(() =>
         {
+            // 指定ID时先关闭已有窗口
+            if (id != null && _windows.TryGetValue(id, out var existing))
+            {
+                existing.Close();
+            }
+
+            if (_windows.Count >= MaxWindows)
+            {
+                throw new InvalidOperationException($"最多同时打开 {MaxWindows} 个HTML遮罩窗口");
+            }
+
             var window = new HtmlMaskWindow(url, id, workDir);
             string wid = window.MaskId;
             _windows[wid] = window;
@@ -146,9 +146,7 @@ public partial class HtmlMaskWindow : Window
     /// </summary>
     public static string[] GetWindowIds()
     {
-        var keys = new string[_windows.Count];
-        _windows.Keys.CopyTo(keys, 0);
-        return keys;
+        return _windows.Keys.ToArray();
     }
 
     /// <summary>
@@ -252,7 +250,7 @@ public partial class HtmlMaskWindow : Window
                 try
                 {
                     string raw = e.TryGetWebMessageAsString();
-                    string url = "";
+                    string messageUrl = "";
                     string data = raw;
                     string? requestId = null;
 
@@ -262,7 +260,7 @@ public partial class HtmlMaskWindow : Window
                         var root = doc.RootElement;
                         if (root.TryGetProperty("url", out var ep))
                         {
-                            url = ep.GetString() ?? "";
+                            messageUrl = ep.GetString() ?? "";
                             data = root.TryGetProperty("data", out var d) ? d.GetRawText() : "{}";
                         }
                         if (root.TryGetProperty("requestId", out var rid))
@@ -272,12 +270,16 @@ public partial class HtmlMaskWindow : Window
                     }
                     catch { }
 
-                    HtmlMask.SendFromHtml(_id, url, data, requestId);
+                    HtmlMask.SendFromHtml(_id, messageUrl, data, requestId);
                 }
                 catch { }
             };
 
             // 页面加载完成后推送队列中待发送的消息
+            WebView.CoreWebView2.NavigationStarting += (_, _) =>
+            {
+                _navigationCompleted = false;
+            };
             WebView.CoreWebView2.NavigationCompleted += (_, _) =>
             {
                 _navigationCompleted = true;
@@ -336,7 +338,7 @@ public partial class HtmlMaskWindow : Window
             if (allowedUrls.Length > 0 && allowedUrls.Any(allowedUrl =>
             {
                 var pattern = "^" + Regex.Escape(allowedUrl).Replace("\\*", ".*") + "$";
-                return Regex.IsMatch(e.Request.Uri, pattern);
+                return Regex.IsMatch(e.Request.Uri, pattern, RegexOptions.IgnoreCase);
             })) return;
 
             // 阻止请求
@@ -356,6 +358,8 @@ public partial class HtmlMaskWindow : Window
             if (gameHandle == IntPtr.Zero) return;
 
             var currentRect = SystemControl.GetCaptureRect(gameHandle);
+            if (currentRect.Width <= 0 || currentRect.Height <= 0) return;
+
             Dispatcher.Invoke(() =>
             {
                 Left = currentRect.Left;

--- a/BetterGenshinImpact/View/HtmlMaskWindow.xaml.cs
+++ b/BetterGenshinImpact/View/HtmlMaskWindow.xaml.cs
@@ -193,7 +193,52 @@ public partial class HtmlMaskWindow : Window
             WebView.CoreWebView2.Settings.IsScriptEnabled = true;
             WebView.CoreWebView2.Settings.IsWebMessageEnabled = true;
 
-            // 监听HTML发来的消息，解析 url + data
+            // 注入 helper JS，提供 window.htmlMask.request / onMessage API
+            await WebView.CoreWebView2.AddScriptToExecuteOnDocumentCreatedAsync(@"
+                window.htmlMask = {
+                    _callbacks: {},
+                    _seq: 0,
+                    request: function(url, data) {
+                        return new Promise(function(resolve, reject) {
+                            var id = '__req_' + (++window.htmlMask._seq);
+                            window.htmlMask._callbacks[id] = { resolve: resolve, reject: reject };
+                            window.chrome.webview.postMessage(JSON.stringify({
+                                url: url,
+                                data: data || {},
+                                requestId: id
+                            }));
+                        });
+                    },
+                    onMessage: null,
+                    _dispatch: function(raw) {
+                        try {
+                            var msg = JSON.parse(raw);
+                            if (msg.requestId && window.htmlMask._callbacks[msg.requestId]) {
+                                window.htmlMask._callbacks[msg.requestId].resolve(msg);
+                                delete window.htmlMask._callbacks[msg.requestId];
+                            } else if (window.htmlMask.onMessage) {
+                                var result = window.htmlMask.onMessage(msg);
+                                if (msg.requestId && result !== undefined) {
+                                    Promise.resolve(result).then(function(data) {
+                                        window.chrome.webview.postMessage(JSON.stringify({
+                                            requestId: msg.requestId,
+                                            url: '/__response__',
+                                            data: data
+                                        }));
+                                    });
+                                }
+                            }
+                        } catch(e) {
+                            if (window.htmlMask.onMessage) window.htmlMask.onMessage(raw);
+                        }
+                    }
+                };
+                window.chrome.webview.addEventListener('message', function(e) {
+                    window.htmlMask._dispatch(e.data);
+                });
+            ");
+
+            // 监听HTML发来的消息，解析 url + data + requestId
             WebView.CoreWebView2.WebMessageReceived += (_, e) =>
             {
                 try
@@ -201,6 +246,7 @@ public partial class HtmlMaskWindow : Window
                     string raw = e.TryGetWebMessageAsString();
                     string url = "";
                     string data = raw;
+                    string? requestId = null;
 
                     try
                     {
@@ -211,10 +257,14 @@ public partial class HtmlMaskWindow : Window
                             url = ep.GetString() ?? "";
                             data = root.TryGetProperty("data", out var d) ? d.GetRawText() : "{}";
                         }
+                        if (root.TryGetProperty("requestId", out var rid))
+                        {
+                            requestId = rid.GetString();
+                        }
                     }
                     catch { }
 
-                    HtmlMask.SendFromHtml(_id, url, data);
+                    HtmlMask.SendFromHtml(_id, url, data, requestId);
                 }
                 catch { }
             };

--- a/BetterGenshinImpact/View/HtmlMaskWindow.xaml.cs
+++ b/BetterGenshinImpact/View/HtmlMaskWindow.xaml.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Concurrent;
 using System.IO;
+using System.Linq;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using System.Windows;
 using System.Windows.Interop;
 using Vanara.PInvoke;
@@ -24,7 +26,9 @@ public partial class HtmlMaskWindow : Window
     private const int MaxWindows = 5;
 
     private readonly string _id;
+    private readonly string _workDir;
     private readonly string _webView2DataPath;
+    private readonly string _pageUrl;
     private bool _navigationCompleted;
 
     /// <summary>
@@ -32,10 +36,12 @@ public partial class HtmlMaskWindow : Window
     /// </summary>
     public string MaskId => _id;
 
-    private HtmlMaskWindow(string url, string? id, string webView2DataPath)
+    private HtmlMaskWindow(string url, string? id, string workDir)
     {
         _id = id ?? Guid.NewGuid().ToString("N");
-        _webView2DataPath = webView2DataPath;
+        _workDir = workDir;
+        _webView2DataPath = Path.Combine(workDir, "WebView2Data");
+        _pageUrl = url;
         InitializeComponent();
         Loaded += OnLoaded;
         InitializeAsync(url);
@@ -59,11 +65,9 @@ public partial class HtmlMaskWindow : Window
             throw new InvalidOperationException($"最多同时打开 {MaxWindows} 个HTML遮罩窗口");
         }
 
-        string webView2DataPath = Path.Combine(workDir, "WebView2Data");
-
         return Application.Current.Dispatcher.Invoke(() =>
         {
-            var window = new HtmlMaskWindow(url, id, webView2DataPath);
+            var window = new HtmlMaskWindow(url, id, workDir);
             string wid = window.MaskId;
             _windows[wid] = window;
             window.Closed += (_, _) =>
@@ -193,6 +197,10 @@ public partial class HtmlMaskWindow : Window
             WebView.CoreWebView2.Settings.IsScriptEnabled = true;
             WebView.CoreWebView2.Settings.IsWebMessageEnabled = true;
 
+            // 拦截网络请求，仅允许注册过的域名
+            WebView.CoreWebView2.AddWebResourceRequestedFilter("*", CoreWebView2WebResourceContext.All);
+            WebView.CoreWebView2.WebResourceRequested += OnWebResourceRequested;
+
             // 注入 helper JS，提供 window.htmlMask.request / onMessage API
             await WebView.CoreWebView2.AddScriptToExecuteOnDocumentCreatedAsync(@"
                 window.htmlMask = {
@@ -289,6 +297,52 @@ public partial class HtmlMaskWindow : Window
             TaskControl.Logger.LogError($"WebView2 初始化失败: {e.Message}");
             Dispatcher.Invoke(() => Close());
         }
+    }
+
+    /// <summary>
+    /// 拦截网络请求，仅允许 file://、data:// 和注册过的域名
+    /// </summary>
+    private void OnWebResourceRequested(object? sender, CoreWebView2WebResourceRequestedEventArgs e)
+    {
+        try
+        {
+            var uri = new Uri(e.Request.Uri);
+
+            // 允许数据URI
+            if (uri.Scheme == "data") return;
+
+            // 本地文件：必须在脚本目录内
+            if (uri.Scheme == "file")
+            {
+                var localPath = Uri.UnescapeDataString(uri.AbsolutePath);
+                var fullDir = Path.GetFullPath(_workDir);
+                var fullFile = Path.GetFullPath(localPath);
+                if (fullFile.StartsWith(fullDir, StringComparison.OrdinalIgnoreCase)) return;
+                e.Response = WebView.CoreWebView2.Environment.CreateWebResourceResponse(null, 403, "Blocked", "");
+                return;
+            }
+
+            // 允许页面自身的初始导航及同源请求
+            if (string.Equals(uri.AbsoluteUri, _pageUrl, StringComparison.OrdinalIgnoreCase)) return;
+            try
+            {
+                var pageUri = new Uri(_pageUrl);
+                if (string.Equals(uri.Host, pageUri.Host, StringComparison.OrdinalIgnoreCase)) return;
+            }
+            catch { }
+
+            // 检查是否匹配 manifest 中注册的允许URL
+            var allowedUrls = TaskContext.Instance().CurrentScriptProject?.Project?.Manifest.HttpAllowedUrls ?? [];
+            if (allowedUrls.Length > 0 && allowedUrls.Any(allowedUrl =>
+            {
+                var pattern = "^" + Regex.Escape(allowedUrl).Replace("\\*", ".*") + "$";
+                return Regex.IsMatch(e.Request.Uri, pattern);
+            })) return;
+
+            // 阻止请求
+            e.Response = WebView.CoreWebView2.Environment.CreateWebResourceResponse(null, 403, "Blocked", "");
+        }
+        catch { }
     }
 
     /// <summary>

--- a/BetterGenshinImpact/View/HtmlMaskWindow.xaml.cs
+++ b/BetterGenshinImpact/View/HtmlMaskWindow.xaml.cs
@@ -64,7 +64,11 @@ public partial class HtmlMaskWindow : Window
             var window = new HtmlMaskWindow(url, id, webView2DataPath);
             string wid = window.MaskId;
             _windows[wid] = window;
-            window.Closed += (_, _) => _windows.TryRemove(wid, out _);
+            window.Closed += (_, _) =>
+            {
+                _windows.TryRemove(wid, out _);
+                window.DisposeWebView();
+            };
             window.Show();
             return wid;
         });
@@ -258,5 +262,17 @@ public partial class HtmlMaskWindow : Window
         var style = (int)GetWindowLong(hwnd, WindowLongFlags.GWL_EXSTYLE);
         User32.SetWindowLong(hwnd, WindowLongFlags.GWL_EXSTYLE,
             (IntPtr)(style | (int)User32.WindowStylesEx.WS_EX_TRANSPARENT));
+    }
+
+    /// <summary>
+    /// 释放 WebView2 资源，停止媒体播放
+    /// </summary>
+    private void DisposeWebView()
+    {
+        try
+        {
+            WebView.Dispose();
+        }
+        catch { }
     }
 }

--- a/BetterGenshinImpact/View/HtmlMaskWindow.xaml.cs
+++ b/BetterGenshinImpact/View/HtmlMaskWindow.xaml.cs
@@ -11,7 +11,6 @@ using static Vanara.PInvoke.User32;
 using BetterGenshinImpact.Core.Script.Dependence;
 using BetterGenshinImpact.GameTask;
 using BetterGenshinImpact.GameTask.Common;
-using BetterGenshinImpact.Helpers;
 using Microsoft.Extensions.Logging;
 using Microsoft.Web.WebView2.Core;
 
@@ -344,7 +343,10 @@ public partial class HtmlMaskWindow : Window
             // 阻止请求
             e.Response = WebView.CoreWebView2.Environment.CreateWebResourceResponse(null, 403, "Blocked", "");
         }
-        catch { }
+        catch (Exception ex)
+        {
+            TaskControl.Logger.LogWarning(ex, "HTML遮罩资源请求拦截异常");
+        }
     }
 
     /// <summary>
@@ -368,7 +370,10 @@ public partial class HtmlMaskWindow : Window
                 Height = currentRect.Height;
             });
         }
-        catch { }
+        catch (Exception ex)
+        {
+            TaskControl.Logger.LogDebug(ex, "HTML遮罩窗口位置更新失败");
+        }
     }
 
     /// <summary>

--- a/BetterGenshinImpact/View/HtmlMaskWindow.xaml.cs
+++ b/BetterGenshinImpact/View/HtmlMaskWindow.xaml.cs
@@ -8,7 +8,9 @@ using Vanara.PInvoke;
 using static Vanara.PInvoke.User32;
 using BetterGenshinImpact.Core.Script.Dependence;
 using BetterGenshinImpact.GameTask;
+using BetterGenshinImpact.GameTask.Common;
 using BetterGenshinImpact.Helpers;
+using Microsoft.Extensions.Logging;
 using Microsoft.Web.WebView2.Core;
 
 namespace BetterGenshinImpact.View;
@@ -181,53 +183,61 @@ public partial class HtmlMaskWindow : Window
 
     private async void InitializeAsync(string url)
     {
-        await WebView.EnsureCoreWebView2Async(
-            await CoreWebView2Environment.CreateAsync(null, _webView2DataPath));
-
-        WebView.DefaultBackgroundColor = System.Drawing.Color.Transparent;
-        WebView.CoreWebView2.Settings.AreDefaultScriptDialogsEnabled = false;
-        WebView.CoreWebView2.Settings.IsScriptEnabled = true;
-        WebView.CoreWebView2.Settings.IsWebMessageEnabled = true;
-
-        // 监听HTML发来的消息，解析 url + data
-        WebView.CoreWebView2.WebMessageReceived += (_, e) =>
+        try
         {
-            try
-            {
-                string raw = e.TryGetWebMessageAsString();
-                string url = "";
-                string data = raw;
+            await WebView.EnsureCoreWebView2Async(
+                await CoreWebView2Environment.CreateAsync(null, _webView2DataPath));
 
+            WebView.DefaultBackgroundColor = System.Drawing.Color.Transparent;
+            WebView.CoreWebView2.Settings.AreDefaultScriptDialogsEnabled = false;
+            WebView.CoreWebView2.Settings.IsScriptEnabled = true;
+            WebView.CoreWebView2.Settings.IsWebMessageEnabled = true;
+
+            // 监听HTML发来的消息，解析 url + data
+            WebView.CoreWebView2.WebMessageReceived += (_, e) =>
+            {
                 try
                 {
-                    using var doc = JsonDocument.Parse(raw);
-                    var root = doc.RootElement;
-                    if (root.TryGetProperty("url", out var ep))
+                    string raw = e.TryGetWebMessageAsString();
+                    string url = "";
+                    string data = raw;
+
+                    try
                     {
-                        url = ep.GetString() ?? "";
-                        data = root.TryGetProperty("data", out var d) ? d.GetRawText() : "{}";
+                        using var doc = JsonDocument.Parse(raw);
+                        var root = doc.RootElement;
+                        if (root.TryGetProperty("url", out var ep))
+                        {
+                            url = ep.GetString() ?? "";
+                            data = root.TryGetProperty("data", out var d) ? d.GetRawText() : "{}";
+                        }
                     }
+                    catch { }
+
+                    HtmlMask.SendFromHtml(_id, url, data);
                 }
                 catch { }
+            };
 
-                HtmlMask.SendFromHtml(_id, url, data);
-            }
-            catch { }
-        };
-
-        // 页面加载完成后推送队列中待发送的消息
-        WebView.CoreWebView2.NavigationCompleted += (_, _) =>
-        {
-            _navigationCompleted = true;
-            HtmlMask.FlushPendingMessages(_id, json =>
+            // 页面加载完成后推送队列中待发送的消息
+            WebView.CoreWebView2.NavigationCompleted += (_, _) =>
             {
-                WebView.CoreWebView2.PostWebMessageAsString(json);
-            });
-        };
+                _navigationCompleted = true;
+                HtmlMask.FlushPendingMessages(_id, json =>
+                {
+                    WebView.CoreWebView2.PostWebMessageAsString(json);
+                });
+            };
 
-        if (!string.IsNullOrEmpty(url))
+            if (!string.IsNullOrEmpty(url))
+            {
+                WebView.Source = new Uri(url);
+            }
+        }
+        catch (Exception e)
         {
-            WebView.Source = new Uri(url);
+            TaskControl.Logger.LogError($"WebView2 初始化失败: {e.Message}");
+            Dispatcher.Invoke(() => Close());
         }
     }
 

--- a/BetterGenshinImpact/View/HtmlMaskWindow.xaml.cs
+++ b/BetterGenshinImpact/View/HtmlMaskWindow.xaml.cs
@@ -1,0 +1,262 @@
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Text.Json;
+using System.Windows;
+using System.Windows.Interop;
+using Vanara.PInvoke;
+using static Vanara.PInvoke.User32;
+using BetterGenshinImpact.Core.Script.Dependence;
+using BetterGenshinImpact.GameTask;
+using BetterGenshinImpact.Helpers;
+using Microsoft.Web.WebView2.Core;
+
+namespace BetterGenshinImpact.View;
+
+/// <summary>
+/// HTML遮罩窗口 - 仅用于显示，不可交互（点击穿透）
+/// </summary>
+public partial class HtmlMaskWindow : Window
+{
+    private static readonly ConcurrentDictionary<string, HtmlMaskWindow> _windows = new();
+    private const int MaxWindows = 5;
+
+    private readonly string _id;
+    private readonly string _webView2DataPath;
+    private bool _navigationCompleted;
+
+    /// <summary>
+    /// 窗口唯一标识
+    /// </summary>
+    public string MaskId => _id;
+
+    private HtmlMaskWindow(string url, string? id, string webView2DataPath)
+    {
+        _id = id ?? Guid.NewGuid().ToString("N");
+        _webView2DataPath = webView2DataPath;
+        InitializeComponent();
+        Loaded += OnLoaded;
+        InitializeAsync(url);
+    }
+
+    #region 静态窗口管理
+
+    /// <summary>
+    /// 显示HTML遮罩窗口
+    /// </summary>
+    public static string Show(string url, string? id, string workDir)
+    {
+        // 指定ID时先关闭已有窗口
+        if (id != null && _windows.TryGetValue(id, out var existing))
+        {
+            existing.Dispatcher.Invoke(() => existing.Close());
+        }
+
+        if (_windows.Count >= MaxWindows)
+        {
+            throw new InvalidOperationException($"最多同时打开 {MaxWindows} 个HTML遮罩窗口");
+        }
+
+        string webView2DataPath = Path.Combine(workDir, "WebView2Data");
+
+        return Application.Current.Dispatcher.Invoke(() =>
+        {
+            var window = new HtmlMaskWindow(url, id, webView2DataPath);
+            string wid = window.MaskId;
+            _windows[wid] = window;
+            window.Closed += (_, _) => _windows.TryRemove(wid, out _);
+            window.Show();
+            return wid;
+        });
+    }
+
+    /// <summary>
+    /// 关闭指定窗口
+    /// </summary>
+    public static bool Close(string id)
+    {
+        if (_windows.TryGetValue(id, out var window))
+        {
+            window.Dispatcher.Invoke(() => window.Close());
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// 关闭所有窗口
+    /// </summary>
+    public static void CloseAll()
+    {
+        foreach (var kvp in _windows)
+        {
+            kvp.Value.Dispatcher.Invoke(() => kvp.Value.Close());
+        }
+    }
+
+    /// <summary>
+    /// 隐藏所有窗口（保留生命，不关闭）
+    /// </summary>
+    public static void HideAll()
+    {
+        foreach (var kvp in _windows)
+        {
+            kvp.Value.Dispatcher.Invoke(() => kvp.Value.Hide());
+        }
+    }
+
+    /// <summary>
+    /// 显示所有窗口
+    /// </summary>
+    public static void ShowAll()
+    {
+        foreach (var kvp in _windows)
+        {
+            kvp.Value.Dispatcher.Invoke(() =>
+            {
+                kvp.Value.Show();
+                kvp.Value.UpdatePosition();
+            });
+        }
+    }
+
+    /// <summary>
+    /// 同步所有窗口位置
+    /// </summary>
+    public static void UpdateAllPositions()
+    {
+        foreach (var kvp in _windows)
+        {
+            kvp.Value.UpdatePosition();
+        }
+    }
+
+    /// <summary>
+    /// 获取所有窗口ID
+    /// </summary>
+    public static string[] GetWindowIds()
+    {
+        var keys = new string[_windows.Count];
+        _windows.Keys.CopyTo(keys, 0);
+        return keys;
+    }
+
+    /// <summary>
+    /// 窗口是否存在
+    /// </summary>
+    public static bool Exists(string id)
+    {
+        return _windows.ContainsKey(id);
+    }
+
+    /// <summary>
+    /// 通知窗口刷新待推送的消息
+    /// </summary>
+    internal static void NotifyFlush(string windowId)
+    {
+        if (!_windows.TryGetValue(windowId, out var window)) return;
+        window.Dispatcher.BeginInvoke(() =>
+        {
+            // 页面还没加载完，消息留在队列中由 NavigationCompleted 统一推送
+            if (!window._navigationCompleted) return;
+            if (window.WebView.CoreWebView2 == null) return;
+            HtmlMask.FlushPendingMessages(windowId, json =>
+            {
+                window.WebView.CoreWebView2.PostWebMessageAsString(json);
+            });
+        });
+    }
+
+    #endregion
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        SetClickThrough();
+        UpdatePosition();
+    }
+
+    private async void InitializeAsync(string url)
+    {
+        await WebView.EnsureCoreWebView2Async(
+            await CoreWebView2Environment.CreateAsync(null, _webView2DataPath));
+
+        WebView.DefaultBackgroundColor = System.Drawing.Color.Transparent;
+        WebView.CoreWebView2.Settings.AreDefaultScriptDialogsEnabled = false;
+        WebView.CoreWebView2.Settings.IsScriptEnabled = true;
+        WebView.CoreWebView2.Settings.IsWebMessageEnabled = true;
+
+        // 监听HTML发来的消息，解析 url + data
+        WebView.CoreWebView2.WebMessageReceived += (_, e) =>
+        {
+            try
+            {
+                string raw = e.TryGetWebMessageAsString();
+                string url = "";
+                string data = raw;
+
+                try
+                {
+                    using var doc = JsonDocument.Parse(raw);
+                    var root = doc.RootElement;
+                    if (root.TryGetProperty("url", out var ep))
+                    {
+                        url = ep.GetString() ?? "";
+                        data = root.TryGetProperty("data", out var d) ? d.GetRawText() : "{}";
+                    }
+                }
+                catch { }
+
+                HtmlMask.SendFromHtml(_id, url, data);
+            }
+            catch { }
+        };
+
+        // 页面加载完成后推送队列中待发送的消息
+        WebView.CoreWebView2.NavigationCompleted += (_, _) =>
+        {
+            _navigationCompleted = true;
+            HtmlMask.FlushPendingMessages(_id, json =>
+            {
+                WebView.CoreWebView2.PostWebMessageAsString(json);
+            });
+        };
+
+        if (!string.IsNullOrEmpty(url))
+        {
+            WebView.Source = new Uri(url);
+        }
+    }
+
+    /// <summary>
+    /// 更新窗口位置
+    /// </summary>
+    public void UpdatePosition()
+    {
+        try
+        {
+            var gameHandle = TaskContext.Instance().GameHandle;
+            if (gameHandle == IntPtr.Zero) return;
+
+            var currentRect = SystemControl.GetCaptureRect(gameHandle);
+            Dispatcher.Invoke(() =>
+            {
+                Left = currentRect.Left;
+                Top = currentRect.Top;
+                Width = currentRect.Width;
+                Height = currentRect.Height;
+            });
+        }
+        catch { }
+    }
+
+    /// <summary>
+    /// 设置点击穿透
+    /// </summary>
+    private void SetClickThrough()
+    {
+        var hwnd = new WindowInteropHelper(this).Handle;
+        var style = (int)GetWindowLong(hwnd, WindowLongFlags.GWL_EXSTYLE);
+        User32.SetWindowLong(hwnd, WindowLongFlags.GWL_EXSTYLE,
+            (IntPtr)(style | (int)User32.WindowStylesEx.WS_EX_TRANSPARENT));
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增透明 HTML 覆盖层窗口，支持多窗口管理（最多 5 个）、显示/隐藏与位置同步，并在游戏激活/失去激活时自动显示或隐藏。
  * 提供与页面的双向消息接口：发送、异步请求/响应（含超时）、接收与轮询，支持通过本地路径或 URL 打开页面，浏览器支持透明背景与点击穿透。

* **修复/改进**
  * 脚本结束、任务停止或异常时自动关闭并清理所有覆盖窗口，提升稳定性与资源释放。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->