### PR TITLE
feat: 通知设置添加超链接查看事件id

### DIFF
--- a/BetterGenshinImpact/View/Pages/NotificationSettingsPage.xaml
+++ b/BetterGenshinImpact/View/Pages/NotificationSettingsPage.xaml
@@ -114,8 +114,19 @@
                     <ui:TextBlock Grid.Row="0"
                                   Grid.Column="0"
                                   FontTypography="Body"
-                                  Text="需要通知的事件"
-                                  TextWrapping="Wrap" />
+                                  TextWrapping="Wrap">
+                        <ui:TextBlock.Inlines>
+                            <Run Text="需要通知的事件" />
+                            <ui:HyperlinkButton Margin="4,0,0,0"
+                                                Padding="0"
+                                                Command="{Binding OpenNotificationEventDocumentCommand}"
+                                                Cursor="Hand">
+                                <ui:HyperlinkButton.Content>
+                                    <TextBlock FontSize="11" Text="打开文档" />
+                                </ui:HyperlinkButton.Content>
+                            </ui:HyperlinkButton>
+                        </ui:TextBlock.Inlines>
+                    </ui:TextBlock>
                     <ui:TextBlock Grid.Row="1"
                                   Grid.Column="0"
                                   Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"

--- a/BetterGenshinImpact/ViewModel/Pages/NotificationSettingsPageViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/NotificationSettingsPageViewModel.cs
@@ -1,10 +1,12 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using BetterGenshinImpact.Core.Config;
 using BetterGenshinImpact.Service.Interface;
 using BetterGenshinImpact.Service.Notification;
 using BetterGenshinImpact.Service.Notifier;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Windows.System;
 using Wpf.Ui.Violeta.Controls;
 
 namespace BetterGenshinImpact.ViewModel.Pages;
@@ -304,5 +306,11 @@ public partial class NotificationSettingsPageViewModel : ObservableObject, IView
             Toast.Error(res.Message);
 
         IsLoading = false;
+    }
+
+    [RelayCommand]
+    private async Task OnOpenNotificationEventDocument()
+    {
+        await Launcher.LaunchUriAsync(new Uri("https://www.bettergi.com/dev/webhook.html#%E4%BA%8B%E4%BB%B6%E5%88%97%E8%A1%A8"));
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 在通知设置页面的事件标签处添加"打开文档"链接，用户可直接访问相关事件文档。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->