### PR TITLE
fix: 修复纪行可选奖励导致流程卡住并补充日志提醒

### DIFF
--- a/BetterGenshinImpact/GameTask/Common/Job/ClaimBattlePassRewardsTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/ClaimBattlePassRewardsTask.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -7,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using BetterGenshinImpact.Core.Recognition;
 using BetterGenshinImpact.Core.Simulator.Extensions;
+using BetterGenshinImpact.GameTask.Common.BgiVision;
 using BetterGenshinImpact.GameTask.Common.Element.Assets;
 using BetterGenshinImpact.GameTask.Model.Area;
 using BetterGenshinImpact.Helpers;
@@ -26,6 +26,8 @@ public class ClaimBattlePassRewardsTask
     private readonly ReturnMainUiTask _returnMainUiTask = new();
 
     private readonly string[] claimAllLocalizedStrings;
+
+    private bool _manualSelectionReminderLogged;
 
     public ClaimBattlePassRewardsTask()
     {
@@ -54,18 +56,13 @@ public class ClaimBattlePassRewardsTask
         await Delay(200, ct);
         TaskContext.Instance().PostMessageSimulator.SimulateAction(GIActions.OpenBattlePassScreen); // F4 开纪行
 
-        // 领取战令1
-        await Delay(1000, ct);
-        await ClaimAll(ct);
-
-
-        // 领取点数
+        // 先领取纪行点数，避免一进入纪行就因可选奖励弹窗阻塞后续流程
         await Delay(1000, ct);
         GameCaptureRegion.GameRegion1080PPosClick(960, 45); // 点中间
         await Delay(500, ct);
         await ClaimAll(ct);
 
-        // 领取战令2
+        // 最后再回到奖励页领取，若存在手动选择奖励则仅记录日志提醒
         await Delay(2500, ct); // 等待升级动画
         // 还可能存在领取到原石的情况
         if (CaptureToRectArea().Find(ElementAssets.Instance.PrimogemRo).IsExist())
@@ -89,13 +86,18 @@ public class ClaimBattlePassRewardsTask
         using var ra = CaptureToRectArea();
         var ocrList = ra.FindMulti(RecognitionObject.Ocr(ra.ToRect().CutRightBottom(0.3, 0.2)));
         var wt = ocrList.FirstOrDefault(txt => this.claimAllLocalizedStrings.Any(i => Regex.IsMatch(txt.Text, i)));
-        Debug.WriteLine(this.claimAllLocalizedStrings);
         if (wt != null)
         {
             wt.Click();
             Logger.LogInformation("纪行：{Text}", "一键领取");
             await Delay(1000, ct);
             using var ra2 = CaptureToRectArea();
+            if (IsManualSelectionDialog(ra2))
+            {
+                LogManualSelectionReminder();
+                return true;
+            }
+
             if (ra2.Find(ElementAssets.Instance.PrimogemRo).IsExist())
             {
                 TaskContext.Instance().PostMessageSimulator.KeyPress(User32.VK.VK_ESCAPE);
@@ -108,5 +110,40 @@ public class ClaimBattlePassRewardsTask
             Logger.LogInformation("纪行：{Text}", "无需领取");
             return false;
         }
+    }
+
+    private static bool IsManualSelectionDialog(ImageRegion region)
+    {
+        if (Bv.IsInPromptDialog(region))
+        {
+            return true;
+        }
+
+        var hasCancelButton = HasDialogButton(region, ElementAssets.Instance.BtnBlackCancel)
+                              || HasDialogButton(region, ElementAssets.Instance.BtnWhiteCancel);
+        if (!hasCancelButton)
+        {
+            return false;
+        }
+
+        return HasDialogButton(region, ElementAssets.Instance.BtnBlackConfirm)
+               || HasDialogButton(region, ElementAssets.Instance.BtnWhiteConfirm);
+    }
+
+    private static bool HasDialogButton(ImageRegion region, RecognitionObject recognitionObject)
+    {
+        using var buttonRegion = region.Find(recognitionObject);
+        return buttonRegion.IsExist();
+    }
+
+    private void LogManualSelectionReminder()
+    {
+        if (_manualSelectionReminderLogged)
+        {
+            return;
+        }
+
+        _manualSelectionReminderLogged = true;
+        Logger.LogWarning("纪行：检测到需手动选择的奖励，请手动处理");
     }
 }


### PR DESCRIPTION
## 关联 Issue
Closes #2445

## 修改说明
- 调整纪行领取顺序，先领取纪行经验页，再回奖励页领取等级奖励，避免一进入纪行就被可选奖励弹窗卡住后续流程
- 保持手动选择奖励的处理方式不变，不自动取消、不发送额外通知，只在日志中输出提醒
- 扩大可选奖励弹窗的识别条件，除了原有提示框特征外，再结合取消/确认按钮组合识别，提升日志提醒命中率

## 验证
- 本地构建通过：dotnet build BetterGenshinImpact/BetterGenshinImpact.csproj -c Debug -p:Platform=x64 -p:RestoreDisableParallel=true -m:1 --no-restore -v:minimal
- 实测纪行经验领取流程恢复正常，出现手动选择奖励时可在日志中看到提醒

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **错误修复**
  * 优化战斗通行证奖励领取流程，调整积分奖励的收集顺序以提高自动领取效率。
  * 改进手动奖励选择对话框的检测机制，确保在遇到需要手动操作的界面时能正确处理并记录提示。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->