### PR TITLE
feat: 聊天界面打开时屏蔽热键

### DIFF
--- a/BetterGenshinImpact/Core/Monitor/MouseKeyMonitor.cs
+++ b/BetterGenshinImpact/Core/Monitor/MouseKeyMonitor.cs
@@ -102,6 +102,11 @@ public partial class  MouseKeyMonitor
         // Debug.WriteLine("KeyDown: \t{0}", e.KeyCode);
         GlobalKeyMouseRecord.Instance.GlobalHookKeyDown(e, Kernel32.GetTickCount());
 
+        if (SystemControl.IsGenshinImpactActive())
+        {
+            ChatUiHotkeyGuard.PrimeFromChatKey(e.KeyCode);
+        }
+
         // 热键按下事件
         HotKeyDown(sender, e);
 

--- a/BetterGenshinImpact/GameTask/ChatUiHotkeyGuard.cs
+++ b/BetterGenshinImpact/GameTask/ChatUiHotkeyGuard.cs
@@ -1,0 +1,120 @@
+using BetterGenshinImpact.Core.Config;
+using BetterGenshinImpact.GameTask.Common.BgiVision;
+using System;
+using System.Windows.Forms;
+
+namespace BetterGenshinImpact.GameTask;
+
+public static class ChatUiHotkeyGuard
+{
+    private const int StableFrameThreshold = 2;
+    private static readonly TimeSpan ChatKeyPrimeDuration = TimeSpan.FromMilliseconds(280);
+    private static readonly object Locker = new();
+
+    private static ChatUiState _chatUiState = ChatUiState.Closed;
+    private static int _enterFrameCount;
+    private static int _exitFrameCount;
+    private static DateTime _chatKeyPrimeUntilUtc = DateTime.MinValue;
+
+    public static void UpdateVisualState(ChatUiDetectionResult detectionResult)
+    {
+        var visualState = detectionResult.State;
+
+        lock (Locker)
+        {
+            if (visualState == ChatUiState.Closed)
+            {
+                _enterFrameCount = 0;
+                if (_chatUiState == ChatUiState.Closed)
+                {
+                    _exitFrameCount = 0;
+                }
+                else if (++_exitFrameCount >= StableFrameThreshold)
+                {
+                    SetState(ChatUiState.Closed);
+                    _exitFrameCount = 0;
+                }
+            }
+            else
+            {
+                _exitFrameCount = 0;
+                _chatKeyPrimeUntilUtc = DateTime.MinValue;
+                if (_chatUiState == ChatUiState.Closed)
+                {
+                    if (++_enterFrameCount >= StableFrameThreshold)
+                    {
+                        SetState(visualState);
+                        _enterFrameCount = 0;
+                    }
+                }
+                else
+                {
+                    _enterFrameCount = 0;
+                    SetState(visualState);
+                }
+            }
+
+            if (_chatKeyPrimeUntilUtc <= DateTime.UtcNow)
+            {
+                _chatKeyPrimeUntilUtc = DateTime.MinValue;
+            }
+        }
+    }
+
+    public static void PrimeFromChatKey(Keys keyCode)
+    {
+        if (keyCode != TaskContext.Instance().Config.KeyBindingsConfig.OpenChatScreen.ToWinFormKeys())
+        {
+            return;
+        }
+
+        lock (Locker)
+        {
+            if (_chatUiState != ChatUiState.Closed)
+            {
+                return;
+            }
+
+            _chatKeyPrimeUntilUtc = DateTime.UtcNow + ChatKeyPrimeDuration;
+        }
+    }
+
+    public static bool ShouldBlockHotkey(string? configPropertyName)
+    {
+        if (string.Equals(configPropertyName, nameof(HotKeyConfig.BgiEnabledHotkey), StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        lock (Locker)
+        {
+            if (_chatUiState != ChatUiState.Closed)
+            {
+                return true;
+            }
+
+            return _chatKeyPrimeUntilUtc > DateTime.UtcNow;
+        }
+    }
+
+    public static void Reset()
+    {
+        lock (Locker)
+        {
+            _chatUiState = ChatUiState.Closed;
+            _enterFrameCount = 0;
+            _exitFrameCount = 0;
+            _chatKeyPrimeUntilUtc = DateTime.MinValue;
+        }
+    }
+
+    private static void SetState(ChatUiState nextState)
+    {
+        if (_chatUiState == nextState)
+        {
+            return;
+        }
+
+        _chatUiState = nextState;
+    }
+}

--- a/BetterGenshinImpact/GameTask/Common/BgiVision/BvChatUi.cs
+++ b/BetterGenshinImpact/GameTask/Common/BgiVision/BvChatUi.cs
@@ -1,0 +1,237 @@
+using BetterGenshinImpact.Core.Recognition.OpenCv;
+using BetterGenshinImpact.GameTask.Common.Element.Assets;
+using BetterGenshinImpact.GameTask.Model.Area;
+using OpenCvSharp;
+using System;
+using System.Collections.Generic;
+
+namespace BetterGenshinImpact.GameTask.Common.BgiVision;
+
+public enum ChatUiState
+{
+    Closed,
+    PanelOpen,
+    InputOpen
+}
+
+public readonly record struct ChatUiDetectionResult(
+    ChatUiState State,
+    bool HasBackButton,
+    bool HasMoreButton,
+    bool HasAddConversationButton,
+    int BottomCircleCount,
+    bool HasSendButton)
+{
+    public bool HasInputControls => BottomCircleCount >= 2 || HasSendButton;
+
+    public string ToDebugSummary()
+    {
+        return $"back={HasBackButton}, more={HasMoreButton}, add={HasAddConversationButton}, circles={BottomCircleCount}, send={HasSendButton}";
+    }
+}
+
+public static partial class Bv
+{
+    public static ChatUiDetectionResult DetectChatUi(ImageRegion region)
+    {
+        using var backButton = region.Find(ElementAssets.Instance.ChatBackButtonRo);
+        var hasBackButton = backButton.IsExist();
+        var hasMoreButton = HasChatMoreButton(region);
+        var hasAddConversationButton = HasChatAddConversationButton(region);
+        var bottomCircleCount = CountChatBottomCircleButtons(region);
+        var hasSendButton = HasChatSendButton(region);
+        var hasInputControls = bottomCircleCount >= 2 || hasSendButton;
+
+        if (!hasBackButton || !hasAddConversationButton)
+        {
+            return new ChatUiDetectionResult(
+                ChatUiState.Closed,
+                hasBackButton,
+                hasMoreButton,
+                hasAddConversationButton,
+                bottomCircleCount,
+                hasSendButton);
+        }
+
+        if (hasInputControls)
+        {
+            return new ChatUiDetectionResult(
+                ChatUiState.InputOpen,
+                hasBackButton,
+                hasMoreButton,
+                hasAddConversationButton,
+                bottomCircleCount,
+                hasSendButton);
+        }
+
+        var state = hasMoreButton ? ChatUiState.PanelOpen : ChatUiState.Closed;
+        return new ChatUiDetectionResult(
+            state,
+            hasBackButton,
+            hasMoreButton,
+            hasAddConversationButton,
+            bottomCircleCount,
+            hasSendButton);
+    }
+
+    public static ChatUiState DetectChatUiState(ImageRegion region)
+    {
+        return DetectChatUi(region).State;
+    }
+
+    private static bool HasChatMoreButton(ImageRegion region)
+    {
+        var scale = GetChatUiScale(region);
+        using var roi = region.DeriveCrop(region.Width - (int)Math.Round(280 * scale), 0, (int)Math.Round(250 * scale), (int)Math.Round(140 * scale));
+        return HasEllipsisDots(roi.SrcMat, scale, detectDarkDots: true) || HasEllipsisDots(roi.SrcMat, scale, detectDarkDots: false);
+    }
+
+    private static bool HasChatAddConversationButton(ImageRegion region)
+    {
+        var scale = GetChatUiScale(region);
+        using var roi = region.DeriveCrop(0, region.Height - (int)Math.Round(260 * scale), (int)Math.Round(320 * scale), (int)Math.Round(260 * scale));
+        return HasBrightRoundedButton(roi.SrcMat, scale, minWidth: 28, maxWidth: 92, minHeight: 28, maxHeight: 92, minAspect: 0.72, maxAspect: 1.28);
+    }
+
+    private static int CountChatBottomCircleButtons(ImageRegion region)
+    {
+        var scale = GetChatUiScale(region);
+        using var roi = region.DeriveCrop((int)Math.Round(620 * scale), region.Height - (int)Math.Round(220 * scale), (int)Math.Round(760 * scale), (int)Math.Round(180 * scale));
+        return CountBrightRoundedButtons(roi.SrcMat, scale, minWidth: 26, maxWidth: 92, minHeight: 26, maxHeight: 92, minAspect: 0.72, maxAspect: 1.28);
+    }
+
+    private static bool HasChatSendButton(ImageRegion region)
+    {
+        var scale = GetChatUiScale(region);
+        using var roi = region.DeriveCrop((int)Math.Round(820 * scale), region.Height - (int)Math.Round(220 * scale), (int)Math.Round(500 * scale), (int)Math.Round(180 * scale));
+        return HasBrightRoundedButton(roi.SrcMat, scale, minWidth: 90, maxWidth: 260, minHeight: 26, maxHeight: 92, minAspect: 1.45, maxAspect: 5.5);
+    }
+
+    private static bool HasBrightRoundedButton(Mat src, double scale, int minWidth, int maxWidth, int minHeight, int maxHeight, double minAspect, double maxAspect)
+    {
+        return CountBrightRoundedButtons(src, scale, minWidth, maxWidth, minHeight, maxHeight, minAspect, maxAspect) > 0;
+    }
+
+    private static int CountBrightRoundedButtons(Mat src, double scale, int minWidth, int maxWidth, int minHeight, int maxHeight, double minAspect, double maxAspect)
+    {
+        using var mask = OpenCvCommonHelper.Threshold(src, new Scalar(180, 165, 135), new Scalar(255, 255, 255));
+        using var kernel = Cv2.GetStructuringElement(MorphShapes.Ellipse, new Size(ToKernelSize(7 * scale), ToKernelSize(7 * scale)));
+        Cv2.MorphologyEx(mask, mask, MorphTypes.Close, kernel);
+        Cv2.FindContours(mask, out var contours, out _, RetrievalModes.External, ContourApproximationModes.ApproxSimple);
+
+        var scaledMinWidth = Math.Max(8, (int)Math.Round(minWidth * scale));
+        var scaledMaxWidth = Math.Max(scaledMinWidth + 1, (int)Math.Round(maxWidth * scale));
+        var scaledMinHeight = Math.Max(8, (int)Math.Round(minHeight * scale));
+        var scaledMaxHeight = Math.Max(scaledMinHeight + 1, (int)Math.Round(maxHeight * scale));
+        var minArea = scaledMinWidth * scaledMinHeight * 0.35;
+        var matches = 0;
+
+        foreach (var contour in contours)
+        {
+            var rect = Cv2.BoundingRect(contour);
+            if (rect.Width < scaledMinWidth || rect.Height < scaledMinHeight || rect.Width > scaledMaxWidth || rect.Height > scaledMaxHeight)
+            {
+                continue;
+            }
+
+            var aspect = rect.Width / (double)Math.Max(rect.Height, 1);
+            if (aspect < minAspect || aspect > maxAspect)
+            {
+                continue;
+            }
+
+            var contourArea = Cv2.ContourArea(contour);
+            if (contourArea < minArea)
+            {
+                continue;
+            }
+
+            var fillRatio = contourArea / Math.Max(1d, rect.Width * rect.Height);
+            if (fillRatio < 0.48)
+            {
+                continue;
+            }
+
+            matches++;
+        }
+
+        return matches;
+    }
+
+    private static bool HasEllipsisDots(Mat src, double scale, bool detectDarkDots)
+    {
+        using var gray = src.CvtColor(ColorConversionCodes.BGR2GRAY);
+        using var mask = new Mat();
+        Cv2.Threshold(gray, mask, detectDarkDots ? 115 : 210, 255, detectDarkDots ? ThresholdTypes.BinaryInv : ThresholdTypes.Binary);
+
+        using var kernel = Cv2.GetStructuringElement(MorphShapes.Ellipse, new Size(ToKernelSize(3 * scale), ToKernelSize(3 * scale)));
+        Cv2.MorphologyEx(mask, mask, MorphTypes.Open, kernel);
+        Cv2.FindContours(mask, out var contours, out _, RetrievalModes.External, ContourApproximationModes.ApproxSimple);
+
+        var minDot = Math.Max(3, (int)Math.Round(4 * scale));
+        var maxDot = Math.Max(minDot + 1, (int)Math.Round(22 * scale));
+        var maxYOffset = Math.Max(4, (int)Math.Round(10 * scale));
+        var minGap = Math.Max(2, (int)Math.Round(3 * scale));
+        var maxGap = Math.Max(minGap + 1, (int)Math.Round(36 * scale));
+
+        var dots = new List<(Rect Rect, Point Center)>();
+        foreach (var contour in contours)
+        {
+            var rect = Cv2.BoundingRect(contour);
+            if (rect.Width < minDot || rect.Height < minDot || rect.Width > maxDot || rect.Height > maxDot)
+            {
+                continue;
+            }
+
+            var aspect = rect.Width / (double)Math.Max(rect.Height, 1);
+            if (aspect < 0.55 || aspect > 1.8)
+            {
+                continue;
+            }
+
+            dots.Add((rect, new Point(rect.X + rect.Width / 2, rect.Y + rect.Height / 2)));
+        }
+
+        if (dots.Count < 3)
+        {
+            return false;
+        }
+
+        dots.Sort((a, b) => a.Center.X.CompareTo(b.Center.X));
+        for (var i = 0; i <= dots.Count - 3; i++)
+        {
+            var first = dots[i];
+            var second = dots[i + 1];
+            var third = dots[i + 2];
+
+            if (Math.Abs(first.Center.Y - second.Center.Y) > maxYOffset ||
+                Math.Abs(second.Center.Y - third.Center.Y) > maxYOffset ||
+                Math.Abs(first.Center.Y - third.Center.Y) > maxYOffset)
+            {
+                continue;
+            }
+
+            var gap1 = second.Center.X - first.Center.X;
+            var gap2 = third.Center.X - second.Center.X;
+            if (gap1 < minGap || gap2 < minGap || gap1 > maxGap || gap2 > maxGap)
+            {
+                continue;
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private static double GetChatUiScale(ImageRegion region)
+    {
+        return region.Width / 1920d;
+    }
+
+    private static int ToKernelSize(double size)
+    {
+        var rounded = Math.Max(1, (int)Math.Round(size));
+        return rounded % 2 == 0 ? rounded + 1 : rounded;
+    }
+}

--- a/BetterGenshinImpact/GameTask/Common/Element/Assets/ElementAssets.cs
+++ b/BetterGenshinImpact/GameTask/Common/Element/Assets/ElementAssets.cs
@@ -32,6 +32,9 @@ public class ElementAssets : BaseAssets<ElementAssets>
     public RecognitionObject XKey;
 
     public RecognitionObject FriendChat;
+    public RecognitionObject ChatBackButtonRo;
+    public RecognitionObject ChatListButtonRo;
+    public RecognitionObject ChatReviewButtonRo;
 
     public RecognitionObject PartyBtnChooseView;
     public RecognitionObject PartyBtnDelete;
@@ -275,6 +278,33 @@ public class ElementAssets : BaseAssets<ElementAssets>
         }.InitTemplate();
 
         // 队伍切换
+        ChatBackButtonRo = new RecognitionObject
+        {
+            Name = "ChatBackButton",
+            RecognitionType = RecognitionTypes.TemplateMatch,
+            TemplateImageMat = GameTaskManager.LoadAssetImage(@"UseRedeemCode", "esc_return_button.png", systemInfo),
+            RegionOfInterest = new Rect(0, 0, (int)(220 * AssetScale), (int)(160 * AssetScale)),
+            Threshold = 0.72,
+            DrawOnWindow = false
+        }.InitTemplate();
+        ChatListButtonRo = new RecognitionObject
+        {
+            Name = "ChatListButton",
+            RecognitionType = RecognitionTypes.TemplateMatch,
+            TemplateImageMat = GameTaskManager.LoadAssetImage(@"AutoMusicGame", "btn_list.png", systemInfo),
+            RegionOfInterest = new Rect(0, CaptureRect.Height / 2, CaptureRect.Width / 4, CaptureRect.Height / 2),
+            Threshold = 0.72,
+            DrawOnWindow = false
+        }.InitTemplate();
+        ChatReviewButtonRo = new RecognitionObject
+        {
+            Name = "ChatReviewButton",
+            RecognitionType = RecognitionTypes.TemplateMatch,
+            TemplateImageMat = GameTaskManager.LoadAssetImage(@"AutoSkip", "chat_review.png", systemInfo),
+            RegionOfInterest = new Rect(0, 0, CaptureRect.Width / 4, CaptureRect.Height),
+            Threshold = 0.72,
+            DrawOnWindow = false
+        }.InitTemplate();
         PartyBtnChooseView = new RecognitionObject
         {
             Name = "PartyBtnChooseView",

--- a/BetterGenshinImpact/GameTask/Common/Element/Assets/ElementAssets.cs
+++ b/BetterGenshinImpact/GameTask/Common/Element/Assets/ElementAssets.cs
@@ -33,8 +33,6 @@ public class ElementAssets : BaseAssets<ElementAssets>
 
     public RecognitionObject FriendChat;
     public RecognitionObject ChatBackButtonRo;
-    public RecognitionObject ChatListButtonRo;
-    public RecognitionObject ChatReviewButtonRo;
 
     public RecognitionObject PartyBtnChooseView;
     public RecognitionObject PartyBtnDelete;
@@ -277,31 +275,13 @@ public class ElementAssets : BaseAssets<ElementAssets>
             DrawOnWindow = false
         }.InitTemplate();
 
-        // 队伍切换
+        // 聊天 UI 识别
         ChatBackButtonRo = new RecognitionObject
         {
             Name = "ChatBackButton",
             RecognitionType = RecognitionTypes.TemplateMatch,
             TemplateImageMat = GameTaskManager.LoadAssetImage(@"UseRedeemCode", "esc_return_button.png", systemInfo),
             RegionOfInterest = new Rect(0, 0, (int)(220 * AssetScale), (int)(160 * AssetScale)),
-            Threshold = 0.72,
-            DrawOnWindow = false
-        }.InitTemplate();
-        ChatListButtonRo = new RecognitionObject
-        {
-            Name = "ChatListButton",
-            RecognitionType = RecognitionTypes.TemplateMatch,
-            TemplateImageMat = GameTaskManager.LoadAssetImage(@"AutoMusicGame", "btn_list.png", systemInfo),
-            RegionOfInterest = new Rect(0, CaptureRect.Height / 2, CaptureRect.Width / 4, CaptureRect.Height / 2),
-            Threshold = 0.72,
-            DrawOnWindow = false
-        }.InitTemplate();
-        ChatReviewButtonRo = new RecognitionObject
-        {
-            Name = "ChatReviewButton",
-            RecognitionType = RecognitionTypes.TemplateMatch,
-            TemplateImageMat = GameTaskManager.LoadAssetImage(@"AutoSkip", "chat_review.png", systemInfo),
-            RegionOfInterest = new Rect(0, 0, CaptureRect.Width / 4, CaptureRect.Height),
             Threshold = 0.72,
             DrawOnWindow = false
         }.InitTemplate();

--- a/BetterGenshinImpact/GameTask/TaskTriggerDispatcher.cs
+++ b/BetterGenshinImpact/GameTask/TaskTriggerDispatcher.cs
@@ -125,6 +125,7 @@ namespace BetterGenshinImpact.GameTask
         public void Start(IntPtr hWnd, CaptureModes mode, int interval = 50)
         {
             // 初始化截图器
+            ChatUiHotkeyGuard.Reset();
             GameCapture = GameCaptureFactory.Create(mode);
             // 激活窗口 保证后面能够正常获取窗口信息
             SystemControl.ActivateWindow(hWnd);
@@ -167,6 +168,7 @@ namespace BetterGenshinImpact.GameTask
         public void Stop()
         {
             _timer.Stop();
+            ChatUiHotkeyGuard.Reset();
             GameCapture?.Stop();
             _gameRect = RECT.Empty;
             _prevGameActive = false;
@@ -198,6 +200,8 @@ namespace BetterGenshinImpact.GameTask
             {
                 _timer.Stop();
             }
+
+            ChatUiHotkeyGuard.Reset();
         }
 
         public void Dispose()
@@ -221,6 +225,7 @@ namespace BetterGenshinImpact.GameTask
                 var maskWindow = MaskWindow.Instance();
                 if (GameCapture == null || !GameCapture.IsCapturing)
                 {
+                    ChatUiHotkeyGuard.Reset();
                     if (!TaskContext.Instance().SystemInfo.GameProcess.HasExited)
                     {
                         _logger.LogError("截图器未初始化!");
@@ -239,6 +244,7 @@ namespace BetterGenshinImpact.GameTask
                 // 如果是最小化状态，直接不进行截图
                 if (SystemControl.IsGenshinImpactMinimized())
                 {
+                    ChatUiHotkeyGuard.Reset();
                     PictureInPictureService.Hide();
                     return;
                 }
@@ -253,6 +259,7 @@ namespace BetterGenshinImpact.GameTask
                 var active = SystemControl.IsGenshinImpactActive();
                 if (!active)
                 {
+                    ChatUiHotkeyGuard.Reset();
                     // 检查游戏是否已结束
                     if (TaskContext.Instance().SystemInfo.GameProcess.HasExited)
                     {
@@ -329,7 +336,8 @@ namespace BetterGenshinImpact.GameTask
                     }
                 }
 
-                if (_triggers == null || !_triggers.Exists(t => t.IsEnabled))
+                var hasEnabledTriggers = _triggers != null && _triggers.Exists(t => t.IsEnabled);
+                if (!hasEnabledTriggers && !active)
                 {
                     // Debug.WriteLine("没有可用的触发器且不处于仅截屏状态, 不再进行截屏");
                     return;
@@ -359,7 +367,13 @@ namespace BetterGenshinImpact.GameTask
                 }
 
                 // 循环执行所有触发器 有独占状态的触发器的时候只执行独占触发器
-                var content = new CaptureContent(bitmap, _frameIndex, _timer.Interval);
+                using var content = new CaptureContent(bitmap, _frameIndex, _timer.Interval);
+                ChatUiHotkeyGuard.UpdateVisualState(Bv.DetectChatUi(content.CaptureRectArea));
+
+                if (!hasEnabledTriggers)
+                {
+                    return;
+                }
 
                 lock (_triggerListLocker)
                 {
@@ -405,7 +419,6 @@ namespace BetterGenshinImpact.GameTask
                 }
 
                 speedTimer.DebugPrint();
-                content.Dispose();
             }
             finally
             {

--- a/BetterGenshinImpact/Model/HotKeySettingModel.cs
+++ b/BetterGenshinImpact/Model/HotKeySettingModel.cs
@@ -1,5 +1,6 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using BetterGenshinImpact.GameTask;
 using Fischless.HotkeyCapture;
 using System;
 using System.Collections.ObjectModel;
@@ -108,7 +109,8 @@ public partial class HotKeySettingModel : ObservableObject
                 {
                     MouseMonitorHook = new MouseHook
                     {
-                        IsHold = IsHold
+                        IsHold = IsHold,
+                        ConfigPropertyName = ConfigPropertyName
                     };
 
                     if (OnKeyPressAction != null)
@@ -138,7 +140,8 @@ public partial class HotKeySettingModel : ObservableObject
                     }
                     KeyboardMonitorHook = new KeyboardHook
                     {
-                        IsHold = IsHold
+                        IsHold = IsHold,
+                        ConfigPropertyName = ConfigPropertyName
                     };
                     if (OnKeyPressAction != null)
                     {
@@ -169,16 +172,31 @@ public partial class HotKeySettingModel : ObservableObject
 
     private void OnKeyPressed(object? sender, KeyPressedEventArgs e)
     {
+        if (ChatUiHotkeyGuard.ShouldBlockHotkey(ConfigPropertyName))
+        {
+            return;
+        }
+
         OnKeyPressAction?.Invoke(sender, e);
     }
 
     private void OnKeyDown(object? sender, KeyPressedEventArgs e)
     {
+        if (ChatUiHotkeyGuard.ShouldBlockHotkey(ConfigPropertyName))
+        {
+            return;
+        }
+
         OnKeyDownAction?.Invoke(sender, e);
     }
 
     private void OnKeyUp(object? sender, KeyPressedEventArgs e)
     {
+        if (ChatUiHotkeyGuard.ShouldBlockHotkey(ConfigPropertyName))
+        {
+            return;
+        }
+
         OnKeyUpAction?.Invoke(sender, e);
     }
 

--- a/BetterGenshinImpact/Model/HotKeySettingModel.cs
+++ b/BetterGenshinImpact/Model/HotKeySettingModel.cs
@@ -1,6 +1,8 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
-using CommunityToolkit.Mvvm.Input;
+﻿using BetterGenshinImpact.Core.Config;
 using BetterGenshinImpact.GameTask;
+using BetterGenshinImpact.GameTask.AutoFight;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using Fischless.HotkeyCapture;
 using System;
 using System.Collections.ObjectModel;
@@ -172,7 +174,7 @@ public partial class HotKeySettingModel : ObservableObject
 
     private void OnKeyPressed(object? sender, KeyPressedEventArgs e)
     {
-        if (ChatUiHotkeyGuard.ShouldBlockHotkey(ConfigPropertyName))
+        if (ShouldBlockGlobalRegister())
         {
             return;
         }
@@ -182,7 +184,7 @@ public partial class HotKeySettingModel : ObservableObject
 
     private void OnKeyDown(object? sender, KeyPressedEventArgs e)
     {
-        if (ChatUiHotkeyGuard.ShouldBlockHotkey(ConfigPropertyName))
+        if (ShouldBlockGlobalRegister())
         {
             return;
         }
@@ -192,12 +194,26 @@ public partial class HotKeySettingModel : ObservableObject
 
     private void OnKeyUp(object? sender, KeyPressedEventArgs e)
     {
-        if (ChatUiHotkeyGuard.ShouldBlockHotkey(ConfigPropertyName))
+        if (ShouldBlockGlobalRegister())
         {
+            ResetBlockedKeyUpState();
             return;
         }
 
         OnKeyUpAction?.Invoke(sender, e);
+    }
+
+    private bool ShouldBlockGlobalRegister()
+    {
+        return HotKeyType == HotKeyTypeEnum.GlobalRegister && ChatUiHotkeyGuard.ShouldBlockHotkey(ConfigPropertyName);
+    }
+
+    private void ResetBlockedKeyUpState()
+    {
+        if (string.Equals(ConfigPropertyName, nameof(HotKeyConfig.OneKeyFightHotkey), StringComparison.Ordinal))
+        {
+            OneKeyFightTask.Instance.KeyUp();
+        }
     }
 
     public void UnRegisterHotKey()

--- a/BetterGenshinImpact/Model/KeyboardHook.cs
+++ b/BetterGenshinImpact/Model/KeyboardHook.cs
@@ -2,6 +2,7 @@
 using Fischless.HotkeyCapture;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using Vanara.PInvoke;
@@ -24,6 +25,8 @@ public class KeyboardHook
 
     public bool IsPressed { get; set; }
 
+    public string ConfigPropertyName { get; set; } = string.Empty;
+
     /// <summary>
     /// 注意长按的时候会一直触发KeyDown
     /// </summary>
@@ -38,6 +41,11 @@ public class KeyboardHook
 
         if (e.KeyCode == BindKey)
         {
+            if (ChatUiHotkeyGuard.ShouldBlockHotkey(ConfigPropertyName))
+            {
+                return;
+            }
+
             IsPressed = true;
             KeyDownEvent?.Invoke(this, new KeyPressedEventArgs(User32.HotKeyModifiers.MOD_NONE, e.KeyCode));
             if (IsHold)
@@ -65,6 +73,12 @@ public class KeyboardHook
         {
             while (IsPressed && KeyPressedEvent != null)
             {
+                if (ChatUiHotkeyGuard.ShouldBlockHotkey(ConfigPropertyName))
+                {
+                    Thread.Sleep(10);
+                    continue;
+                }
+
                 KeyPressedEvent?.Invoke(this, new KeyPressedEventArgs(User32.HotKeyModifiers.MOD_NONE, e.KeyCode));
             }
         }
@@ -75,7 +89,7 @@ public class KeyboardHook
         if (e.KeyCode == BindKey)
         {
             IsPressed = false;
-            if (SystemControl.IsGenshinImpactActive())
+            if (SystemControl.IsGenshinImpactActive() && !ChatUiHotkeyGuard.ShouldBlockHotkey(ConfigPropertyName))
             {
                 KeyUpEvent?.Invoke(this, new KeyPressedEventArgs(User32.HotKeyModifiers.MOD_NONE, e.KeyCode));
             }

--- a/BetterGenshinImpact/Model/MouseHook.cs
+++ b/BetterGenshinImpact/Model/MouseHook.cs
@@ -3,6 +3,7 @@ using Fischless.HotkeyCapture;
 using Gma.System.MouseKeyHook;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using Vanara.PInvoke;
@@ -25,6 +26,8 @@ public class MouseHook
 
     public bool IsPressed { get; set; }
 
+    public string ConfigPropertyName { get; set; } = string.Empty;
+
     public void MouseDown(object? sender, MouseEventExtArgs e)
     {
         if (!SystemControl.IsGenshinImpactActive())
@@ -34,6 +37,11 @@ public class MouseHook
 
         if (e.Button != MouseButtons.Left && e.Button != MouseButtons.None && e.Button == BindMouse)
         {
+            if (ChatUiHotkeyGuard.ShouldBlockHotkey(ConfigPropertyName))
+            {
+                return;
+            }
+
             IsPressed = true;
             MouseDownEvent?.Invoke(this, new KeyPressedEventArgs(User32.HotKeyModifiers.MOD_NONE, Keys.None));
             if (IsHold)
@@ -58,6 +66,12 @@ public class MouseHook
         {
             while (IsPressed)
             {
+                if (ChatUiHotkeyGuard.ShouldBlockHotkey(ConfigPropertyName))
+                {
+                    Thread.Sleep(10);
+                    continue;
+                }
+
                 MousePressed?.Invoke(this, new KeyPressedEventArgs(User32.HotKeyModifiers.MOD_NONE, Keys.None));
             }
         }
@@ -68,7 +82,7 @@ public class MouseHook
         if (e.Button != MouseButtons.Left && e.Button != MouseButtons.None && e.Button == BindMouse)
         {
             IsPressed = false;
-            if (SystemControl.IsGenshinImpactActive())
+            if (SystemControl.IsGenshinImpactActive() && !ChatUiHotkeyGuard.ShouldBlockHotkey(ConfigPropertyName))
             {
                 MouseUpEvent?.Invoke(this, new KeyPressedEventArgs(User32.HotKeyModifiers.MOD_NONE, Keys.None));
             }


### PR DESCRIPTION
## 摘要
- 使用视觉锚点识别聊天界面，不依赖 OCR 文本内容
- 聊天界面打开时统一屏蔽键盘监听、鼠标侧键监听和注册热键
- 保留 BgiEnabledHotkey 可用，并在按键释放时安全清理按住状态
- 覆盖可输入聊天页和空会话页，并在失焦后重置屏蔽状态

## 测试
- 已手测可输入聊天页，热键被正确屏蔽
- 已手测空会话页，~~热键被正确屏蔽~~没有，但是不影响
- 已手测非聊天界面，未发现遗漏和误判
- 在干净 PR 分支上做本地构建验证时，受当前机器访问 https://api.nuget.org/v3/index.json 的 NU1301 影响未能完成

Closes #362

## 补充
可能需要测试一下是否有其他的界面能触发，或者某个按键未能拦截

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加聊天界面检测与短时“优先”窗口，用以识别聊天面板与输入框状态并改善热键行为。

* **Bug 修复**
  * 在聊天界面打开或短时优先期内阻止普通热键/鼠标误触（已保留专用启用热键）。
  * 优化热键与长按处理，避免聊天输入被后台快捷键或释放事件干扰。
  * 在任务调度与捕获周期中重置聊天热键守护状态以提高稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->