### PR TITLE
fix: 移除 TrySwitch 中遗留的调试用 SaveImage 调用

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
@@ -262,7 +262,6 @@ public class Avatar
                 if (i == tryTimes - 1)
                 {
                     Logger.LogWarning("切换角色失败，最后一次尝试，当前角色编号:{CurrentIndex}，期望角色编号:{ExpectedIndex}", CombatScenes.GetActiveAvatarIndex(region, context), Index);
-                    region.SrcMat.SaveImage($"log/{Name}_切换失败.png");
                 }
             }
 


### PR DESCRIPTION
﻿## 问题

`Avatar.TrySwitch` 中存在一行遗留的调试用 `SaveImage` 调用（commit [`eec45186`](https://github.com/babalae/better-genshin-impact/commit/eec45186058e30e1432702137a1547d4605dc56c)，0.59.0 引入）：

`csharp
region.SrcMat.SaveImage($"log/{Name}_切换失败.png");
`

文件名含中文字符，在非中文 ANSI 代码页的 Windows 环境下（如英文 Windows，ACP=1252），OpenCvSharp 的 ANSI 路径封送会触发：

`System.ArgumentException: Cannot marshal: Encountered unmappable character.`

从 commit message（"切换角色问题测试用代码"）看，这是排查问题时的临时调试代码，不是功能需求。

## 修改

删除该行 `SaveImage` 调用。保留原有的 `LogWarning` 日志输出。

## 验证

- 改动仅删除一行调试代码，不影响切换角色的业务逻辑
- `LogWarning` 仍然会记录切换失败信息

Closes #3031


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 版本更新

* **优化改进**
  * 简化了自动战斗中角色切换的日志处理机制，移除了不必要的输出，优化程序性能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->