### PR TITLE
fix: FindActiveIndexRectByColor 方法3 返回 0-based 索引修正为 1-based

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoFight/Model/PartyAvatarSideIndexHelper.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Model/PartyAvatarSideIndexHelper.cs
@@ -407,7 +407,8 @@ public class PartyAvatarSideIndexHelper
                 // 方法3：使用更加靠谱的差值识别（-1是未识别），但是不支持非满队
                 if (mats.Length == 4)
                 {
-                    return ImageDifferenceDetector.FindMostDifferentImage(mats);
+                    var result = ImageDifferenceDetector.FindMostDifferentImage(mats);
+                    return result >= 0 ? result + 1 : -1;
                 }
                 else
                 {


### PR DESCRIPTION
﻿## 问题

`FindActiveIndexRectByColor` 的方法3（差值检测 fallback）直接返回了 `ImageDifferenceDetector.FindMostDifferentImage` 的结果：

```csharp
// PartyAvatarSideIndexHelper.cs
return ImageDifferenceDetector.FindMostDifferentImage(mats);
```

但 `FindMostDifferentImage` 返回的是 **0-based** 索引（0-3），而 `GetActiveAvatarIndex` 整个调用链期望 **1-based** 索引（1-4），用 `> 0` 判定有效。

这导致：
| 实际出战 | detector 返回 | 被当成 |
|----------|---------------|--------|
| 1 号位 | 0 | 失败（<=0） |
| 2 号位 | 1 | **1 号位** |
| 3 号位 | 2 | **2 号位** |
| 4 号位 | 3 | **3 号位** |

从日志看，04-10 的 212 次切换失败中 181 次（85%）是 `当前角色编号:1，期望角色编号:2`——正好是 "实际 2 号位被误判为 1 号位" 的表现。

该 bug 只在方法1（白色矩形）和方法2（边缘颜色）都失败后才会触发。更换队伍成员后方法1/2 识别率下降，导致更频繁 fall through 到方法3，切换失败率从 ~5% 飙升到 ~22%。

## 修改

```csharp
var result = ImageDifferenceDetector.FindMostDifferentImage(mats);
return result >= 0 ? result + 1 : -1;
```

将 0-based 结果转为 1-based，与调用链约定一致。

Closes #3034


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 修复

* **Bug 修复**
  * 改进了队伍角色识别功能的检测逻辑，提升了特定场景下的角色识别准确性和稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->