### PR TITLE
修复游泳检测问题

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
@@ -165,9 +165,13 @@ public class Avatar
                     pathExecutor.MoveTo(AutoFightTask.FightWaypoint).GetAwaiter().GetResult();
                     Logger.LogInformation("游泳检测：移动结束");
                 }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    throw;
+                }
                 catch (OperationCanceledException)
                 {
-                    Logger.LogWarning("游泳检测：回到战斗地点超时或被取消");
+                    Logger.LogWarning("游泳检测：回到战斗地点超时");
                 }
                 catch (Exception ex)
                 {

--- a/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
@@ -134,29 +134,40 @@ public class Avatar
         {
             if (AutoFightTask.FightWaypoint is not null)
             {
+                // 二次确认：延迟 800ms 后重新截屏，避免同帧误判
+                Sleep(800, ct);
                 using var ra = CaptureToRectArea();
-                if (!SwimmingConfirm(ra)) //二次确认
+                if (!SwimmingConfirm(ra))
                 {
                     return;
                 }
                 
                 Logger.LogInformation("游泳检测：尝试回到战斗地点");
-                var cts = new CancellationTokenSource();
-                var pathExecutor = new PathExecutor(cts.Token);
+                
+                // 保存原始 MoveMode，用于 finally 还原
+                var originalMoveMode = AutoFightTask.FightWaypoint.MoveMode;
+                // 链接外部取消令牌，确保外部取消时能及时响应；using 确保自动 Dispose
+                using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
                 
                 try
                 {
-                    pathExecutor.FaceTo(AutoFightTask.FightWaypoint).Wait(2000,cts.Token);
-                    AutoFightTask.FightWaypoint.MoveMode = MoveModeEnum.Fly.Code; // 改为跳飞
+                    var pathExecutor = new PathExecutor(cts.Token);
+                    
+                    // FaceTo 朝向战斗点，超时 2 秒
+                    cts.CancelAfter(2000);
+                    pathExecutor.FaceTo(AutoFightTask.FightWaypoint).GetAwaiter().GetResult();
+                    
+                    // 重置超时，MoveTo 超时 15 秒
+                    cts.CancelAfter(15000);
+                    // 使用 Climb 模式：MoveTo 内部对 Climb 模式跳过卡死脱困检测，避免水中 TrapEscaper 死循环
+                    AutoFightTask.FightWaypoint.MoveMode = MoveModeEnum.Climb.Code;
                     Simulation.SendInput.Mouse.RightButtonDown();
-                    pathExecutor.MoveTo(AutoFightTask.FightWaypoint).Wait(15000,cts.Token);
-                    cts.Cancel();
-                    AutoFightTask.FightWaypoint = null;
-                    Simulation.SendInput.Mouse.RightButtonUp();
+                    pathExecutor.MoveTo(AutoFightTask.FightWaypoint).GetAwaiter().GetResult();
+                    Logger.LogInformation("游泳检测：移动结束");
                 }
-                catch (TaskCanceledException)
+                catch (OperationCanceledException)
                 {
-                    Logger.LogError("游泳检测：回到战斗地点任务被取消");
+                    Logger.LogWarning("游泳检测：回到战斗地点超时或被取消");
                 }
                 catch (Exception ex)
                 {
@@ -164,6 +175,11 @@ public class Avatar
                 }
                 finally
                 {
+                    // 确保所有资源和状态在任何路径都被正确清理
+                    cts.Cancel(); // 终止 PathExecutor 内部截屏循环
+                    AutoFightTask.FightWaypoint.MoveMode = originalMoveMode;
+                    AutoFightTask.FightWaypoint = null;
+                    Simulation.SendInput.Mouse.RightButtonUp();
                     Simulation.ReleaseAllKey();
                 }
                 
@@ -171,7 +187,7 @@ public class Avatar
                 if (!SwimmingConfirm(bitmap2))
                 {
                     Logger.LogInformation("游泳检测：游泳脱困成功");
-                   return;
+                    return;
                 }
                 
                 Logger.LogWarning("游泳检测：回到战斗地点失败");
@@ -243,7 +259,7 @@ public class Avatar
             // Debug.WriteLine($"切换到{Index}号位");
             // Cv2.ImWrite($"log/切换.png", region.SrcMat);
 
-            // 第13次重试时，战斗状态下执行脱困动作
+            // 第10次重试时，战斗状态下执行脱困动作
             if (i == 10 && AutoFightTask.FightStatusFlag)
             {
                 PerformUnstuckAction(Ct);


### PR DESCRIPTION
修复：游泳检测回战斗点导致内存爆炸和卡死

游泳检测触发后调用 PathExecutor.MoveTo 回战斗点时，存在多个资源管理缺陷导致内存持续增长和程序卡死。

修复内容
问题修复CancellationTokenSource未链接外部令牌且未释放：using var cts = CreateLinkedTokenSource(ct)
PathExecutor 卡死脱困在水中触发死循环：MoveMode 改为 Climb（MoveTo 内部对 Climb 跳过脱困检测）
.Wait(timeout) 超时后底层任务继续运行：cts.CancelAfter(timeout) + .GetAwaiter().GetResult()
FightWaypoint.MoveMode 修改后异常路径未还原：finally 中还原为原始值
鼠标右键按下后异常路径未释放：RightButtonUp 移入 finally
二次确认与首次检测几乎同帧：加 800ms 延迟

改动

仅修改 Avatar.cs 的 ThrowWhenDefeated 方法中游泳回战斗点代码块，不涉及 PathExecutor 或其他文件。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 在角色被击败后增加额外延迟与二次截图确认，提高返回战斗路点的稳定性
  * 优化路点移动的取消与超时控制，避免长时间卡死
  * 调整默认移动模式以提升穿越障碍的可靠性
  * 改进异常与取消处理逻辑，更准确区分超时与外部取消
  * 确保状态清理与鼠标/按键释放在正确顺序执行
  * 降低自动脱困的重试阈值（由13次调整为10次）
<!-- end of auto-generated comment: release notes by coderabbit.ai -->