### PR TITLE
自动地脉花补充战斗中寻敌配置

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoLeyLineOutcrop/AutoLeyLineOutcropFightConfig.cs
+++ b/BetterGenshinImpact/GameTask/AutoLeyLineOutcrop/AutoLeyLineOutcropFightConfig.cs
@@ -48,6 +48,9 @@ public partial class AutoLeyLineOutcropFightConfig : ObservableObject
     [ObservableProperty] private bool _kazuhaPickupEnabled = true;
     [ObservableProperty] private bool _qinDoublePickUp = false;
     [ObservableProperty] private int _timeout = 120;
+    [ObservableProperty] private bool _seekEnemyEnabled = false;
+    [ObservableProperty] private int _seekEnemyIntervalSeconds = 3;
+    [ObservableProperty] private int _seekEnemyRotaryFactor = 6;
 
     public void CopyFromAutoFightConfig(AutoFightConfig source)
     {

--- a/BetterGenshinImpact/GameTask/AutoLeyLineOutcrop/AutoLeyLineOutcropTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoLeyLineOutcrop/AutoLeyLineOutcropTask.cs
@@ -81,6 +81,7 @@ public class AutoLeyLineOutcropTask : ISoloTask
     private const string OcrFlowOverlayKey = "AutoLeyLineOutcrop.OcrFlow";
     private const string OcrFightOverlayKey = "AutoLeyLineOutcrop.OcrFight";
     private const int OcrOverlayRenderLeadMs = 300;
+    private static readonly TimeSpan LeyLineFightSeekInitialDelay = TimeSpan.FromSeconds(2);
     private static readonly Rect HandbookTrackActionButtonRoi = new(ScaleTo1080(1120), ScaleTo1080(680), ScaleTo1080(700), ScaleTo1080(320));
     private static readonly System.Drawing.Pen OcrOverlayPen = new(System.Drawing.Color.Lime, 2);
     private static readonly object PickLock = new();
@@ -1183,7 +1184,9 @@ public class AutoLeyLineOutcropTask : ISoloTask
     {
         var fightCts = CancellationTokenSource.CreateLinkedTokenSource(_ct);
         using var autoFightConfigScope = UseLeyLineAutoFightConfigScope();
-        // Ley line uses OCR-based finish detection; disable auto-fight finish detect.
+        // 地脉花战斗拆成两条并行链路：
+        // 1. AutoFightTask 持续执行战斗脚本，不负责任何结束判定。
+        // 2. RecognizeTextInRegion 只通过 OCR 判定胜负，并在轮询间隙补一次内部寻敌辅助。
         var fightTask = StartAutoFightWithoutFinishDetect(fightCts.Token);
         var fightResult = await RecognizeTextInRegion(timeoutSeconds * 1000);
         fightCts.Cancel();
@@ -1272,19 +1275,26 @@ public class AutoLeyLineOutcropTask : ISoloTask
     {
         var start = DateTime.UtcNow;
         var noTextCount = 0;
+        var fightTextDetectedAt = DateTime.MinValue;
+        var lastSeekAssistAt = DateTime.MinValue;
+        var seekEnemyEnabled = _taskParam.FightConfig.SeekEnemyEnabled;
+        var seekEnemyInterval = TimeSpan.FromSeconds(Math.Clamp(_taskParam.FightConfig.SeekEnemyIntervalSeconds, 1, 60));
+        var seekEnemyRotaryFactor = Math.Clamp(_taskParam.FightConfig.SeekEnemyRotaryFactor, 1, 13);
         var successKeywords = new[] { "挑战达成", "战斗胜利", "挑战成功" };
         var failureKeywords = new[] { "挑战失败" };
 
         while ((DateTime.UtcNow - start).TotalMilliseconds < timeoutMs)
         {
-            using var capture = CaptureToRectArea();
-            using var ocrOverlayScope = DrawOcrOverlayScope(capture, OcrFightOverlayKey, _ocrRo1!.RegionOfInterest, _ocrRo2!.RegionOfInterest);
-            await WaitOcrOverlayRenderTick();
             string text;
             bool foundText;
-            var result = capture.Find(_ocrRo1!);
-            text = result.Text;
-            foundText = RecognizeFightText(capture);
+            using (var capture = CaptureToRectArea())
+            using (var ocrOverlayScope = DrawOcrOverlayScope(capture, OcrFightOverlayKey, _ocrRo1!.RegionOfInterest, _ocrRo2!.RegionOfInterest))
+            {
+                await WaitOcrOverlayRenderTick();
+                var result = capture.Find(_ocrRo1!);
+                text = result.Text;
+                foundText = RecognizeFightText(capture);
+            }
 
             if (successKeywords.Any(text.Contains))
             {
@@ -1308,13 +1318,57 @@ public class AutoLeyLineOutcropTask : ISoloTask
             }
             else
             {
+                var now = DateTime.UtcNow;
+                if (fightTextDetectedAt == DateTime.MinValue)
+                {
+                    fightTextDetectedAt = now;
+                }
+
                 noTextCount = 0;
+                if (ShouldRunLeyLineFightSeek(seekEnemyEnabled, now, fightTextDetectedAt, lastSeekAssistAt, seekEnemyInterval))
+                {
+                    lastSeekAssistAt = now;
+                    await TrySeekEnemyDuringLeyLineFight(seekEnemyRotaryFactor);
+                }
             }
 
             await Delay(1000, _ct);
         }
 
         return false;
+    }
+
+    private static bool ShouldRunLeyLineFightSeek(bool seekEnemyEnabled, DateTime now, DateTime fightTextDetectedAt, DateTime lastSeekAssistAt, TimeSpan seekEnemyInterval)
+    {
+        if (!seekEnemyEnabled)
+        {
+            return false;
+        }
+
+        if (fightTextDetectedAt == DateTime.MinValue)
+        {
+            return false;
+        }
+
+        if (now - fightTextDetectedAt < LeyLineFightSeekInitialDelay)
+        {
+            return false;
+        }
+
+        return lastSeekAssistAt == DateTime.MinValue || now - lastSeekAssistAt >= seekEnemyInterval;
+    }
+
+    private async Task TrySeekEnemyDuringLeyLineFight(int rotaryFactor)
+    {
+        try
+        {
+            // isEndCheck=true prevents AutoFightSeek from falling back to any party-screen finish check.
+            await AutoFightSeek.SeekAndFightAsync(_logger, 0, 0, _ct, true, rotaryFactor);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogDebug(ex, "地脉花战斗中内部寻敌异常");
+        }
     }
 
     private bool RecognizeFightText(ImageRegion captureRegion)

--- a/BetterGenshinImpact/View/Pages/TaskSettingsPage.xaml
+++ b/BetterGenshinImpact/View/Pages/TaskSettingsPage.xaml
@@ -2429,6 +2429,93 @@
                                 Text="{Binding Config.AutoLeyLineOutcropConfig.FightConfig.ActionSchedulerByCd, Mode=TwoWay}"
                                 TextWrapping="Wrap" />
                 </Grid>
+                <Grid Margin="16,0,16,16">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <ui:TextBlock Grid.Row="0"
+                                  Grid.Column="0"
+                                  FontTypography="Body"
+                                  Text="旋转寻找敌人位置"
+                                  Margin="0,0,0,10"
+                                  HorizontalAlignment="Left"
+                                  VerticalAlignment="Center"
+                                  TextWrapping="Wrap" />
+                    <ui:TextBlock Grid.Row="0"
+                                  Grid.Column="1"
+                                  FontTypography="Body"
+                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                  FontSize="9"
+                                  Text="旋转速度(建议单次360°左右)："
+                                  Margin="5,8,0,10"
+                                  HorizontalAlignment="Left"
+                                  VerticalAlignment="Center"
+                                  TextWrapping="Wrap" />
+                    <Slider Grid.Row="0"
+                            Grid.Column="2"
+                            Minimum="1"
+                            Maximum="13"
+                            Value="{Binding Config.AutoLeyLineOutcropConfig.FightConfig.SeekEnemyRotaryFactor, Mode=TwoWay}"
+                            Margin="3,0,5,10"
+                            TickFrequency="1"
+                            IsSnapToTickEnabled="True"
+                            IsEnabled="{Binding Config.AutoLeyLineOutcropConfig.FightConfig.SeekEnemyEnabled}"
+                            HorizontalAlignment="Left"
+                            VerticalAlignment="Center" />
+                    <ui:TextBlock Grid.Row="1"
+                                  Grid.Column="0"
+                                  Grid.ColumnSpan="3"
+                                  Grid.RowSpan="2"
+                                  HorizontalAlignment="Stretch"
+                                  VerticalAlignment="Stretch"
+                                  Margin="0,0,5,0"
+                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                  Text="(实验性功能) 战斗时按下方设置的间隔尝试靠近或旋转寻找敌人。"
+                                  TextWrapping="Wrap" />
+                    <ui:ToggleSwitch Grid.Row="0"
+                                     Grid.Column="3"
+                                     Margin="10,0,36,10"
+                                     IsChecked="{Binding Config.AutoLeyLineOutcropConfig.FightConfig.SeekEnemyEnabled, Mode=TwoWay}" />
+                </Grid>
+                <Grid Margin="16,0,16,16">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <ui:TextBlock Grid.Row="0"
+                                  Grid.Column="0"
+                                  FontTypography="Body"
+                                  Text="寻敌间隔（秒）"
+                                  TextWrapping="Wrap" />
+                    <ui:TextBlock Grid.Row="1"
+                                  Grid.Column="0"
+                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                  Text="仅在已启用“旋转寻找敌人位置”后生效，最小 1 秒。"
+                                  TextWrapping="Wrap" />
+                    <ui:NumberBox Grid.Row="0"
+                                  Grid.RowSpan="2"
+                                  Grid.Column="1"
+                                  MinWidth="120"
+                                  Minimum="1"
+                                  Maximum="60"
+                                  SmallChange="1"
+                                  LargeChange="5"
+                                  ValidationMode="InvalidInputOverwritten"
+                                  IsEnabled="{Binding Config.AutoLeyLineOutcropConfig.FightConfig.SeekEnemyEnabled}"
+                                  Value="{Binding Config.AutoLeyLineOutcropConfig.FightConfig.SeekEnemyIntervalSeconds, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                </Grid>
                 <Separator Margin="-18,0" BorderThickness="0,1,0,0" />
                 <Grid Margin="16,16,16,13">
                     <Grid.RowDefinitions>


### PR DESCRIPTION
## Summary
- 为自动地脉花增加专用的战斗中寻敌配置：启用开关、寻敌间隔、旋转速度
- 在 `AutoLeyLineOutcropTask` 的 OCR 轮询中，仅当识别到地脉花仍在战斗中时按配置节流触发内部寻敌
- 地脉花战斗结束判定仍然只依赖 OCR 成功/失败文本，不启用非 OCR 的结束检测路径
- 自动地脉花设置页复用自动战斗的“旋转寻找敌人位置”样式来承载这组专用配置

## Test
- `dotnet build BetterGenshinImpact/BetterGenshinImpact.csproj -c Debug -p:Platform=x64 -p:RestoreDisableParallel=true -m:1 -v:minimal '-clp:Summary;ErrorsOnly'`

Closes #3028

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 地脉花副本战斗中新增自动寻敌功能，用户可在设置中配置是否启用、敌人搜索间隔（1-60秒）及旋转搜索幅度（1-13）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->