### PR TITLE
新增自动秘境中可自定义添加配置组执行

### DIFF
--- a/BetterGenshinImpact/Core/Config/OneDragonFlowConfig.cs
+++ b/BetterGenshinImpact/Core/Config/OneDragonFlowConfig.cs
@@ -35,6 +35,10 @@ public partial class OneDragonFlowConfig : ObservableObject
     [ObservableProperty]
     private string _domainName = string.Empty;
 
+    // 自定义配置组名称列表（用于在秘境选择中添加自定义脚本配置组）
+    [ObservableProperty]
+    private List<string> _customDomainList = new();
+
     [ObservableProperty]
     private bool _weeklyDomainEnabled = false;
     

--- a/BetterGenshinImpact/Helpers/DomainCascadingItems.cs
+++ b/BetterGenshinImpact/Helpers/DomainCascadingItems.cs
@@ -10,11 +10,30 @@ public static class DomainCascadingItems
     private static IReadOnlyList<ICascadingItem>? _items;
 
     public static IReadOnlyList<ICascadingItem> Items =>
-        _items ??= BuildItems();
+        _items ??= BuildItems(null);
 
-    private static IReadOnlyList<ICascadingItem> BuildItems()
+    /// <summary>
+    /// 重建级联数据，支持动态自定义分类
+    /// </summary>
+    public static void Rebuild(List<string>? customDomainList)
     {
-        return MapLazyAssets.Instance.CountryToDomains.Keys
+        _items = BuildItems(customDomainList);
+    }
+
+    private static IReadOnlyList<ICascadingItem> BuildItems(List<string>? customDomainList)
+    {
+        var items = new List<ICascadingItem>();
+
+        // 自定义配置组分类（仅在列表非空时显示）
+        if (customDomainList != null && customDomainList.Count > 0)
+        {
+            items.Add(new CascadingItem("自定义",
+                customDomainList.Select(name =>
+                    (ICascadingItem)new CascadingItem(name) { Tag = name })));
+        }
+
+        // 标准秘境分类（按国家分组）
+        items.AddRange(MapLazyAssets.Instance.CountryToDomains.Keys
             .Reverse()
             .Select(country => (ICascadingItem)new CascadingItem(
                 country,
@@ -26,7 +45,8 @@ public static class DomainCascadingItems
                     {
                         Tag = d.Name
                     })
-            ))
-            .ToList();
+            )));
+
+        return items;
     }
 }

--- a/BetterGenshinImpact/Model/OneDragonTaskItem.cs
+++ b/BetterGenshinImpact/Model/OneDragonTaskItem.cs
@@ -1,16 +1,20 @@
 ﻿using System;
+using System.IO;
 using System.Threading.Tasks;
 using BetterGenshinImpact.ViewModel.Pages.OneDragon;
 using CommunityToolkit.Mvvm.ComponentModel;
 using System.Windows.Media;
 using BetterGenshinImpact.Core.Config;
 using BetterGenshinImpact.Core.Script;
+using BetterGenshinImpact.Core.Script.Group;
 using BetterGenshinImpact.GameTask;
 using BetterGenshinImpact.GameTask.AutoDomain;
 using BetterGenshinImpact.GameTask.AutoLeyLineOutcrop;
 using BetterGenshinImpact.GameTask.AutoStygianOnslaught;
 using BetterGenshinImpact.GameTask.Common;
 using BetterGenshinImpact.GameTask.Common.Job;
+using BetterGenshinImpact.Service;
+using BetterGenshinImpact.Service.Interface;
 using BetterGenshinImpact.ViewModel.Pages;
 using Microsoft.Extensions.Logging;
 
@@ -98,18 +102,59 @@ public partial class OneDragonTaskItem : ObservableObject
                         TaskControl.Logger.LogError("一条龙配置内{Msg}需要刷的秘境，跳过", "未选择");
                         return;
                     }
+
+                    // 判断是否为自定义配置组
+                    if (config.CustomDomainList.Contains(domainName))
+                    {
+                        try
+                        {
+                            var filePath = Global.Absolute($@"User\ScriptGroup\{domainName}.json");
+                            if (!File.Exists(filePath))
+                            {
+                                TaskControl.Logger.LogError("自定义配置组 {Name} 对应的文件不存在，跳过", domainName);
+                                return;
+                            }
+
+                            TaskControl.Logger.LogInformation("自动秘境任务：执行自定义配置组 {Name}", domainName);
+                            var group = ScriptGroup.FromJson(await File.ReadAllTextAsync(filePath));
+                            var projects = ScriptControlViewModel.GetNextProjects(group);
+
+                            // 直接内联执行脚本项目，避免 RunMulti 创建新的 TaskRunner 导致冲突
+                            var scriptService = App.GetService<IScriptService>() as ScriptService;
+                            if (scriptService == null)
+                            {
+                                TaskControl.Logger.LogError("ScriptService 获取失败，跳过自定义配置组");
+                                return;
+                            }
+
+                            foreach (var project in projects)
+                            {
+                                if (CancellationContext.Instance.Cts.IsCancellationRequested)
+                                    break;
+
+                                if (project.Status != "Enabled")
+                                    continue;
+
+                                await scriptService.ExecuteProjectPublic(project);
+                                await Task.Delay(1000);
+                            }
+                        }
+                        catch (Exception e)
+                        {
+                            TaskControl.Logger.LogError("自定义配置组 {Name} 执行异常：{Msg}", domainName, e.Message);
+                        }
+                    }
                     else
                     {
                         TaskControl.Logger.LogInformation("自动秘境任务：执行");
+                        var autoDomainParam = new AutoDomainParam(0, path)
+                        {
+                            PartyName = partyName,
+                            DomainName = domainName,
+                            SundaySelectedValue = sundaySelectedValue
+                        };
+                        await new AutoDomainTask(autoDomainParam).Start(CancellationContext.Instance.Cts.Token);
                     }
-
-                    var autoDomainParam = new AutoDomainParam(0, path)
-                    {
-                        PartyName = partyName,
-                        DomainName = domainName,
-                        SundaySelectedValue = sundaySelectedValue
-                    };
-                    await new AutoDomainTask(autoDomainParam).Start(CancellationContext.Instance.Cts.Token);
                 };
                 break;
             case "自动幽境危战":

--- a/BetterGenshinImpact/Model/OneDragonTaskItem.cs
+++ b/BetterGenshinImpact/Model/OneDragonTaskItem.cs
@@ -131,7 +131,8 @@ public partial class OneDragonTaskItem : ObservableObject
                         }
                         catch (Exception e)
                         {
-                            TaskControl.Logger.LogError("自定义配置组 {Name} 执行异常：{Msg}", domainName, e.Message);
+                            var filePath = Global.Absolute($@"User\ScriptGroup\{domainName}.json");
+                            TaskControl.Logger.LogError(e, "自定义配置组 {Name} 执行异常，配置文件：{Path}", domainName, filePath);
                         }
                     }
                     else

--- a/BetterGenshinImpact/Model/OneDragonTaskItem.cs
+++ b/BetterGenshinImpact/Model/OneDragonTaskItem.cs
@@ -119,7 +119,7 @@ public partial class OneDragonTaskItem : ObservableObject
                             var group = ScriptGroup.FromJson(await File.ReadAllTextAsync(filePath));
                             var projects = ScriptControlViewModel.GetNextProjects(group);
 
-                            // 直接内联执行脚本项目，避免 RunMulti 创建新的 TaskRunner 导致冲突
+                            // 使用 RunMultiInline 内联执行，复用完整的跳过规则、月卡检测、触发器清理等语义
                             var scriptService = App.GetService<IScriptService>() as ScriptService;
                             if (scriptService == null)
                             {
@@ -127,17 +127,7 @@ public partial class OneDragonTaskItem : ObservableObject
                                 return;
                             }
 
-                            foreach (var project in projects)
-                            {
-                                if (CancellationContext.Instance.Cts.IsCancellationRequested)
-                                    break;
-
-                                if (project.Status != "Enabled")
-                                    continue;
-
-                                await scriptService.ExecuteProjectPublic(project);
-                                await Task.Delay(1000);
-                            }
+                            await scriptService.RunMultiInline(projects, domainName);
                         }
                         catch (Exception e)
                         {

--- a/BetterGenshinImpact/Service/ScriptService.cs
+++ b/BetterGenshinImpact/Service/ScriptService.cs
@@ -505,15 +505,86 @@ public partial class ScriptService : IScriptService
     // }
 
     /// <summary>
-    /// 公开的项目执行入口，供一条龙自定义配置组内联调用（不创建新的 TaskRunner）
+    /// 内联执行配置组项目列表，复用 RunMulti 的全部语义（跳过规则、月卡检测、触发器清理、通知等），
+    /// 但不创建新的 TaskRunner，供一条龙等已在 TaskRunner 内的场景调用。
     /// </summary>
-    public async Task ExecuteProjectPublic(ScriptGroupProject project)
+    public async Task RunMultiInline(IEnumerable<ScriptGroupProject> projectList, string? groupName = null)
     {
-        // 重新加载项目以确保脚本引用正确
-        var reloaded = ReloadScriptProjects(new[] { project });
-        if (reloaded.Count > 0)
+        groupName ??= "默认";
+        var list = ReloadScriptProjects(projectList);
+        foreach (var p in projectList) p.SkipFlag = false;
+
+        _logger.LogInformation("配置组 {Name} 加载完成，共{Cnt}个脚本，开始内联执行", groupName, list.Count);
+
+        bool first = true;
+        _projectExecutionCount.Clear();
+        var stopwatch = new Stopwatch();
+
+        for (int x = 0; x < list.Count; x++)
         {
-            await ExecuteProject(reloaded[0]);
+            var project = list[x];
+
+            if (project is { SkipFlag: true }) continue;
+            if (ShouldSkipTask(project)) continue;
+
+            // 月卡检测
+            await _blessingOfTheWelkinMoonTask.Start(CancellationContext.Instance.Cts.Token);
+
+            if (project.Status != "Enabled")
+            {
+                _logger.LogInformation("脚本 {Name} 状态为禁用，跳过执行", project.Name);
+                continue;
+            }
+
+            if (CancellationContext.Instance.Cts.IsCancellationRequested) break;
+
+            if (first)
+            {
+                first = false;
+                Notify.Event(NotificationEvent.GroupStart).Success($"配置组{groupName}启动");
+            }
+
+            for (var i = 0; i < project.RunNum; i++)
+            {
+                try
+                {
+                    TaskTriggerDispatcher.Instance().ClearTriggers();
+                    _logger.LogInformation("------------------------------");
+                    stopwatch.Reset();
+                    stopwatch.Start();
+
+                    await ExecuteProject(project);
+
+                    if (project.RunNum > 1 && ShouldSkipTask(project)) continue;
+                }
+                catch (NormalEndException) { throw; }
+                catch (TaskCanceledException e)
+                {
+                    _logger.LogInformation("取消执行配置组: {Msg}", e.Message);
+                    throw;
+                }
+                catch (Exception e)
+                {
+                    _logger.LogDebug(e, "执行脚本时发生异常");
+                    _logger.LogError("执行脚本时发生异常: {Msg}", e.Message);
+                }
+                finally
+                {
+                    stopwatch.Stop();
+                    var elapsed = TimeSpan.FromMilliseconds(stopwatch.ElapsedMilliseconds);
+                    _logger.LogInformation("→ 脚本执行结束: {Name}, 耗时: {Minutes}分{Seconds:0.000}秒",
+                        project.Name, elapsed.Hours * 60 + elapsed.Minutes, elapsed.TotalSeconds % 60);
+                    _logger.LogInformation("------------------------------");
+                }
+
+                await Task.Delay(1000);
+            }
+        }
+
+        _logger.LogInformation("配置组 {Name} 内联执行结束", groupName);
+        if (!first && CancellationContext.Instance.IsManualStop is false)
+        {
+            Notify.Event(NotificationEvent.GroupEnd).Success($"配置组{groupName}结束");
         }
     }
 

--- a/BetterGenshinImpact/Service/ScriptService.cs
+++ b/BetterGenshinImpact/Service/ScriptService.cs
@@ -504,6 +504,19 @@ public partial class ScriptService : IScriptService
     //     return jsProjects;
     // }
 
+    /// <summary>
+    /// 公开的项目执行入口，供一条龙自定义配置组内联调用（不创建新的 TaskRunner）
+    /// </summary>
+    public async Task ExecuteProjectPublic(ScriptGroupProject project)
+    {
+        // 重新加载项目以确保脚本引用正确
+        var reloaded = ReloadScriptProjects(new[] { project });
+        if (reloaded.Count > 0)
+        {
+            await ExecuteProject(reloaded[0]);
+        }
+    }
+
     private async Task ExecuteProject(ScriptGroupProject project)
     {
         TaskContext.Instance().CurrentScriptProject = project;

--- a/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml
+++ b/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml
@@ -430,6 +430,7 @@
                                     <ColumnDefinition Width="Auto" />
                                     <ColumnDefinition Width="Auto" />
                                     <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="Auto" />
                                     <ColumnDefinition Width="*" />
                                 </Grid.ColumnDefinitions>
                                 <ui:TextBlock Grid.Row="0"
@@ -446,16 +447,95 @@
                                               Text="秘境名称"
                                               Width="Auto"
                                               TextWrapping="Wrap" />
+                                <ToggleButton Grid.Row="0"
+                                        Grid.Column="1"
+                                        x:Name="AddDomainToggle"
+                                        Margin="5,0,0,0"
+                                        FontFamily="{StaticResource TextThemeFontFamily}"
+                                        VerticalAlignment="Center"
+                                        HorizontalAlignment="Left"
+                                        Width="16" Height="16"
+                                        BorderThickness="1"
+                                        Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                        Background="Transparent"
+                                        Padding="0"
+                                        ToolTip="添加自定义配置组">
+                                    <Viewbox><TextBlock Text="+" /></Viewbox>
+                                </ToggleButton>
+                                <!-- 添加自定义配置组弹窗 -->
+                                <Popup Grid.Row="0" Grid.Column="1"
+                                       IsOpen="{Binding IsChecked, ElementName=AddDomainToggle}"
+                                       PlacementTarget="{Binding ElementName=AddDomainToggle}"
+                                       Placement="Bottom"
+                                       StaysOpen="False"
+                                       AllowsTransparency="True"
+                                       PopupAnimation="Fade"
+                                       Opened="AddDomainPopup_Opened">
+                                    <Border CornerRadius="8"
+                                            Background="{DynamicResource ApplicationBackgroundBrush}"
+                                            BorderBrush="{DynamicResource SystemAccentColorPrimaryBrush}"
+                                            BorderThickness="1"
+                                            Padding="12" Margin="4">
+                                        <StackPanel MinWidth="200">
+                                            <ui:TextBlock Text="选择要添加的配置组" FontSize="13" Margin="0,0,0,8" />
+                                            <ComboBox ItemsSource="{Binding AvailableScriptGroups}"
+                                                      SelectedItem="{Binding SelectedCustomDomainToAdd, Mode=TwoWay}"
+                                                      MinWidth="180" Margin="0,0,0,8" />
+                                            <Button Content="确定" HorizontalAlignment="Right"
+                                                    Command="{Binding ConfirmAddCustomDomainCommand}"
+                                                    Click="ClosePopup_Click" />
+                                        </StackPanel>
+                                    </Border>
+                                </Popup>
+                                <ToggleButton Grid.Row="1"
+                                        Grid.Column="1"
+                                        x:Name="RemoveDomainToggle"
+                                        Margin="5,0,0,0"
+                                        FontFamily="{StaticResource TextThemeFontFamily}"
+                                        VerticalAlignment="Center"
+                                        HorizontalAlignment="Left"
+                                        Width="16" Height="16"
+                                        Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                        Background="Transparent"
+                                        Padding="0"
+                                        IsEnabled="{Binding HasCustomDomains}"
+                                        ToolTip="删除自定义配置组">
+                                    <Viewbox><TextBlock Text="-" /></Viewbox>
+                                </ToggleButton>
+                                <!-- 删除自定义配置组弹窗 -->
+                                <Popup Grid.Row="1" Grid.Column="1"
+                                       IsOpen="{Binding IsChecked, ElementName=RemoveDomainToggle}"
+                                       PlacementTarget="{Binding ElementName=RemoveDomainToggle}"
+                                       Placement="Bottom"
+                                       StaysOpen="False"
+                                       AllowsTransparency="True"
+                                       PopupAnimation="Fade">
+                                    <Border CornerRadius="8"
+                                            Background="{DynamicResource ApplicationBackgroundBrush}"
+                                            BorderBrush="{DynamicResource SystemAccentColorPrimaryBrush}"
+                                            BorderThickness="1"
+                                            Padding="12" Margin="4">
+                                        <StackPanel MinWidth="200">
+                                            <ui:TextBlock Text="选择要删除的配置组" FontSize="13" Margin="0,0,0,8" />
+                                            <ComboBox ItemsSource="{Binding SelectedConfig.CustomDomainList}"
+                                                      SelectedItem="{Binding SelectedCustomDomainToRemove, Mode=TwoWay}"
+                                                      MinWidth="180" Margin="0,0,0,8" />
+                                            <Button Content="确定" HorizontalAlignment="Right"
+                                                    Command="{Binding ConfirmRemoveCustomDomainCommand}"
+                                                    Click="ClosePopup_Click" />
+                                        </StackPanel>
+                                    </Border>
+                                </Popup>
                                 <vio:CascadingComboBox Grid.Row="0"
                                           Grid.RowSpan="2"
-                                          Grid.Column="1"
+                                          Grid.Column="2"
                                           Width="100"
                                           HorizontalAlignment="Left"
                                           Margin="10,0,10,0"
-                                          ItemsSource="{x:Static helpers:DomainCascadingItems.Items}"
+                                          ItemsSource="{Binding DomainItems}"
                                           SelectedCascadingItem="{Binding SelectedConfig.DomainName, Mode=TwoWay, Converter={StaticResource DomainNameConverter}}" />
                                 <ui:TextBlock Grid.Row="0"
-                                              Grid.Column="2"
+                                              Grid.Column="3"
                                               Margin="10,0,10,0"
                                               FontTypography="Body"
                                               HorizontalAlignment="Right"
@@ -463,7 +543,7 @@
                                               Width="Auto"
                                               TextWrapping="Wrap" />
                                 <ui:TextBlock Grid.Row="1"
-                                              Grid.Column="2"
+                                              Grid.Column="3"
                                               Margin="10,0,10,0"
                                               Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
                                               HorizontalAlignment="Right"
@@ -471,7 +551,7 @@
                                               Width="Auto"
                                               TextWrapping="Wrap" />
                                 <ComboBox Grid.Row="0"
-                                          Grid.Column="3"
+                                          Grid.Column="4"
                                           Grid.RowSpan="2"
                                           MinWidth="60"
                                           Margin="0,0,36,0"
@@ -531,6 +611,91 @@
                                               Text="周期始于凌晨 4:00 ，如周一 4:00 至周二 3:59 刷取周一秘境" 
                                               TextWrapping="Wrap">
                                 </ui:TextBlock>
+                                <!-- 自定义增减配置组到自动秘境任务 -->
+                                <Grid HorizontalAlignment="Center">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+                                    <ui:TextBlock Grid.Column="0"
+                                                  Margin="0,0,0,-5"
+                                                  VerticalAlignment="Center"
+                                                  HorizontalAlignment="Left"
+                                                  FontTypography="Body"
+                                                  FontSize="12"
+                                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                                  Text="自定义增减配置组到自动秘境任务：" />
+                                    <ToggleButton Grid.Column="1"
+                                            x:Name="AddDomainToggle2"
+                                            Margin="5,0,0,0"
+                                            FontFamily="{StaticResource TextThemeFontFamily}"
+                                            VerticalAlignment="Center"
+                                            HorizontalAlignment="Left"
+                                            Width="16" Height="16"
+                                            BorderThickness="1"
+                                            Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                            Background="Transparent"
+                                            Padding="0"
+                                            ToolTip="添加自定义配置组">
+                                        <Viewbox><TextBlock Text="+" /></Viewbox>
+                                    </ToggleButton>
+                                    <Popup Grid.Column="1"
+                                           IsOpen="{Binding IsChecked, ElementName=AddDomainToggle2}"
+                                           PlacementTarget="{Binding ElementName=AddDomainToggle2}"
+                                           Placement="Bottom" StaysOpen="False"
+                                           AllowsTransparency="True" PopupAnimation="Fade"
+                                           Opened="AddDomainPopup_Opened">
+                                        <Border CornerRadius="8"
+                                                Background="{DynamicResource ApplicationBackgroundBrush}"
+                                                BorderBrush="{DynamicResource SystemAccentColorPrimaryBrush}"
+                                                BorderThickness="1" Padding="12" Margin="4">
+                                            <StackPanel MinWidth="200">
+                                                <ui:TextBlock Text="选择要添加的配置组" FontSize="13" Margin="0,0,0,8" />
+                                                <ComboBox ItemsSource="{Binding AvailableScriptGroups}"
+                                                          SelectedItem="{Binding SelectedCustomDomainToAdd, Mode=TwoWay}"
+                                                          MinWidth="180" Margin="0,0,0,8" />
+                                                <Button Content="确定" HorizontalAlignment="Right"
+                                                        Command="{Binding ConfirmAddCustomDomainCommand}"
+                                                        Click="ClosePopup_Click" />
+                                            </StackPanel>
+                                        </Border>
+                                    </Popup>
+                                    <ToggleButton Grid.Column="2"
+                                            x:Name="RemoveDomainToggle2"
+                                            Margin="5,0,0,0"
+                                            FontFamily="{StaticResource TextThemeFontFamily}"
+                                            VerticalAlignment="Center"
+                                            HorizontalAlignment="Left"
+                                            Width="16" Height="16"
+                                            Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                            Background="Transparent"
+                                            Padding="0"
+                                            IsEnabled="{Binding HasCustomDomains}"
+                                            ToolTip="删除自定义配置组">
+                                        <Viewbox><TextBlock Text="-" /></Viewbox>
+                                    </ToggleButton>
+                                    <Popup Grid.Column="2"
+                                           IsOpen="{Binding IsChecked, ElementName=RemoveDomainToggle2}"
+                                           PlacementTarget="{Binding ElementName=RemoveDomainToggle2}"
+                                           Placement="Bottom" StaysOpen="False"
+                                           AllowsTransparency="True" PopupAnimation="Fade">
+                                        <Border CornerRadius="8"
+                                                Background="{DynamicResource ApplicationBackgroundBrush}"
+                                                BorderBrush="{DynamicResource SystemAccentColorPrimaryBrush}"
+                                                BorderThickness="1" Padding="12" Margin="4">
+                                            <StackPanel MinWidth="200">
+                                                <ui:TextBlock Text="选择要删除的配置组" FontSize="13" Margin="0,0,0,8" />
+                                                <ComboBox ItemsSource="{Binding SelectedConfig.CustomDomainList}"
+                                                          SelectedItem="{Binding SelectedCustomDomainToRemove, Mode=TwoWay}"
+                                                          MinWidth="180" Margin="0,0,0,8" />
+                                                <Button Content="确定" HorizontalAlignment="Right"
+                                                        Command="{Binding ConfirmRemoveCustomDomainCommand}"
+                                                        Click="ClosePopup_Click" />
+                                            </StackPanel>
+                                        </Border>
+                                    </Popup>
+                                </Grid>
                            
                             <Grid Margin="16">
                                 <Grid.ColumnDefinitions>
@@ -557,7 +722,7 @@
                                           Grid.Column="2"
                                           Width="100"
                                           Margin="0,0,36,0"
-                                          ItemsSource="{x:Static helpers:DomainCascadingItems.Items}"
+                                          ItemsSource="{Binding DomainItems}"
                                           SelectedCascadingItem="{Binding SelectedConfig.MondayDomainName, Mode=TwoWay, Converter={StaticResource DomainNameConverter}}" />
                             </Grid>
                             <Grid Margin="16">
@@ -586,7 +751,7 @@
                                           Grid.Column="2"
                                           Width="100"
                                           Margin="0,0,36,0"
-                                          ItemsSource="{x:Static helpers:DomainCascadingItems.Items}"
+                                          ItemsSource="{Binding DomainItems}"
                                           SelectedCascadingItem="{Binding SelectedConfig.TuesdayDomainName, Mode=TwoWay, Converter={StaticResource DomainNameConverter}}" />
                             </Grid>
                             <Grid Margin="16">
@@ -614,7 +779,7 @@
                                           Grid.Column="2"
                                           Width="100"
                                           Margin="0,0,36,0"
-                                          ItemsSource="{x:Static helpers:DomainCascadingItems.Items}"
+                                          ItemsSource="{Binding DomainItems}"
                                           SelectedCascadingItem="{Binding SelectedConfig.WednesdayDomainName, Mode=TwoWay, Converter={StaticResource DomainNameConverter}}" />
 
                             </Grid>
@@ -643,7 +808,7 @@
                                           Grid.Column="2"
                                           Width="100"
                                           Margin="0,0,36,0"
-                                          ItemsSource="{x:Static helpers:DomainCascadingItems.Items}"
+                                          ItemsSource="{Binding DomainItems}"
                                           SelectedCascadingItem="{Binding SelectedConfig.ThursdayDomainName, Mode=TwoWay, Converter={StaticResource DomainNameConverter}}" />
 
                             </Grid>
@@ -672,7 +837,7 @@
                                           Grid.Column="2"
                                           Width="100"
                                           Margin="0,0,36,0"
-                                          ItemsSource="{x:Static helpers:DomainCascadingItems.Items}"
+                                          ItemsSource="{Binding DomainItems}"
                                           SelectedCascadingItem="{Binding SelectedConfig.FridayDomainName, Mode=TwoWay, Converter={StaticResource DomainNameConverter}}" />
 
 
@@ -702,7 +867,7 @@
                                           Grid.Column="2"
                                           Width="100"
                                           Margin="0,0,36,0"
-                                          ItemsSource="{x:Static helpers:DomainCascadingItems.Items}"
+                                          ItemsSource="{Binding DomainItems}"
                                           SelectedCascadingItem="{Binding SelectedConfig.SaturdayDomainName, Mode=TwoWay, Converter={StaticResource DomainNameConverter}}" />
 
                             </Grid>
@@ -736,7 +901,7 @@
                                           Grid.Column="2"
                                           Width="100"
                                           Margin="0,0,36,0"
-                                          ItemsSource="{x:Static helpers:DomainCascadingItems.Items}"
+                                          ItemsSource="{Binding DomainItems}"
                                           SelectedCascadingItem="{Binding SelectedConfig.SundayDomainName, Mode=TwoWay, Converter={StaticResource DomainNameConverter}}" />
                                 <Border Grid.Row="1"
                                         Grid.Column="0"

--- a/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml
+++ b/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml
@@ -464,7 +464,7 @@
                                 </ToggleButton>
                                 <!-- 添加自定义配置组弹窗 -->
                                 <Popup Grid.Row="0" Grid.Column="1"
-                                       IsOpen="{Binding IsChecked, ElementName=AddDomainToggle}"
+                                       IsOpen="{Binding IsChecked, ElementName=AddDomainToggle, Mode=TwoWay}"
                                        PlacementTarget="{Binding ElementName=AddDomainToggle}"
                                        Placement="Bottom"
                                        StaysOpen="False"
@@ -504,7 +504,7 @@
                                 </ToggleButton>
                                 <!-- 删除自定义配置组弹窗 -->
                                 <Popup Grid.Row="1" Grid.Column="1"
-                                       IsOpen="{Binding IsChecked, ElementName=RemoveDomainToggle}"
+                                       IsOpen="{Binding IsChecked, ElementName=RemoveDomainToggle, Mode=TwoWay}"
                                        PlacementTarget="{Binding ElementName=RemoveDomainToggle}"
                                        Placement="Bottom"
                                        StaysOpen="False"
@@ -641,7 +641,7 @@
                                         <Viewbox><TextBlock Text="+" /></Viewbox>
                                     </ToggleButton>
                                     <Popup Grid.Column="1"
-                                           IsOpen="{Binding IsChecked, ElementName=AddDomainToggle2}"
+                                           IsOpen="{Binding IsChecked, ElementName=AddDomainToggle2, Mode=TwoWay}"
                                            PlacementTarget="{Binding ElementName=AddDomainToggle2}"
                                            Placement="Bottom" StaysOpen="False"
                                            AllowsTransparency="True" PopupAnimation="Fade"
@@ -676,7 +676,7 @@
                                         <Viewbox><TextBlock Text="-" /></Viewbox>
                                     </ToggleButton>
                                     <Popup Grid.Column="2"
-                                           IsOpen="{Binding IsChecked, ElementName=RemoveDomainToggle2}"
+                                           IsOpen="{Binding IsChecked, ElementName=RemoveDomainToggle2, Mode=TwoWay}"
                                            PlacementTarget="{Binding ElementName=RemoveDomainToggle2}"
                                            Placement="Bottom" StaysOpen="False"
                                            AllowsTransparency="True" PopupAnimation="Fade">

--- a/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml.cs
+++ b/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml.cs
@@ -71,5 +71,34 @@ public partial class OneDragonFlowPage
         }
         
     }
+
+    /// <summary>
+    /// 添加配置组弹窗打开时刷新可用列表
+    /// </summary>
+    private void AddDomainPopup_Opened(object sender, System.EventArgs e)
+    {
+        ViewModel.RefreshAvailableScriptGroupsCommand.Execute(null);
+    }
+
+    /// <summary>
+    /// 关闭弹窗（确定按钮点击后）
+    /// </summary>
+    private void ClosePopup_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is FrameworkElement fe)
+        {
+            // 向上查找 Popup 并关闭
+            var parent = fe.Parent;
+            while (parent != null)
+            {
+                if (parent is System.Windows.Controls.Primitives.Popup popup)
+                {
+                    popup.IsOpen = false;
+                    return;
+                }
+                parent = (parent as FrameworkElement)?.Parent;
+            }
+        }
+    }
     
 }

--- a/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml.cs
+++ b/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml.cs
@@ -81,19 +81,24 @@ public partial class OneDragonFlowPage
     }
 
     /// <summary>
-    /// 关闭弹窗（确定按钮点击后）
+    /// 关闭弹窗并复位 ToggleButton（确定按钮点击后）
     /// </summary>
     private void ClosePopup_Click(object sender, RoutedEventArgs e)
     {
         if (sender is FrameworkElement fe)
         {
-            // 向上查找 Popup 并关闭
+            // 向上查找 Popup 并关闭，同时复位宿主 ToggleButton
             var parent = fe.Parent;
             while (parent != null)
             {
                 if (parent is System.Windows.Controls.Primitives.Popup popup)
                 {
                     popup.IsOpen = false;
+                    // 复位绑定的 ToggleButton，防止下次需要点两下才能打开
+                    if (popup.PlacementTarget is System.Windows.Controls.Primitives.ToggleButton toggle)
+                    {
+                        toggle.IsChecked = false;
+                    }
                     return;
                 }
                 parent = (parent as FrameworkElement)?.Parent;

--- a/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
@@ -602,8 +602,13 @@ public partial class OneDragonFlowViewModel : ViewModel
     {
         if (SelectedConfig == null || string.IsNullOrEmpty(SelectedCustomDomainToAdd)) return;
 
+        // 校验：不允许与已有自定义配置组重名
         if (SelectedConfig.CustomDomainList.Contains(SelectedCustomDomainToAdd))
         { Toast.Warning("自定义配置组已存在"); return; }
+
+        // 校验：不允许与系统预定义秘境名称重名，防止运行时误判执行路径
+        if (MapLazyAssets.Instance.DomainNameList.Contains(SelectedCustomDomainToAdd))
+        { Toast.Warning("名称与系统秘境冲突"); return; }
 
         SelectedConfig.CustomDomainList.Add(SelectedCustomDomainToAdd);
         // 重新赋值触发 PropertyChanged，使绑定的 ComboBox 刷新

--- a/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
@@ -287,6 +287,11 @@ public partial class OneDragonFlowViewModel : ViewModel
 
     [ObservableProperty] private List<string> _domainNameList = ["", ..MapLazyAssets.Instance.DomainNameList];
 
+    /// <summary>
+    /// 秘境级联选择器数据源（包含自定义配置组）
+    /// </summary>
+    [ObservableProperty] private IReadOnlyList<ICascadingItem> _domainItems = DomainCascadingItems.Items;
+
     [ObservableProperty] private List<string> _completionActionList = ["无", "关闭游戏", "关闭游戏和软件", "关机"];
 
     [ObservableProperty] private List<string> _sundayEverySelectedValueList = ["","1", "2", "3"];
@@ -396,6 +401,8 @@ public partial class OneDragonFlowViewModel : ViewModel
         SelectedConfig = selected;
         LoadDisplayTaskListFromConfig(); // 加载 DisplayTaskList 从配置文件
         SetSomeSelectedConfig(SelectedConfig);
+        // 首次加载时需要更新 ItemsSource 以包含自定义配置组
+        RefreshDomainItems(updateItemsSource: true);
     }
 
     // 新增方法：从配置文件加载 DisplayTaskList
@@ -497,7 +504,147 @@ public partial class OneDragonFlowViewModel : ViewModel
             }
 
             LoadDisplayTaskListFromConfig();
+            RefreshDomainItems();
         }
+    }
+
+    /// <summary>
+    /// 是否存在自定义配置组（用于控制"-"按钮的启用状态）
+    /// </summary>
+    public bool HasCustomDomains => SelectedConfig?.CustomDomainList?.Count > 0;
+
+    /// <summary>
+    /// 刷新秘境级联选择器数据源，重建包含自定义配置组的级联数据
+    /// </summary>
+    private bool _suppressConfigSave;
+
+    private void RefreshDomainItems(bool updateItemsSource = false)
+    {
+        // 始终重建静态级联数据（供 Converter 查找使用）
+        DomainCascadingItems.Rebuild(SelectedConfig?.CustomDomainList);
+
+        // 仅在显式要求时更新 ItemsSource（添加/删除自定义配置组时）
+        // CascadingComboBox 在 ItemsSource 变更时会清空选中项并通过 TwoWay 绑定写回空值
+        // 因此需要临时保存并恢复所有 DomainName 字段
+        if (updateItemsSource && SelectedConfig != null)
+        {
+            // 保存当前所有秘境选择值
+            var savedDomain = SelectedConfig.DomainName;
+            var savedMon = SelectedConfig.MondayDomainName;
+            var savedTue = SelectedConfig.TuesdayDomainName;
+            var savedWed = SelectedConfig.WednesdayDomainName;
+            var savedThu = SelectedConfig.ThursdayDomainName;
+            var savedFri = SelectedConfig.FridayDomainName;
+            var savedSat = SelectedConfig.SaturdayDomainName;
+            var savedSun = SelectedConfig.SundayDomainName;
+
+            // 抑制 ConfigPropertyChanged 中的自动保存，防止空值被持久化
+            _suppressConfigSave = true;
+            DomainItems = DomainCascadingItems.Items;
+            _suppressConfigSave = false;
+
+            // 恢复被清空的秘境选择值
+            SelectedConfig.DomainName = savedDomain;
+            SelectedConfig.MondayDomainName = savedMon;
+            SelectedConfig.TuesdayDomainName = savedTue;
+            SelectedConfig.WednesdayDomainName = savedWed;
+            SelectedConfig.ThursdayDomainName = savedThu;
+            SelectedConfig.FridayDomainName = savedFri;
+            SelectedConfig.SaturdayDomainName = savedSat;
+            SelectedConfig.SundayDomainName = savedSun;
+        }
+        else if (updateItemsSource)
+        {
+            DomainItems = DomainCascadingItems.Items;
+        }
+
+        OnPropertyChanged(nameof(HasCustomDomains));
+    }
+
+    /// <summary>
+    /// 可添加的配置组列表（供 XAML Popup 绑定）
+    /// </summary>
+    [ObservableProperty] private List<string> _availableScriptGroups = new();
+
+    /// <summary>
+    /// 添加对话框中选中的配置组名称
+    /// </summary>
+    [ObservableProperty] private string? _selectedCustomDomainToAdd;
+
+    /// <summary>
+    /// 删除对话框中选中的配置组名称
+    /// </summary>
+    [ObservableProperty] private string? _selectedCustomDomainToRemove;
+
+    /// <summary>
+    /// 刷新可添加的配置组列表（排除已添加的和系统秘境同名的）
+    /// </summary>
+    [RelayCommand]
+    private void RefreshAvailableScriptGroups()
+    {
+        var scriptGroupPath = Global.Absolute(@"User\ScriptGroup");
+        if (!Directory.Exists(scriptGroupPath)) { AvailableScriptGroups = new(); return; }
+
+        var existing = SelectedConfig?.CustomDomainList ?? new();
+        var systemNames = MapLazyAssets.Instance.DomainNameList;
+        AvailableScriptGroups = Directory.GetFiles(scriptGroupPath, "*.json")
+            .Select(Path.GetFileNameWithoutExtension)
+            .Where(n => !string.IsNullOrEmpty(n) && !existing.Contains(n!) && !systemNames.Contains(n!))
+            .ToList()!;
+        SelectedCustomDomainToAdd = AvailableScriptGroups.FirstOrDefault();
+    }
+
+    /// <summary>
+    /// 确认添加自定义配置组
+    /// </summary>
+    [RelayCommand]
+    private void ConfirmAddCustomDomain()
+    {
+        if (SelectedConfig == null || string.IsNullOrEmpty(SelectedCustomDomainToAdd)) return;
+
+        if (SelectedConfig.CustomDomainList.Contains(SelectedCustomDomainToAdd))
+        { Toast.Warning("自定义配置组已存在"); return; }
+
+        SelectedConfig.CustomDomainList.Add(SelectedCustomDomainToAdd);
+        // 重新赋值触发 PropertyChanged，使绑定的 ComboBox 刷新
+        SelectedConfig.CustomDomainList = new List<string>(SelectedConfig.CustomDomainList);
+        SaveConfig();
+        RefreshDomainItems(updateItemsSource: true);
+        Toast.Success($"已添加自定义配置组「{SelectedCustomDomainToAdd}」");
+    }
+
+    /// <summary>
+    /// 确认删除自定义配置组，并清理所有引用
+    /// </summary>
+    [RelayCommand]
+    private void ConfirmRemoveCustomDomain()
+    {
+        if (SelectedConfig == null || string.IsNullOrEmpty(SelectedCustomDomainToRemove)) return;
+
+        var name = SelectedCustomDomainToRemove;
+        SelectedConfig.CustomDomainList.Remove(name);
+        // 重新赋值触发 PropertyChanged，使绑定的 ComboBox 刷新
+        SelectedConfig.CustomDomainList = new List<string>(SelectedConfig.CustomDomainList);
+        ClearDomainReferences(SelectedConfig, name);
+        SaveConfig();
+        RefreshDomainItems(updateItemsSource: true);
+        SelectedCustomDomainToRemove = SelectedConfig.CustomDomainList.FirstOrDefault();
+        Toast.Success($"已删除自定义配置组「{name}」");
+    }
+
+    /// <summary>
+    /// 将配置中所有等于指定名称的秘境字段重置为空
+    /// </summary>
+    private static void ClearDomainReferences(OneDragonFlowConfig config, string name)
+    {
+        if (config.DomainName == name) config.DomainName = string.Empty;
+        if (config.MondayDomainName == name) config.MondayDomainName = string.Empty;
+        if (config.TuesdayDomainName == name) config.TuesdayDomainName = string.Empty;
+        if (config.WednesdayDomainName == name) config.WednesdayDomainName = string.Empty;
+        if (config.ThursdayDomainName == name) config.ThursdayDomainName = string.Empty;
+        if (config.FridayDomainName == name) config.FridayDomainName = string.Empty;
+        if (config.SaturdayDomainName == name) config.SaturdayDomainName = string.Empty;
+        if (config.SundayDomainName == name) config.SundayDomainName = string.Empty;
     }
 
     private async void TaskPropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -508,6 +655,8 @@ public partial class OneDragonFlowViewModel : ViewModel
 
     private void ConfigPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
+        // 刷新 DomainItems 期间抑制自动保存，防止 CascadingComboBox 清空选中项时写入空值
+        if (_suppressConfigSave) return;
         SaveConfig();
         WriteConfig(SelectedConfig);
     }


### PR DESCRIPTION
## 新增自动秘境自定义配置组执行

### 功能说明

一条龙的自动秘境支持添加自定义配置组（ScriptGroup）作为秘境选项。选中自定义配置组后，一条龙执行时运行对应的脚本配置组而非标准秘境任务。

- 每日秘境和每周秘境配置区域均可通过 +/- 按钮管理自定义配置组
- 自定义配置组在级联菜单中以"自定义"分类展示
- 每个配置单独立存储自定义列表，持久化到 JSON，旧版本配置文件向后兼容

### 涉及文件

| 文件 | 改动说明 |
|------|----------|
| `Core/Config/OneDragonFlowConfig.cs` | 新增 `CustomDomainList` 属性 |
| `Helpers/DomainCascadingItems.cs` | 支持 `Rebuild()` 动态插入"自定义"分类 |
| `Model/OneDragonTaskItem.cs` | 自动秘境执行时判断自定义配置组，内联执行 ScriptGroup |
| `Service/ScriptService.cs` | 新增 `ExecuteProjectPublic` 避免 TaskRunner 冲突 |
| `View/Pages/OneDragonFlowPage.xaml` | XAML Popup 实现添加/删除对话框，绑定 DomainItems |
| `View/Pages/OneDragonFlowPage.xaml.cs` | Popup 打开时刷新列表、关闭弹窗事件 |
| `ViewModel/Pages/OneDragonFlowViewModel.cs` | 数据属性 + 确认命令，无 UI 代码 |

### 技术要点

- UI 对话框全部在 XAML 中定义（ToggleButton + Popup + ComboBox），ViewModel 只暴露数据属性和命令
- `DomainCascadingItems.Rebuild()` 重建级联数据后，仅在添加/删除时更新 `ItemsSource`，配置切换时不更新，防止 `CascadingComboBox` 丢失选中项
- 更新 `ItemsSource` 时临时保存并恢复所有 DomainName 字段，抑制自动保存，防止空值被持久化
- 自定义配置组执行通过 `ScriptService.ExecuteProjectPublic` 内联执行，不创建新 TaskRunner，避免"当前存在正在运行中的独立任务"冲突
- `CustomDomainList` 操作后重新赋值 `new List<string>(...)` 触发 PropertyChanged，确保 Popup 中的 ComboBox 实时刷新


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 支持在秘境刷取配置中添加/删除自定义配置组，界面新增“+/-”按钮、弹窗与选择控件。
  * 新增内联批量执行方法，自动秘境任务可识别并运行自定义配置组内脚本。

* **Improvements**
  * 可用脚本组列表支持刷新并在运行时重建级联选择器数据源，保留并恢复用户已选项与界面状态。
  * 增加可视化状态属性与命令（刷新/确认添加/确认移除），并在弹窗打开时自动刷新列表。
  * 提供显式重建与同步机制以反映自定义组变更。

* **Bug Fixes**
  * 对自定义脚本加载增加存在性检查、错误处理与日志，提升执行鲁棒性并避免误触发原有流程。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->