### PR TITLE
新增自动秘境支持选择一条龙任务和配置组执行

### DIFF
--- a/BetterGenshinImpact/Helpers/DomainCascadingItems.cs
+++ b/BetterGenshinImpact/Helpers/DomainCascadingItems.cs
@@ -1,18 +1,90 @@
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using BetterGenshinImpact.Core.Config;
 using BetterGenshinImpact.GameTask.Common.Element.Assets;
 using Wpf.Ui.Violeta.Controls;
 
 namespace BetterGenshinImpact.Helpers;
 
+/// <summary>
+/// 秘境级联选择器数据源：一条龙任务 + 配置组 + 标准秘境（按国家分组）
+/// 输出 Dictionary&lt;string, List&lt;string&gt;&gt; 供 CascadeSelector 控件使用
+/// </summary>
 public static class DomainCascadingItems
 {
-    private static IReadOnlyList<ICascadingItem>? _items;
+    private static Dictionary<string, List<string>>? _options;
 
-    public static IReadOnlyList<ICascadingItem> Items =>
-        _items ??= BuildItems();
+    /// <summary>
+    /// 一条龙默认任务名称列表（由 ViewModel 初始化时设置）
+    /// </summary>
+    public static List<string> DefaultTaskNames { get; set; } = new();
 
-    private static IReadOnlyList<ICascadingItem> BuildItems()
+    /// <summary>
+    /// 级联选项数据源（一级分类 → 二级列表），供 CascadeSelector 控件使用
+    /// </summary>
+    public static Dictionary<string, List<string>> Options =>
+        _options ??= BuildOptions();
+
+    /// <summary>
+    /// ICascadingItem 格式数据源，供 TaskSettingsPage 的 CascadingComboBox 使用
+    /// </summary>
+    public static IReadOnlyList<ICascadingItem> Items => BuildCascadingItems();
+
+    /// <summary>
+    /// 重建级联数据（页面加载时调用）
+    /// </summary>
+    public static void Rebuild()
+    {
+        _options = BuildOptions();
+    }
+
+    private static Dictionary<string, List<string>> BuildOptions()
+    {
+        var options = new Dictionary<string, List<string>>();
+
+        // 一条龙任务分类
+        if (DefaultTaskNames.Count > 0)
+        {
+            options["一条龙任务"] = new List<string>(DefaultTaskNames);
+        }
+
+        // 配置组分类（自动扫描 ScriptGroup 目录）
+        var scriptGroupPath = Global.Absolute(@"User\ScriptGroup");
+        if (Directory.Exists(scriptGroupPath))
+        {
+            var scripts = Directory.GetFiles(scriptGroupPath, "*.json")
+                .Select(Path.GetFileNameWithoutExtension)
+                .Where(n => !string.IsNullOrEmpty(n))
+                .OrderBy(n => n)
+                .ToList();
+            if (scripts.Count > 0)
+            {
+                options["配置组"] = scripts!;
+            }
+        }
+
+        // 标准秘境分类（按国家分组，显示名称带奖励信息）
+        foreach (var country in MapLazyAssets.Instance.CountryToDomains.Keys.Reverse())
+        {
+            var domains = MapLazyAssets.Instance.CountryToDomains[country]
+                .AsEnumerable()
+                .Reverse()
+                .Select(d => d.Name!)
+                .ToList();
+            if (domains.Count > 0)
+            {
+                options[country] = domains;
+            }
+        }
+
+        return options;
+    }
+
+    /// <summary>
+    /// 构建 ICascadingItem 格式数据（兼容 TaskSettingsPage 的 CascadingComboBox）
+    /// </summary>
+    private static IReadOnlyList<ICascadingItem> BuildCascadingItems()
     {
         return MapLazyAssets.Instance.CountryToDomains.Keys
             .Reverse()

--- a/BetterGenshinImpact/Helpers/DomainCascadingItems.cs
+++ b/BetterGenshinImpact/Helpers/DomainCascadingItems.cs
@@ -9,25 +9,34 @@ namespace BetterGenshinImpact.Helpers;
 
 /// <summary>
 /// 秘境级联选择器数据源：一条龙任务 + 配置组 + 标准秘境（按国家分组）
-/// 输出 Dictionary&lt;string, List&lt;string&gt;&gt; 供 CascadeSelector 控件使用
+/// 
+/// 存储格式约定：DomainName 使用 "type:name" 前缀区分来源
+///   - "task:领取邮件"   → 一条龙默认任务
+///   - "script:我的配置" → 配置组（ScriptGroup）
+///   - "忘却之峡"        → 标准秘境（无前缀，向后兼容）
 /// </summary>
 public static class DomainCascadingItems
 {
+    /// <summary>类型前缀：一条龙默认任务</summary>
+    public const string TaskPrefix = "task:";
+    /// <summary>类型前缀：配置组</summary>
+    public const string ScriptPrefix = "script:";
+
     private static Dictionary<string, List<string>>? _options;
 
     /// <summary>
-    /// 一条龙默认任务名称列表（由 ViewModel 初始化时设置）
+    /// 一条龙默认任务名称列表（由 ViewModel 初始化时设置，不含"自动秘境"自身）
     /// </summary>
     public static List<string> DefaultTaskNames { get; set; } = new();
 
     /// <summary>
-    /// 级联选项数据源（一级分类 → 二级列表），供 CascadeSelector 控件使用
+    /// 级联选项数据源（一级分类 → 二级列表），值带类型前缀
     /// </summary>
     public static Dictionary<string, List<string>> Options =>
         _options ??= BuildOptions();
 
     /// <summary>
-    /// ICascadingItem 格式数据源，供 TaskSettingsPage 的 CascadingComboBox 使用
+    /// ICascadingItem 格式数据源，供 TaskSettingsPage 的 CascadingComboBox 使用（仅标准秘境）
     /// </summary>
     public static IReadOnlyList<ICascadingItem> Items => BuildCascadingItems();
 
@@ -39,17 +48,33 @@ public static class DomainCascadingItems
         _options = BuildOptions();
     }
 
+    /// <summary>
+    /// 从带前缀的 DomainName 中解析类型和名称
+    /// </summary>
+    public static (string type, string name) Parse(string? domainName)
+    {
+        if (string.IsNullOrEmpty(domainName))
+            return ("", "");
+        if (domainName.StartsWith(TaskPrefix))
+            return ("task", domainName[TaskPrefix.Length..]);
+        if (domainName.StartsWith(ScriptPrefix))
+            return ("script", domainName[ScriptPrefix.Length..]);
+        return ("domain", domainName); // 标准秘境无前缀
+    }
+
     private static Dictionary<string, List<string>> BuildOptions()
     {
         var options = new Dictionary<string, List<string>>();
 
-        // 一条龙任务分类
+        // 一条龙任务分类（带 task: 前缀）
         if (DefaultTaskNames.Count > 0)
         {
-            options["一条龙任务"] = new List<string>(DefaultTaskNames);
+            options["一条龙任务"] = DefaultTaskNames
+                .Select(n => TaskPrefix + n)
+                .ToList();
         }
 
-        // 配置组分类（自动扫描 ScriptGroup 目录）
+        // 配置组分类（带 script: 前缀，自动扫描 ScriptGroup 目录）
         var scriptGroupPath = Global.Absolute(@"User\ScriptGroup");
         if (Directory.Exists(scriptGroupPath))
         {
@@ -57,14 +82,15 @@ public static class DomainCascadingItems
                 .Select(Path.GetFileNameWithoutExtension)
                 .Where(n => !string.IsNullOrEmpty(n))
                 .OrderBy(n => n)
+                .Select(n => ScriptPrefix + n)
                 .ToList();
             if (scripts.Count > 0)
             {
-                options["配置组"] = scripts!;
+                options["配置组"] = scripts;
             }
         }
 
-        // 标准秘境分类（按国家分组，显示名称带奖励信息）
+        // 标准秘境分类（无前缀，向后兼容）
         foreach (var country in MapLazyAssets.Instance.CountryToDomains.Keys.Reverse())
         {
             var domains = MapLazyAssets.Instance.CountryToDomains[country]
@@ -82,7 +108,7 @@ public static class DomainCascadingItems
     }
 
     /// <summary>
-    /// 构建 ICascadingItem 格式数据（兼容 TaskSettingsPage 的 CascadingComboBox）
+    /// 构建 ICascadingItem 格式数据（兼容 TaskSettingsPage 的 CascadingComboBox，仅标准秘境）
     /// </summary>
     private static IReadOnlyList<ICascadingItem> BuildCascadingItems()
     {

--- a/BetterGenshinImpact/Helpers/DomainCascadingItems.cs
+++ b/BetterGenshinImpact/Helpers/DomainCascadingItems.cs
@@ -62,9 +62,15 @@ public static class DomainCascadingItems
         return ("domain", domainName); // 标准秘境无前缀
     }
 
+    /// <summary>
+    /// 标准秘境的显示名称映射（"秘境名" → "秘境名 | 奖励物料"），供 CascadeSelector 二级列表显示
+    /// </summary>
+    public static Dictionary<string, string> DomainDisplayNames { get; private set; } = new();
+
     private static Dictionary<string, List<string>> BuildOptions()
     {
         var options = new Dictionary<string, List<string>>();
+        DomainDisplayNames.Clear();
 
         // 一条龙任务分类（带 task: 前缀）
         if (DefaultTaskNames.Count > 0)
@@ -90,17 +96,22 @@ public static class DomainCascadingItems
             }
         }
 
-        // 标准秘境分类（无前缀，向后兼容）
+        // 标准秘境分类（无前缀，向后兼容；同时构建显示名称映射）
         foreach (var country in MapLazyAssets.Instance.CountryToDomains.Keys.Reverse())
         {
             var domains = MapLazyAssets.Instance.CountryToDomains[country]
                 .AsEnumerable()
                 .Reverse()
-                .Select(d => d.Name!)
                 .ToList();
-            if (domains.Count > 0)
+            var names = new List<string>();
+            foreach (var d in domains)
             {
-                options[country] = domains;
+                names.Add(d.Name!);
+                DomainDisplayNames[d.Name!] = d.Name! + " | " + string.Join(" ", d.Rewards);
+            }
+            if (names.Count > 0)
+            {
+                options[country] = names;
             }
         }
 

--- a/BetterGenshinImpact/Model/OneDragonTaskItem.cs
+++ b/BetterGenshinImpact/Model/OneDragonTaskItem.cs
@@ -1,16 +1,21 @@
 ﻿using System;
+using System.IO;
 using System.Threading.Tasks;
 using BetterGenshinImpact.ViewModel.Pages.OneDragon;
 using CommunityToolkit.Mvvm.ComponentModel;
 using System.Windows.Media;
 using BetterGenshinImpact.Core.Config;
+using BetterGenshinImpact.Helpers;
 using BetterGenshinImpact.Core.Script;
+using BetterGenshinImpact.Core.Script.Group;
 using BetterGenshinImpact.GameTask;
 using BetterGenshinImpact.GameTask.AutoDomain;
 using BetterGenshinImpact.GameTask.AutoLeyLineOutcrop;
 using BetterGenshinImpact.GameTask.AutoStygianOnslaught;
 using BetterGenshinImpact.GameTask.Common;
 using BetterGenshinImpact.GameTask.Common.Job;
+using BetterGenshinImpact.Service;
+using BetterGenshinImpact.Service.Interface;
 using BetterGenshinImpact.ViewModel.Pages;
 using Microsoft.Extensions.Logging;
 
@@ -98,18 +103,60 @@ public partial class OneDragonTaskItem : ObservableObject
                         TaskControl.Logger.LogError("一条龙配置内{Msg}需要刷的秘境，跳过", "未选择");
                         return;
                     }
+
+                    // 判断是否为非标准秘境（一条龙任务或配置组）
+                    var scriptFilePath = Global.Absolute($@"User\ScriptGroup\{domainName}.json");
+                    var isScriptGroup = File.Exists(scriptFilePath);
+                    var isDefaultTask = DomainCascadingItems.DefaultTaskNames.Contains(domainName);
+
+                    if (isScriptGroup || isDefaultTask)
+                    {
+                        try
+                        {
+                            if (isScriptGroup)
+                            {
+                                // 配置组：加载并内联执行
+                                TaskControl.Logger.LogInformation("自动秘境任务：执行配置组 {Name}", domainName);
+                                var group = ScriptGroup.FromJson(await File.ReadAllTextAsync(scriptFilePath));
+                                var projects = ScriptControlViewModel.GetNextProjects(group);
+
+                                var scriptService = App.GetService<IScriptService>() as ScriptService;
+                                if (scriptService == null)
+                                {
+                                    TaskControl.Logger.LogError("ScriptService 获取失败，跳过");
+                                    return;
+                                }
+
+                                await scriptService.RunMultiInline(projects, domainName);
+                            }
+                            else
+                            {
+                                // 一条龙默认任务：创建临时 TaskItem 执行
+                                TaskControl.Logger.LogInformation("自动秘境任务：执行一条龙任务 {Name}", domainName);
+                                var taskItem = new OneDragonTaskItem(domainName);
+                                taskItem.InitAction(config);
+                                if (taskItem.Action != null)
+                                {
+                                    await taskItem.Action();
+                                }
+                            }
+                        }
+                        catch (Exception e)
+                        {
+                            TaskControl.Logger.LogError(e, "非标准秘境 {Name} 执行异常，文件：{Path}", domainName, scriptFilePath);
+                        }
+                    }
                     else
                     {
                         TaskControl.Logger.LogInformation("自动秘境任务：执行");
+                        var autoDomainParam = new AutoDomainParam(0, path)
+                        {
+                            PartyName = partyName,
+                            DomainName = domainName,
+                            SundaySelectedValue = sundaySelectedValue
+                        };
+                        await new AutoDomainTask(autoDomainParam).Start(CancellationContext.Instance.Cts.Token);
                     }
-
-                    var autoDomainParam = new AutoDomainParam(0, path)
-                    {
-                        PartyName = partyName,
-                        DomainName = domainName,
-                        SundaySelectedValue = sundaySelectedValue
-                    };
-                    await new AutoDomainTask(autoDomainParam).Start(CancellationContext.Instance.Cts.Token);
                 };
                 break;
             case "自动幽境危战":

--- a/BetterGenshinImpact/Model/OneDragonTaskItem.cs
+++ b/BetterGenshinImpact/Model/OneDragonTaskItem.cs
@@ -104,55 +104,71 @@ public partial class OneDragonTaskItem : ObservableObject
                         return;
                     }
 
-                    // 判断是否为非标准秘境（一条龙任务或配置组）
-                    var scriptFilePath = Global.Absolute($@"User\ScriptGroup\{domainName}.json");
-                    var isScriptGroup = File.Exists(scriptFilePath);
-                    var isDefaultTask = DomainCascadingItems.DefaultTaskNames.Contains(domainName);
+                    // 解析 DomainName 的类型前缀，确定执行路径
+                    var (domainType, domainDisplayName) = DomainCascadingItems.Parse(domainName);
 
-                    if (isScriptGroup || isDefaultTask)
+                    if (domainType == "script")
                     {
+                        // 配置组：加载并内联执行
                         try
                         {
-                            if (isScriptGroup)
+                            var scriptFilePath = Global.Absolute($@"User\ScriptGroup\{domainDisplayName}.json");
+                            if (!File.Exists(scriptFilePath))
                             {
-                                // 配置组：加载并内联执行
-                                TaskControl.Logger.LogInformation("自动秘境任务：执行配置组 {Name}", domainName);
-                                var group = ScriptGroup.FromJson(await File.ReadAllTextAsync(scriptFilePath));
-                                var projects = ScriptControlViewModel.GetNextProjects(group);
-
-                                var scriptService = App.GetService<IScriptService>() as ScriptService;
-                                if (scriptService == null)
-                                {
-                                    TaskControl.Logger.LogError("ScriptService 获取失败，跳过");
-                                    return;
-                                }
-
-                                await scriptService.RunMultiInline(projects, domainName);
+                                TaskControl.Logger.LogError("配置组 {Name} 对应的文件不存在，跳过", domainDisplayName);
+                                return;
                             }
-                            else
+
+                            TaskControl.Logger.LogInformation("自动秘境任务：执行配置组 {Name}", domainDisplayName);
+                            var group = ScriptGroup.FromJson(await File.ReadAllTextAsync(scriptFilePath));
+                            var projects = ScriptControlViewModel.GetNextProjects(group);
+
+                            var scriptService = App.GetService<IScriptService>() as ScriptService;
+                            if (scriptService == null)
                             {
-                                // 一条龙默认任务：创建临时 TaskItem 执行
-                                TaskControl.Logger.LogInformation("自动秘境任务：执行一条龙任务 {Name}", domainName);
-                                var taskItem = new OneDragonTaskItem(domainName);
-                                taskItem.InitAction(config);
-                                if (taskItem.Action != null)
-                                {
-                                    await taskItem.Action();
-                                }
+                                TaskControl.Logger.LogError("ScriptService 获取失败，跳过");
+                                return;
+                            }
+
+                            await scriptService.RunMultiInline(projects, domainDisplayName);
+                        }
+                        catch (Exception e)
+                        {
+                            TaskControl.Logger.LogError(e, "配置组 {Name} 执行异常", domainDisplayName);
+                        }
+                    }
+                    else if (domainType == "task")
+                    {
+                        // 一条龙默认任务：防止递归调用自身
+                        if (domainDisplayName == "自动秘境")
+                        {
+                            TaskControl.Logger.LogError("不能在自动秘境中选择自动秘境自身，跳过");
+                            return;
+                        }
+
+                        try
+                        {
+                            TaskControl.Logger.LogInformation("自动秘境任务：执行一条龙任务 {Name}", domainDisplayName);
+                            var taskItem = new OneDragonTaskItem(domainDisplayName);
+                            taskItem.InitAction(config);
+                            if (taskItem.Action != null)
+                            {
+                                await taskItem.Action();
                             }
                         }
                         catch (Exception e)
                         {
-                            TaskControl.Logger.LogError(e, "非标准秘境 {Name} 执行异常，文件：{Path}", domainName, scriptFilePath);
+                            TaskControl.Logger.LogError(e, "一条龙任务 {Name} 执行异常", domainDisplayName);
                         }
                     }
                     else
                     {
+                        // 标准秘境：使用解析后的显示名称（无前缀）
                         TaskControl.Logger.LogInformation("自动秘境任务：执行");
                         var autoDomainParam = new AutoDomainParam(0, path)
                         {
                             PartyName = partyName,
-                            DomainName = domainName,
+                            DomainName = domainDisplayName,
                             SundaySelectedValue = sundaySelectedValue
                         };
                         await new AutoDomainTask(autoDomainParam).Start(CancellationContext.Instance.Cts.Token);

--- a/BetterGenshinImpact/Service/ScriptService.cs
+++ b/BetterGenshinImpact/Service/ScriptService.cs
@@ -504,6 +504,90 @@ public partial class ScriptService : IScriptService
     //     return jsProjects;
     // }
 
+    /// <summary>
+    /// 内联执行配置组项目列表，复用 RunMulti 的全部语义（跳过规则、月卡检测、触发器清理、通知等），
+    /// 但不创建新的 TaskRunner，供一条龙等已在 TaskRunner 内的场景调用。
+    /// </summary>
+    public async Task RunMultiInline(IEnumerable<ScriptGroupProject> projectList, string? groupName = null)
+    {
+        groupName ??= "默认";
+        var list = ReloadScriptProjects(projectList);
+        foreach (var p in projectList) p.SkipFlag = false;
+
+        _logger.LogInformation("配置组 {Name} 加载完成，共{Cnt}个脚本，开始内联执行", groupName, list.Count);
+
+        bool first = true;
+        _projectExecutionCount.Clear();
+        var stopwatch = new Stopwatch();
+
+        for (int x = 0; x < list.Count; x++)
+        {
+            var project = list[x];
+
+            if (project is { SkipFlag: true }) continue;
+            if (ShouldSkipTask(project)) continue;
+
+            // 月卡检测
+            await _blessingOfTheWelkinMoonTask.Start(CancellationContext.Instance.Cts.Token);
+
+            if (project.Status != "Enabled")
+            {
+                _logger.LogInformation("脚本 {Name} 状态为禁用，跳过执行", project.Name);
+                continue;
+            }
+
+            if (CancellationContext.Instance.Cts.IsCancellationRequested) break;
+
+            if (first)
+            {
+                first = false;
+                Notify.Event(NotificationEvent.GroupStart).Success($"配置组{groupName}启动");
+            }
+
+            for (var i = 0; i < project.RunNum; i++)
+            {
+                try
+                {
+                    TaskTriggerDispatcher.Instance().ClearTriggers();
+                    _logger.LogInformation("------------------------------");
+                    stopwatch.Reset();
+                    stopwatch.Start();
+
+                    await ExecuteProject(project);
+
+                    if (project.RunNum > 1 && ShouldSkipTask(project)) continue;
+                }
+                catch (NormalEndException) { throw; }
+                catch (TaskCanceledException e)
+                {
+                    _logger.LogInformation("取消执行配置组: {Msg}", e.Message);
+                    throw;
+                }
+                catch (Exception e)
+                {
+                    _logger.LogDebug(e, "执行脚本时发生异常");
+                    _logger.LogError("执行脚本时发生异常: {Msg}", e.Message);
+                }
+                finally
+                {
+                    stopwatch.Stop();
+                    var elapsed = TimeSpan.FromMilliseconds(stopwatch.ElapsedMilliseconds);
+                    _logger.LogInformation("→ 脚本执行结束: {Name}, 耗时: {Minutes}分{Seconds:0.000}秒",
+                        project.Name, elapsed.Hours * 60 + elapsed.Minutes, elapsed.TotalSeconds % 60);
+                    _logger.LogInformation("------------------------------");
+                }
+
+                await Task.Delay(1000);
+            }
+        }
+
+        _logger.LogInformation("配置组 {Name} 内联执行结束", groupName);
+        if (!first && CancellationContext.Instance.IsManualStop is false)
+        {
+            Notify.Event(NotificationEvent.GroupEnd).Success($"配置组{groupName}结束");
+        }
+    }
+
     private async Task ExecuteProject(ScriptGroupProject project)
     {
         TaskContext.Instance().CurrentScriptProject = project;

--- a/BetterGenshinImpact/View/Controls/CascadeSelector.xaml
+++ b/BetterGenshinImpact/View/Controls/CascadeSelector.xaml
@@ -44,9 +44,10 @@
                PlacementTarget="{Binding ElementName=MainToggle}"
                StaysOpen="False"
                AllowsTransparency="True"
-               PopupAnimation="Slide"
+               PopupAnimation="None"
                Opened="MainPopup_Opened"
                Closed="MainPopup_Closed">
+            <!-- 固定尺寸的弹窗容器，防止内容变化时抖动 -->
             <Border x:Name="PopupBorder"
                     Background="{DynamicResource ApplicationBackgroundBrush}"
                     BorderBrush="{DynamicResource SurfaceStrokeColorDefaultBrush}"
@@ -54,19 +55,17 @@
                     CornerRadius="8"
                     Margin="0,4,0,0"
                     Padding="4"
-                    MinHeight="100"
-                    MaxHeight="300"
-                    MinWidth="120"
-                    MaxWidth="600"
+                    Width="400"
+                    Height="350"
                     PreviewMouseWheel="PopupBorder_PreviewMouseWheel">
                 <Border.Effect>
                     <DropShadowEffect BlurRadius="10" ShadowDepth="2" Direction="270" Color="Black" Opacity="0.2"/>
                 </Border.Effect>
                 <Grid>
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="Auto" MinWidth="100"/>
+                        <ColumnDefinition Width="*"/>
                         <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="Auto" MinWidth="100"/>
+                        <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>
 
                     <ui:ListView x:Name="FirstLevelListView"

--- a/BetterGenshinImpact/View/Controls/CascadeSelector.xaml
+++ b/BetterGenshinImpact/View/Controls/CascadeSelector.xaml
@@ -55,7 +55,8 @@
                     CornerRadius="8"
                     Margin="0,4,0,0"
                     Padding="4"
-                    Width="400"
+                    MinWidth="300"
+                    MaxWidth="800"
                     Height="350"
                     PreviewMouseWheel="PopupBorder_PreviewMouseWheel">
                 <Border.Effect>
@@ -63,9 +64,9 @@
                 </Border.Effect>
                 <Grid>
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto" MinWidth="80" MaxWidth="120"/>
                         <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="Auto" MinWidth="200"/>
                     </Grid.ColumnDefinitions>
 
                     <ui:ListView x:Name="FirstLevelListView"

--- a/BetterGenshinImpact/View/Controls/CascadeSelector.xaml
+++ b/BetterGenshinImpact/View/Controls/CascadeSelector.xaml
@@ -27,7 +27,7 @@
                                 <ColumnDefinition Width="*"/>
                                 <ColumnDefinition Width="Auto"/>
                             </Grid.ColumnDefinitions>
-                            <TextBlock Text="{Binding SelectedValue, ElementName=Root, TargetNullValue='请选择', FallbackValue='请选择'}"
+                            <TextBlock Text="{Binding DisplayValue, ElementName=Root, TargetNullValue='请选择', FallbackValue='请选择'}"
                                        VerticalAlignment="Center"
                                        Margin="5,0,0,0"
                                        TextTrimming="CharacterEllipsis"/>

--- a/BetterGenshinImpact/View/Controls/CascadeSelector.xaml.cs
+++ b/BetterGenshinImpact/View/Controls/CascadeSelector.xaml.cs
@@ -104,9 +104,22 @@ public partial class CascadeSelector : UserControl
         DependencyProperty.Register("DisplayValue", typeof(string), typeof(CascadeSelector), new PropertyMetadata(null));
 
     /// <summary>
-    /// 去掉类型前缀，返回显示名称
+    /// 去掉类型前缀，返回显示名称（标准秘境附加奖励信息）
     /// </summary>
     private static string StripPrefix(string value)
+    {
+        if (value.StartsWith("task:")) return value[5..];
+        if (value.StartsWith("script:")) return value[7..];
+        // 标准秘境：查显示名称映射，附加奖励信息
+        if (Helpers.DomainCascadingItems.DomainDisplayNames.TryGetValue(value, out var display))
+            return display;
+        return value;
+    }
+
+    /// <summary>
+    /// 去掉类型前缀，返回简短名称（用于 ToggleButton 文本，不带奖励）
+    /// </summary>
+    private static string StripPrefixShort(string value)
     {
         if (value.StartsWith("task:")) return value[5..];
         if (value.StartsWith("script:")) return value[7..];
@@ -122,8 +135,8 @@ public partial class CascadeSelector : UserControl
 
     private void HandleSelectedValueChanged(string? newValue)
     {
-        // 更新显示值（去掉前缀）
-        DisplayValue = string.IsNullOrEmpty(newValue) ? null : StripPrefix(newValue);
+        // 更新显示值（去掉前缀，ToggleButton 显示简短名称）
+        DisplayValue = string.IsNullOrEmpty(newValue) ? null : StripPrefixShort(newValue);
 
         if (string.IsNullOrEmpty(newValue) || CascadeOptions == null)
         {

--- a/BetterGenshinImpact/View/Controls/CascadeSelector.xaml.cs
+++ b/BetterGenshinImpact/View/Controls/CascadeSelector.xaml.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
@@ -11,13 +10,6 @@ namespace BetterGenshinImpact.View.Controls;
 
 public partial class CascadeSelector : UserControl
 {
-    private const double HorizontalMargin = 40;
-    private const double MinFirstLevelWidth = 100;
-    private const double MaxFirstLevelWidth = 300;
-    private const double MinSecondLevelWidth = 100;
-    private const double MaxSecondLevelWidth = 300;
-    private const double MinPopupWidth = 120;
-    private const double MaxPopupWidth = 600;
 
     public CascadeSelector()
     {
@@ -29,7 +21,6 @@ public partial class CascadeSelector : UserControl
     private void OnLoaded(object sender, RoutedEventArgs e)
     {
         UpdateFirstLevelOptions();
-        UpdatePopupWidth();
     }
 
     /// <summary>
@@ -73,16 +64,7 @@ public partial class CascadeSelector : UserControl
 
     public static readonly DependencyProperty SecondLevelOptionsProperty =
         DependencyProperty.Register("SecondLevelOptions", typeof(List<string>), typeof(CascadeSelector), 
-            new PropertyMetadata(null, OnSecondLevelOptionsChanged));
-
-    private static void OnSecondLevelOptionsChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
-    {
-        var control = (CascadeSelector)d;
-        control.Dispatcher.BeginInvoke(() =>
-        {
-            control.AdjustSecondLevelListWidth();
-        }, System.Windows.Threading.DispatcherPriority.Render);
-    }
+            new PropertyMetadata(null));
 
     public string? SelectedValue
     {
@@ -109,141 +91,9 @@ public partial class CascadeSelector : UserControl
     public static readonly DependencyProperty DefaultValueProperty =
         DependencyProperty.Register("DefaultValue", typeof(string), typeof(CascadeSelector), new PropertyMetadata(null));
 
-    private double MeasureTextWidth(string text, double fontSize)
-    {
-        if (string.IsNullOrEmpty(text))
-        {
-            return 0;
-        }
-
-        var formattedText = new FormattedText(
-            text,
-            CultureInfo.CurrentCulture,
-            FlowDirection.LeftToRight,
-            new Typeface(FontFamily, FontStyle, FontWeight, FontStretch),
-            fontSize,
-            Brushes.Black,
-            new NumberSubstitution(),
-            TextFormattingMode.Display,
-            VisualTreeHelper.GetDpi(this).PixelsPerDip);
-        return formattedText.WidthIncludingTrailingWhitespace;
-    }
-
-    private void AdjustFirstLevelListWidth()
-    {
-        if (FirstLevelOptions == null || FirstLevelOptions.Count == 0)
-        {
-            return;
-        }
-
-        double maxWidth = MinFirstLevelWidth;
-        foreach (var option in FirstLevelOptions)
-        {
-            double textWidth = MeasureTextWidth(option, FontSize) + HorizontalMargin;
-            if (textWidth > maxWidth)
-            {
-                maxWidth = textWidth;
-            }
-        }
-
-        if (maxWidth > MaxFirstLevelWidth)
-        {
-            maxWidth = MaxFirstLevelWidth;
-        }
-
-        var grid = PopupBorder?.Child as Grid;
-        var firstColumn = grid?.ColumnDefinitions[0];
-        if (firstColumn != null)
-        {
-            firstColumn.Width = new GridLength(maxWidth);
-        }
-    }
-
-    private void AdjustSecondLevelListWidth()
-    {
-        if (SecondLevelOptions == null || SecondLevelOptions.Count == 0)
-        {
-            UpdatePopupWidth();
-            return;
-        }
-
-        double maxWidth = MinSecondLevelWidth;
-        foreach (var option in SecondLevelOptions)
-        {
-            double textWidth = MeasureTextWidth(option, FontSize) + HorizontalMargin;
-            if (textWidth > maxWidth)
-            {
-                maxWidth = textWidth;
-            }
-        }
-
-        if (maxWidth > MaxSecondLevelWidth)
-        {
-            maxWidth = MaxSecondLevelWidth;
-        }
-
-        var grid = PopupBorder?.Child as Grid;
-        var thirdColumn = grid?.ColumnDefinitions[2];
-        if (thirdColumn != null)
-        {
-            thirdColumn.Width = new GridLength(maxWidth);
-        }
-
-        Dispatcher.BeginInvoke(() => UpdatePopupWidth(), System.Windows.Threading.DispatcherPriority.Render);
-    }
-
-    private void UpdatePopupWidth()
-    {
-        var grid = PopupBorder?.Child as Grid;
-        if (grid == null || grid.ColumnDefinitions.Count < 3)
-        {
-            return;
-        }
-
-        double totalWidth = 0;
-
-        var firstColumn = grid.ColumnDefinitions[0];
-        var secondColumn = grid.ColumnDefinitions[1];
-        var thirdColumn = grid.ColumnDefinitions[2];
-
-        if (firstColumn.Width.IsAuto)
-        {
-            firstColumn.Width = new GridLength(MinFirstLevelWidth);
-        }
-        totalWidth += firstColumn.Width.Value;
-
-        totalWidth += secondColumn.Width.Value;
-        totalWidth += thirdColumn.Width.Value;
-
-        totalWidth += 8;
-
-        if (totalWidth < MinPopupWidth)
-        {
-            totalWidth = MinPopupWidth;
-        }
-        if (totalWidth > MaxPopupWidth)
-        {
-            totalWidth = MaxPopupWidth;
-        }
-
-        PopupBorder.Width = totalWidth;
-    }
-
     private void UpdateFirstLevelOptions()
     {
-        if (CascadeOptions != null)
-        {
-            FirstLevelOptions = CascadeOptions.Keys.ToList();
-            Dispatcher.BeginInvoke(() =>
-            {
-                AdjustFirstLevelListWidth();
-                UpdatePopupWidth();
-            }, System.Windows.Threading.DispatcherPriority.Render);
-        }
-        else
-        {
-            FirstLevelOptions = new List<string>();
-        }
+        FirstLevelOptions = CascadeOptions?.Keys.ToList() ?? new List<string>();
     }
 
     private void HandleSelectedValueChanged(string? newValue)

--- a/BetterGenshinImpact/View/Controls/CascadeSelector.xaml.cs
+++ b/BetterGenshinImpact/View/Controls/CascadeSelector.xaml.cs
@@ -91,13 +91,40 @@ public partial class CascadeSelector : UserControl
     public static readonly DependencyProperty DefaultValueProperty =
         DependencyProperty.Register("DefaultValue", typeof(string), typeof(CascadeSelector), new PropertyMetadata(null));
 
+    /// <summary>
+    /// 显示用的值（去掉类型前缀），供 ToggleButton 文本绑定
+    /// </summary>
+    public string? DisplayValue
+    {
+        get { return (string?)GetValue(DisplayValueProperty); }
+        set { SetValue(DisplayValueProperty, value); }
+    }
+
+    public static readonly DependencyProperty DisplayValueProperty =
+        DependencyProperty.Register("DisplayValue", typeof(string), typeof(CascadeSelector), new PropertyMetadata(null));
+
+    /// <summary>
+    /// 去掉类型前缀，返回显示名称
+    /// </summary>
+    private static string StripPrefix(string value)
+    {
+        if (value.StartsWith("task:")) return value[5..];
+        if (value.StartsWith("script:")) return value[7..];
+        return value;
+    }
+
     private void UpdateFirstLevelOptions()
     {
         FirstLevelOptions = CascadeOptions?.Keys.ToList() ?? new List<string>();
+        // 数据源变化后重新同步当前选中项的定位
+        HandleSelectedValueChanged(SelectedValue);
     }
 
     private void HandleSelectedValueChanged(string? newValue)
     {
+        // 更新显示值（去掉前缀）
+        DisplayValue = string.IsNullOrEmpty(newValue) ? null : StripPrefix(newValue);
+
         if (string.IsNullOrEmpty(newValue) || CascadeOptions == null)
         {
             return;
@@ -108,20 +135,28 @@ public partial class CascadeSelector : UserControl
             if (kvp.Value.Contains(newValue))
             {
                 FirstLevelListView.SelectedItem = kvp.Key;
-                SecondLevelOptions = kvp.Value;
-                SecondLevelListView.SelectedItem = newValue;
+                _secondLevelDisplayNames = kvp.Value.Select(StripPrefix).ToList();
+                SecondLevelOptions = _secondLevelDisplayNames;
+                SecondLevelListView.SelectedItem = StripPrefix(newValue);
                 break;
             }
         }
     }
 
+    /// <summary>
+    /// 当前二级列表的显示名称（去掉前缀）
+    /// </summary>
+    private List<string> _secondLevelDisplayNames = new();
+
     private void FirstLevelListView_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
         if (FirstLevelListView.SelectedItem is string selectedFirstLevel)
         {
-            if (CascadeOptions != null && CascadeOptions.TryGetValue(selectedFirstLevel, out var secondLevelOptions))
+            if (CascadeOptions != null && CascadeOptions.TryGetValue(selectedFirstLevel, out var secondLevelValues))
             {
-                SecondLevelOptions = secondLevelOptions;
+                // 存储原始值用于选择时回写
+                _secondLevelDisplayNames = secondLevelValues.Select(StripPrefix).ToList();
+                SecondLevelOptions = _secondLevelDisplayNames;
                 SecondLevelListView.SelectedItem = null;
             }
         }
@@ -129,9 +164,20 @@ public partial class CascadeSelector : UserControl
 
     private void SecondLevelListView_SelectionChanged(object sender, SelectionChangedEventArgs e)
     {
-        if (SecondLevelListView.SelectedItem is string selectedSecondLevel)
+        if (SecondLevelListView.SelectedItem is string selectedDisplay)
         {
-            SelectedValue = selectedSecondLevel;
+            // 从当前一级分类中找到对应的完整值（带前缀）
+            if (FirstLevelListView.SelectedItem is string firstLevel
+                && CascadeOptions != null
+                && CascadeOptions.TryGetValue(firstLevel, out var values))
+            {
+                var idx = _secondLevelDisplayNames.IndexOf(selectedDisplay);
+                if (idx >= 0 && idx < values.Count)
+                {
+                    SelectedValue = values[idx]; // 写回带前缀的完整值
+                }
+            }
+
             if (MainToggle.IsChecked == true)
             {
                 MainToggle.IsChecked = false;

--- a/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml
+++ b/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml
@@ -349,7 +349,7 @@
                     <StackPanel Orientation="Horizontal" VerticalAlignment="Bottom" Margin="4,0,0,4">
                         <TextBlock FontSize="14"
                                    Foreground="{DynamicResource SystemAccentColorPrimaryBrush}"
-                                   Text="自动秘境" />
+                                   Text="自动秘境/任务" />
                         <TextBlock Margin="4,0,0,0"
                                    VerticalAlignment="Center"
                                    FontSize="11"
@@ -374,12 +374,12 @@
                                 <ui:TextBlock Grid.Row="0"
                                               Grid.Column="0"
                                               FontTypography="Body"
-                                              Text="每日秘境刷取配置"
+                                              Text="每日秘境/任务配置"
                                               TextWrapping="Wrap" />
                                 <ui:TextBlock Grid.Row="1"
                                               Grid.Column="0"
                                               Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
-                                              Text="前往指定秘境消耗树脂，并自动领取奖励。"
+                                              Text="选择秘境、一条龙任务或配置组执行"
                                               TextWrapping="Wrap">
                                 </ui:TextBlock>
                                 <ui:ToggleSwitch Grid.Row="0"
@@ -390,7 +390,8 @@
                             </Grid>
                         </ui:CardExpander.Header>
                         <StackPanel>
-                            <Grid Margin="16">
+                            <!-- 队伍名称（仅标准秘境时显示） -->
+                            <Grid Margin="16" x:Name="PartyNameGrid">
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="Auto" />
                                     <RowDefinition Height="Auto" />
@@ -436,24 +437,24 @@
                                               Grid.Column="0"
                                               FontTypography="Body"
                                               HorizontalAlignment="Left"
-                                              Text="选择秘境"
+                                              Text="选择秘境/任务"
                                               Width="Auto"
                                               TextWrapping="Wrap" />
                                 <ui:TextBlock Grid.Row="1"
                                               Grid.Column="0"
                                               Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
                                               HorizontalAlignment="Left"
-                                              Text="秘境名称"
+                                              Text="秘境/任务名称"
                                               Width="Auto"
                                               TextWrapping="Wrap" />
-                                <vio:CascadingComboBox Grid.Row="0"
+                                <controls:CascadeSelector Grid.Row="0"
                                           Grid.RowSpan="2"
                                           Grid.Column="1"
                                           Width="100"
                                           HorizontalAlignment="Left"
                                           Margin="10,0,10,0"
-                                          ItemsSource="{x:Static helpers:DomainCascadingItems.Items}"
-                                          SelectedCascadingItem="{Binding SelectedConfig.DomainName, Mode=TwoWay, Converter={StaticResource DomainNameConverter}}" />
+                                          CascadeOptions="{Binding DomainOptions}"
+                                          SelectedValue="{Binding SelectedConfig.DomainName, Mode=TwoWay}" />
                                 <ui:TextBlock Grid.Row="0"
                                               Grid.Column="2"
                                               Margin="10,0,10,0"
@@ -461,7 +462,8 @@
                                               HorizontalAlignment="Right"
                                               Text="周日或限时"
                                               Width="Auto"
-                                              TextWrapping="Wrap" />
+                                              TextWrapping="Wrap"
+                                              x:Name="SundayLabelText" />
                                 <ui:TextBlock Grid.Row="1"
                                               Grid.Column="2"
                                               Margin="10,0,10,0"
@@ -469,7 +471,8 @@
                                               HorizontalAlignment="Right"
                                               Text="选择序号"
                                               Width="Auto"
-                                              TextWrapping="Wrap" />
+                                              TextWrapping="Wrap"
+                                              x:Name="SundaySubLabelText" />
                                 <ComboBox Grid.Row="0"
                                           Grid.Column="3"
                                           Grid.RowSpan="2"
@@ -477,7 +480,8 @@
                                           Margin="0,0,36,0"
                                           Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
                                           HorizontalContentAlignment="Center"
-                                          HorizontalAlignment="Stretch" 
+                                          HorizontalAlignment="Stretch"
+                                          x:Name="SundayComboBox" 
                                           ItemsSource="{Binding SundayEverySelectedValueList}"
                                           SelectedItem="{Binding SelectedConfig.SundayEverySelectedValue, Mode=TwoWay}">
                                 </ComboBox>
@@ -553,12 +557,12 @@
                                             VerticalAlignment="Center"
                                             TextAlignment="Center"
                                             PlaceholderText="填写队伍名称 " />
-                                <vio:CascadingComboBox Grid.Row="0"
+                                <controls:CascadeSelector Grid.Row="0"
                                           Grid.Column="2"
                                           Width="100"
                                           Margin="0,0,36,0"
-                                          ItemsSource="{x:Static helpers:DomainCascadingItems.Items}"
-                                          SelectedCascadingItem="{Binding SelectedConfig.MondayDomainName, Mode=TwoWay, Converter={StaticResource DomainNameConverter}}" />
+                                          CascadeOptions="{Binding DomainOptions}"
+                                          SelectedValue="{Binding SelectedConfig.MondayDomainName, Mode=TwoWay}" />
                             </Grid>
                             <Grid Margin="16">
                                 <Grid.ColumnDefinitions>
@@ -582,12 +586,12 @@
                                             VerticalAlignment="Center"
                                             TextAlignment="Center"
                                             PlaceholderText="填写队伍名称 " />
-                                <vio:CascadingComboBox Grid.Row="0"
+                                <controls:CascadeSelector Grid.Row="0"
                                           Grid.Column="2"
                                           Width="100"
                                           Margin="0,0,36,0"
-                                          ItemsSource="{x:Static helpers:DomainCascadingItems.Items}"
-                                          SelectedCascadingItem="{Binding SelectedConfig.TuesdayDomainName, Mode=TwoWay, Converter={StaticResource DomainNameConverter}}" />
+                                          CascadeOptions="{Binding DomainOptions}"
+                                          SelectedValue="{Binding SelectedConfig.TuesdayDomainName, Mode=TwoWay}" />
                             </Grid>
                             <Grid Margin="16">
                                 <Grid.ColumnDefinitions>
@@ -610,12 +614,12 @@
                                             VerticalAlignment="Center"
                                             TextAlignment="Center"
                                             PlaceholderText="填写队伍名称 " />
-                                <vio:CascadingComboBox Grid.Row="0"
+                                <controls:CascadeSelector Grid.Row="0"
                                           Grid.Column="2"
                                           Width="100"
                                           Margin="0,0,36,0"
-                                          ItemsSource="{x:Static helpers:DomainCascadingItems.Items}"
-                                          SelectedCascadingItem="{Binding SelectedConfig.WednesdayDomainName, Mode=TwoWay, Converter={StaticResource DomainNameConverter}}" />
+                                          CascadeOptions="{Binding DomainOptions}"
+                                          SelectedValue="{Binding SelectedConfig.WednesdayDomainName, Mode=TwoWay}" />
 
                             </Grid>
                             <Grid Margin="16">
@@ -639,12 +643,12 @@
                                             VerticalAlignment="Center"
                                             TextAlignment="Center"
                                             PlaceholderText="填写队伍名称 " />
-                                <vio:CascadingComboBox Grid.Row="0"
+                                <controls:CascadeSelector Grid.Row="0"
                                           Grid.Column="2"
                                           Width="100"
                                           Margin="0,0,36,0"
-                                          ItemsSource="{x:Static helpers:DomainCascadingItems.Items}"
-                                          SelectedCascadingItem="{Binding SelectedConfig.ThursdayDomainName, Mode=TwoWay, Converter={StaticResource DomainNameConverter}}" />
+                                          CascadeOptions="{Binding DomainOptions}"
+                                          SelectedValue="{Binding SelectedConfig.ThursdayDomainName, Mode=TwoWay}" />
 
                             </Grid>
                             <Grid Margin="16">
@@ -668,12 +672,12 @@
                                             VerticalAlignment="Center"
                                             TextAlignment="Center"
                                             PlaceholderText="填写队伍名称 " />
-                                <vio:CascadingComboBox Grid.Row="0"
+                                <controls:CascadeSelector Grid.Row="0"
                                           Grid.Column="2"
                                           Width="100"
                                           Margin="0,0,36,0"
-                                          ItemsSource="{x:Static helpers:DomainCascadingItems.Items}"
-                                          SelectedCascadingItem="{Binding SelectedConfig.FridayDomainName, Mode=TwoWay, Converter={StaticResource DomainNameConverter}}" />
+                                          CascadeOptions="{Binding DomainOptions}"
+                                          SelectedValue="{Binding SelectedConfig.FridayDomainName, Mode=TwoWay}" />
 
 
                             </Grid>
@@ -698,12 +702,12 @@
                                             VerticalAlignment="Center"
                                             TextAlignment="Center"
                                             PlaceholderText="填写队伍名称 " />
-                                <vio:CascadingComboBox Grid.Row="0"
+                                <controls:CascadeSelector Grid.Row="0"
                                           Grid.Column="2"
                                           Width="100"
                                           Margin="0,0,36,0"
-                                          ItemsSource="{x:Static helpers:DomainCascadingItems.Items}"
-                                          SelectedCascadingItem="{Binding SelectedConfig.SaturdayDomainName, Mode=TwoWay, Converter={StaticResource DomainNameConverter}}" />
+                                          CascadeOptions="{Binding DomainOptions}"
+                                          SelectedValue="{Binding SelectedConfig.SaturdayDomainName, Mode=TwoWay}" />
 
                             </Grid>
                             <Grid Margin="16">
@@ -732,12 +736,12 @@
                                             VerticalAlignment="Center"
                                             TextAlignment="Center"
                                             PlaceholderText="填写队伍名称 " />
-                                <vio:CascadingComboBox Grid.Row="0"
+                                <controls:CascadeSelector Grid.Row="0"
                                           Grid.Column="2"
                                           Width="100"
                                           Margin="0,0,36,0"
-                                          ItemsSource="{x:Static helpers:DomainCascadingItems.Items}"
-                                          SelectedCascadingItem="{Binding SelectedConfig.SundayDomainName, Mode=TwoWay, Converter={StaticResource DomainNameConverter}}" />
+                                          CascadeOptions="{Binding DomainOptions}"
+                                          SelectedValue="{Binding SelectedConfig.SundayDomainName, Mode=TwoWay}" />
                                 <Border Grid.Row="1"
                                         Grid.Column="0"
                                         Grid.ColumnSpan="3"

--- a/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml.cs
+++ b/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml.cs
@@ -33,7 +33,63 @@ public partial class OneDragonFlowPage
             { ExpBottleBigCheckBox, "祝圣精华" },
             { ExpBottleSmallCheckBox, "祝圣油膏" }
         };
-        
+
+        // 监听配置切换和 DomainName 变化，更新秘境相关控件的显隐
+        viewModel.PropertyChanged += (s, e) =>
+        {
+            if (e.PropertyName == nameof(viewModel.SelectedConfig))
+            {
+                WatchDomainNameChange();
+                UpdateDomainVisibility();
+            }
+        };
+        WatchDomainNameChange();
+    }
+
+    private System.ComponentModel.PropertyChangedEventHandler? _configHandler;
+
+    /// <summary>
+    /// 监听当前配置单的 DomainName 属性变化
+    /// </summary>
+    private void WatchDomainNameChange()
+    {
+        // 移除旧监听
+        if (_configHandler != null && ViewModel.SelectedConfig != null)
+            ViewModel.SelectedConfig.PropertyChanged -= _configHandler;
+
+        _configHandler = (s, e) =>
+        {
+            if (e.PropertyName == nameof(BetterGenshinImpact.Core.Config.OneDragonFlowConfig.DomainName))
+                UpdateDomainVisibility();
+        };
+
+        if (ViewModel.SelectedConfig != null)
+            ViewModel.SelectedConfig.PropertyChanged += _configHandler;
+    }
+
+    /// <summary>
+    /// 根据当前 DomainName 判断是否为标准秘境，控制队伍名称和选择序号的显隐
+    /// </summary>
+    private void UpdateDomainVisibility()
+    {
+        var name = ViewModel.SelectedConfig?.DomainName;
+        bool isStandard = true;
+
+        if (!string.IsNullOrEmpty(name))
+        {
+            // 一条龙默认任务
+            if (Helpers.DomainCascadingItems.DefaultTaskNames.Contains(name))
+                isStandard = false;
+            // 配置组文件
+            else if (System.IO.File.Exists(Core.Config.Global.Absolute($@"User\ScriptGroup\{name}.json")))
+                isStandard = false;
+        }
+
+        var vis = isStandard ? Visibility.Visible : Visibility.Collapsed;
+        PartyNameGrid.Visibility = vis;
+        SundayLabelText.Visibility = vis;
+        SundaySubLabelText.Visibility = vis;
+        SundayComboBox.Visibility = vis;
     }
     
     private async void SereniteaPotTpType_Clicked(object sender, RoutedEventArgs e)

--- a/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml.cs
+++ b/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml.cs
@@ -47,15 +47,18 @@ public partial class OneDragonFlowPage
     }
 
     private System.ComponentModel.PropertyChangedEventHandler? _configHandler;
+    private BetterGenshinImpact.Core.Config.OneDragonFlowConfig? _watchedConfig;
 
     /// <summary>
     /// 监听当前配置单的 DomainName 属性变化
     /// </summary>
     private void WatchDomainNameChange()
     {
-        // 移除旧监听
-        if (_configHandler != null && ViewModel.SelectedConfig != null)
-            ViewModel.SelectedConfig.PropertyChanged -= _configHandler;
+        // 从旧配置对象上解绑（而非当前 SelectedConfig，避免切换后解绑错对象）
+        if (_configHandler != null && _watchedConfig != null)
+            _watchedConfig.PropertyChanged -= _configHandler;
+
+        _watchedConfig = ViewModel.SelectedConfig;
 
         _configHandler = (s, e) =>
         {
@@ -63,29 +66,22 @@ public partial class OneDragonFlowPage
                 UpdateDomainVisibility();
         };
 
-        if (ViewModel.SelectedConfig != null)
-            ViewModel.SelectedConfig.PropertyChanged += _configHandler;
+        if (_watchedConfig != null)
+            _watchedConfig.PropertyChanged += _configHandler;
+
+        // 立即更新一次，确保初始状态正确
+        UpdateDomainVisibility();
     }
 
     /// <summary>
-    /// 根据当前 DomainName 判断是否为标准秘境，控制队伍名称和选择序号的显隐
+    /// 根据当前 DomainName 的类型前缀判断是否为标准秘境，控制队伍名称和选择序号的显隐
     /// </summary>
     private void UpdateDomainVisibility()
     {
         var name = ViewModel.SelectedConfig?.DomainName;
-        bool isStandard = true;
-
-        if (!string.IsNullOrEmpty(name))
-        {
-            // 一条龙默认任务
-            if (Helpers.DomainCascadingItems.DefaultTaskNames.Contains(name))
-                isStandard = false;
-            // 配置组文件
-            else if (System.IO.File.Exists(Core.Config.Global.Absolute($@"User\ScriptGroup\{name}.json")))
-                isStandard = false;
-        }
-
-        var vis = isStandard ? Visibility.Visible : Visibility.Collapsed;
+        var (type, _) = Helpers.DomainCascadingItems.Parse(name);
+        // 标准秘境（type == "domain" 或空）显示，一条龙任务和配置组隐藏
+        var vis = (type == "domain" || type == "") ? Visibility.Visible : Visibility.Collapsed;
         PartyNameGrid.Visibility = vis;
         SundayLabelText.Visibility = vis;
         SundaySubLabelText.Visibility = vis;

--- a/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
@@ -264,7 +264,7 @@ public partial class OneDragonFlowViewModel : ViewModel
                     }
                 }
             }
-            return string.Join(",", selectedItems);
+            return selectedItems.Count > 0 ? string.Join(",", selectedItems) : null;
         }
         return null;
     }
@@ -507,7 +507,11 @@ public partial class OneDragonFlowViewModel : ViewModel
     /// </summary>
     private void RefreshDomainItems()
     {
-        DomainCascadingItems.DefaultTaskNames = ScriptGroupsdefault.Select(t => t.Name).ToList();
+        // 排除"自动秘境"自身，防止递归调用
+        DomainCascadingItems.DefaultTaskNames = ScriptGroupsdefault
+            .Select(t => t.Name)
+            .Where(n => n != "自动秘境")
+            .ToList();
         DomainCascadingItems.Rebuild();
         DomainOptions = DomainCascadingItems.Options;
     }

--- a/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
@@ -218,59 +218,53 @@ public partial class OneDragonFlowViewModel : ViewModel
     {
         var stackPanel = new StackPanel();
         var checkBoxes = new Dictionary<ScriptGroup, CheckBox>();
-        CheckBox selectedCheckBox = null; // 用于保存当前选中的 CheckBox
         foreach (var scriptGroup in ScriptGroups)
         {
             if (TaskList.Any(taskName => scriptGroup.Name == taskName.Name))
             {
-                continue; // 只有当文件名完全相同时才跳过显示
+                continue;
             }
             var checkBox = new CheckBox
             {
                 Content = scriptGroup.Name,
                 Tag = scriptGroup,
-                IsChecked = false // 初始状态下都未选中
+                IsChecked = false
             };
             checkBoxes[scriptGroup] = checkBox;
             stackPanel.Children.Add(checkBox);
         }
         var uiMessageBox = new Wpf.Ui.Controls.MessageBox
         {
-        Title = "选择增加的配置组（可多选）",
-        Content = new ScrollViewer
-        {
-            Content = stackPanel,
-            VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
-        },
-        CloseButtonText = "关闭",
-        PrimaryButtonText = "确认",
-        Owner = Application.Current.ShutdownMode == ShutdownMode.OnMainWindowClose ? null : Application.Current.MainWindow,
-        WindowStartupLocation = WindowStartupLocation.CenterOwner,
-        SizeToContent = SizeToContent.Width , // 确保弹窗根据内容自动调整大小
-        MaxHeight = 600,
+            Title = "选择增加的配置组（可多选）",
+            Content = new ScrollViewer
+            {
+                Content = stackPanel,
+                VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+            },
+            CloseButtonText = "关闭",
+            PrimaryButtonText = "确认",
+            Owner = Application.Current.ShutdownMode == ShutdownMode.OnMainWindowClose ? null : Application.Current.MainWindow,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            SizeToContent = SizeToContent.Width,
+            MaxHeight = 600,
         };
         uiMessageBox.SourceInitialized += (s, e) => WindowHelper.TryApplySystemBackdrop(uiMessageBox);
         var result = await uiMessageBox.ShowDialogAsync();
         if (result == Wpf.Ui.Controls.MessageBoxResult.Primary)
         {
-            List<string> selectedItems = new List<string>(); // 用于存储所有选中的项
+            List<string> selectedItems = new List<string>();
             foreach (var checkBox in checkBoxes.Values)
             {
                 if (checkBox.IsChecked == true)
                 {
-                    // 确保 Tag 是 ScriptGroup 类型，并返回其 Name 属性
                     var scriptGroup = checkBox.Tag as ScriptGroup;
                     if (scriptGroup != null)
-                    { 
-                        selectedItems.Add(scriptGroup.Name);
-                    }
-                    else
                     {
-                        Toast.Error("配置组加载失败");
+                        selectedItems.Add(scriptGroup.Name);
                     }
                 }
             }
-            return string.Join(",", selectedItems); // 返回所有选中的项
+            return string.Join(",", selectedItems);
         }
         return null;
     }
@@ -286,6 +280,11 @@ public partial class OneDragonFlowViewModel : ViewModel
     [ObservableProperty] private List<string> _adventurersGuildCountry = ["挪德卡莱", "枫丹", "稻妻", "璃月", "蒙德"];
 
     [ObservableProperty] private List<string> _domainNameList = ["", ..MapLazyAssets.Instance.DomainNameList];
+
+    /// <summary>
+    /// 秘境级联选择器数据源（一条龙任务 + 配置组 + 标准秘境）
+    /// </summary>
+    [ObservableProperty] private Dictionary<string, List<string>> _domainOptions = DomainCascadingItems.Options;
 
     [ObservableProperty] private List<string> _completionActionList = ["无", "关闭游戏", "关闭游戏和软件", "关机"];
 
@@ -396,6 +395,8 @@ public partial class OneDragonFlowViewModel : ViewModel
         SelectedConfig = selected;
         LoadDisplayTaskListFromConfig(); // 加载 DisplayTaskList 从配置文件
         SetSomeSelectedConfig(SelectedConfig);
+        // 首次加载时构建级联数据
+        RefreshDomainItems();
     }
 
     // 新增方法：从配置文件加载 DisplayTaskList
@@ -497,7 +498,18 @@ public partial class OneDragonFlowViewModel : ViewModel
             }
 
             LoadDisplayTaskListFromConfig();
+            RefreshDomainItems();
         }
+    }
+
+    /// <summary>
+    /// 刷新秘境级联选择器数据源（自动扫描一条龙任务 + 配置组 + 标准秘境）
+    /// </summary>
+    private void RefreshDomainItems()
+    {
+        DomainCascadingItems.DefaultTaskNames = ScriptGroupsdefault.Select(t => t.Name).ToList();
+        DomainCascadingItems.Rebuild();
+        DomainOptions = DomainCascadingItems.Options;
     }
 
     private async void TaskPropertyChanged(object? sender, PropertyChangedEventArgs e)


### PR DESCRIPTION
## 自动秘境支持选择一条龙任务和配置组执行

### 功能说明

**_目的是在自动秘境/任务中就可以选择所有消耗树脂的途径。_**

一条龙的"自动秘境"任务不再局限于标准秘境，级联选择器内置三组选项：

- **一条龙任务**：领取邮件、合成树脂、自动地脉花等默认任务
- **配置组**：自动扫描 `User\ScriptGroup` 目录下的所有脚本配置组
- **标准秘境**：按国家分组的原有秘境列表

选择后一条龙执行时自动判断类型：标准秘境走 AutoDomainTask，配置组走 ScriptGroup 内联执行，一条龙任务走对应的 TaskItem。

无需手动添加/删除，零配置，打开即用。

### UI 变化

- 秘境选择器从 `CascadingComboBox`（第三方控件）替换为自定义 `CascadeSelector`（固定尺寸弹窗，防止滚动穿透和抖动）
- 标题从"每日秘境刷取配置"改为"每日秘境/任务配置"
- 选择一条龙任务或配置组时，队伍名称和选择序号自动隐藏（仅标准秘境显示）

### 涉及文件

| 文件 | 改动说明 |
|------|----------|
| `Helpers/DomainCascadingItems.cs` | 输出 `Dictionary<string, List<string>>` 格式，自动扫描 ScriptGroup 目录，内置一条龙默认任务 |
| `Model/OneDragonTaskItem.cs` | 自动秘境执行时判断类型，配置组走 `RunMultiInline`，一条龙任务走 TaskItem |
| `Service/ScriptService.cs` | 新增 `RunMultiInline` 方法，复用 RunMulti 完整语义（跳过规则、月卡检测、触发器清理、通知），不创建新 TaskRunner |
| `View/Controls/CascadeSelector.xaml` | 固定 `Width=400 Height=350`，`PopupAnimation=None`，列用 `*` 等分 |
| `View/Controls/CascadeSelector.xaml.cs` | 删除所有动态宽度计算代码（约 -100 行），保留滚轮拦截 |
| `View/Pages/OneDragonFlowPage.xaml` | 8 处 `CascadingComboBox` 替换为 `CascadeSelector`，标题和描述更新 |
| `View/Pages/OneDragonFlowPage.xaml.cs` | 监听 DomainName 变化，控制队伍名称和选择序号的显隐 |
| `ViewModel/Pages/OneDragonFlowViewModel.cs` | `DomainOptions` 属性 + `RefreshDomainItems()` 数据源管理 |

### 不涉及的文件

- `OneDragonFlowConfig.cs` — 无新增属性
- `App.xaml` — 无改动
- 无新增文件


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 秘境选择器支持按类别展示（默认任务、脚本组、各国标准秘境）并识别带前缀的条目；支持一键执行脚本组项目的批量内联运行。

* **改进**
  * 级联选择器显示与值分离，布局与交互更稳定；页面根据选择智能显示/隐藏队伍名称并即时同步选项。

* **修复**
  * 提升脚本与自动秘境执行的容错、日志与异常可见性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->