### PR TITLE
优化添加一条龙任务添加的弹窗UI

### DIFF
--- a/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml
+++ b/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml
@@ -71,7 +71,54 @@
             Grid.Row="0"
             Margin="0,0,10,0"
             Icon="{ui:SymbolIcon Add24}"
-            Command="{Binding AddTaskGroupCommand}" />
+            x:Name="AddTaskGroupButton"
+            Click="AddTaskGroupButton_Click" />
+            
+        <!-- 添加配置组弹窗 -->
+        <Popup x:Name="AddConfigGroupPopup"
+               Placement="Absolute"
+               AllowsTransparency="True"
+               PopupAnimation="Fade"
+               StaysOpen="False">
+            <Border CornerRadius="8"
+                    Background="{DynamicResource ApplicationBackgroundBrush}"
+                    BorderBrush="{DynamicResource SystemAccentColorPrimaryBrush}"
+                    BorderThickness="1"
+                    MinWidth="300"
+                    MaxHeight="400">
+                <StackPanel Margin="16">
+                    <TextBlock Text="选择增加的配置组（可多选）"
+                               FontSize="16"
+                               FontWeight="Bold"
+                               Margin="0,0,0,12"
+                               HorizontalAlignment="Center"/>
+                    
+                    <ScrollViewer MaxHeight="250" VerticalScrollBarVisibility="Auto">
+                        <ItemsControl x:Name="ScriptGroupItemsControl">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate>
+                                    <CheckBox Content="{Binding Name}"
+                                              Tag="{Binding}"
+                                              Margin="0,2"/>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </ScrollViewer>
+                    
+                    <StackPanel Orientation="Horizontal" 
+                                HorizontalAlignment="Center" 
+                                Margin="0,12,0,0">
+                        <Button Content="确认" 
+                                Width="70" 
+                                Margin="0,0,10,0"
+                                Click="ConfirmButton_Click"/>
+                        <Button Content="取消" 
+                                Width="70"
+                                Click="CancelButton_Click"/>
+                    </StackPanel>
+                </StackPanel>
+            </Border>
+        </Popup>
     </Grid>
     <Grid DockPanel.Dock="Top"
         Margin="0,0,0,10">

--- a/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml.cs
+++ b/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml.cs
@@ -6,6 +6,8 @@ using Wpf.Ui.Violeta.Controls;
 using System.Linq; 
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using BetterGenshinImpact.Core.Script.Group;
+using System;
 
 namespace BetterGenshinImpact.View.Pages;
 
@@ -34,6 +36,133 @@ public partial class OneDragonFlowPage
             { ExpBottleSmallCheckBox, "祝圣油膏" }
         };
         
+        // 监听ViewModel的属性变化
+        ViewModel.PropertyChanged += ViewModel_PropertyChanged;
+    }
+    
+    private void ViewModel_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(ViewModel.ShouldShowAddTaskGroupPopup) && ViewModel.ShouldShowAddTaskGroupPopup)
+        {
+            // 重置属性
+            ViewModel.ShouldShowAddTaskGroupPopup = false;
+            
+            // 显示弹窗
+            ShowAddTaskGroupPopup();
+        }
+    }
+    
+    private void ShowAddTaskGroupPopup()
+    {
+        try
+        {
+            // 读取配置组
+            ViewModel.ReadScriptGroup();
+            
+            // 检查是否有ScriptGroups
+            if (ViewModel.ScriptGroups == null || !ViewModel.ScriptGroups.Any())
+            {
+                Toast.Warning("没有找到配置组");
+                return;
+            }
+            
+            // 过滤已存在的配置组
+            var availableGroups = ViewModel.ScriptGroups
+                .Where(sg => ViewModel.TaskList == null || !ViewModel.TaskList.Any(task => task.Name == sg.Name))
+                .ToList();
+                
+            if (!availableGroups.Any())
+            {
+                Toast.Warning("没有可添加的配置组");
+                return;
+            }
+            
+            // 设置ItemsControl的数据源
+            ScriptGroupItemsControl.ItemsSource = availableGroups;
+            
+            // 获取主窗口
+            var mainWindow = Application.Current.MainWindow;
+            if (mainWindow != null)
+            {
+                // 获取主窗口的位置和大小
+                var windowLeft = mainWindow.Left;
+                var windowTop = mainWindow.Top;
+                var windowWidth = mainWindow.ActualWidth;
+                var windowHeight = mainWindow.ActualHeight;
+                
+                // 估算弹窗大小
+                var popupWidth = 350.0;
+                var popupHeight = 300.0;
+                
+                // 计算居中位置（相对于主窗口）
+                AddConfigGroupPopup.HorizontalOffset = windowLeft + (windowWidth - popupWidth) / 2;
+                AddConfigGroupPopup.VerticalOffset = windowTop + (windowHeight - popupHeight) / 2;
+            }
+            
+            // 显示弹窗
+            AddConfigGroupPopup.IsOpen = true;
+        }
+        catch (Exception ex)
+        {
+            Toast.Error($"添加任务组时出错: {ex.Message}");
+        }
+    }
+    
+    private void AddTaskGroupButton_Click(object sender, RoutedEventArgs e)
+    {
+        ShowAddTaskGroupPopup();
+    }
+    
+    private void ConfirmButton_Click(object sender, RoutedEventArgs e)
+    {
+        var selectedGroups = new List<string>();
+        
+        // 遍历所有CheckBox，收集选中的项
+        foreach (var item in ScriptGroupItemsControl.Items)
+        {
+            var container = ScriptGroupItemsControl.ItemContainerGenerator.ContainerFromItem(item) as FrameworkElement;
+            if (container != null)
+            {
+                var checkBox = FindVisualChild<CheckBox>(container);
+                if (checkBox?.IsChecked == true && checkBox.Tag is ScriptGroup scriptGroup)
+                {
+                    selectedGroups.Add(scriptGroup.Name);
+                }
+            }
+        }
+        
+        if (selectedGroups.Any())
+        {
+            // 调用ViewModel的方法处理选中的配置组
+            ViewModel.ProcessSelectedGroups(selectedGroups);
+            
+            // 保存配置并重置选中项
+            ViewModel.SaveConfig();
+            ViewModel.SelectedTask = null;
+        }
+        
+        AddConfigGroupPopup.IsOpen = false;
+    }
+    
+    private void CancelButton_Click(object sender, RoutedEventArgs e)
+    {
+        AddConfigGroupPopup.IsOpen = false;
+    }
+    
+    // 辅助方法：查找子控件
+    private static T FindVisualChild<T>(DependencyObject parent) where T : DependencyObject
+    {
+        for (int i = 0; i < System.Windows.Media.VisualTreeHelper.GetChildrenCount(parent); i++)
+        {
+            var child = System.Windows.Media.VisualTreeHelper.GetChild(parent, i);
+            if (child is T result)
+                return result;
+            
+            var childOfChild = FindVisualChild<T>(child);
+            if (childOfChild != null)
+                return childOfChild;
+        }
+        return null;
     }
     
     private async void SereniteaPotTpType_Clicked(object sender, RoutedEventArgs e)

--- a/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
@@ -23,17 +23,10 @@ using BetterGenshinImpact.Service.Notification.Model.Enum;
 using BetterGenshinImpact.View.Windows;
 using CommunityToolkit.Mvvm.Input;
 using Newtonsoft.Json;
-using Wpf.Ui.Controls;
-using Wpf.Ui.Violeta.Controls;
-using System.Windows.Controls;
-using ABI.Windows.UI.UIAutomation;
-using Wpf.Ui;
-using StackPanel = Wpf.Ui.Controls.StackPanel;
-using BetterGenshinImpact.Core.Config;
 using BetterGenshinImpact.Core.Script.Project;
 using BetterGenshinImpact.Service.Interface;
-using TextBlock = Wpf.Ui.Controls.TextBlock;
 using System.Collections.Specialized;
+using Wpf.Ui.Violeta.Controls;
 
 namespace BetterGenshinImpact.ViewModel.Pages;
 
@@ -93,7 +86,7 @@ public partial class OneDragonFlowViewModel : ViewModel
     private readonly string _scriptGroupPath = Global.Absolute(@"User\ScriptGroup");
     private readonly string _basePath = AppDomain.CurrentDomain.BaseDirectory;
     
-    private void ReadScriptGroup()
+    public void ReadScriptGroup()
     {
         try
         {
@@ -147,19 +140,26 @@ public partial class OneDragonFlowViewModel : ViewModel
 
     private async void AddNewTaskGroup()
     {
-        ReadScriptGroup();
-        var selectedGroupNamePick = await OnStartMultiScriptGroupAsync();
-        if (selectedGroupNamePick == null)
+        // 这个方法现在由XAML中的Popup处理，保留为空或者可以删除
+        // 实际逻辑已经移到ProcessSelectedGroups方法中
+    }
+
+    public void ProcessSelectedGroups(List<string> selectedGroupNames)
+    {
+        if (selectedGroupNames == null || !selectedGroupNames.Any())
         {
             return;
         }
-        int pickTaskCount = selectedGroupNamePick.Split(',').Count();
-        foreach (var selectedGroupName in selectedGroupNamePick.Split(','))
+
+        int pickTaskCount = selectedGroupNames.Count;
+        
+        foreach (var selectedGroupName in selectedGroupNames)
         {
             var taskItem = new OneDragonTaskItem(selectedGroupName)
             {
                 IsEnabled = true
             };
+            
             if (TaskList.All(task => task.Name != taskItem.Name))
             {
                 var names = selectedGroupName.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
@@ -167,6 +167,7 @@ public partial class OneDragonFlowViewModel : ViewModel
                     .ToList();
                 bool containsAnyDefaultGroup =
                     names.Any(name => ScriptGroupsdefault.Any(defaultSg => defaultSg.Name == name));
+                    
                 if (containsAnyDefaultGroup)
                 {
                     int lastDefaultGroupIndex = -1;
@@ -210,70 +211,11 @@ public partial class OneDragonFlowViewModel : ViewModel
         }
         if (pickTaskCount > 1)
         {
-                Toast.Success(pickTaskCount + " 个任务添加成功");  
+            Toast.Success(pickTaskCount + " 个任务添加成功");  
         }
     }
 
-    public async Task<string?> OnStartMultiScriptGroupAsync()
-    {
-        var stackPanel = new StackPanel();
-        var checkBoxes = new Dictionary<ScriptGroup, CheckBox>();
-        CheckBox selectedCheckBox = null; // 用于保存当前选中的 CheckBox
-        foreach (var scriptGroup in ScriptGroups)
-        {
-            if (TaskList.Any(taskName => scriptGroup.Name == taskName.Name))
-            {
-                continue; // 只有当文件名完全相同时才跳过显示
-            }
-            var checkBox = new CheckBox
-            {
-                Content = scriptGroup.Name,
-                Tag = scriptGroup,
-                IsChecked = false // 初始状态下都未选中
-            };
-            checkBoxes[scriptGroup] = checkBox;
-            stackPanel.Children.Add(checkBox);
-        }
-        var uiMessageBox = new Wpf.Ui.Controls.MessageBox
-        {
-        Title = "选择增加的配置组（可多选）",
-        Content = new ScrollViewer
-        {
-            Content = stackPanel,
-            VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
-        },
-        CloseButtonText = "关闭",
-        PrimaryButtonText = "确认",
-        Owner = Application.Current.ShutdownMode == ShutdownMode.OnMainWindowClose ? null : Application.Current.MainWindow,
-        WindowStartupLocation = WindowStartupLocation.CenterOwner,
-        SizeToContent = SizeToContent.Width , // 确保弹窗根据内容自动调整大小
-        MaxHeight = 600,
-        };
-        uiMessageBox.SourceInitialized += (s, e) => WindowHelper.TryApplySystemBackdrop(uiMessageBox);
-        var result = await uiMessageBox.ShowDialogAsync();
-        if (result == Wpf.Ui.Controls.MessageBoxResult.Primary)
-        {
-            List<string> selectedItems = new List<string>(); // 用于存储所有选中的项
-            foreach (var checkBox in checkBoxes.Values)
-            {
-                if (checkBox.IsChecked == true)
-                {
-                    // 确保 Tag 是 ScriptGroup 类型，并返回其 Name 属性
-                    var scriptGroup = checkBox.Tag as ScriptGroup;
-                    if (scriptGroup != null)
-                    { 
-                        selectedItems.Add(scriptGroup.Name);
-                    }
-                    else
-                    {
-                        Toast.Error("配置组加载失败");
-                    }
-                }
-            }
-            return string.Join(",", selectedItems); // 返回所有选中的项
-        }
-        return null;
-    }
+    // 原来的OnStartMultiScriptGroupAsync方法已被移除，功能已迁移到XAML Popup中
     
     [ObservableProperty] private ObservableCollection<OneDragonFlowConfig> _configList = [];
     /// <summary>
@@ -471,10 +413,13 @@ public partial class OneDragonFlowViewModel : ViewModel
     [RelayCommand]
     private void AddTaskGroup()
     {
-        AddNewTaskGroup();
-        SaveConfig();
-        SelectedTask = null;
+        // 触发弹窗显示的事件，让View层处理
+        // 我们可以通过一个属性来通知View显示弹窗
+        ShouldShowAddTaskGroupPopup = true;
     }
+    
+    [ObservableProperty]
+    private bool _shouldShowAddTaskGroupPopup = false;
 
     [RelayCommand]
     private void SaveActionConfig()


### PR DESCRIPTION
## 一条龙"添加任务"弹窗 XAML 化重构

### 功能说明

将 `OneDragonFlowViewModel` 中命令式构建的"添加配置组"弹窗迁移为 XAML 声明式 Popup，彻底移除 ViewModel 中的 UI 控件创建代码，实现关注点分离。

功能行为与原版完全一致：

- 弹窗展示所有未添加的配置组，支持多选
- 默认任务插入到任务列表中最后一个默认任务之后
- 自定义配置组追加到列表末尾
- 重复添加时给出 Toast 警告
- 单个/多个任务添加成功分别给出对应 Toast 提示

### 改动说明

**重构前**：`AddNewTaskGroup` 和 `OnStartMultiScriptGroupAsync` 在 ViewModel 中直接 `new StackPanel()`、`new CheckBox()`、`new ScrollViewer()`，并调用 `Wpf.Ui.Controls.MessageBox.ShowDialogAsync()`，ViewModel 直接依赖 UI 层。

**重构后**：弹窗完全由 XAML Popup 声明，ViewModel 只负责业务逻辑，通过 `ShouldShowAddTaskGroupPopup` 属性通知 View 层显示弹窗。

### 涉及文件

| 文件 | 改动说明 |
|------|----------|
| `View/Pages/OneDragonFlowPage.xaml` | 新增 Popup 控件（标题、ScrollViewer + ItemsControl 复选框列表、确认/取消按钮），按钮改为 Click 事件 |
| `View/Pages/OneDragonFlowPage.xaml.cs` | 新增 `ShowAddTaskGroupPopup()`、`ConfirmButton_Click()`、`CancelButton_Click()` 事件处理，监听 `ShouldShowAddTaskGroupPopup` 属性变化 |
| `ViewModel/Pages/OneDragonFlowViewModel.cs` | 删除 `OnStartMultiScriptGroupAsync()` 方法及所有 UI 控件引用，`AddNewTaskGroup` 清空，新增 `ProcessSelectedGroups()` 处理业务逻辑，新增 `ShouldShowAddTaskGroupPopup` 属性，`ReadScriptGroup` 改为 public，清理无用 using |

### 不涉及的文件

- 无新增文件
- `OneDragonFlowConfig.cs` — 无改动
- 其他 ViewModel/Model — 无改动

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 改进了添加新配置组的用户界面交互方式，现采用模态弹出窗口形式进行多选，并提供"确认/取消"按钮操作。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->