### PR TITLE
fix: 自定义的模块解析器导致缓存失效

### DIFF
--- a/BetterGenshinImpact/Core/Script/PackageDocumentLoader.cs
+++ b/BetterGenshinImpact/Core/Script/PackageDocumentLoader.cs
@@ -12,6 +12,7 @@ namespace BetterGenshinImpact.Core.Script
     public class PackageDocumentLoader : DocumentLoader
     {
         private readonly string _scriptRootPath;
+        private readonly Dictionary<string, Document> _moduleCache = new();
 
         public PackageDocumentLoader(string scriptRootPath)
         {
@@ -30,9 +31,16 @@ namespace BetterGenshinImpact.Core.Script
             // 处理 JS 文件的重写
             if (Path.GetExtension(targetPath).ToLower() == ".js")
             {
+                if (_moduleCache.TryGetValue(targetPath, out var cached))
+                {
+                    return cached;
+                }
+
                 string content = await File.ReadAllTextAsync(targetPath);
                 string processedCode = RewriteScriptCode(content, targetPath);
-                return new StringDocument(new DocumentInfo(targetPath) { Category = ModuleCategory.Standard }, processedCode);
+                var document = new StringDocument(new DocumentInfo(targetPath) { Category = ModuleCategory.Standard }, processedCode);
+                _moduleCache[targetPath] = document;
+                return document;
             }
 
             return await Default.LoadDocumentAsync(settings, sourceInfo, specifier, category, contextCallback);

--- a/BetterGenshinImpact/Core/Script/Project/ScriptProject.cs
+++ b/BetterGenshinImpact/Core/Script/Project/ScriptProject.cs
@@ -116,9 +116,6 @@ public class ScriptProject
 
             if (useModule)
             {
-                // 清除Document缓存
-                DocumentLoader.Default.DiscardCachedDocuments();
-
                 string mainScriptPath = Path.Combine(ProjectPath, Manifest.Main);
                 string runtimeCode = loader.RewriteScriptCode(code, mainScriptPath);
                 


### PR DESCRIPTION
之前在进行公有资源支持时使用的自行继承的解析器正好覆盖了原有自带的模块缓存机制，导致在导入时，并不能正常从缓存中读取，单例模式会失效，修复后，个别脚本可能会受到影响，但模块缓存应当是正确的js引擎运行机制

#3066 


@breadgrocery @Kirito520Asuna

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 性能优化

* 优化了脚本模块加载缓存机制，避免重复加载相同模块，提升加载效率。
* 改进缓存管理流程，减少不必要的缓存清理操作，进一步提高应用响应速度。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->