### PR TITLE
fix(js): 修复模块被导入时副作用代码被重复执行

### DIFF
--- a/BetterGenshinImpact/Core/Script/PackageDocumentLoader.cs
+++ b/BetterGenshinImpact/Core/Script/PackageDocumentLoader.cs
@@ -32,7 +32,8 @@ namespace BetterGenshinImpact.Core.Script
             {
                 string content = await File.ReadAllTextAsync(targetPath);
                 string processedCode = RewriteScriptCode(content, targetPath);
-                return new StringDocument(new DocumentInfo(targetPath) { Category = ModuleCategory.Standard }, processedCode);
+                var documentInfo = new DocumentInfo(new Uri(targetPath)) { Category = ModuleCategory.Standard };
+                return new StringDocument(documentInfo, processedCode);
             }
 
             return await Default.LoadDocumentAsync(settings, sourceInfo, specifier, category, contextCallback);

--- a/BetterGenshinImpact/Core/Script/Project/ScriptProject.cs
+++ b/BetterGenshinImpact/Core/Script/Project/ScriptProject.cs
@@ -122,7 +122,8 @@ public class ScriptProject
                 string mainScriptPath = Path.Combine(ProjectPath, Manifest.Main);
                 string runtimeCode = loader.RewriteScriptCode(code, mainScriptPath);
                 
-                var evaluation = engine.Evaluate(new DocumentInfo(mainScriptPath) { Category = ModuleCategory.Standard }, runtimeCode);
+                var documentInfo = new DocumentInfo(new Uri(mainScriptPath)) { Category = ModuleCategory.Standard };
+                var evaluation = engine.Evaluate(documentInfo, runtimeCode);
                 if (evaluation is Task task) await task;
             }
             else


### PR DESCRIPTION
由于自定义Loader返回模块信息时未提供URI，导致同一个模块即使路径一模一样也会被是识别成两个模块，副作用代码被重复执行。例如下列代码正常应该只打印一次“副作用代码”
```js
// foo.js
log.info("副作用代码");
export const foo = "baz";
```

```js
// a.js
import {foo} from "./foo.js"
export const f1 = ()=>"a" + foo ;
```

```js
// b.js
import {foo} from "./foo.js"
export const f2 = ()=>"b" + foo ;
```

```js
// main.js
import {f1} from "./a.js";
import {f2} from "./b.js"
f1();
f2();
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 改进脚本系统的文档加载机制，优化文件路径在脚本执行过程中的处理方式，增强脚本引擎对文件位置的准确识别能力。
  * 提升脚本执行的稳定性和可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->