### PR TITLE
fix: 跳过空月祝福使用硬件输入模拟代替窗口消息避免云原神中不生效

### DIFF
--- a/BetterGenshinImpact/GameTask/Common/Job/BlessingOfTheWelkinMoonTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/BlessingOfTheWelkinMoonTask.cs
@@ -34,8 +34,8 @@ public class BlessingOfTheWelkinMoonTask
                         if (j == 0)
                         {
                             // 双击快速跳过
-                            TaskContext.Instance().PostMessageSimulator.LeftButtonClickBackground();
-                            TaskContext.Instance().PostMessageSimulator.LeftButtonClickBackground();
+                            GameCaptureRegion.GameRegion1080PPosClick(100, 100);
+                            GameCaptureRegion.GameRegion1080PPosClick(100, 100);
                         }
                         await Delay(500, ct);
                         using var ra2 = CaptureToRectArea();

--- a/BetterGenshinImpact/GameTask/Common/Job/BlessingOfTheWelkinMoonTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/BlessingOfTheWelkinMoonTask.cs
@@ -35,6 +35,7 @@ public class BlessingOfTheWelkinMoonTask
                         {
                             // 双击快速跳过
                             GameCaptureRegion.GameRegion1080PPosClick(100, 100);
+                            await Task.Delay(100, ct);
                             GameCaptureRegion.GameRegion1080PPosClick(100, 100);
                         }
                         await Delay(500, ct);


### PR DESCRIPTION
云原神4点月卡点击没有生效

系统：win11，bgi版本：0.60.2-alpha.2，客户端：云原神 6.5.0
当前点不掉月卡的记录，有触发检测和进入月卡处理，但是点不掉：

https://github.com/user-attachments/assets/ae6f00da-ecd5-4ba6-99e9-7ecf74e15774

更换点击方法后生效：

https://github.com/user-attachments/assets/40324f9b-da7e-44d3-9286-c7187b170f6a

录屏用的 [ffmpeg](https://ffmpeg.org/)参考 [Capturing Your Desktop / Screen Recording ](https://trac.ffmpeg.org/wiki/Capture/Desktop#Windows)
等到3：55开始录屏十分钟
```powershell
$now=Get-Date; $target=[datetime]::Today.AddHours(3).AddMinutes(55); $seconds=[int](($target.AddDays($now -gt $target) - $now).TotalSeconds); Start-Sleep -Seconds $seconds; ffmpeg -f gdigrab -framerate 30 -i desktop -c:v libx264 -t 00:10:00 output_$(Get-Date -Format 'yyyyMMdd_HHmmss').mp4
```

closes #3079 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化了“祝圣月满”任务的跳过机制：改为使用更确定的点击与短暂等待以增强交互稳定性，减少误触和丢帧导致的跳过失败，提升整体任务执行可靠性与一致性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->