### PR TITLE
feat(脚本控制): 添加配置组引用功能

### DIFF
--- a/BetterGenshinImpact/Core/Script/Group/ScriptGroupProject.cs
+++ b/BetterGenshinImpact/Core/Script/Group/ScriptGroupProject.cs
@@ -1,4 +1,4 @@
-﻿using BetterGenshinImpact.Core.Config;
+using BetterGenshinImpact.Core.Config;
 using BetterGenshinImpact.Core.Recorder;
 using BetterGenshinImpact.Core.Script.Project;
 using BetterGenshinImpact.GameTask;
@@ -165,6 +165,11 @@ public partial class ScriptGroupProject : ObservableObject
     public static ScriptGroupProject BuildPathingProject(string name, string folder)
     {
         return new ScriptGroupProject(name, folder, "Pathing");
+    }
+
+    public static ScriptGroupProject BuildScriptGroupRefProject(string scriptGroupName)
+    {
+        return new ScriptGroupProject(scriptGroupName, "", "ScriptGroupRef");
     }
 
     /// <summary>
@@ -409,7 +414,8 @@ public class ScriptGroupProjectExtensions
         { "Javascript", "JS脚本" },
         { "KeyMouse", "键鼠脚本" },
         { "Pathing", "地图追踪" },
-        { "Shell", "Shell" }
+        { "Shell", "Shell" },
+        { "ScriptGroupRef", "配置组引用" }
     };
 
     public static readonly Dictionary<string, string> StatusDescriptions = new()

--- a/BetterGenshinImpact/Service/ScriptService.cs
+++ b/BetterGenshinImpact/Service/ScriptService.cs
@@ -74,7 +74,7 @@ public partial class ScriptService : IScriptService
                     _logger.LogInformation($"{project.Name}任务已经不在执行周期（当前值${index}!=配置值${tcc.Index}），将跳过此任务！");
                     return true;
                 }
-               
+                
             }
             
         }
@@ -129,9 +129,7 @@ public partial class ScriptService : IScriptService
             scriptGroupProject.SkipFlag = false;
         }
 
-
-
-        // // 针对JS 脚本，检查是否包含定时器操作
+        // 针对JS 脚本，检查是否包含定时器操作
         // var jsProjects = ExtractJsProjects(list);
         // if (!hasTimer && jsProjects.Count > 0)
         // {
@@ -329,7 +327,6 @@ public partial class ScriptService : IScriptService
                             {
                                 TaskTriggerDispatcher.Instance().ClearTriggers();
 
-
                                 _logger.LogInformation("------------------------------");
 
                                 stopwatch.Reset();
@@ -511,6 +508,30 @@ public partial class ScriptService : IScriptService
     //     return jsProjects;
     // }
 
+    private async Task<bool> ExecuteProjectWithBlessingAsync(ScriptGroupProject project)
+    {
+        try
+        {
+            await _blessingOfTheWelkinMoonTask.Start(CancellationContext.Instance.Cts.Token);
+            await ExecuteProject(project);
+            return true;
+        }
+        catch (NormalEndException)
+        {
+            throw;
+        }
+        catch (TaskCanceledException)
+        {
+            throw;
+        }
+        catch (Exception e)
+        {
+            _logger.LogDebug(e, "执行项目时发生异常");
+            _logger.LogError("执行项目时发生异常: {Msg}", e.Message);
+            return false;
+        }
+    }
+
     private async Task ExecuteProject(ScriptGroupProject project)
     {
         TaskContext.Instance().CurrentScriptProject = project;
@@ -591,7 +612,7 @@ public partial class ScriptService : IScriptService
                             stopwatch.Reset();
                             stopwatch.Start();
 
-                            await ExecuteProject(refProject);
+                            await ExecuteProjectWithBlessingAsync(refProject);
 
                             if (refProject.RunNum > 1 && ShouldSkipTask(refProject))
                             {

--- a/BetterGenshinImpact/Service/ScriptService.cs
+++ b/BetterGenshinImpact/Service/ScriptService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -31,6 +31,7 @@ public partial class ScriptService : IScriptService
 {
     private readonly ILogger<ScriptService> _logger = App.GetLogger<ScriptService>();
     private readonly BlessingOfTheWelkinMoonTask _blessingOfTheWelkinMoonTask = new();
+    private readonly HashSet<string> _executingScriptGroupRefs = new();
     private static bool IsCurrentHourEqual(string input)
     {
         // 尝试将输入字符串转换为整数
@@ -535,6 +536,45 @@ public partial class ScriptService : IScriptService
             _logger.LogInformation("→ 开始执行shell: {Name}", project.Name);
             if (RunnerContext.Instance.IsPreExecution) _logger.LogInformation("此任务为优先执行任务！");
             await project.Run();
+        }
+        else if (project.Type == "ScriptGroupRef")
+        {
+            if (_executingScriptGroupRefs.Contains(project.Name))
+            {
+                _logger.LogWarning("检测到配置组引用循环依赖 [{Name}]，跳过执行以避免无限递归", project.Name);
+                return;
+            }
+
+            _logger.LogInformation("→ 开始执行配置组引用: {Name}", project.Name);
+            if (RunnerContext.Instance.IsPreExecution) _logger.LogInformation("此任务为优先执行任务！");
+            var scriptGroupRef = App.GetService<ScriptControlViewModel>().ScriptGroups.FirstOrDefault(g => g.Name == project.Name);
+            if (scriptGroupRef == null)
+            {
+                _logger.LogWarning("配置组引用 [{Name}] 未找到，跳过执行", project.Name);
+                return;
+            }
+
+            _executingScriptGroupRefs.Add(project.Name);
+            try
+            {
+                foreach (var refProject in scriptGroupRef.Projects)
+                {
+                    if (refProject.Status != "Enabled")
+                    {
+                        _logger.LogInformation("配置组引用 [{Name}] 中的脚本 {ProjectName} 状态为禁用，跳过执行", project.Name, refProject.Name);
+                        continue;
+                    }
+                    if (CancellationContext.Instance.Cts.IsCancellationRequested)
+                    {
+                        break;
+                    }
+                    await ExecuteProject(refProject);
+                }
+            }
+            finally
+            {
+                _executingScriptGroupRefs.Remove(project.Name);
+            }
         }
     }
 

--- a/BetterGenshinImpact/Service/ScriptService.cs
+++ b/BetterGenshinImpact/Service/ScriptService.cs
@@ -474,6 +474,12 @@ public partial class ScriptService : IScriptService
                 list.Add(newProject);
                 // hasTimer = true;
             }
+            else if (project.Type == "ScriptGroupRef")
+            {
+                var newProject = ScriptGroupProject.BuildScriptGroupRefProject(project.Name);
+                CopyProjectProperties(project, newProject);
+                list.Add(newProject);
+            }
         }
 
         return list;
@@ -557,8 +563,14 @@ public partial class ScriptService : IScriptService
             _executingScriptGroupRefs.Add(project.Name);
             try
             {
-                foreach (var refProject in scriptGroupRef.Projects)
+                var refProjects = ReloadScriptProjects(scriptGroupRef.Projects);
+                foreach (var refProject in refProjects)
                 {
+                    if (refProject is { SkipFlag: true } || ShouldSkipTask(refProject))
+                    {
+                        continue;
+                    }
+
                     if (refProject.Status != "Enabled")
                     {
                         _logger.LogInformation("配置组引用 [{Name}] 中的脚本 {ProjectName} 状态为禁用，跳过执行", project.Name, refProject.Name);

--- a/BetterGenshinImpact/Service/ScriptService.cs
+++ b/BetterGenshinImpact/Service/ScriptService.cs
@@ -564,6 +564,7 @@ public partial class ScriptService : IScriptService
             try
             {
                 var refProjects = ReloadScriptProjects(scriptGroupRef.Projects);
+                var stopwatch = new Stopwatch();
                 foreach (var refProject in refProjects)
                 {
                     if (refProject is { SkipFlag: true } || ShouldSkipTask(refProject))
@@ -580,7 +581,48 @@ public partial class ScriptService : IScriptService
                     {
                         break;
                     }
-                    await ExecuteProject(refProject);
+
+                    for (var i = 0; i < refProject.RunNum; i++)
+                    {
+                        try
+                        {
+                            TaskTriggerDispatcher.Instance().ClearTriggers();
+                            _logger.LogInformation("------------------------------");
+                            stopwatch.Reset();
+                            stopwatch.Start();
+
+                            await ExecuteProject(refProject);
+
+                            if (refProject.RunNum > 1 && ShouldSkipTask(refProject))
+                            {
+                                break;
+                            }
+                        }
+                        catch (NormalEndException)
+                        {
+                            throw;
+                        }
+                        catch (TaskCanceledException)
+                        {
+                            throw;
+                        }
+                        catch (Exception e)
+                        {
+                            _logger.LogDebug(e, "执行引用组脚本时发生异常");
+                            _logger.LogError("执行引用组脚本时发生异常: {Msg}", e.Message);
+                            break;
+                        }
+                        finally
+                        {
+                            stopwatch.Stop();
+                            var elapsedTime = TimeSpan.FromMilliseconds(stopwatch.ElapsedMilliseconds);
+                            _logger.LogInformation("→ 脚本执行结束: {Name}, 耗时: {Minutes}分{Seconds:0.000}秒", refProject.Name,
+                                elapsedTime.Hours * 60 + elapsedTime.Minutes, elapsedTime.TotalSeconds % 60);
+                            _logger.LogInformation("------------------------------");
+                        }
+
+                        await Task.Delay(1000);
+                    }
                 }
             }
             finally

--- a/BetterGenshinImpact/View/Pages/ScriptControlPage.xaml
+++ b/BetterGenshinImpact/View/Pages/ScriptControlPage.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="BetterGenshinImpact.View.Pages.ScriptControlPage"
+<UserControl x:Class="BetterGenshinImpact.View.Pages.ScriptControlPage"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:b="http://schemas.microsoft.com/xaml/behaviors"
@@ -234,6 +234,7 @@
                                 <MenuItem Header="地图追踪任务" Command="{Binding AddPathingCommand}" />
                                 <MenuItem Header="键鼠脚本" Command="{Binding AddKmScriptCommand}" />
                                 <MenuItem Header="Shell" Command="{Binding AddShellCommand}" />
+                                <MenuItem Header="配置组引用" Command="{Binding AddScriptGroupRefCommand}" />
                             </ContextMenu>
                         </ui:DropDownButton.Flyout>
                     </ui:DropDownButton>
@@ -335,6 +336,7 @@
                             <MenuItem Command="{Binding AddPathingCommand}" Header="添加地图追踪任务" />
                             <MenuItem Command="{Binding AddKmScriptCommand}" Header="添加键鼠脚本" />
                             <MenuItem Command="{Binding AddShellCommand}" Header="添加Shell" />
+                            <MenuItem Command="{Binding AddScriptGroupRefCommand}" Header="添加配置组引用" />
                             <MenuItem Command="{Binding AddNextFlagCommand}" Header="下一次任务从此处执行"
                                       CommandParameter="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=ContextMenu}, Path=PlacementTarget.SelectedItem}"
                                       />

--- a/BetterGenshinImpact/ViewModel/Pages/ScriptControlViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/ScriptControlViewModel.cs
@@ -874,6 +874,42 @@ public partial class ScriptControlViewModel : ViewModel
     }
 
     [RelayCommand]
+    private void OnAddScriptGroupRef()
+    {
+        if (SelectedScriptGroup == null)
+        {
+            return;
+        }
+
+        var availableGroups = ScriptGroups
+            .Where(g => g.Name != SelectedScriptGroup.Name)
+            .Select(g => g.Name)
+            .ToList();
+
+        if (availableGroups.Count == 0)
+        {
+            Toast.Warning("没有其他可引用的配置组");
+            return;
+        }
+
+        var combobox = new ComboBox
+        {
+            VerticalAlignment = VerticalAlignment.Top
+        };
+
+        foreach (var groupName in availableGroups)
+        {
+            combobox.Items.Add(groupName);
+        }
+
+        var result = PromptDialog.Prompt("请选择需要引用的配置组", "添加配置组引用", combobox);
+        if (!string.IsNullOrEmpty(result))
+        {
+            SelectedScriptGroup.AddProject(ScriptGroupProject.BuildScriptGroupRefProject(result));
+        }
+    }
+
+    [RelayCommand]
     private async Task OnAddPathing()
     {
         try


### PR DESCRIPTION
实现配置组之间的引用功能，允许一个配置组引用另一个配置组的项目
添加循环依赖检测防止无限递归
在UI菜单中增加配置组引用选项

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 在脚本配置中新增“配置组引用”类型，支持在“添加”下拉与任务右键菜单快速创建引用并选择目标配置组。
  * 新增在创建引用时的选择与提示流程，用户无其他可引用组时会收到友好提示。

* **可靠性**
  * 执行引用时按原有规则逐项运行子项目（支持跳过/禁用/运行次数/间隔/取消），遇错会停止当前引用序列并记录情况。
  * 防止循环引用；在运行每个子项目前会确保相关前置任务已启动以保证执行环境。
* **修复**
  * 修正界面文件开头的字符问题。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->