### PR TITLE
修复自动地脉花战后切队与结束检测问题

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoDomain/AutoDomainTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoDomain/AutoDomainTask.cs
@@ -1271,13 +1271,13 @@ public class AutoDomainTask : ISoloTask
         Bv.ClickBlackConfirmButton(CaptureToRectArea());
     }
 
-    public static (bool, int) PressUseResin(ImageRegion ra, string resinName)
+    public static (bool, int) PressUseResin(ImageRegion ra, string resinName, string logPrefix = "自动秘境")
     {
         var regionList = ra.FindMulti(RecognitionObject.Ocr(ra.Width * 0.25, ra.Height * 0.2, ra.Width * 0.5, ra.Height * 0.6));
-        return PressUseResin(regionList, resinName);
+        return PressUseResin(regionList, resinName, logPrefix);
     }
 
-    public static (bool, int) PressUseResin(List<Region> regionList, string resinName)
+    public static (bool, int) PressUseResin(List<Region> regionList, string resinName, string logPrefix = "自动秘境")
     {
         if (resinName == "原粹树脂20" || resinName == "原粹树脂40")
         {
@@ -1301,18 +1301,18 @@ public class AutoDomainTask : ISoloTask
                     // 解决水龙王按下左键后没松开，然后后续点击按下就没反应了。使用双击
                     Sleep(60);
                     useKey.Click();
-                    var num = GetResinNum(resinKey, resinName);
-                    Logger.LogInformation("自动秘境：使用 {ResinName}, 数量：{Num}", resinName, num);
+                    var num = GetResinNum(resinKey, resinName, logPrefix);
+                    Logger.LogInformation("{LogPrefix}：使用 {ResinName}, 数量：{Num}", logPrefix, resinName, num);
                     return (true, num);
                 }
                 else
                 {
-                    Logger.LogWarning("自动秘境：未找到 {ResinName} 的使用按键", resinName);
+                    Logger.LogWarning("{LogPrefix}：未找到 {ResinName} 的使用按键", logPrefix, resinName);
                 }
             }
             else
             {
-                Logger.LogWarning("自动秘境：未找到 {ResinName} 的使用按键", resinName);
+                Logger.LogWarning("{LogPrefix}：未找到 {ResinName} 的使用按键", logPrefix, resinName);
             }
         }
 
@@ -1359,7 +1359,7 @@ public class AutoDomainTask : ISoloTask
         }, TimeSpan.FromMilliseconds(500), 10);
     }
 
-    private static int GetResinNum(Region region, string resinName)
+    private static int GetResinNum(Region region, string resinName, string logPrefix)
     {
         if (resinName == "原粹树脂")
         {
@@ -1373,7 +1373,7 @@ public class AutoDomainTask : ISoloTask
             }
             else
             {
-                Logger.LogWarning("自动秘境：未识别到原粹树脂消耗体力数量，默认按20计算");
+                Logger.LogWarning("{LogPrefix}：未识别到原粹树脂消耗体力数量，默认按20计算", logPrefix);
                 return 20;
             }
         }

--- a/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
@@ -438,7 +438,7 @@ public class AutoFightTask : ISoloTask
                         }
 
                         #region check动作触发战斗结束检测
-                        if (command.Method == Method.Check)
+                        if (command.Method == Method.Check && _taskParam.FightFinishDetectEnabled)
                         {
                             fightEndFlag = await CheckFightFinish(delayTime, detectDelayTime);
                         }

--- a/BetterGenshinImpact/GameTask/AutoLeyLineOutcrop/AutoLeyLineOutcropTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoLeyLineOutcrop/AutoLeyLineOutcropTask.cs
@@ -81,6 +81,7 @@ public class AutoLeyLineOutcropTask : ISoloTask
     private const string OcrFlowOverlayKey = "AutoLeyLineOutcrop.OcrFlow";
     private const string OcrFightOverlayKey = "AutoLeyLineOutcrop.OcrFight";
     private const int OcrOverlayRenderLeadMs = 300;
+    private const int KazuhaPickupPostSkillWaitMs = 3000;
     private static readonly TimeSpan LeyLineFightSeekInitialDelay = TimeSpan.FromSeconds(2);
     private static readonly Rect HandbookTrackActionButtonRoi = new(ScaleTo1080(1120), ScaleTo1080(680), ScaleTo1080(700), ScaleTo1080(320));
     private static readonly System.Drawing.Pen OcrOverlayPen = new(System.Drawing.Color.Lime, 2);
@@ -1085,6 +1086,8 @@ public class AutoLeyLineOutcropTask : ISoloTask
         Simulation.SendInput.SimulateAction(GIActions.NormalAttack);
         await Delay(1500, _ct);
         kazuha.AfterUseSkill();
+        _logger.LogInformation("战后聚集拾取：万叶长E动作完成，等待拾取动作结束");
+        await Delay(KazuhaPickupPostSkillWaitMs, _ct);
         _logger.LogInformation("战后聚集拾取：万叶长E聚集动作执行完成");
     }
 
@@ -1961,7 +1964,7 @@ public class AutoLeyLineOutcropTask : ISoloTask
         Simulation.SendInput.Mouse.LeftButtonUp();
         await Delay(60, _ct);
 
-        var (success, _) = AutoDomainTask.PressUseResin(promptRegions, resinName);
+        var (success, _) = AutoDomainTask.PressUseResin(promptRegions, resinName, Name);
         if (success)
         {
             _logger.LogDebug("奖励页面已尝试使用树脂：{ResinName}", resinName);

--- a/BetterGenshinImpact/GameTask/AutoStygianOnslaught/AutoStygianOnslaughtTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoStygianOnslaught/AutoStygianOnslaughtTask.cs
@@ -704,12 +704,12 @@ public class AutoStygianOnslaughtTask : StateMachineBase<StygianState, BvPage>, 
 
             if (resinStatus.CondensedResinCount > 0)
             {
-                AutoDomainTask.PressUseResin(ra, "浓缩树脂");
+                AutoDomainTask.PressUseResin(ra, "浓缩树脂", Name);
                 resinStatus.CondensedResinCount -= 1;
             }
             else if (resinStatus.OriginalResinCount >= 20)
             {
-                var (_, num) = AutoDomainTask.PressUseResin(ra, "原粹树脂");
+                var (_, num) = AutoDomainTask.PressUseResin(ra, "原粹树脂", Name);
                 resinStatus.OriginalResinCount -= num;
             }
 
@@ -724,7 +724,7 @@ public class AutoStygianOnslaughtTask : StateMachineBase<StygianState, BvPage>, 
             {
                 if (record.RemainCount > 0)
                 {
-                    var (success, _) = AutoDomainTask.PressUseResin(textList, record.Name);
+                    var (success, _) = AutoDomainTask.PressUseResin(textList, record.Name, Name);
                     if (success)
                     {
                         record.RemainCount -= 1;


### PR DESCRIPTION
## 变更说明
- 为自动地脉花的万叶长 E 拾取增加固定等待，避免拾取动作打断切换好感队
- 让自动战斗中的 check 动作仅在开启战斗结束检测时才触发结束检查
- 为复用的树脂领取逻辑增加日志前缀参数，修正自动地脉花/自动幽境危战的领奖日志名称

## 验证
- dotnet build BetterGenshinImpact/BetterGenshinImpact.csproj -c Debug -p:Platform=x64 -p:RestoreDisableParallel=true -m:1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 更新内容

* **问题修复**
  * 修复战斗检测逻辑，现在仅在启用时才执行战斗完成检测。

* **改进**
  * 优化秘境任务的日志记录，提供更详细的执行上下文信息。
  * 调整「绝缘之旗」秘境采集流程，在角色技能后增加3秒延迟。
  * 增强树脂消耗相关任务的信息追踪。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->