### PR TITLE
fix: 修复ClearScript桥接取消异常导致的错误日志

### DIFF
--- a/BetterGenshinImpact/App.xaml.cs
+++ b/BetterGenshinImpact/App.xaml.cs
@@ -309,6 +309,11 @@ public partial class App : Application
                 return true;
             }
 
+            if (ex is ObjectDisposedException ode && ode.ObjectName?.Contains("V8Script") == true)
+            {
+                return true;
+            }
+
             ex = ex.InnerException;
         }
 

--- a/BetterGenshinImpact/Core/Script/Dependence/AutoPathingScript.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/AutoPathingScript.cs
@@ -1,8 +1,9 @@
 using System;
-using BetterGenshinImpact.GameTask.AutoPathing;
-using BetterGenshinImpact.GameTask.AutoPathing.Model;
+using System.Threading;
 using System.Threading.Tasks;
 using BetterGenshinImpact.Core.Config;
+using BetterGenshinImpact.GameTask.AutoPathing;
+using BetterGenshinImpact.GameTask.AutoPathing.Model;
 using BetterGenshinImpact.GameTask.Common;
 using Microsoft.Extensions.Logging;
 
@@ -34,6 +35,10 @@ public class AutoPathingScript
 
             await pathExecutor.Pathing(task);
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception e)
         {
             TaskControl.Logger.LogDebug(e,"执行地图追踪时候发生错误");
@@ -47,6 +52,10 @@ public class AutoPathingScript
         {
             var json = await new LimitedFile(_rootPath).ReadText(path);
             await Run(json);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception e)
         {

--- a/BetterGenshinImpact/Service/ScriptService.cs
+++ b/BetterGenshinImpact/Service/ScriptService.cs
@@ -23,6 +23,7 @@ using BetterGenshinImpact.Service.Interface;
 using BetterGenshinImpact.Service.Notification;
 using BetterGenshinImpact.Service.Notification.Model.Enum;
 using BetterGenshinImpact.ViewModel.Pages;
+using Microsoft.ClearScript;
 using Microsoft.Extensions.Logging;
 
 namespace BetterGenshinImpact.Service;
@@ -359,8 +360,18 @@ public partial class ScriptService : IScriptService
                                 _logger.LogInformation("取消执行配置组: {Msg}", e.Message);
                                 throw;
                             }
+                            catch (OperationCanceledException)
+                            {
+                                throw;
+                            }
                             catch (Exception e)
                             {
+                                if (e is ScriptEngineException see && IsTaskCanceledInside(see))
+                                {
+                                    _logger.LogInformation("取消执行");
+                                    throw;
+                                }
+
                                 _logger.LogDebug(e, "执行脚本时发生异常");
                                 _logger.LogError("执行脚本时发生异常: {Msg}", e.Message);
                                 if (!RunnerContext.Instance.IsPreExecution && taskProgress != null && taskProgress.CurrentScriptGroupProjectInfo != null)
@@ -556,6 +567,24 @@ public partial class ScriptService : IScriptService
         }
 
         return codeList;
+    }
+
+    /// <summary>
+    /// 检查 ScriptEngineException 的内部异常链中是否包含 TaskCanceledException，
+    /// 用于处理 ClearScript Task-Promise 桥接将取消异常包装为 ScriptEngineException 的情况
+    /// </summary>
+    private static bool IsTaskCanceledInside(Exception ex)
+    {
+        var inner = ex.InnerException;
+        while (inner != null)
+        {
+            if (inner is TaskCanceledException)
+            {
+                return true;
+            }
+            inner = inner.InnerException;
+        }
+        return false;
     }
 
     private bool HasTimerOperation(IEnumerable<string> codeList)

--- a/BetterGenshinImpact/Service/ScriptService.cs
+++ b/BetterGenshinImpact/Service/ScriptService.cs
@@ -578,7 +578,7 @@ public partial class ScriptService : IScriptService
         var inner = ex.InnerException;
         while (inner != null)
         {
-            if (inner is TaskCanceledException)
+            if (inner is OperationCanceledException)
             {
                 return true;
             }


### PR DESCRIPTION
ClearScript 的 Task-Promise 桥接会在 .NET 的 ThreadPool 上注册 continuation，当 Task 完成（取消）时，这些 continuation 会被线程池调度执行，尝试回调 V8 引擎来 resolve/reject Promise。engine.Interrupt() 无法取消已经被 ThreadPool 排队的 continuation 回调。引擎 Dispose() 后，这些排队的回调仍然会执行并触发 ObjectDisposedException

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 改进了对已释放脚本引擎相关异常的识别，减少误报
  * 优化了脚本执行的取消流程，确保取消请求正确传播和中断长运行脚本
  * 增强了异常链的检测与处理，在复杂嵌套异常场景下表现更稳健
<!-- end of auto-generated comment: release notes by coderabbit.ai -->