### PR TITLE
feat: 增加 HTML 遮罩窗口点击穿透模式切换功能

### DIFF
--- a/BetterGenshinImpact/Core/Script/Dependence/HtmlMask.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/HtmlMask.cs
@@ -152,9 +152,6 @@ public class HtmlMask : IDisposable
     /// <param name="enabled">true=点击穿透，false=可交互</param>
     public void SetClickThrough(string windowId, bool enabled)
     {
-        if (!HtmlMaskWindow.Exists(windowId))
-            throw new InvalidOperationException($"HTML遮罩窗口不存在或已关闭: {windowId}");
-
         HtmlMaskWindow.SetClickThrough(windowId, enabled);
     }
 
@@ -165,9 +162,6 @@ public class HtmlMask : IDisposable
     /// <returns>true=点击穿透，false=可交互</returns>
     public bool GetClickThrough(string windowId)
     {
-        if (!HtmlMaskWindow.Exists(windowId))
-            throw new InvalidOperationException($"HTML遮罩窗口不存在或已关闭: {windowId}");
-
         return HtmlMaskWindow.GetClickThrough(windowId);
     }
 
@@ -177,9 +171,6 @@ public class HtmlMask : IDisposable
     /// <param name="windowId">窗口ID</param>
     public void ToggleClickThrough(string windowId)
     {
-        if (!HtmlMaskWindow.Exists(windowId))
-            throw new InvalidOperationException($"HTML遮罩窗口不存在或已关闭: {windowId}");
-
         HtmlMaskWindow.ToggleClickThrough(windowId);
     }
 

--- a/BetterGenshinImpact/Core/Script/Dependence/HtmlMask.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/HtmlMask.cs
@@ -145,6 +145,44 @@ public class HtmlMask : IDisposable
     /// </summary>
     public bool Exists(string id) => HtmlMaskWindow.Exists(id);
 
+    /// <summary>
+    /// 设置窗口的点击穿透模式
+    /// </summary>
+    /// <param name="windowId">窗口ID</param>
+    /// <param name="enabled">true=点击穿透，false=可交互</param>
+    public void SetClickThrough(string windowId, bool enabled)
+    {
+        if (!HtmlMaskWindow.Exists(windowId))
+            throw new InvalidOperationException($"HTML遮罩窗口不存在或已关闭: {windowId}");
+
+        HtmlMaskWindow.SetClickThrough(windowId, enabled);
+    }
+
+    /// <summary>
+    /// 获取窗口的点击穿透状态
+    /// </summary>
+    /// <param name="windowId">窗口ID</param>
+    /// <returns>true=点击穿透，false=可交互</returns>
+    public bool GetClickThrough(string windowId)
+    {
+        if (!HtmlMaskWindow.Exists(windowId))
+            throw new InvalidOperationException($"HTML遮罩窗口不存在或已关闭: {windowId}");
+
+        return HtmlMaskWindow.GetClickThrough(windowId);
+    }
+
+    /// <summary>
+    /// 切换窗口的点击穿透模式
+    /// </summary>
+    /// <param name="windowId">窗口ID</param>
+    public void ToggleClickThrough(string windowId)
+    {
+        if (!HtmlMaskWindow.Exists(windowId))
+            throw new InvalidOperationException($"HTML遮罩窗口不存在或已关闭: {windowId}");
+
+        HtmlMaskWindow.ToggleClickThrough(windowId);
+    }
+
     #endregion
 
     #region 消息通信

--- a/BetterGenshinImpact/GameTask/TaskRunner.cs
+++ b/BetterGenshinImpact/GameTask/TaskRunner.cs
@@ -190,6 +190,7 @@ public class TaskRunner
         TaskTriggerDispatcher.Instance().SetTriggers(GameTaskManager.LoadInitialTriggers());
 
         VisionContext.Instance().DrawContent.ClearAll();
+        HtmlMaskWindow.CloseAll();
     }
 
 }

--- a/BetterGenshinImpact/View/HtmlMaskWindow.xaml
+++ b/BetterGenshinImpact/View/HtmlMaskWindow.xaml
@@ -9,7 +9,9 @@
         WindowStartupLocation="Manual"
         ShowInTaskbar="False"
         Topmost="True">
-    <Grid>
-        <wv2:WebView2 x:Name="WebView" DefaultBackgroundColor="Transparent"/>
-    </Grid>
+    <Border x:Name="ClickThroughBorder" Background="Transparent">
+        <Grid>
+            <wv2:WebView2 x:Name="WebView" DefaultBackgroundColor="Transparent"/>
+        </Grid>
+    </Border>
 </Window>

--- a/BetterGenshinImpact/View/HtmlMaskWindow.xaml.cs
+++ b/BetterGenshinImpact/View/HtmlMaskWindow.xaml.cs
@@ -17,7 +17,7 @@ using Microsoft.Web.WebView2.Core;
 namespace BetterGenshinImpact.View;
 
 /// <summary>
-/// HTML遮罩窗口 - 仅用于显示，不可交互（点击穿透）
+/// HTML遮罩窗口
 /// </summary>
 public partial class HtmlMaskWindow : Window
 {
@@ -460,6 +460,37 @@ public partial class HtmlMaskWindow : Window
         _isClickThrough = enabled;
 
         SetBackgroundOpacity(!enabled);
+
+        if (!enabled)
+        {
+            // 禁用穿透：激活遮罩窗口，确保获得键盘和鼠标焦点
+            try
+            {
+                User32.SetForegroundWindow(hwnd);
+                User32.BringWindowToTop(hwnd);
+                Dispatcher.Invoke(() => Activate());
+            }
+            catch (Exception ex)
+            {
+                TaskControl.Logger.LogDebug(ex, "HTML遮罩窗口激活失败");
+            }
+        }
+        else
+        {
+            // 开启穿透：将焦点还给游戏窗口
+            try
+            {
+                var gameHandle = TaskContext.Instance().GameHandle;
+                if (gameHandle != IntPtr.Zero)
+                {
+                    SystemControl.FocusWindow(gameHandle);
+                }
+            }
+            catch (Exception ex)
+            {
+                TaskControl.Logger.LogDebug(ex, "HTML遮罩恢复游戏焦点失败");
+            }
+        }
     }
 
     /// <summary>
@@ -474,7 +505,7 @@ public partial class HtmlMaskWindow : Window
     }
 
     /// <summary>
-    /// 设置点击穿透模式（公开方法）
+    /// 设置点击穿透模式
     /// </summary>
     /// <param name="enabled">true=点击穿透，false=可交互</param>
     public void SetClickThroughMode(bool enabled)
@@ -483,7 +514,7 @@ public partial class HtmlMaskWindow : Window
     }
 
     /// <summary>
-    /// 原子切换点击穿透模式（在UI线程上执行读取和设置，避免竞态条件）
+    /// 切换点击穿透模式
     /// </summary>
     private void ToggleClickThroughCore()
     {

--- a/BetterGenshinImpact/View/HtmlMaskWindow.xaml.cs
+++ b/BetterGenshinImpact/View/HtmlMaskWindow.xaml.cs
@@ -29,11 +29,20 @@ public partial class HtmlMaskWindow : Window
     private readonly string _webView2DataPath;
     private readonly string _pageUrl;
     private bool _navigationCompleted;
+    private bool _styleCaptured;
+    private int _originalStyle;
+    private volatile bool _isClickThrough = true;
+    private readonly System.Windows.Media.SolidColorBrush _backgroundBrush = new();
 
     /// <summary>
     /// 窗口唯一标识
     /// </summary>
     public string MaskId => _id;
+
+    /// <summary>
+    /// 当前是否处于点击穿透模式
+    /// </summary>
+    public bool IsClickThrough => _isClickThrough;
 
     private HtmlMaskWindow(string url, string? id, string workDir)
     {
@@ -42,6 +51,7 @@ public partial class HtmlMaskWindow : Window
         _webView2DataPath = Path.Combine(workDir, "WebView2Data");
         _pageUrl = url;
         InitializeComponent();
+        ClickThroughBorder.Background = _backgroundBrush;
         Loaded += OnLoaded;
         InitializeAsync(url);
     }
@@ -157,6 +167,54 @@ public partial class HtmlMaskWindow : Window
     }
 
     /// <summary>
+    /// 设置指定窗口的点击穿透模式
+    /// </summary>
+    /// <param name="windowId">窗口ID</param>
+    /// <param name="enabled">true=点击穿透，false=可交互</param>
+    public static void SetClickThrough(string windowId, bool enabled)
+    {
+        if (_windows.TryGetValue(windowId, out var window))
+        {
+            window.SetClickThroughMode(enabled);
+        }
+        else
+        {
+            TaskControl.Logger.LogWarning("设置点击穿透失败，窗口不存在: {WindowId}", windowId);
+        }
+    }
+
+    /// <summary>
+    /// 获取指定窗口的点击穿透状态
+    /// </summary>
+    /// <param name="windowId">窗口ID</param>
+    /// <returns>点击穿透状态</returns>
+    public static bool GetClickThrough(string windowId)
+    {
+        if (_windows.TryGetValue(windowId, out var window))
+        {
+            return window.IsClickThrough;
+        }
+        TaskControl.Logger.LogWarning("获取点击穿透状态失败，窗口不存在: {WindowId}", windowId);
+        return false;
+    }
+
+    /// <summary>
+    /// 原子切换指定窗口的点击穿透模式
+    /// </summary>
+    /// <param name="windowId">窗口ID</param>
+    public static void ToggleClickThrough(string windowId)
+    {
+        if (_windows.TryGetValue(windowId, out var window))
+        {
+            window.ToggleClickThroughCore();
+        }
+        else
+        {
+            TaskControl.Logger.LogWarning("切换点击穿透失败，窗口不存在: {WindowId}", windowId);
+        }
+    }
+
+    /// <summary>
     /// 通知窗口刷新待推送的消息
     /// </summary>
     internal static void NotifyFlush(string windowId)
@@ -178,7 +236,7 @@ public partial class HtmlMaskWindow : Window
 
     private void OnLoaded(object sender, RoutedEventArgs e)
     {
-        SetClickThrough();
+        SetClickThrough(true);
         UpdatePosition();
     }
 
@@ -387,14 +445,56 @@ public partial class HtmlMaskWindow : Window
     }
 
     /// <summary>
-    /// 设置点击穿透
+    /// 设置点击穿透模式
     /// </summary>
-    private void SetClickThrough()
+    /// <param name="enabled">true=点击穿透，false=可交互</param>
+    private void SetClickThrough(bool enabled)
     {
         var hwnd = new WindowInteropHelper(this).Handle;
-        var style = (int)GetWindowLong(hwnd, WindowLongFlags.GWL_EXSTYLE);
-        User32.SetWindowLong(hwnd, WindowLongFlags.GWL_EXSTYLE,
-            (IntPtr)(style | (int)User32.WindowStylesEx.WS_EX_TRANSPARENT));
+        if (hwnd == IntPtr.Zero) return;
+
+        if (!_styleCaptured)
+        {
+            _originalStyle = (int)GetWindowLong(hwnd, WindowLongFlags.GWL_EXSTYLE);
+            _styleCaptured = true;
+        }
+
+        int newStyle = enabled
+            ? (_originalStyle | (int)User32.WindowStylesEx.WS_EX_TRANSPARENT | (int)User32.WindowStylesEx.WS_EX_LAYERED)
+            : (_originalStyle & ~(int)User32.WindowStylesEx.WS_EX_TRANSPARENT & ~(int)User32.WindowStylesEx.WS_EX_LAYERED);
+
+        User32.SetWindowLong(hwnd, WindowLongFlags.GWL_EXSTYLE, (IntPtr)newStyle);
+        _isClickThrough = enabled;
+
+        SetBackgroundOpacity(!enabled);
+    }
+
+    /// <summary>
+    /// 设置背景透明度
+    /// </summary>
+    /// <param name="isInteractive">是否处于交互模式</param>
+    private void SetBackgroundOpacity(bool isInteractive)
+    {
+        _backgroundBrush.Color = isInteractive
+            ? System.Windows.Media.Color.FromArgb(1, 0, 0, 0)
+            : System.Windows.Media.Color.FromArgb(0, 0, 0, 0);
+    }
+
+    /// <summary>
+    /// 设置点击穿透模式（公开方法）
+    /// </summary>
+    /// <param name="enabled">true=点击穿透，false=可交互</param>
+    public void SetClickThroughMode(bool enabled)
+    {
+        Dispatcher.Invoke(() => SetClickThrough(enabled));
+    }
+
+    /// <summary>
+    /// 原子切换点击穿透模式（在UI线程上执行读取和设置，避免竞态条件）
+    /// </summary>
+    private void ToggleClickThroughCore()
+    {
+        Dispatcher.Invoke(() => SetClickThrough(!_isClickThrough));
     }
 
     /// <summary>

--- a/BetterGenshinImpact/View/HtmlMaskWindow.xaml.cs
+++ b/BetterGenshinImpact/View/HtmlMaskWindow.xaml.cs
@@ -215,13 +215,24 @@ public partial class HtmlMaskWindow : Window
         if (!_windows.TryGetValue(windowId, out var window)) return;
         window.Dispatcher.BeginInvoke(() =>
         {
-            // 页面还没加载完，消息留在队列中由 NavigationCompleted 统一推送
-            if (!window._navigationCompleted) return;
-            if (window.WebView.CoreWebView2 == null) return;
-            HtmlMask.FlushPendingMessages(windowId, json =>
+            try
             {
-                window.WebView.CoreWebView2.PostWebMessageAsString(json);
-            });
+                // 页面还没加载完，消息留在队列中由 NavigationCompleted 统一推送
+                if (!window._navigationCompleted) return;
+                if (window.WebView.CoreWebView2 == null) return;
+                HtmlMask.FlushPendingMessages(windowId, json =>
+                {
+                    window.WebView.CoreWebView2.PostWebMessageAsString(json);
+                });
+            }
+            catch (ObjectDisposedException)
+            {
+                // WebView 已被释放，忽略此消息推送
+            }
+            catch (Exception ex)
+            {
+                TaskControl.Logger.LogDebug(ex, "HTML遮罩窗口消息推送异常");
+            }
         });
     }
 

--- a/BetterGenshinImpact/View/HtmlMaskWindow.xaml.cs
+++ b/BetterGenshinImpact/View/HtmlMaskWindow.xaml.cs
@@ -167,20 +167,25 @@ public partial class HtmlMaskWindow : Window
     }
 
     /// <summary>
+    /// 获取窗口实例，不存在则抛出异常
+    /// </summary>
+    /// <param name="windowId">窗口ID</param>
+    /// <returns>窗口实例</returns>
+    private static HtmlMaskWindow GetWindowOrThrow(string windowId)
+    {
+        if (_windows.TryGetValue(windowId, out var window))
+            return window;
+        throw new InvalidOperationException($"HTML遮罩窗口不存在或已关闭: {windowId}");
+    }
+
+    /// <summary>
     /// 设置指定窗口的点击穿透模式
     /// </summary>
     /// <param name="windowId">窗口ID</param>
     /// <param name="enabled">true=点击穿透，false=可交互</param>
     public static void SetClickThrough(string windowId, bool enabled)
     {
-        if (_windows.TryGetValue(windowId, out var window))
-        {
-            window.SetClickThroughMode(enabled);
-        }
-        else
-        {
-            TaskControl.Logger.LogWarning("设置点击穿透失败，窗口不存在: {WindowId}", windowId);
-        }
+        GetWindowOrThrow(windowId).SetClickThroughMode(enabled);
     }
 
     /// <summary>
@@ -190,12 +195,7 @@ public partial class HtmlMaskWindow : Window
     /// <returns>点击穿透状态</returns>
     public static bool GetClickThrough(string windowId)
     {
-        if (_windows.TryGetValue(windowId, out var window))
-        {
-            return window.IsClickThrough;
-        }
-        TaskControl.Logger.LogWarning("获取点击穿透状态失败，窗口不存在: {WindowId}", windowId);
-        return false;
+        return GetWindowOrThrow(windowId).IsClickThrough;
     }
 
     /// <summary>
@@ -204,14 +204,7 @@ public partial class HtmlMaskWindow : Window
     /// <param name="windowId">窗口ID</param>
     public static void ToggleClickThrough(string windowId)
     {
-        if (_windows.TryGetValue(windowId, out var window))
-        {
-            window.ToggleClickThroughCore();
-        }
-        else
-        {
-            TaskControl.Logger.LogWarning("切换点击穿透失败，窗口不存在: {WindowId}", windowId);
-        }
+        GetWindowOrThrow(windowId).ToggleClickThroughCore();
     }
 
     /// <summary>
@@ -461,7 +454,7 @@ public partial class HtmlMaskWindow : Window
 
         int newStyle = enabled
             ? (_originalStyle | (int)User32.WindowStylesEx.WS_EX_TRANSPARENT | (int)User32.WindowStylesEx.WS_EX_LAYERED)
-            : (_originalStyle & ~(int)User32.WindowStylesEx.WS_EX_TRANSPARENT & ~(int)User32.WindowStylesEx.WS_EX_LAYERED);
+            : _originalStyle;
 
         User32.SetWindowLong(hwnd, WindowLongFlags.GWL_EXSTYLE, (IntPtr)newStyle);
         _isClickThrough = enabled;


### PR DESCRIPTION

补充了一个停止脚本时关闭遮罩

------------------------------


### 概述

为 `HtmlMaskWindow` 新增点击穿透模式的动态切换能力，允许 JS 脚本在运行时控制遮罩窗口是否接收鼠标点击事件。此前遮罩窗口一旦创建即处于点击穿透状态，无法切换为可交互模式。


### 新增 API

#### JS 脚本层（`HtmlMask` 类）

```js
// 设置点击穿透模式
mask.SetClickThrough(windowId, true);   // 点击穿透（鼠标事件穿过窗口）
mask.SetClickThrough(windowId, false);  // 可交互（窗口可接收鼠标点击）

// 获取当前状态
var isClickThrough = mask.GetClickThrough(windowId);

// 切换模式（穿透 ↔ 可交互）
mask.ToggleClickThrough(windowId);
```

### 实现细节

#### Win32 窗口样式管理

通过 `SetWindowLong` 修改窗口扩展样式来控制点击穿透：

- **启用穿透**：在原始样式基础上添加 `WS_EX_TRANSPARENT | WS_EX_LAYERED`
- **禁用穿透**：直接恢复原始样式 `_originalStyle`

WPF 窗口在 `AllowsTransparency="True"` 且背景完全透明（Alpha=0）时，即使移除了 `WS_EX_TRANSPARENT`，窗口仍可能无法接收鼠标点击。因此在交互模式下，将 `ClickThroughBorder` 的背景设置为 `ARGB(1, 0, 0, 0)`（极低不透明度，视觉上不可见但足以让窗口命中测试通过）。



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 添加窗口“点击穿透”控制：支持设置、查询与切换指定窗口的穿透状态。
  * 启动时显式初始化穿透状态并将视觉透明度与穿透行为联动，提升交互一致性。
* **修复/优化**
  * 结束任务时会关闭所有相关遮罩窗口，避免遗留窗口影响后续交互。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->