### PR TITLE
重置鼠标按键，发送 3 次普攻指令，确保枫原万叶下落拾取动作完整执行

### DIFF
--- a/BetterGenshinImpact/Core/Simulator/Simulation.cs
+++ b/BetterGenshinImpact/Core/Simulator/Simulation.cs
@@ -28,6 +28,9 @@ public class Simulation
                 SendInput.Keyboard.KeyUp(key);
             }
         }
+		SendInput.Mouse.LeftButtonUp();
+        SendInput.Mouse.RightButtonUp();
+        SendInput.Mouse.MiddleButtonUp();
     }
 
     public static bool IsKeyDown(User32.VK key)

--- a/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
@@ -689,6 +689,7 @@ public class AutoFightTask : ISoloTask
                             await Delay(100, ct);
                             Simulation.SendInput.SimulateAction(GIActions.NormalAttack);
                             await Delay(1500, ct);
+                            picker.AfterUseSkill();
                         }
                     }
                     else

--- a/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
@@ -684,6 +684,10 @@ public class AutoFightTask : ISoloTask
                             picker.UseSkill(true);
                             await Delay(50, ct);
                             Simulation.SendInput.SimulateAction(GIActions.NormalAttack);
+                            await Delay(100, ct);
+                            Simulation.SendInput.SimulateAction(GIActions.NormalAttack);
+                            await Delay(100, ct);
+                            Simulation.SendInput.SimulateAction(GIActions.NormalAttack);
                             await Delay(1500, ct);
                         }
                     }

--- a/BetterGenshinImpact/GameTask/AutoLeyLineOutcrop/AutoLeyLineOutcropTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoLeyLineOutcrop/AutoLeyLineOutcropTask.cs
@@ -1084,6 +1084,10 @@ public class AutoLeyLineOutcropTask : ISoloTask
         kazuha.UseSkill(true);
         await Delay(50, _ct);
         Simulation.SendInput.SimulateAction(GIActions.NormalAttack);
+        await Delay(100, _ct);
+        Simulation.SendInput.SimulateAction(GIActions.NormalAttack);
+        await Delay(100, _ct);
+        Simulation.SendInput.SimulateAction(GIActions.NormalAttack);
         await Delay(1500, _ct);
         kazuha.AfterUseSkill();
         _logger.LogInformation("战后聚集拾取：万叶长E动作完成，等待拾取动作结束");

--- a/BetterGenshinImpact/GameTask/AutoPathing/Handler/PickUpCollectHandler.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/Handler/PickUpCollectHandler.cs
@@ -25,8 +25,8 @@ public class PickUpCollectHandler : IActionHandler
     /// </summary>
     public static readonly string[] PickUpActions =
     [
-        "枫原万叶-长E keydown(E),wait(0.7),keyup(E),attack(0.2),wait(0.5)",
-        "枫原万叶-短E e,attack(0.15)",
+        "枫原万叶-长E attack(0.08),keydown(E),wait(1),keyup(E),attack(0.5)",
+        "枫原万叶-短E attack(0.08),keydown(E),wait(0.47),keyup(E),attack(0.5)",
         "琴-短E wait(0.1),keydown(E),wait(0.4),moveby(1000,0),wait(0.2),moveby(1000,0),wait(0.2),moveby(1000,0),wait(0.2),moveby(1000,-3500),wait(1.8),keyup(E),wait(0.3),click(middle)",
         "琴-长E wait(0.1),click(middle),keydown(E),click(middle),wait(0.4),moveby(500,0),wait(0.1),moveby(500,0),wait(0.1)," +
         "moveby(500,0),wait(0.1),moveby(500,0),wait(0.1),moveby(500,0),wait(0.1),moveby(500,0),wait(0.1),moveby(500,0),wait(0.1)," +


### PR DESCRIPTION
确保输入状态清理并提升攻击 / 拾取稳定性：
在Simulation.cs中释放鼠标左键、右键、中键，避免鼠标按键状态卡死；
在AutoFightTask.cs和AutoLeyLineOutcropTask.cs中新增两次带短时延迟的普攻调用，改为连续发送 3 次普攻指令； 更新PickUpCollectHandler.cs中的拾取动作逻辑，通过发送 3 次普攻指令，保证枫原万叶下落拾取动作完整。 更新PickUpCollectHandler.cs中的万叶中E、长E动作

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复了在结束操作时鼠标按键未正确释放的问题。

* **Improvements**
  * 优化了枫原万叶的拾取操作节奏与连击输入，提升拾取稳定性。
  * 调整了元素战技后的连招间隔与普通攻击次数，改进触发时机。
  * 精细化拾取脚本的按键与等待时序，以提高自动拾取一致性与成功率。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->