### PR TITLE
[优化] 重构万叶战后长E拾取逻辑：提取公共输入时序、增强防卡键保护及OCR释放校验

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
@@ -680,36 +680,20 @@ public class AutoFightTask : ISoloTask
                         await Delay(200, ct);
                         if (picker.TrySwitch(10))
                         {
+                            // 等待元素战技 CD 就绪
                             await picker.WaitSkillCd(ct);
-                            Simulation.SendInput.Mouse.LeftButtonUp();
-                            await Delay(10, ct);
-                            Simulation.SendInput.SimulateAction(GIActions.ElementalSkill, KeyType.KeyDown);
-                            try
-                            {
-                                await Delay(800, ct);
-                            }
-                            finally
-                            {
-                                Simulation.SendInput.SimulateAction(GIActions.ElementalSkill, KeyType.KeyUp);
-                            }
-                            await Delay(50, ct);
-                            try
-                            {
-                                for (var i = 0; i < 6; i++)
-                                {
-                                    Simulation.SendInput.Mouse.LeftButtonUp();
-                                    await Delay(10, ct);
-                                    Simulation.SendInput.Mouse.LeftButtonDown();
-                                    await Delay(35, ct);
-                                    Simulation.SendInput.Mouse.LeftButtonUp();
-                                    await Delay(50, ct);
-                                }
-                            }
-                            finally
-                            {
-                                Simulation.SendInput.Mouse.LeftButtonUp();
-                            }
+                            
+                            // 调用统一的辅助方法，模拟万叶长按 E 的输入序列：
+                            // 包含释放鼠标左键前摇防卡键 -> E 键 KeyDown -> 延时 800ms -> E 键 KeyUp -> 延时 50ms
+                            await SimulateHoldElementalSkillAsync(800, ct);    
+                            
+                            // 调用统一的辅助方法，模拟 6 次鼠标左键连续点击：
+                            // 配合万叶长 E 的滞空特性执行下落攻击，内部包含 try/finally 以保证取消任务时安全释放左键
+                            await SimulateMouseLeftClickLoopAsync(6, ct);      
+                            
+                            // 等待下落攻击和聚怪拾取动作彻底结束
                             await Delay(1500, ct);
+                            // 截图并更新技能最新冷却时间
                             picker.AfterUseSkill();
                         }
                     }

--- a/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
@@ -681,13 +681,27 @@ public class AutoFightTask : ISoloTask
                         if (picker.TrySwitch(10))
                         {
                             await picker.WaitSkillCd(ct);
-                            picker.UseSkill(true);
+                            Simulation.SendInput.Mouse.LeftButtonUp();
+                            await Delay(10, ct);
+                            Simulation.SendInput.SimulateAction(GIActions.ElementalSkill, KeyType.KeyDown);
+                            try
+                            {
+                                await Delay(800, ct);
+                            }
+                            finally
+                            {
+                                Simulation.SendInput.SimulateAction(GIActions.ElementalSkill, KeyType.KeyUp);
+                            }
                             await Delay(50, ct);
-                            Simulation.SendInput.SimulateAction(GIActions.NormalAttack);
-                            await Delay(100, ct);
-                            Simulation.SendInput.SimulateAction(GIActions.NormalAttack);
-                            await Delay(100, ct);
-                            Simulation.SendInput.SimulateAction(GIActions.NormalAttack);
+                            for (var i = 0; i < 6; i++)
+                            {
+                                Simulation.SendInput.Mouse.LeftButtonUp();
+                                await Delay(10, ct);
+                                Simulation.SendInput.Mouse.LeftButtonDown();
+                                await Delay(35, ct);
+                                Simulation.SendInput.Mouse.LeftButtonUp();
+                                await Delay(50, ct);
+                            }
                             await Delay(1500, ct);
                             picker.AfterUseSkill();
                         }

--- a/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
@@ -693,14 +693,21 @@ public class AutoFightTask : ISoloTask
                                 Simulation.SendInput.SimulateAction(GIActions.ElementalSkill, KeyType.KeyUp);
                             }
                             await Delay(50, ct);
-                            for (var i = 0; i < 6; i++)
+                            try
+                            {
+                                for (var i = 0; i < 6; i++)
+                                {
+                                    Simulation.SendInput.Mouse.LeftButtonUp();
+                                    await Delay(10, ct);
+                                    Simulation.SendInput.Mouse.LeftButtonDown();
+                                    await Delay(35, ct);
+                                    Simulation.SendInput.Mouse.LeftButtonUp();
+                                    await Delay(50, ct);
+                                }
+                            }
+                            finally
                             {
                                 Simulation.SendInput.Mouse.LeftButtonUp();
-                                await Delay(10, ct);
-                                Simulation.SendInput.Mouse.LeftButtonDown();
-                                await Delay(35, ct);
-                                Simulation.SendInput.Mouse.LeftButtonUp();
-                                await Delay(50, ct);
                             }
                             await Delay(1500, ct);
                             picker.AfterUseSkill();

--- a/BetterGenshinImpact/GameTask/AutoLeyLineOutcrop/AutoLeyLineOutcropTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoLeyLineOutcrop/AutoLeyLineOutcropTask.cs
@@ -1,4 +1,4 @@
-﻿using BetterGenshinImpact.Core.Recognition;
+using BetterGenshinImpact.Core.Recognition;
 using BetterGenshinImpact.Core.Recognition.OpenCv;
 using BetterGenshinImpact.Core.Recognition.OCR;
 using BetterGenshinImpact.Core.Config;
@@ -11,6 +11,7 @@ using BetterGenshinImpact.GameTask.AutoPathing.Handler;
 using BetterGenshinImpact.GameTask.AutoPathing.Model;
 using BetterGenshinImpact.GameTask.AutoTrackPath;
 using BetterGenshinImpact.GameTask.AutoFight;
+using BetterGenshinImpact.GameTask.AutoFight.Assets;
 using BetterGenshinImpact.GameTask.AutoPick.Assets;
 using BetterGenshinImpact.GameTask.AutoFight.Model;
 using BetterGenshinImpact.GameTask.AutoFight.Script;
@@ -1081,15 +1082,44 @@ public class AutoLeyLineOutcropTask : ISoloTask
 
         _logger.LogInformation("战后聚集拾取：万叶已切换，等待元素战技CD");
         await kazuha.WaitSkillCd(_ct);
-        kazuha.UseSkill(true);
+        Simulation.SendInput.Mouse.LeftButtonUp();
+        await Delay(10, _ct);
+        Simulation.SendInput.SimulateAction(GIActions.ElementalSkill, KeyType.KeyDown);
+        try
+        {
+            await Delay(1000, _ct);
+        }
+        finally
+        {
+            Simulation.SendInput.SimulateAction(GIActions.ElementalSkill, KeyType.KeyUp);
+        }
+        await Delay(200, _ct);
+        using (var region = CaptureToRectArea())
+        {
+            using var eRa = region.DeriveCrop(AutoFightAssets.Instance.ECooldownRect);
+            using var eRaWhite = OpenCvCommonHelper.InRangeHsv(eRa.SrcMat, new Scalar(0, 0, 235), new Scalar(0, 25, 255));
+            var text = OcrFactory.Paddle.OcrWithoutDetector(eRaWhite);
+            var hasOcrCd = double.TryParse(text, out var ocrCd) && ocrCd > 0;
+            var isVisualReady = Bv.IsSkillReady(region, kazuha.Index, false);
+            if (!hasOcrCd && isVisualReady)
+            {
+                _logger.LogWarning("战后聚集拾取：万叶长E释放确认失败（OCR：{Text}），跳过后续拾取动作", text);
+                return;
+            }
+
+            kazuha.AfterUseSkill(region);
+        }
         await Delay(50, _ct);
-        Simulation.SendInput.SimulateAction(GIActions.NormalAttack);
-        await Delay(100, _ct);
-        Simulation.SendInput.SimulateAction(GIActions.NormalAttack);
-        await Delay(100, _ct);
-        Simulation.SendInput.SimulateAction(GIActions.NormalAttack);
+        for (var i = 0; i < 6; i++)
+        {
+            Simulation.SendInput.Mouse.LeftButtonUp();
+            await Delay(10, _ct);
+            Simulation.SendInput.Mouse.LeftButtonDown();
+            await Delay(35, _ct);
+            Simulation.SendInput.Mouse.LeftButtonUp();
+            await Delay(50, _ct);
+        }
         await Delay(1500, _ct);
-        kazuha.AfterUseSkill();
         _logger.LogInformation("战后聚集拾取：万叶长E动作完成，等待拾取动作结束");
         await Delay(KazuhaPickupPostSkillWaitMs, _ct);
         _logger.LogInformation("战后聚集拾取：万叶长E聚集动作执行完成");

--- a/BetterGenshinImpact/GameTask/AutoLeyLineOutcrop/AutoLeyLineOutcropTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoLeyLineOutcrop/AutoLeyLineOutcropTask.cs
@@ -1110,14 +1110,21 @@ public class AutoLeyLineOutcropTask : ISoloTask
             kazuha.AfterUseSkill(region);
         }
         await Delay(50, _ct);
-        for (var i = 0; i < 6; i++)
+        try
+        {
+            for (var i = 0; i < 6; i++)
+            {
+                Simulation.SendInput.Mouse.LeftButtonUp();
+                await Delay(10, _ct);
+                Simulation.SendInput.Mouse.LeftButtonDown();
+                await Delay(35, _ct);
+                Simulation.SendInput.Mouse.LeftButtonUp();
+                await Delay(50, _ct);
+            }
+        }
+        finally
         {
             Simulation.SendInput.Mouse.LeftButtonUp();
-            await Delay(10, _ct);
-            Simulation.SendInput.Mouse.LeftButtonDown();
-            await Delay(35, _ct);
-            Simulation.SendInput.Mouse.LeftButtonUp();
-            await Delay(50, _ct);
         }
         await Delay(1500, _ct);
         _logger.LogInformation("战后聚集拾取：万叶长E动作完成，等待拾取动作结束");

--- a/BetterGenshinImpact/GameTask/AutoLeyLineOutcrop/AutoLeyLineOutcropTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoLeyLineOutcrop/AutoLeyLineOutcropTask.cs
@@ -1082,50 +1082,33 @@ public class AutoLeyLineOutcropTask : ISoloTask
 
         _logger.LogInformation("战后聚集拾取：万叶已切换，等待元素战技CD");
         await kazuha.WaitSkillCd(_ct);
-        Simulation.SendInput.Mouse.LeftButtonUp();
-        await Delay(10, _ct);
-        Simulation.SendInput.SimulateAction(GIActions.ElementalSkill, KeyType.KeyDown);
-        try
-        {
-            await Delay(1000, _ct);
-        }
-        finally
-        {
-            Simulation.SendInput.SimulateAction(GIActions.ElementalSkill, KeyType.KeyUp);
-        }
+        await SimulateHoldElementalSkillAsync(1000, _ct);
         await Delay(200, _ct);
+
+        // 获取游戏画面，进行 OCR 及视觉状态双重验证，以确认长E技能是否真正释放成功
         using (var region = CaptureToRectArea())
         {
+            // 裁剪技能 CD 区域并做 HSV 颜色过滤，分离出白色的 CD 数字
             using var eRa = region.DeriveCrop(AutoFightAssets.Instance.ECooldownRect);
             using var eRaWhite = OpenCvCommonHelper.InRangeHsv(eRa.SrcMat, new Scalar(0, 0, 235), new Scalar(0, 25, 255));
             var text = OcrFactory.Paddle.OcrWithoutDetector(eRaWhite);
-            var hasOcrCd = double.TryParse(text, out var ocrCd) && ocrCd > 0;
-            var isVisualReady = Bv.IsSkillReady(region, kazuha.Index, false);
+            
+            // 如果成功读到了大于 0 的 CD 数值，说明技能已释放
+            var hasOcrCd = double.TryParse(text, out var ocrCd) && ocrCd > 0;  
+            // 视觉上判断当前技能图标是否高亮就绪，如果不亮（false）也说明技能释放进入了冷却
+            var isVisualReady = Bv.IsSkillReady(region, kazuha.Index, false);  
+            
+            // 当 OCR 没读出 CD（可能网络卡顿技能没放出来），并且视觉上技能图标依然亮着就绪时，判断为释放失败
             if (!hasOcrCd && isVisualReady)
             {
                 _logger.LogWarning("战后聚集拾取：万叶长E释放确认失败（OCR：{Text}），跳过后续拾取动作", text);
                 return;
             }
 
+            // 更新技能冷却记录，防止干扰后续冷却判断
             kazuha.AfterUseSkill(region);
         }
-        await Delay(50, _ct);
-        try
-        {
-            for (var i = 0; i < 6; i++)
-            {
-                Simulation.SendInput.Mouse.LeftButtonUp();
-                await Delay(10, _ct);
-                Simulation.SendInput.Mouse.LeftButtonDown();
-                await Delay(35, _ct);
-                Simulation.SendInput.Mouse.LeftButtonUp();
-                await Delay(50, _ct);
-            }
-        }
-        finally
-        {
-            Simulation.SendInput.Mouse.LeftButtonUp();
-        }
+        await SimulateMouseLeftClickLoopAsync(6, _ct);
         await Delay(1500, _ct);
         _logger.LogInformation("战后聚集拾取：万叶长E动作完成，等待拾取动作结束");
         await Delay(KazuhaPickupPostSkillWaitMs, _ct);

--- a/BetterGenshinImpact/GameTask/AutoPathing/Handler/PickUpCollectHandler.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/Handler/PickUpCollectHandler.cs
@@ -25,7 +25,7 @@ public class PickUpCollectHandler : IActionHandler
     /// </summary>
     public static readonly string[] PickUpActions =
     [
-        "枫原万叶-长E attack(0.08),keydown(E),wait(1),keyup(E),attack(0.5)",
+        "枫原万叶-长E attack(0.08),keydown(E),wait(0.8),keyup(E),attack(0.5)",
         "枫原万叶-短E attack(0.08),keydown(E),wait(0.47),keyup(E),attack(0.5)",
         "琴-短E wait(0.1),keydown(E),wait(0.4),moveby(1000,0),wait(0.2),moveby(1000,0),wait(0.2),moveby(1000,0),wait(0.2),moveby(1000,-3500),wait(1.8),keyup(E),wait(0.3),click(middle)",
         "琴-长E wait(0.1),click(middle),keydown(E),click(middle),wait(0.4),moveby(500,0),wait(0.1),moveby(500,0),wait(0.1)," +

--- a/BetterGenshinImpact/GameTask/Common/TaskControl.cs
+++ b/BetterGenshinImpact/GameTask/Common/TaskControl.cs
@@ -193,9 +193,9 @@ public class TaskControl
     /// <param name="ct">用于监控任务取消的取消令牌</param>
     public static async Task SimulateHoldActionAsync(GIActions action, int holdMs, CancellationToken ct)
     {
-        Simulation.SendInput.SimulateAction(action, KeyType.KeyDown);
         try
         {
+            Simulation.SendInput.SimulateAction(action, KeyType.KeyDown);
             await Delay(holdMs, ct);
         }
         finally

--- a/BetterGenshinImpact/GameTask/Common/TaskControl.cs
+++ b/BetterGenshinImpact/GameTask/Common/TaskControl.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Drawing;
 using System.Threading;
 using System.Threading.Tasks;
@@ -9,6 +9,7 @@ using Fischless.GameCapture;
 using Microsoft.Extensions.Logging;
 using OpenCvSharp;
 using Vanara.PInvoke;
+using BetterGenshinImpact.Core.Simulator.Extensions;
 
 namespace BetterGenshinImpact.GameTask.Common;
 
@@ -181,6 +182,90 @@ public class TaskControl
         if (ct is { IsCancellationRequested: true })
         {
             throw new NormalEndException("取消自动任务");
+        }
+    }
+
+    /// <summary>
+    /// 模拟长按指定动作。使用 try/finally 块确保在任务被取消或发生异常时，按键也能安全释放，防止卡键。
+    /// </summary>
+    /// <param name="action">需要模拟的游戏动作（如元素战技、普通攻击等）</param>
+    /// <param name="holdMs">长按持续的时间（毫秒）</param>
+    /// <param name="ct">用于监控任务取消的取消令牌</param>
+    public static async Task SimulateHoldActionAsync(GIActions action, int holdMs, CancellationToken ct)
+    {
+        Simulation.SendInput.SimulateAction(action, KeyType.KeyDown);
+        try
+        {
+            await Delay(holdMs, ct);
+        }
+        finally
+        {
+            Simulation.SendInput.SimulateAction(action, KeyType.KeyUp);        
+        }
+    }
+
+    /// <summary>
+    /// 模拟长按元素战技（如万叶长E）。包含释放前摇、长按以及释放后的缓冲延时。
+    /// </summary>
+    /// <param name="holdMs">元素战技按住的时间（毫秒）</param>
+    /// <param name="ct">用于监控任务取消的取消令牌</param>
+    /// <param name="releaseLeftMouseBefore">是否在按下元素战技前先松开鼠标左键，避免输入冲突，默认 true</param>
+    /// <param name="releaseLeftMouseDelayMs">松开鼠标左键后的缓冲时间（毫秒），默认 10ms</param>
+    /// <param name="postKeyUpDelayMs">元素战技释放后的缓冲时间（毫秒），默认 50ms</param>
+    public static async Task SimulateHoldElementalSkillAsync(
+        int holdMs,
+        CancellationToken ct,
+        bool releaseLeftMouseBefore = true,
+        int releaseLeftMouseDelayMs = 10,
+        int postKeyUpDelayMs = 50)
+    {
+        if (releaseLeftMouseBefore)
+        {
+            Simulation.SendInput.Mouse.LeftButtonUp();
+            await Delay(releaseLeftMouseDelayMs, ct);
+        }
+
+        await SimulateHoldActionAsync(GIActions.ElementalSkill, holdMs, ct);   
+        await Delay(postKeyUpDelayMs, ct);
+    }
+
+    /// <summary>
+    /// 模拟鼠标左键连续点击循环（如万叶长E后的下落攻击）。双层 try/finally 设计以确保无论在循环的哪个阶段发生取消或异常，鼠标左键都会被强制释放。
+    /// </summary>
+    /// <param name="repeatCount">需要循环点击的次数</param>
+    /// <param name="ct">用于监控任务取消的取消令牌</param>
+    /// <param name="preUpDelayMs">每次点击前，预先抬起左键后的缓冲延时（毫秒），默认 10ms</param>
+    /// <param name="downHoldMs">鼠标左键按下的保持时间（毫秒），默认 35ms</param>
+    /// <param name="postUpDelayMs">每次点击完成后的等待时间（毫秒），默认 50ms</param>
+    public static async Task SimulateMouseLeftClickLoopAsync(
+        int repeatCount,
+        CancellationToken ct,
+        int preUpDelayMs = 10,
+        int downHoldMs = 35,
+        int postUpDelayMs = 50)
+    {
+        try
+        {
+            for (var i = 0; i < repeatCount; i++)
+            {
+                Simulation.SendInput.Mouse.LeftButtonUp();
+                await Delay(preUpDelayMs, ct);
+                Simulation.SendInput.Mouse.LeftButtonDown();
+                try
+                {
+                    await Delay(downHoldMs, ct);
+                }
+                finally
+                {
+                    Simulation.SendInput.Mouse.LeftButtonUp();
+                }
+
+                await Delay(postUpDelayMs, ct);
+            }
+        }
+        finally
+        {
+            Simulation.SendInput.Mouse.LeftButtonUp();
         }
     }
 


### PR DESCRIPTION
- 提取公共输入时序方法 ( TaskControl.cs )
- 新增 SimulateHoldActionAsync 、 SimulateHoldElementalSkillAsync ：封装了包含前摇处理、精准延时按压和后摇缓冲的长按逻辑。
- 新增 SimulateMouseLeftClickLoopAsync ：封装了左键连续点击循环。
- 核心安全提升 ：在上述所有涉及 KeyDown/LeftButtonDown 的方法中，全面引入了双层 try/finally 块，确保在任何异常或手动停止任务的情况下，必然触发 KeyUp/LeftButtonUp 。
- 重构自动战斗拾取 ( AutoFightTask.cs )
- 移除 picker.UseSkill(true) ，接入新的公共方法，将长 E 持续时间精准设定为 800ms 。
- 重构地脉拾取并增加状态双重校验 ( AutoLeyLineOutcropTask.cs )
- 接入公共方法，将长 E 持续时间设定为 1000ms 。
- 新增校验拦截 ：在松开 E 键后，截取当前画面，通过 HSV过滤 + PaddleOCR 读取技能 CD 数字，结合 Bv.IsSkillReady 进行双重验证。若未读取到 CD 且图标依然高亮（技能未成功释放），则提前 return 跳过后续左键下落攻击动作，并 阻断 AfterUseSkill 的调用，避免污染 CD 池。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **错误修复**
  * 优化枫原万叶长E拾取交互，改为受控的按键按住/释放与循环点击，确保在异常或取消时按键可靠释放，提升稳定性。
  * 增强技能冷却检测，加入截图 + OCR 与视觉双重校验，检测不一致时记录警告并跳过异常动作，减少误判。
  * 调整按键/点击节奏与后置等待时机（包括循环点击次数与延迟），提高拾取成功率与行为一致性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->