### PR TITLE
feat(脚本引擎): 提供对 战斗策略 目录的访问

### DIFF
--- a/BetterGenshinImpact/Core/Script/Dependence/AutoPathingScript.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/AutoPathingScript.cs
@@ -88,10 +88,11 @@ public class AutoPathingScript
 
     /// <summary>
     /// 读取 AutoPathing 目录下指定文件夹的内容（非递归方式）
+    /// 目录不存在时返回空数组，不会自动创建目录
     /// </summary>
     /// <param name="subPath">相对于 User\AutoPathing 的子目录路径，默认为相对根目录</param>
     /// <returns>文件夹内所有文件和文件夹的相对路径数组，出错时返回空数组</returns>
-    public string[] ReadPathSync(string subPath = "./") => AutoPathingFile.ReadPathSync(subPath);
+    public string[] ReadPathSync(string subPath = "./") => AutoPathingFile.ReadPathSync(subPath, false);
 
     /// <summary>
     /// LimitedFile 实例，用于操作 AutoPathing 目录

--- a/BetterGenshinImpact/Core/Script/Dependence/AutoPathingScript.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/AutoPathingScript.cs
@@ -92,7 +92,7 @@ public class AutoPathingScript
     /// </summary>
     /// <param name="subPath">相对于 User\AutoPathing 的子目录路径，默认为相对根目录</param>
     /// <returns>文件夹内所有文件和文件夹的相对路径数组，出错时返回空数组</returns>
-    public string[] ReadPathSync(string subPath = "./") => AutoPathingFile.ReadPathSync(subPath, false);
+    public string[] ReadPathSync(string subPath = "./") => AutoPathingFile.ReadPathSync(subPath);
 
     /// <summary>
     /// LimitedFile 实例，用于操作 AutoPathing 目录

--- a/BetterGenshinImpact/Core/Script/Dependence/LimitedFile.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/LimitedFile.cs
@@ -15,33 +15,28 @@ public class LimitedFile(string rootPath)
 {
     /// <summary>
     /// 读取指定文件夹内所有文件和文件夹的路径（非递归方式）。
+    /// 目录不存在时返回空数组
     /// </summary>
     /// <param name="folderPath">文件夹路径（相对于根目录）</param>
-    /// <param name="createIfNotExists">目录不存在时是否自动创建，默认为 true</param>
     /// <returns>文件夹内所有文件和文件夹的路径数组</returns>
-    public string[] ReadPathSync(string folderPath, bool createIfNotExists = true)
+    public string[] ReadPathSync(string folderPath)
     {
         try
         {
             // 对传入的文件夹路径进行标准化
-            string normalizedFolderPath = NormalizePath(folderPath);
+            string fullPath = NormalizePath(folderPath);
 
-            // 确保目录存在
-            if (createIfNotExists && !Directory.Exists(normalizedFolderPath))
+            if (!Directory.Exists(fullPath))
             {
-                Directory.CreateDirectory(normalizedFolderPath);
-            }
-            else if (!Directory.Exists(normalizedFolderPath))
-            {
-                TaskControl.Logger.LogError("ReadPathSync 目录不存在: {Path}", normalizedFolderPath);
+                TaskControl.Logger.LogError("ReadPathSync 目录不存在: {Path}", fullPath);
                 return Array.Empty<string>();
             }
 
             // 获取指定文件夹下的所有文件（非递归）
-            string[] files = Directory.GetFiles(normalizedFolderPath, "*", SearchOption.TopDirectoryOnly);
+            string[] files = Directory.GetFiles(fullPath, "*", SearchOption.TopDirectoryOnly);
 
             // 获取指定文件夹下的所有子文件夹（非递归）
-            string[] directories = Directory.GetDirectories(normalizedFolderPath, "*", SearchOption.TopDirectoryOnly);
+            string[] directories = Directory.GetDirectories(fullPath, "*", SearchOption.TopDirectoryOnly);
 
             // 合并文件和文件夹路径
             string[] combined = files.Concat(directories).ToArray();
@@ -51,7 +46,6 @@ public class LimitedFile(string rootPath)
         }
         catch (Exception ex)
         {
-            // 记录异常并返回空数组
             TaskControl.Logger.LogError("ReadPathSync 异常: {Message}", ex.Message);
             return Array.Empty<string>();
         }

--- a/BetterGenshinImpact/Core/Script/Dependence/LimitedFile.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/LimitedFile.cs
@@ -52,6 +52,28 @@ public class LimitedFile(string rootPath)
     }
 
     /// <summary>
+    /// 创建指定路径的目录，如果已存在则跳过
+    /// </summary>
+    /// <param name="folderPath">文件夹路径（相对于根目录）</param>
+    /// <returns>是否创建成功或目录已存在</returns>
+    public bool CreateDirectory(string folderPath)
+    {
+        try
+        {
+            // 对传入的文件夹路径进行标准化
+            string fullPath = NormalizePath(folderPath);
+            // 如果目录不存在，自动创建
+            if (!Directory.Exists(fullPath)){Directory.CreateDirectory(fullPath);}
+            return true;
+        }
+        catch (Exception ex)
+        {
+            TaskControl.Logger.LogError("CreateDir 异常: {Message}", ex.Message);
+            return false;
+        }
+    }
+
+    /// <summary>
     /// 判断指定路径是否为文件夹。
     /// </summary>
     /// <param name="path">文件或文件夹路径（相对于根目录）。</param>

--- a/BetterGenshinImpact/Core/Script/Dependence/LimitedFile.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/LimitedFile.cs
@@ -17,8 +17,9 @@ public class LimitedFile(string rootPath)
     /// 读取指定文件夹内所有文件和文件夹的路径（非递归方式）。
     /// </summary>
     /// <param name="folderPath">文件夹路径（相对于根目录）</param>
+    /// <param name="createIfNotExists">目录不存在时是否自动创建，默认为 true</param>
     /// <returns>文件夹内所有文件和文件夹的路径数组</returns>
-    public string[] ReadPathSync(string folderPath)
+    public string[] ReadPathSync(string folderPath, bool createIfNotExists = true)
     {
         try
         {
@@ -26,9 +27,14 @@ public class LimitedFile(string rootPath)
             string normalizedFolderPath = NormalizePath(folderPath);
 
             // 确保目录存在
-            if (!Directory.Exists(normalizedFolderPath))
+            if (createIfNotExists && !Directory.Exists(normalizedFolderPath))
             {
                 Directory.CreateDirectory(normalizedFolderPath);
+            }
+            else if (!Directory.Exists(normalizedFolderPath))
+            {
+                TaskControl.Logger.LogError("ReadPathSync 目录不存在: {Path}", normalizedFolderPath);
+                return Array.Empty<string>();
             }
 
             // 获取指定文件夹下的所有文件（非递归）

--- a/BetterGenshinImpact/Core/Script/Dependence/StrategyFile.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/StrategyFile.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Linq;
+using BetterGenshinImpact.Core.Config;
+
+namespace BetterGenshinImpact.Core.Script.Dependence;
+
+/// <summary>
+/// 战斗策略文件访问类
+/// 提供JS脚本环境访问 User\AutoFight 目录下战斗策略文件的方法
+/// </summary>
+public class StrategyFile
+{
+    private readonly LimitedFile _strategyFile = new(Global.Absolute(@"User\AutoFight"));
+
+    /// <summary>
+    /// 判断 User\AutoFight 目录下的路径是否为文件夹
+    /// </summary>
+    /// <param name="subPath">相对于 User\AutoFight 的路径</param>
+    /// <returns>是文件夹返回 true，否则返回 false</returns>
+    public bool IsFolder(string subPath) => _strategyFile.IsFolder(subPath);
+
+    /// <summary>
+    /// 判断 User\AutoFight 目录下的路径是否为文件
+    /// </summary>
+    /// <param name="subPath">相对于 User\AutoFight 的路径</param>
+    /// <returns>是文件返回 true，否则返回 false</returns>
+    public bool IsFile(string subPath) => _strategyFile.IsFile(subPath);
+
+    /// <summary>
+    /// 判断 User\AutoFight 目录下的路径是否存在
+    /// </summary>
+    /// <param name="subPath">相对于 User\AutoFight 的路径</param>
+    /// <returns>存在返回 true，否则返回 false</returns>
+    public bool IsExists(string subPath) => _strategyFile.IsExists(subPath);
+
+    /// <summary>
+    /// 读取 User\AutoFight 目录下指定文件夹的内容（非递归方式）
+    /// 目录不存在时返回空数组，不会自动创建目录
+    /// </summary>
+    /// <param name="subPath">相对于 User\AutoFight 的子目录路径，默认为根目录</param>
+    /// <returns>文件夹内所有文件和文件夹的相对路径数组，出错时返回空数组</returns>
+    public string[] ReadPathSync(string subPath = "./") => _strategyFile.ReadPathSync(subPath, false);
+}

--- a/BetterGenshinImpact/Core/Script/Dependence/StrategyFile.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/StrategyFile.cs
@@ -39,5 +39,5 @@ public class StrategyFile
     /// </summary>
     /// <param name="subPath">相对于 User\AutoFight 的子目录路径，默认为根目录</param>
     /// <returns>文件夹内所有文件和文件夹的相对路径数组，出错时返回空数组</returns>
-    public string[] ReadPathSync(string subPath = "./") => _strategyFile.ReadPathSync(subPath, false);
+    public string[] ReadPathSync(string subPath = "./") => _strategyFile.ReadPathSync(subPath);
 }

--- a/BetterGenshinImpact/Core/Script/EngineExtend.cs
+++ b/BetterGenshinImpact/Core/Script/EngineExtend.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using BetterGenshinImpact.Core.Script.Dependence;
 using BetterGenshinImpact.Core.Script.Dependence.Model;
@@ -77,6 +77,7 @@ public class EngineExtend
         engine.AddHostType("AutoFightParam", typeof(AutoFightParam)); 
         engine.AddHostType("AutoLeyLineOutcropParam", typeof(AutoLeyLineOutcropParam));
         engine.AddHostType("AutoStygianOnslaughtParam", typeof(AutoStygianOnslaughtParam));
+        engine.AddHostObject("strategyFile", new StrategyFile());
         //鼠标回调
         engine.AddHostType("KeyMouseHook", typeof(KeyMouseHook)); 
         // 添加C#的类型


### PR DESCRIPTION
与LimitedFile不同，战斗策略跟地图追踪的`ReadPathSync`方法，不会在目录不存在时自动创建。


`LimitedFile.ReadPathSync`方法新增`createIfNotExists`参数。参数控制目录不存在时是否创建，默认为`true`不影响现有脚本。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增脚本可访问的“策略文件”接口（可判断是否为文件/目录、检测存在性、列出目录内容）。
  * 通过宿主对象向脚本暴露该策略文件接口。

* **改进**
  * 读取目录时更可控：当目标目录不存在时返回空结果且不再自动创建。
  * 新增显式创建目录的接口方法，调用时才会尝试建表目录并在失败时返回错误提示。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/babalae/better-genshin-impact/pull/3111)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->