### PR TITLE
fix: 修改配置组的扫描掉落物光柱时长能正确生效了

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
@@ -528,7 +528,7 @@ public class AutoFightTask : ISoloTask
                     // 经验值检测未通过，跳过拾取（但仍执行扫描拾取逻辑）
                     if (_taskParam is { PickDropsAfterFightEnabled: true })
                     {
-                        await new ScanPickTask().Start(ct);
+                        await new ScanPickTask().Start(ct, _taskParam.PickDropsAfterFightSeconds);
                     }
                     return;
                 }
@@ -802,7 +802,7 @@ public class AutoFightTask : ISoloTask
         if (_taskParam is { PickDropsAfterFightEnabled: true } )
         {
             // 执行扫描掉落物光柱并靠近的功能
-            await new ScanPickTask().Start(ct);
+            await new ScanPickTask().Start(ct, _taskParam.PickDropsAfterFightSeconds);
         }
     }
 

--- a/BetterGenshinImpact/GameTask/AutoLeyLineOutcrop/AutoLeyLineOutcropTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoLeyLineOutcrop/AutoLeyLineOutcropTask.cs
@@ -1046,14 +1046,10 @@ public class AutoLeyLineOutcropTask : ISoloTask
             return;
         }
 
-        var autoFightConfig = TaskContext.Instance().Config.AutoFightConfig;
-        var originalSeconds = autoFightConfig.PickDropsAfterFightSeconds;
-
         try
         {
-            autoFightConfig.PickDropsAfterFightSeconds = scanSeconds;
             _logger.LogInformation("领取奖励后开始扫描掉落物光柱，时长 {Seconds} 秒", scanSeconds);
-            await new ScanPickTask().Start(_ct);
+            await new ScanPickTask().Start(_ct, scanSeconds);
         }
         catch (Exception ex) when (ex is OperationCanceledException or TaskCanceledException)
         {
@@ -1065,7 +1061,6 @@ public class AutoLeyLineOutcropTask : ISoloTask
         }
         finally
         {
-            autoFightConfig.PickDropsAfterFightSeconds = originalSeconds;
             Simulation.ReleaseAllKey();
         }
     }

--- a/BetterGenshinImpact/GameTask/Common/Job/ScanPickTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/ScanPickTask.cs
@@ -28,11 +28,11 @@ public class ScanPickTask
     private readonly RECT _realCaptureRect = TaskContext.Instance().SystemInfo.CaptureAreaRect;
 
 
-    public async Task Start(CancellationToken ct)
+    public async Task Start(CancellationToken ct, int? seconds = null)
     {
         try
         {
-            await DoOnce(ct);
+            await DoOnce(ct, seconds);
         }
         catch (Exception e)
         {
@@ -45,9 +45,9 @@ public class ScanPickTask
         }
     }
 
-    public async Task DoOnce(CancellationToken ct)
+    public async Task DoOnce(CancellationToken ct, int? seconds = null)
     {
-        var sec = TaskContext.Instance().Config.AutoFightConfig.PickDropsAfterFightSeconds;
+        var sec = seconds ?? TaskContext.Instance().Config.AutoFightConfig.PickDropsAfterFightSeconds;
         Stopwatch timeoutStopwatch = Stopwatch.StartNew();
         TimeSpan finishTime = TimeSpan.FromSeconds(sec);
 


### PR DESCRIPTION
ScanPickTask 原本硬编码读取全局 Config.AutoFightConfig.PickDropsAfterFightSeconds， 导致一条龙路径配置组中填写的时长被忽略（始终使用全局默认15秒）。

改为通过参数传入时长，不传则回退到全局配置，三个调用点均已同步。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **功能改进**
  * 战斗后拾取掉落物品的时间延迟现支持按任务灵活配置，提升了不同场景下的处理效率。

* **重构优化**
  * 优化了拾取扫描逻辑的参数传递机制，增强了代码的灵活性和可维护性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/babalae/better-genshin-impact/pull/3119)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->