### PR TITLE
新增可配置遮罩指标栏

### DIFF
--- a/BetterGenshinImpact/App.xaml.cs
+++ b/BetterGenshinImpact/App.xaml.cs
@@ -151,6 +151,7 @@ public partial class App : Application
                 // services.AddSingleton<TcgViewModel>();
 
                 // My Services
+                services.AddSingleton<OverlayMetricsService>();
                 services.AddSingleton<TaskTriggerDispatcher>();
                 services.AddSingleton<NotificationService>();
                 services.AddHostedService(sp => sp.GetRequiredService<NotificationService>());

--- a/BetterGenshinImpact/BetterGenshinImpact.csproj
+++ b/BetterGenshinImpact/BetterGenshinImpact.csproj
@@ -54,6 +54,7 @@
 		<PackageReference Include="Emoji.Wpf" Version="0.3.4" />
 		<PackageReference Include="LibGit2Sharp" Version="0.31.0" />
 		<PackageReference Include="LazyCache" Version="2.4.0" />
+		<PackageReference Include="LibreHardwareMonitorLib" Version="0.9.6" />
 		<PackageReference Include="MailKit" Version="4.14.0" />
 		<PackageReference Include="Meziantou.Framework.Win32.CredentialManager" Version="1.7.4" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.4" />

--- a/BetterGenshinImpact/Core/Config/MaskWindowConfig.cs
+++ b/BetterGenshinImpact/Core/Config/MaskWindowConfig.cs
@@ -1,6 +1,8 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using OpenCvSharp;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace BetterGenshinImpact.Core.Config;
 
@@ -10,6 +12,23 @@ namespace BetterGenshinImpact.Core.Config;
 [Serializable]
 public partial class MaskWindowConfig : ObservableObject
 {
+    // 指标栏布局和遮罩里其它元素一样按 1920x1080 折算比例保存，默认放在状态栏/日志上方以避开游戏底部 UI。
+    public const double DefaultMetricsLeftRatio = 20.0 / 1920;
+    public const double DefaultMetricsTopRatio = 744.0 / 1080;
+    public const double DefaultMetricsWidthRatio = 477.0 / 1920;
+    public const double DefaultMetricsHeightRatio = 58.0 / 1080;
+
+    // 这些是开发评审过程中曾下发过的默认布局；用户没有手动调整时迁移到最新默认值，避免旧默认继续挡住游戏 UI。
+    private static readonly (double Left, double Top, double Width, double Height)[] LegacyMetricsLayouts =
+    [
+        (4.0 / 1920, 4.0 / 1080, 720.0 / 1920, 42.0 / 1080),
+        (600.0 / 1920, 16.0 / 1080, 720.0 / 1920, 42.0 / 1080),
+        (20.0 / 1920, 724.0 / 1080, 760.0 / 1920, 58.0 / 1080),
+        (20.0 / 1920, 724.0 / 1080, 760.0 / 1920, 42.0 / 1080),
+        (20.0 / 1920, 760.0 / 1080, 477.0 / 1920, 42.0 / 1080),
+        (20.0 / 1920, 760.0 / 1080, 477.0 / 1920, 58.0 / 1080)
+    ];
+
     /// <summary>
     ///     方位提示是否启用
     /// </summary>
@@ -64,6 +83,15 @@ public partial class MaskWindowConfig : ObservableObject
     private bool _showFps = false;
 
     /// <summary>
+    /// 显示遮罩指标栏
+    /// </summary>
+    [ObservableProperty]
+    private bool _showOverlayMetrics = false;
+
+    // 配置文件里使用 string key 便于兼容旧版本，读取后由 EnsureOverlayMetricItems 约束回固定枚举集合。
+    public Dictionary<string, bool> OverlayMetricItems { get; set; } = OverlayMetricItemDefaults.CreateDefaultItems();
+
+    /// <summary>
     /// 遮罩文本透明度 (0.0-1.0)
     /// </summary>
     [ObservableProperty]
@@ -95,4 +123,85 @@ public partial class MaskWindowConfig : ObservableObject
 
     [ObservableProperty]
     private double _statusListHeightRatio = 24.0 / 1080;
+
+    [ObservableProperty]
+    private double _metricsLeftRatio = DefaultMetricsLeftRatio;
+
+    [ObservableProperty]
+    private double _metricsTopRatio = DefaultMetricsTopRatio;
+
+    [ObservableProperty]
+    private double _metricsWidthRatio = DefaultMetricsWidthRatio;
+
+    [ObservableProperty]
+    private double _metricsHeightRatio = DefaultMetricsHeightRatio;
+
+    public void ResetOverlayMetricsLayout()
+    {
+        MetricsLeftRatio = DefaultMetricsLeftRatio;
+        MetricsTopRatio = DefaultMetricsTopRatio;
+        MetricsWidthRatio = DefaultMetricsWidthRatio;
+        MetricsHeightRatio = DefaultMetricsHeightRatio;
+    }
+
+    public void MigrateLegacyOverlayMetricsLayout()
+    {
+        if (LegacyMetricsLayouts.Any(layout =>
+                IsSameRatio(MetricsLeftRatio, layout.Left)
+                && IsSameRatio(MetricsTopRatio, layout.Top)
+                && IsSameRatio(MetricsWidthRatio, layout.Width)
+                && IsSameRatio(MetricsHeightRatio, layout.Height)))
+        {
+            ResetOverlayMetricsLayout();
+        }
+    }
+
+    private static bool IsSameRatio(double left, double right)
+    {
+        return Math.Abs(left - right) < 0.0000001;
+    }
+
+    public void EnsureOverlayMetricItems()
+    {
+        // 旧配置可能缺少新指标或残留废弃指标，这里统一补默认项并移除非法 key，避免 UI 渲染任意字符串。
+        OverlayMetricItems ??= [];
+
+        // TriggerInterval 第一版展示的是配置值，现已替换为 PeakProcessingCost；保留用户原来的勾选状态。
+        const string legacyTriggerIntervalKey = "TriggerInterval";
+        var peakProcessingCostKey = OverlayMetricItem.PeakProcessingCost.ToString();
+        if (OverlayMetricItems.TryGetValue(legacyTriggerIntervalKey, out var legacyEnabled)
+            && !OverlayMetricItems.ContainsKey(peakProcessingCostKey))
+        {
+            OverlayMetricItems[peakProcessingCostKey] = legacyEnabled;
+        }
+
+        foreach (var item in OverlayMetricItemDefaults.AllItems)
+        {
+            var key = item.ToString();
+            if (!OverlayMetricItems.ContainsKey(key))
+            {
+                OverlayMetricItems[key] = OverlayMetricItemDefaults.IsEnabledByDefault(item);
+            }
+        }
+
+        var validKeys = OverlayMetricItemDefaults.AllItems.Select(item => item.ToString()).ToHashSet();
+        foreach (var key in OverlayMetricItems.Keys.Where(key => !validKeys.Contains(key)).ToList())
+        {
+            OverlayMetricItems.Remove(key);
+        }
+    }
+
+    public bool IsOverlayMetricEnabled(OverlayMetricItem item)
+    {
+        return OverlayMetricItems != null && OverlayMetricItems.TryGetValue(item.ToString(), out var enabled)
+            ? enabled
+            : OverlayMetricItemDefaults.IsEnabledByDefault(item);
+    }
+
+    public void SetOverlayMetricEnabled(OverlayMetricItem item, bool enabled)
+    {
+        EnsureOverlayMetricItems();
+        OverlayMetricItems[item.ToString()] = enabled;
+        OnPropertyChanged(nameof(OverlayMetricItems));
+    }
 }

--- a/BetterGenshinImpact/Core/Config/OverlayMetricItem.cs
+++ b/BetterGenshinImpact/Core/Config/OverlayMetricItem.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BetterGenshinImpact.Core.Config;
+
+public enum OverlayMetricItem
+{
+    GameFps,
+    ProcessingCost,
+    PeakProcessingCost,
+    CaptureCost,
+    TriggerCost,
+    SkippedTicks,
+    CpuUsage,
+    GpuUsage,
+    MemoryUsage
+}
+
+public static class OverlayMetricItemDefaults
+{
+    // 显式顺序同时决定遮罩三行三列显示顺序和设置页复选框顺序，不要随手改回 Enum.GetValues。
+    public static IReadOnlyList<OverlayMetricItem> AllItems { get; } =
+    [
+        OverlayMetricItem.GameFps,
+        OverlayMetricItem.ProcessingCost,
+        OverlayMetricItem.PeakProcessingCost,
+        OverlayMetricItem.CaptureCost,
+        OverlayMetricItem.TriggerCost,
+        OverlayMetricItem.SkippedTicks,
+        OverlayMetricItem.GpuUsage,
+        OverlayMetricItem.CpuUsage,
+        OverlayMetricItem.MemoryUsage
+    ];
+
+    public static Dictionary<string, bool> CreateDefaultItems()
+    {
+        return AllItems.ToDictionary(item => item.ToString(), IsEnabledByDefault);
+    }
+
+    public static bool IsEnabledByDefault(OverlayMetricItem item)
+    {
+        // 默认只开启低风险的常用实时指标；硬件传感器项由用户按需开启，读不到时也不会占位显示。
+        return item is OverlayMetricItem.GameFps
+            or OverlayMetricItem.ProcessingCost
+            or OverlayMetricItem.PeakProcessingCost
+            or OverlayMetricItem.CaptureCost
+            or OverlayMetricItem.SkippedTicks
+            or OverlayMetricItem.MemoryUsage;
+    }
+
+    public static string GetDisplayName(OverlayMetricItem item)
+    {
+        return item switch
+        {
+            OverlayMetricItem.GameFps => "游戏帧率",
+            OverlayMetricItem.ProcessingCost => "处理耗时",
+            OverlayMetricItem.PeakProcessingCost => "峰值耗时",
+            OverlayMetricItem.CaptureCost => "截图耗时",
+            OverlayMetricItem.TriggerCost => "触发器耗时",
+            OverlayMetricItem.SkippedTicks => "跳过次数",
+            OverlayMetricItem.CpuUsage => "CPU占用",
+            OverlayMetricItem.GpuUsage => "显卡占用",
+            OverlayMetricItem.MemoryUsage => "内存占用",
+            _ => item.ToString()
+        };
+    }
+
+    public static string GetToolTipText(OverlayMetricItem item)
+    {
+        return item switch
+        {
+            OverlayMetricItem.GameFps => "游戏当前渲染帧率。",
+            OverlayMetricItem.ProcessingCost => "BetterGI 每轮截图、识别和触发器处理的总耗时。",
+            OverlayMetricItem.PeakProcessingCost => "最近 5 秒内 BetterGI 单轮处理耗时的峰值。",
+            OverlayMetricItem.CaptureCost => "单次获取游戏画面的耗时。",
+            OverlayMetricItem.TriggerCost => "本轮实际执行触发器的总耗时。",
+            OverlayMetricItem.SkippedTicks => "上一轮未结束导致本秒跳过的调度次数。",
+            OverlayMetricItem.CpuUsage => "CPU 总占用率，读取不到时自动隐藏。",
+            OverlayMetricItem.GpuUsage => "显卡核心占用率，读取不到时自动隐藏。",
+            OverlayMetricItem.MemoryUsage => "系统内存占用率，读取不到时自动隐藏。",
+            _ => string.Empty
+        };
+    }
+}

--- a/BetterGenshinImpact/GameTask/TaskTriggerDispatcher.cs
+++ b/BetterGenshinImpact/GameTask/TaskTriggerDispatcher.cs
@@ -24,6 +24,7 @@ namespace BetterGenshinImpact.GameTask
     public class TaskTriggerDispatcher : IDisposable
     {
         private readonly ILogger<TaskTriggerDispatcher> _logger = App.GetLogger<TaskTriggerDispatcher>();
+        private readonly OverlayMetricsService? _metricsService = App.GetService<OverlayMetricsService>();
 
         private static TaskTriggerDispatcher? _instance;
 
@@ -213,11 +214,18 @@ namespace BetterGenshinImpact.GameTask
         public void Tick(object? sender, EventArgs e)
         {
             var hasLock = false;
+            var shouldRecordMetrics = false;
+            var tickStart = 0L;
+            var processingCostMs = 0d;
+            var captureCostMs = 0d;
+            var triggerCostMs = 0d;
             try
             {
+                // 上一帧还没处理完时只记录跳过次数，不等待锁；等待时间不应混入本轮处理耗时。
                 Monitor.TryEnter(_locker, ref hasLock);
                 if (!hasLock)
                 {
+                    _metricsService?.RecordSkippedTick();
                     // 正在执行时跳过
                     return;
                 }
@@ -351,8 +359,13 @@ namespace BetterGenshinImpact.GameTask
                 _frameIndex = (_frameIndex + 1) % (int)(CaptureContent.MaxFrameIndexSecond * 1000d / _timer.Interval);
 
                 var speedTimer = new SpeedTimer();
+                // 从真正开始截图处计时，前面的窗口状态检查不计入 BetterGI 本轮处理耗时。
+                tickStart = Stopwatch.GetTimestamp();
+                shouldRecordMetrics = true;
+                var captureStart = tickStart;
                 // 捕获游戏画面
                 var bitmap = GameCapture.Capture();
+                captureCostMs = Stopwatch.GetElapsedTime(captureStart).TotalMilliseconds;
                 speedTimer.Record("截图");
 
                 if (bitmap == null)
@@ -413,7 +426,10 @@ namespace BetterGenshinImpact.GameTask
                             if ((PrevGameUiCategory != content.CurrentGameUiCategory || (DateTime.Now - PrevGameUiChangeTime).TotalSeconds <= 30) // UI变化了后的30s内则所有触发器执行一遍
                                 || trigger.SupportedGameUiCategory == content.CurrentGameUiCategory)
                             {
+                                // 触发器耗时只累计触发器执行本体，便于和截图耗时、总处理耗时拆开观察。
+                                var triggerStart = Stopwatch.GetTimestamp();
                                 trigger.OnCapture(content);
+                                triggerCostMs += Stopwatch.GetElapsedTime(triggerStart).TotalMilliseconds;
                                 speedTimer.Record(trigger.Name);
                             }
                         }
@@ -426,6 +442,11 @@ namespace BetterGenshinImpact.GameTask
             }
             finally
             {
+                if (shouldRecordMetrics)
+                {
+                    processingCostMs = Stopwatch.GetElapsedTime(tickStart).TotalMilliseconds;
+                }
+
                 if ((DateTime.Now - _prevManualGc).TotalSeconds > 2)
                 {
                     GC.Collect();
@@ -435,6 +456,15 @@ namespace BetterGenshinImpact.GameTask
                 if (hasLock)
                 {
                     Monitor.Exit(_locker);
+                }
+
+                if (shouldRecordMetrics)
+                {
+                    // 释放调度锁后再发布指标，避免 UI 订阅回调参与实时触发器锁竞争。
+                    _metricsService?.RecordDispatcherTick(
+                        processingCostMs,
+                        captureCostMs,
+                        triggerCostMs);
                 }
             }
         }

--- a/BetterGenshinImpact/GameTask/TaskTriggerDispatcher.cs
+++ b/BetterGenshinImpact/GameTask/TaskTriggerDispatcher.cs
@@ -16,6 +16,8 @@ using BetterGenshinImpact.GameTask.Common.BgiVision;
 using BetterGenshinImpact.GameTask.GameLoading;
 using Fischless.GameCapture.Graphics;
 using BetterGenshinImpact.Service;
+using BetterGenshinImpact.Service.Model;
+using BetterGenshinImpact.Service.Model.OverlayMetric;
 using Vanara.PInvoke;
 using Rect = OpenCvSharp.Rect;
 
@@ -214,11 +216,7 @@ namespace BetterGenshinImpact.GameTask
         public void Tick(object? sender, EventArgs e)
         {
             var hasLock = false;
-            var shouldRecordMetrics = false;
-            var tickStart = 0L;
-            var processingCostMs = 0d;
-            var captureCostMs = 0d;
-            var triggerCostMs = 0d;
+            var tickMetrics = new DispatcherTickMetrics();
             try
             {
                 // 上一帧还没处理完时只记录跳过次数，不等待锁；等待时间不应混入本轮处理耗时。
@@ -360,12 +358,10 @@ namespace BetterGenshinImpact.GameTask
 
                 var speedTimer = new SpeedTimer();
                 // 从真正开始截图处计时，前面的窗口状态检查不计入 BetterGI 本轮处理耗时。
-                tickStart = Stopwatch.GetTimestamp();
-                shouldRecordMetrics = true;
-                var captureStart = tickStart;
+                tickMetrics.Begin();
                 // 捕获游戏画面
                 var bitmap = GameCapture.Capture();
-                captureCostMs = Stopwatch.GetElapsedTime(captureStart).TotalMilliseconds;
+                tickMetrics.EndCapture();
                 speedTimer.Record("截图");
 
                 if (bitmap == null)
@@ -429,7 +425,7 @@ namespace BetterGenshinImpact.GameTask
                                 // 触发器耗时只累计触发器执行本体，便于和截图耗时、总处理耗时拆开观察。
                                 var triggerStart = Stopwatch.GetTimestamp();
                                 trigger.OnCapture(content);
-                                triggerCostMs += Stopwatch.GetElapsedTime(triggerStart).TotalMilliseconds;
+                                tickMetrics.AddTriggerCost(triggerStart);
                                 speedTimer.Record(trigger.Name);
                             }
                         }
@@ -442,10 +438,7 @@ namespace BetterGenshinImpact.GameTask
             }
             finally
             {
-                if (shouldRecordMetrics)
-                {
-                    processingCostMs = Stopwatch.GetElapsedTime(tickStart).TotalMilliseconds;
-                }
+                tickMetrics.EndProcessing();
 
                 if ((DateTime.Now - _prevManualGc).TotalSeconds > 2)
                 {
@@ -458,13 +451,10 @@ namespace BetterGenshinImpact.GameTask
                     Monitor.Exit(_locker);
                 }
 
-                if (shouldRecordMetrics)
+                if (tickMetrics.IsEnabled)
                 {
                     // 释放调度锁后再发布指标，避免 UI 订阅回调参与实时触发器锁竞争。
-                    _metricsService?.RecordDispatcherTick(
-                        processingCostMs,
-                        captureCostMs,
-                        triggerCostMs);
+                    tickMetrics.Publish(_metricsService);
                 }
             }
         }

--- a/BetterGenshinImpact/Service/Model/OverlayMetric/DispatcherTickMetrics.cs
+++ b/BetterGenshinImpact/Service/Model/OverlayMetric/DispatcherTickMetrics.cs
@@ -1,0 +1,67 @@
+using System.Diagnostics;
+
+namespace BetterGenshinImpact.Service.Model.OverlayMetric;
+
+public class DispatcherTickMetrics
+{
+    private long _tickStart;
+    private long _captureStart;
+
+    public bool IsEnabled { get; private set; }
+
+    public double ProcessingCostMs { get; private set; }
+
+    public double CaptureCostMs { get; private set; }
+
+    public double TriggerCostMs { get; private set; }
+
+    public void Begin()
+    {
+        _tickStart = Stopwatch.GetTimestamp();
+        _captureStart = _tickStart;
+        IsEnabled = true;
+    }
+
+    public void EndCapture()
+    {
+        if (!IsEnabled)
+        {
+            return;
+        }
+
+        CaptureCostMs = Stopwatch.GetElapsedTime(_captureStart).TotalMilliseconds;
+    }
+
+    public void AddTriggerCost(long triggerStart)
+    {
+        if (!IsEnabled)
+        {
+            return;
+        }
+
+        TriggerCostMs += Stopwatch.GetElapsedTime(triggerStart).TotalMilliseconds;
+    }
+
+    public void EndProcessing()
+    {
+        if (!IsEnabled)
+        {
+            return;
+        }
+
+        ProcessingCostMs = Stopwatch.GetElapsedTime(_tickStart).TotalMilliseconds;
+    }
+
+    public void Publish(OverlayMetricsService? metricsService)
+    {
+        if (!IsEnabled)
+        {
+            return;
+        }
+
+        metricsService?.RecordDispatcherTick(
+            ProcessingCostMs,
+            CaptureCostMs,
+            TriggerCostMs);
+    }
+}

--- a/BetterGenshinImpact/Service/Model/OverlayMetric/OverlayMetricsSnapshot.cs
+++ b/BetterGenshinImpact/Service/Model/OverlayMetric/OverlayMetricsSnapshot.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace BetterGenshinImpact.Service;
+namespace BetterGenshinImpact.Service.Model.OverlayMetric;
 
 public sealed record OverlayMetricDisplayItem(string Name, string Value)
 {

--- a/BetterGenshinImpact/Service/OverlayMetricsService.cs
+++ b/BetterGenshinImpact/Service/OverlayMetricsService.cs
@@ -6,6 +6,8 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using BetterGenshinImpact.Service.Model;
+using BetterGenshinImpact.Service.Model.OverlayMetric;
 
 namespace BetterGenshinImpact.Service;
 

--- a/BetterGenshinImpact/Service/OverlayMetricsService.cs
+++ b/BetterGenshinImpact/Service/OverlayMetricsService.cs
@@ -1,0 +1,341 @@
+using BetterGenshinImpact.Core.Config;
+using BetterGenshinImpact.Service.Interface;
+using LibreHardwareMonitor.Hardware;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+
+namespace BetterGenshinImpact.Service;
+
+public sealed class OverlayMetricsService : IDisposable
+{
+    // 调度器可能按几十毫秒上报一次，遮罩文本和硬件传感器分别节流，避免 UI 与 LibreHardwareMonitor 高频刷新。
+    private static readonly TimeSpan PublishInterval = TimeSpan.FromMilliseconds(500);
+    private static readonly TimeSpan HardwareRefreshInterval = TimeSpan.FromSeconds(1);
+    private static readonly TimeSpan PeakProcessingCostWindow = TimeSpan.FromSeconds(5);
+
+    private readonly ILogger<OverlayMetricsService> _logger = App.GetLogger<OverlayMetricsService>();
+    private readonly IConfigService? _configService = App.GetService<IConfigService>();
+    private readonly object _locker = new();
+    private readonly object _hardwareLocker = new();
+    private readonly MaskWindowConfig? _maskWindowConfig;
+
+    private Computer? _computer;
+    private bool _hardwareInitialized;
+    private bool _hardwareWarningLogged;
+
+    private double? _gameFps;
+    private double? _processingCostMs;
+    private double? _peakProcessingCostMs;
+    private double? _captureCostMs;
+    private double? _triggerCostMs;
+    private double? _cpuUsage;
+    private double? _gpuUsage;
+    private double? _memoryUsage;
+
+    private long _skippedTicks;
+    private long _lastPublishedSkippedTicks;
+    private readonly Queue<(DateTime Time, double Value)> _processingCostSamples = new();
+    private DateTime _lastPublishTime = DateTime.MinValue;
+    private DateTime _lastHardwareRefreshTime = DateTime.MinValue;
+
+    public event EventHandler<OverlayMetricsSnapshot>? MetricsUpdated;
+
+    public OverlayMetricsSnapshot CurrentSnapshot { get; private set; } = OverlayMetricsSnapshot.Empty;
+
+    public OverlayMetricsService()
+    {
+        _maskWindowConfig = _configService?.Get().MaskWindowConfig;
+        _maskWindowConfig?.EnsureOverlayMetricItems();
+        if (_maskWindowConfig != null)
+        {
+            _maskWindowConfig.PropertyChanged += MaskWindowConfigOnPropertyChanged;
+        }
+    }
+
+    public void UpdateGameFps(double fps)
+    {
+        lock (_locker)
+        {
+            _gameFps = fps;
+        }
+
+        TryPublish();
+    }
+
+    public void RecordSkippedTick()
+    {
+        lock (_locker)
+        {
+            _skippedTicks++;
+        }
+
+        TryPublish();
+    }
+
+    public void RecordDispatcherTick(double processingCostMs, double captureCostMs, double triggerCostMs)
+    {
+        lock (_locker)
+        {
+            RecordPeakProcessingCost(processingCostMs, DateTime.UtcNow);
+            _processingCostMs = Smooth(_processingCostMs, processingCostMs);
+            _captureCostMs = Smooth(_captureCostMs, captureCostMs);
+            _triggerCostMs = Smooth(_triggerCostMs, triggerCostMs);
+        }
+
+        TryPublish();
+    }
+
+    public void Refresh()
+    {
+        TryPublish(force: true);
+    }
+
+    private void MaskWindowConfigOnPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName is nameof(MaskWindowConfig.ShowOverlayMetrics)
+            or nameof(MaskWindowConfig.OverlayMetricItems))
+        {
+            TryPublish(force: true, refreshHardware: false);
+        }
+    }
+
+    private void TryPublish(bool force = false, bool refreshHardware = true)
+    {
+        var allConfig = _configService?.Get();
+        var config = allConfig?.MaskWindowConfig;
+        if (allConfig == null || config == null)
+        {
+            return;
+        }
+
+        config.EnsureOverlayMetricItems();
+        var now = DateTime.UtcNow;
+        // 即使实时触发器高频运行，遮罩只需要半秒级更新；手动刷新和配置变更用 force 立即同步。
+        if (!force && now - _lastPublishTime < PublishInterval)
+        {
+            return;
+        }
+
+        // 硬件采样相对更重，只有用户开启对应指标时才按秒级刷新。
+        if (refreshHardware && ShouldRefreshHardware(config, now))
+        {
+            RefreshHardwareMetrics();
+        }
+
+        OverlayMetricsSnapshot snapshot;
+        lock (_locker)
+        {
+            var elapsedSeconds = _lastPublishTime == DateTime.MinValue
+                ? PublishInterval.TotalSeconds
+                : Math.Max(0.001, (now - _lastPublishTime).TotalSeconds);
+            var skippedDelta = _skippedTicks - _lastPublishedSkippedTicks;
+            var skippedPerSecond = skippedDelta / elapsedSeconds;
+
+            snapshot = BuildSnapshot(config, skippedPerSecond);
+            CurrentSnapshot = snapshot;
+            _lastPublishedSkippedTicks = _skippedTicks;
+            _lastPublishTime = now;
+        }
+
+        MetricsUpdated?.Invoke(this, snapshot);
+    }
+
+    private bool ShouldRefreshHardware(MaskWindowConfig config, DateTime now)
+    {
+        if (!config.ShowOverlayMetrics || !HardwareMetricsEnabled(config))
+        {
+            return false;
+        }
+
+        return now - _lastHardwareRefreshTime >= HardwareRefreshInterval;
+    }
+
+    private static bool HardwareMetricsEnabled(MaskWindowConfig config)
+    {
+        return config.IsOverlayMetricEnabled(OverlayMetricItem.CpuUsage)
+               || config.IsOverlayMetricEnabled(OverlayMetricItem.GpuUsage)
+               || config.IsOverlayMetricEnabled(OverlayMetricItem.MemoryUsage);
+    }
+
+    private OverlayMetricsSnapshot BuildSnapshot(MaskWindowConfig config, double skippedPerSecond)
+    {
+        if (!config.ShowOverlayMetrics)
+        {
+            return OverlayMetricsSnapshot.Empty;
+        }
+
+        var items = new List<OverlayMetricDisplayItem>();
+        AddMetric(items, config, OverlayMetricItem.GameFps, _gameFps, value => $"{value:0}");
+        AddMetric(items, config, OverlayMetricItem.ProcessingCost, _processingCostMs, value => $"{value:0}ms");
+        AddMetric(items, config, OverlayMetricItem.PeakProcessingCost, _peakProcessingCostMs, value => $"{value:0}ms");
+        AddMetric(items, config, OverlayMetricItem.CaptureCost, _captureCostMs, value => $"{value:0}ms");
+        AddMetric(items, config, OverlayMetricItem.TriggerCost, _triggerCostMs, value => $"{value:0}ms");
+        AddMetric(items, config, OverlayMetricItem.SkippedTicks, skippedPerSecond, value => $"{value:0}次/秒");
+        AddMetric(items, config, OverlayMetricItem.GpuUsage, _gpuUsage, value => $"{value:0}%");
+        AddMetric(items, config, OverlayMetricItem.CpuUsage, _cpuUsage, value => $"{value:0}%");
+        AddMetric(items, config, OverlayMetricItem.MemoryUsage, _memoryUsage, value => $"{value:0}%");
+
+        return items.Count == 0 ? OverlayMetricsSnapshot.Empty : new OverlayMetricsSnapshot(items);
+    }
+
+    private static void AddMetric(List<OverlayMetricDisplayItem> items, MaskWindowConfig config, OverlayMetricItem item, double? value, Func<double, string> formatter)
+    {
+        // 传感器不可用或数值未产生时直接跳过，遮罩不要显示 N/A 或空占位。
+        if (!config.IsOverlayMetricEnabled(item) || value == null || double.IsNaN(value.Value) || double.IsInfinity(value.Value))
+        {
+            return;
+        }
+
+        items.Add(new OverlayMetricDisplayItem(OverlayMetricItemDefaults.GetDisplayName(item), formatter(value.Value)));
+    }
+
+    private void RecordPeakProcessingCost(double processingCostMs, DateTime now)
+    {
+        _processingCostSamples.Enqueue((now, processingCostMs));
+
+        var cutoff = now - PeakProcessingCostWindow;
+        while (_processingCostSamples.Count > 0 && _processingCostSamples.Peek().Time < cutoff)
+        {
+            _processingCostSamples.Dequeue();
+        }
+
+        _peakProcessingCostMs = _processingCostSamples.Count == 0
+            ? null
+            : _processingCostSamples.Max(sample => sample.Value);
+    }
+
+    private void RefreshHardwareMetrics()
+    {
+        // LibreHardwareMonitor 在不同硬件上的传感器名称不完全一致，先匹配常见总量名称，再退回首个可用 Load 传感器。
+        lock (_hardwareLocker)
+        {
+            _lastHardwareRefreshTime = DateTime.UtcNow;
+
+            if (!EnsureHardwareInitialized())
+            {
+                return;
+            }
+
+            try
+            {
+                double? cpuUsage = null;
+                double? gpuUsage = null;
+                double? memoryUsage = null;
+
+                foreach (var hardware in _computer!.Hardware)
+                {
+                    hardware.Update();
+                    foreach (var subHardware in hardware.SubHardware)
+                    {
+                        subHardware.Update();
+                    }
+
+                    if (hardware.HardwareType == HardwareType.Cpu)
+                    {
+                        cpuUsage = TryGetLoad(hardware, "CPU Total") ?? TryGetFirstSensorValue(hardware, SensorType.Load);
+                    }
+                    else if (IsGpu(hardware.HardwareType))
+                    {
+                        gpuUsage = TryGetLoad(hardware, "GPU Core") ?? TryGetFirstSensorValue(hardware, SensorType.Load) ?? gpuUsage;
+                    }
+                    else if (hardware.HardwareType == HardwareType.Memory)
+                    {
+                        memoryUsage = TryGetLoad(hardware, "Memory") ?? TryGetFirstSensorValue(hardware, SensorType.Load);
+                    }
+                }
+
+                lock (_locker)
+                {
+                    _cpuUsage = cpuUsage;
+                    _gpuUsage = gpuUsage;
+                    _memoryUsage = memoryUsage;
+                }
+            }
+            catch (Exception ex)
+            {
+                LogHardwareWarning(ex);
+            }
+        }
+    }
+
+    private bool EnsureHardwareInitialized()
+    {
+        // 硬件指标是可选能力，初始化失败只隐藏硬件项并记录一次警告，不影响 BetterGI 自身指标。
+        if (_hardwareInitialized)
+        {
+            return _computer != null;
+        }
+
+        _hardwareInitialized = true;
+        try
+        {
+            _computer = new Computer
+            {
+                IsCpuEnabled = true,
+                IsGpuEnabled = true,
+                IsMemoryEnabled = true
+            };
+            _computer.Open();
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _computer?.Close();
+            _computer = null;
+            LogHardwareWarning(ex);
+            return false;
+        }
+    }
+
+    private void LogHardwareWarning(Exception ex)
+    {
+        if (_hardwareWarningLogged)
+        {
+            return;
+        }
+
+        _hardwareWarningLogged = true;
+        _logger.LogWarning(ex, "遮罩硬件指标初始化或读取失败，将自动隐藏不可用指标");
+    }
+
+    private static bool IsGpu(HardwareType hardwareType)
+    {
+        return hardwareType is HardwareType.GpuAmd or HardwareType.GpuIntel or HardwareType.GpuNvidia;
+    }
+
+    private static double? TryGetLoad(IHardware hardware, string preferredName)
+    {
+        return hardware.Sensors
+            .Where(sensor => sensor.SensorType == SensorType.Load && sensor.Value != null)
+            .OrderByDescending(sensor => sensor.Name.Contains(preferredName, StringComparison.OrdinalIgnoreCase))
+            .Select(sensor => (double?)sensor.Value!.Value)
+            .FirstOrDefault();
+    }
+
+    private static double? TryGetFirstSensorValue(IHardware hardware, SensorType sensorType)
+    {
+        return hardware.Sensors
+            .Where(sensor => sensor.SensorType == sensorType && sensor.Value != null)
+            .Select(sensor => (double?)sensor.Value!.Value)
+            .FirstOrDefault();
+    }
+
+    private static double Smooth(double? currentValue, double newValue)
+    {
+        // 简单平滑可减少单帧截图或触发器尖峰导致的遮罩数值跳动。
+        return currentValue == null ? newValue : currentValue.Value * 0.7 + newValue * 0.3;
+    }
+
+    public void Dispose()
+    {
+        if (_maskWindowConfig != null)
+        {
+            _maskWindowConfig.PropertyChanged -= MaskWindowConfigOnPropertyChanged;
+        }
+
+        _computer?.Close();
+    }
+}

--- a/BetterGenshinImpact/Service/OverlayMetricsSnapshot.cs
+++ b/BetterGenshinImpact/Service/OverlayMetricsSnapshot.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BetterGenshinImpact.Service;
+
+public sealed record OverlayMetricDisplayItem(string Name, string Value)
+{
+    public string DisplayText => $"{Name} {Value}";
+}
+
+public sealed record OverlayMetricsSnapshot(IReadOnlyList<OverlayMetricDisplayItem> Items)
+{
+    public static OverlayMetricsSnapshot Empty { get; } = new([]);
+
+    public string CombinedText => string.Join("   ", Items.Select(item => item.DisplayText));
+}

--- a/BetterGenshinImpact/View/MaskWindow.xaml
+++ b/BetterGenshinImpact/View/MaskWindow.xaml
@@ -288,6 +288,95 @@
                         </d:FlowDocument>
                     </RichTextBox>
                 </overlay:AdjustableOverlayItem>
+
+                <!-- 指标栏复用可拖拽容器；单项固定宽度，只允许在指标之间换行，避免中文标签被拆开。 -->
+                <overlay:AdjustableOverlayItem x:Name="MetricsWrapper"
+                                               Padding="4,2"
+                                               Background="#00000000"
+                                               BorderBrush="#00000000"
+                                               BorderThickness="0"
+                                               MinWidth="260"
+                                               MinHeight="24"
+                                               IsEditEnabled="{Binding Config.MaskWindowConfig.OverlayLayoutEditEnabled}"
+                                               LayoutKey="Metrics"
+                                               SnapsToDevicePixels="True"
+                                               UseLayoutRounding="True"
+                                               Visibility="{Binding IsOverlayMetricsVisible, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <Canvas.Left>
+                        <MultiBinding Converter="{StaticResource OverlayRelativeOrAbsoluteConverter}">
+                            <Binding Path="Config.MaskWindowConfig.MetricsLeftRatio" />
+                            <Binding RelativeSource="{RelativeSource AncestorType=Window}" Path="ActualWidth" />
+                        </MultiBinding>
+                    </Canvas.Left>
+                    <Canvas.Top>
+                        <MultiBinding Converter="{StaticResource OverlayRelativeOrAbsoluteConverter}">
+                            <Binding Path="Config.MaskWindowConfig.MetricsTopRatio" />
+                            <Binding RelativeSource="{RelativeSource AncestorType=Window}" Path="ActualHeight" />
+                        </MultiBinding>
+                    </Canvas.Top>
+                    <overlay:AdjustableOverlayItem.Width>
+                        <MultiBinding Converter="{StaticResource OverlayRelativeOrAbsoluteConverter}">
+                            <Binding Path="Config.MaskWindowConfig.MetricsWidthRatio" />
+                            <Binding RelativeSource="{RelativeSource AncestorType=Window}" Path="ActualWidth" />
+                        </MultiBinding>
+                    </overlay:AdjustableOverlayItem.Width>
+                    <overlay:AdjustableOverlayItem.Height>
+                        <MultiBinding Converter="{StaticResource OverlayRelativeOrAbsoluteConverter}">
+                            <Binding Path="Config.MaskWindowConfig.MetricsHeightRatio" />
+                            <Binding RelativeSource="{RelativeSource AncestorType=Window}" Path="ActualHeight" />
+                        </MultiBinding>
+                    </overlay:AdjustableOverlayItem.Height>
+                    <b:Interaction.Triggers>
+                        <b:EventTrigger EventName="LayoutCommitted">
+                            <b:InvokeCommandAction Command="{Binding OverlayLayoutCommittedCommand}"
+                                                   PassEventArgsToCommand="True" />
+                        </b:EventTrigger>
+                        <b:EventTrigger EventName="PreviewMouseRightButtonDown">
+                            <b:InvokeCommandAction Command="{Binding ExitOverlayLayoutEditModeCommand}" />
+                        </b:EventTrigger>
+                    </b:Interaction.Triggers>
+                    <overlay:AdjustableOverlayItem.Effect>
+                        <DropShadowEffect Opacity="0.4" BlurRadius="4" ShadowDepth="0" />
+                    </overlay:AdjustableOverlayItem.Effect>
+                    <ItemsControl HorizontalAlignment="Stretch"
+                                  VerticalAlignment="Top"
+                                  ClipToBounds="True"
+                                  IsHitTestVisible="False"
+                                  ItemsSource="{Binding OverlayMetricDisplayItems}"
+                                  Opacity="{Binding Config.MaskWindowConfig.TextOpacity}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <!-- 列宽和设置页的三列顺序保持一致，拖窄后也按完整指标项折行。 -->
+                                <WrapPanel ItemWidth="116" ItemHeight="16" />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Grid Width="116" Height="16">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="68" />
+                                        <ColumnDefinition Width="*" />
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0"
+                                               FontFamily="Cascadia Mono, Consolas, Courier New, monospace, /Resources/Fonts/MiSans-Regular.ttf#MiSans"
+                                               FontSize="12"
+                                               Foreground="LightGray"
+                                               LineHeight="15"
+                                               Text="{Binding Name}"
+                                               TextWrapping="NoWrap" />
+                                    <TextBlock Grid.Column="1"
+                                               FontFamily="Cascadia Mono, Consolas, Courier New, monospace, /Resources/Fonts/MiSans-Regular.ttf#MiSans"
+                                               FontSize="12"
+                                               Foreground="LightGray"
+                                               LineHeight="15"
+                                               Text="{Binding Value}"
+                                               TextTrimming="CharacterEllipsis"
+                                               TextWrapping="NoWrap" />
+                                </Grid>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </overlay:AdjustableOverlayItem>
             </Canvas>
 
             <Grid Grid.Row="0"
@@ -423,7 +512,7 @@
                     CornerRadius="4"
                     Opacity="0.5"
                     IsHitTestVisible="False"
-                    Visibility="{Binding Config.MaskWindowConfig.ShowFps, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    Visibility="Collapsed">
                 <TextBlock HorizontalAlignment="Center"
                            VerticalAlignment="Center"
                            FontFamily="{StaticResource DigitalThemeFontFamily}"

--- a/BetterGenshinImpact/View/Pages/CommonSettingsPage.xaml
+++ b/BetterGenshinImpact/View/Pages/CommonSettingsPage.xaml
@@ -206,7 +206,7 @@
                     <ui:TextBlock Grid.Row="1"
                                   Grid.Column="0"
                                   Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
-                                  Text="开启后可以拖拽调整日志与状态栏位置，并调整大小"
+                                  Text="开启后可以拖拽调整日志、状态栏与指标栏位置，并调整大小"
                                   TextWrapping="Wrap" />
                     <ui:ToggleSwitch Grid.Row="0"
                                      Grid.RowSpan="2"
@@ -275,19 +275,54 @@
                     <ui:TextBlock Grid.Row="0"
                                   Grid.Column="0"
                                   FontTypography="Body"
-                                  Text="显示游戏FPS（实验功能）"
+                                  Text="显示遮罩指标栏"
                                   TextWrapping="Wrap" />
                     <ui:TextBlock Grid.Row="1"
                                   Grid.Column="0"
                                   Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
-                                  Text="修改设置后重启生效，可能存在使游戏崩溃的BUG"
+                                  Text="显示游戏帧率、处理耗时和硬件占用，指标项可单独选择"
                                   TextWrapping="Wrap" />
                     <ui:ToggleSwitch Grid.Row="0"
                                      Grid.RowSpan="2"
                                      Grid.Column="1"
                                      Margin="0,0,36,0"
-                                     IsChecked="{Binding Config.MaskWindowConfig.ShowFps, Mode=TwoWay}" />
+                                     IsChecked="{Binding Config.MaskWindowConfig.ShowOverlayMetrics, Mode=TwoWay}">
+                        <b:Interaction.Triggers>
+                            <b:EventTrigger EventName="Unchecked">
+                                <b:InvokeCommandAction Command="{Binding RefreshMaskSettingsCommand}" />
+                            </b:EventTrigger>
+                            <b:EventTrigger EventName="Checked">
+                                <b:InvokeCommandAction Command="{Binding RefreshMaskSettingsCommand}" />
+                            </b:EventTrigger>
+                        </b:Interaction.Triggers>
+                    </ui:ToggleSwitch>
                 </Grid>
+                <!-- 固定三行三列，顺序来自 OverlayMetricItemDefaults.AllItems，与遮罩实际展示顺序一致。 -->
+                <ItemsControl Margin="48,0,52,12"
+                              ItemsSource="{Binding OverlayMetricItems}">
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <UniformGrid Columns="3" Rows="3" />
+                        </ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <CheckBox Width="132"
+                                      Height="28"
+                                      HorizontalAlignment="Left"
+                                      HorizontalContentAlignment="Left"
+                                      VerticalContentAlignment="Center"
+                                      IsChecked="{Binding IsEnabled, Mode=TwoWay}"
+                                      ToolTip="{Binding ToolTipText}">
+                                <ui:TextBlock Margin="4,0,0,0"
+                                              FontTypography="Body"
+                                              Text="{Binding DisplayName}"
+                                              TextTrimming="CharacterEllipsis"
+                                              TextWrapping="NoWrap" />
+                            </CheckBox>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
                 <!--<Grid Margin="16">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />

--- a/BetterGenshinImpact/ViewModel/MaskWindowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/MaskWindowViewModel.cs
@@ -41,6 +41,14 @@ namespace BetterGenshinImpact.ViewModel
         public AllConfig? Config { get; set; }
 
         [ObservableProperty] private string _fps = "0";
+
+        [ObservableProperty] private string _overlayMetricsText = string.Empty;
+
+        [ObservableProperty] private IReadOnlyList<OverlayMetricDisplayItem> _overlayMetricDisplayItems = [];
+
+        public bool HasOverlayMetricsText => OverlayMetricDisplayItems.Count > 0;
+
+        public bool IsOverlayMetricsVisible => Config?.MaskWindowConfig.ShowOverlayMetrics == true && HasOverlayMetricsText;
         
         [ObservableProperty] private double _maskWindowWidth;
 
@@ -111,6 +119,9 @@ namespace BetterGenshinImpact.ViewModel
         private int _mapLabelItemsLoadVersion;
         private int _mapPointsLoadVersion;
         private readonly SemaphoreSlim _iconLoadSemaphore = new(10, 10);
+        private readonly OverlayMetricsService? _overlayMetricsService = App.GetService<OverlayMetricsService>();
+        private bool _metricsSubscribed;
+        private bool _fpsStarted;
 
         public MaskWindowViewModel()
         {
@@ -140,7 +151,7 @@ namespace BetterGenshinImpact.ViewModel
         {
             RefreshSettings();
             InitializeStatusList();
-            InitFps();
+            InitMetrics();
         }
 
         [RelayCommand]
@@ -205,11 +216,15 @@ namespace BetterGenshinImpact.ViewModel
             InitConfig();
             if (Config != null)
             {
+                Config.MaskWindowConfig.EnsureOverlayMetricItems();
+                Config.MaskWindowConfig.MigrateLegacyOverlayMetricsLayout();
                 OnPropertyChanged(nameof(Config));
+                OnPropertyChanged(nameof(IsOverlayMetricsVisible));
             }
 
             SyncSelectedMapPointApiProviderFromConfig();
             SyncSelectedHoYoLabLanguageFromConfig();
+            InitMetrics();
         }
 
         /// <summary>
@@ -340,14 +355,43 @@ namespace BetterGenshinImpact.ViewModel
             }
         }
 
-        private void InitFps()
+        private void InitMetrics()
         {
-            if (Config!.MaskWindowConfig.ShowFps)
+            if (_overlayMetricsService != null && !_metricsSubscribed)
             {
+                _overlayMetricsService.MetricsUpdated += OverlayMetricsServiceOnMetricsUpdated;
+                _metricsSubscribed = true;
+                OverlayMetricDisplayItems = _overlayMetricsService.CurrentSnapshot.Items;
+                OverlayMetricsText = _overlayMetricsService.CurrentSnapshot.CombinedText;
+            }
+
+            if (Config?.MaskWindowConfig.IsOverlayMetricEnabled(OverlayMetricItem.GameFps) == true && !_fpsStarted)
+            {
+                // FPS 由 PresentMon 长任务持续采样，只有用户勾选游戏帧率时才启动一次，避免无意义后台采样。
+                _fpsStarted = true;
                 nint targetHWnd = TaskContext.Instance().GameHandle;
                 _ = User32.GetWindowThreadProcessId(targetHWnd, out var pid);
-                Task.Run(async () => { await FpsInspector.StartForeverAsync(new FpsRequest(pid), (result) => { Fps = $"{result.Fps:0}"; }); });
+                Task.Run(async () =>
+                {
+                    await FpsInspector.StartForeverAsync(new FpsRequest(pid), result =>
+                    {
+                        Fps = $"{result.Fps:0}";
+                        _overlayMetricsService?.UpdateGameFps(result.Fps);
+                    });
+                });
             }
+
+            _overlayMetricsService?.Refresh();
+        }
+
+        private void OverlayMetricsServiceOnMetricsUpdated(object? sender, OverlayMetricsSnapshot snapshot)
+        {
+            // OverlayMetricsService 可能在计时器线程发布事件，绑定集合必须切回 UI 线程更新。
+            UIDispatcherHelper.Invoke(() =>
+            {
+                OverlayMetricDisplayItems = snapshot.Items;
+                OverlayMetricsText = snapshot.CombinedText;
+            });
         }
 
         [RelayCommand]
@@ -387,6 +431,12 @@ namespace BetterGenshinImpact.ViewModel
                     Config.MaskWindowConfig.StatusListWidthRatio = widthRatio;
                     Config.MaskWindowConfig.StatusListHeightRatio = heightRatio;
                     break;
+                case "Metrics":
+                    Config.MaskWindowConfig.MetricsLeftRatio = leftRatio;
+                    Config.MaskWindowConfig.MetricsTopRatio = topRatio;
+                    Config.MaskWindowConfig.MetricsWidthRatio = widthRatio;
+                    Config.MaskWindowConfig.MetricsHeightRatio = heightRatio;
+                    break;
             }
         }
 
@@ -423,6 +473,17 @@ namespace BetterGenshinImpact.ViewModel
                 > 1 => 1,
                 _ => ratio
             };
+        }
+
+        partial void OnOverlayMetricsTextChanged(string value)
+        {
+            OnPropertyChanged(nameof(IsOverlayMetricsVisible));
+        }
+
+        partial void OnOverlayMetricDisplayItemsChanged(IReadOnlyList<OverlayMetricDisplayItem> value)
+        {
+            OnPropertyChanged(nameof(HasOverlayMetricsText));
+            OnPropertyChanged(nameof(IsOverlayMetricsVisible));
         }
 
         partial void OnIsInBigMapUiChanged(bool value)

--- a/BetterGenshinImpact/ViewModel/MaskWindowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/MaskWindowViewModel.cs
@@ -23,6 +23,8 @@ using System.Windows.Threading;
 using BetterGenshinImpact.GameTask.Common.Element.Assets;
 using BetterGenshinImpact.Service;
 using BetterGenshinImpact.Model.MaskMap;
+using BetterGenshinImpact.Service.Model;
+using BetterGenshinImpact.Service.Model.OverlayMetric;
 using Vanara.PInvoke;
 using MaskMapPoint = BetterGenshinImpact.Model.MaskMap.MaskMapPoint;
 using MaskMapPointLabel = BetterGenshinImpact.Model.MaskMap.MaskMapPointLabel;

--- a/BetterGenshinImpact/ViewModel/Pages/CommonSettingsPageViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/CommonSettingsPageViewModel.cs
@@ -67,8 +67,13 @@ public partial class CommonSettingsPageViewModel : ViewModel
         NotificationService notificationService)
     {
         Config = configService.Get();
+        Config.MaskWindowConfig.EnsureOverlayMetricItems();
+        Config.MaskWindowConfig.MigrateLegacyOverlayMetricsLayout();
         _navigationService = navigationService;
         _notificationService = notificationService;
+        // 设置页需要可绑定对象，避免把 Dictionary<string, bool> 直接暴露给 XAML 并丢失固定枚举顺序。
+        OverlayMetricItems = new ObservableCollection<OverlayMetricSettingItem>(
+            OverlayMetricItemDefaults.AllItems.Select(item => new OverlayMetricSettingItem(Config.MaskWindowConfig, item, OnRefreshMaskSettings)));
         InitializeCountries();
         InitializeMiyousheCookie();
         // 初始化OCR模型选择
@@ -76,6 +81,7 @@ public partial class CommonSettingsPageViewModel : ViewModel
     }
 
     public AllConfig Config { get; set; }
+    public ObservableCollection<OverlayMetricSettingItem> OverlayMetricItems { get; }
     public ObservableCollection<string> CountryList { get; } = new();
     public ObservableCollection<string> Areas { get; } = new();
 
@@ -316,6 +322,8 @@ public partial class CommonSettingsPageViewModel : ViewModel
         c.LogTextBoxWidthRatio = 477.0 / 1920;
         c.LogTextBoxHeightRatio = 188.0 / 1080;
 
+        c.ResetOverlayMetricsLayout();
+
         OnRefreshMaskSettings();
     }
 
@@ -454,5 +462,44 @@ public partial class CommonSettingsPageViewModel : ViewModel
     {
         Config.OtherConfig.OcrConfig.PaddleOcrModelConfig = value;
         await App.ServiceProvider.GetRequiredService<OcrFactory>().Unload();
+    }
+}
+
+// 只服务于设置页：把固定指标枚举、显示文案和配置字典中的开关包装成复选框可双向绑定的对象。
+public sealed class OverlayMetricSettingItem : ObservableObject
+{
+    private readonly MaskWindowConfig _config;
+    private readonly Action _onChanged;
+    private bool _isEnabled;
+
+    public OverlayMetricSettingItem(MaskWindowConfig config, OverlayMetricItem item, Action onChanged)
+    {
+        _config = config;
+        _onChanged = onChanged;
+        Item = item;
+        DisplayName = OverlayMetricItemDefaults.GetDisplayName(item);
+        ToolTipText = OverlayMetricItemDefaults.GetToolTipText(item);
+        _isEnabled = config.IsOverlayMetricEnabled(item);
+    }
+
+    public OverlayMetricItem Item { get; }
+
+    public string DisplayName { get; }
+
+    public string ToolTipText { get; }
+
+    public bool IsEnabled
+    {
+        get => _isEnabled;
+        set
+        {
+            if (!SetProperty(ref _isEnabled, value))
+            {
+                return;
+            }
+
+            _config.SetOverlayMetricEnabled(Item, value);
+            _onChanged();
+        }
     }
 }


### PR DESCRIPTION
## 摘要
- 新增默认关闭的遮罩指标栏，指标名称使用直观中文标签。
- 支持在设置页按三行三列复选指标项，并复用遮罩拖拽编辑调整位置和大小。
- 记录 BetterGI 实时处理指标，包括处理耗时、峰值耗时、截图耗时、触发器耗时、跳过次数。
- 增加 CPU、显卡、内存占用的可选硬件指标，不可用时自动隐藏。

## 验证
- dotnet build BetterGenshinImpact\BetterGenshinImpact.csproj -c Debug -p:Platform=x64 -p:RestoreDisableParallel=true -m:1

Closes #582
Closes #942

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 添加遮罩指标栏功能，支持实时显示帧率、处理耗时、硬件资源占用等多项性能指标。
  * 在设置中新增逐项配置，允许用户选择要显示的指标。
  * 指标栏支持拖拽调整位置和大小。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->