### PR TITLE
Translate notification and dialog surfaces

### DIFF
--- a/BetterGenshinImpact/App.xaml.cs
+++ b/BetterGenshinImpact/App.xaml.cs
@@ -88,22 +88,21 @@ public partial class App : Application
                 services.AddSingleton<IMissingTranslationReporter, SupabaseMissingTranslationReporter>();
                 services.AddSingleton<ITranslationService, JsonTranslationService>();
 
-                services.AddLogging(c => c.AddSerilog());
-                // if ("zh-Hans".Equals(all.OtherConfig.UiCultureInfoName, StringComparison.OrdinalIgnoreCase))
-                // {
-                //     services.AddLogging(c => c.AddSerilog());
-                // }
-                // else
-                // {
-                //     services.AddLogging(logging =>
-                //     {
-                //         logging.ClearProviders();
-                //         logging.SetMinimumLevel(LogLevel.Debug);
-                //         logging.AddFilter("Microsoft", LogLevel.Warning);
-                //         logging.AddFilter("Microsoft.Hosting.Lifetime", LogLevel.Warning);
-                //         logging.Services.AddSingleton<ILoggerProvider, TranslatingSerilogLoggerProvider>();
-                //     });
-                // }
+                if ("zh-Hans".Equals(all.OtherConfig.UiCultureInfoName, StringComparison.OrdinalIgnoreCase))
+                {
+                    services.AddLogging(c => c.AddSerilog());
+                }
+                else
+                {
+                    services.AddLogging(logging =>
+                    {
+                        logging.ClearProviders();
+                        logging.SetMinimumLevel(LogLevel.Debug);
+                        logging.AddFilter("Microsoft", LogLevel.Warning);
+                        logging.AddFilter("Microsoft.Hosting.Lifetime", LogLevel.Warning);
+                        logging.Services.AddSingleton<ILoggerProvider, TranslatingSerilogLoggerProvider>();
+                    });
+                }
 
                 services.AddLocalization();
 

--- a/BetterGenshinImpact/GameTask/AutoLeyLineOutcrop/AutoLeyLineOutcropTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoLeyLineOutcrop/AutoLeyLineOutcropTask.cs
@@ -315,12 +315,12 @@ public class AutoLeyLineOutcropTask : ISoloTask
         if (_taskParam.IsNotification)
         {
             var text =
-                "树脂耗尽模式统计结果:\n" +
-                $"原粹树脂次数: {result.OriginalResinTimes}\n" +
-                $"浓缩树脂次数: {result.CondensedResinTimes}\n" +
-                $"须臾树脂次数: {result.TransientResinTimes}\n" +
-                $"脆弱树脂次数: {result.FragileResinTimes}\n" +
-                $"总次数: {result.Count}";
+                TranslationHelper.T("树脂耗尽模式统计结果:", MissingTextSource.Notification) + "\n" +
+                TranslationHelper.Format("原粹树脂次数: {0}", MissingTextSource.Notification, result.OriginalResinTimes) + "\n" +
+                TranslationHelper.Format("浓缩树脂次数: {0}", MissingTextSource.Notification, result.CondensedResinTimes) + "\n" +
+                TranslationHelper.Format("须臾树脂次数: {0}", MissingTextSource.Notification, result.TransientResinTimes) + "\n" +
+                TranslationHelper.Format("脆弱树脂次数: {0}", MissingTextSource.Notification, result.FragileResinTimes) + "\n" +
+                TranslationHelper.Format("总次数: {0}", MissingTextSource.Notification, result.Count);
             Notify.Event("AutoLeyLineOutcrop").Send(text);
         }
 

--- a/BetterGenshinImpact/GameTask/AutoLeyLineOutcrop/AutoLeyLineOutcropTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoLeyLineOutcrop/AutoLeyLineOutcropTask.cs
@@ -23,6 +23,8 @@ using BetterGenshinImpact.GameTask;
 using BetterGenshinImpact.GameTask.Model;
 using BetterGenshinImpact.GameTask.Model.Area;
 using BetterGenshinImpact.Service.Notification;
+using BetterGenshinImpact.Helpers;
+using BetterGenshinImpact.Service.Interface;
 using BetterGenshinImpact.View.Drawable;
 using Microsoft.Extensions.Logging;
 using OpenCvSharp;
@@ -132,7 +134,8 @@ public class AutoLeyLineOutcropTask : ISoloTask
             _logger.LogError("自动地脉花执行失败:" + e.Message);
             if (_taskParam.IsNotification)
             {
-                Notify.Event("AutoLeyLineOutcrop").Error($"任务失败: {e.Message}");
+                Notify.Event("AutoLeyLineOutcrop").Error(
+                    TranslationHelper.Format("任务失败: {0}", MissingTextSource.Notification, e.Message));
             }
 
             throw new Exception($"自动地脉花执行失败: {e.Message}", e);

--- a/BetterGenshinImpact/GameTask/AutoStygianOnslaught/AutoStygianOnslaughtTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoStygianOnslaught/AutoStygianOnslaughtTask.cs
@@ -23,6 +23,8 @@ using BetterGenshinImpact.GameTask.QuickTeleport.Assets;
 using BetterGenshinImpact.Helpers.Extensions;
 using BetterGenshinImpact.Service.Notification;
 using BetterGenshinImpact.Service.Notification.Model.Enum;
+using BetterGenshinImpact.Helpers;
+using BetterGenshinImpact.Service.Interface;
 using Microsoft.Extensions.Logging;
 using OpenCvSharp;
 using System;
@@ -188,7 +190,8 @@ public class AutoStygianOnslaughtTask : StateMachineBase<StygianState, BvPage>, 
         Initialize(ct, StygianState.Unknown);
 
         Init();
-        Notify.Event(NotificationEvent.DomainStart).Success($"{Name}启动");
+        Notify.Event(NotificationEvent.DomainStart).Success(
+            TranslationHelper.Format("{0}启动", MissingTextSource.Notification, Name));
 
         try
         {
@@ -205,7 +208,8 @@ public class AutoStygianOnslaughtTask : StateMachineBase<StygianState, BvPage>, 
 
         await Delay(3000, ct);
         await ArtifactSalvage();
-        Notify.Event(NotificationEvent.DomainEnd).Success($"{Name}结束");
+        Notify.Event(NotificationEvent.DomainEnd).Success(
+            TranslationHelper.Format("{0}结束", MissingTextSource.Notification, Name));
     }
 
     private async Task DoDomain()
@@ -598,7 +602,8 @@ public class AutoStygianOnslaughtTask : StateMachineBase<StygianState, BvPage>, 
                 break;
             }
 
-            Notify.Event(NotificationEvent.DomainReward).Success($"{Name}奖励领取");
+            Notify.Event(NotificationEvent.DomainReward).Success(
+                TranslationHelper.Format("{0}奖励领取", MissingTextSource.Notification, Name));
             // 点击继续后会直接进入战斗场地（等待 ContinueOrExit 的邻接状态）
             CurrentState = StygianState.ContinueOrExit;
             await EnsureNextStateTransition(60000);

--- a/BetterGenshinImpact/GameTask/Common/Job/CheckRewardsTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/CheckRewardsTask.cs
@@ -8,6 +8,7 @@ using BetterGenshinImpact.Core.Recognition;
 using BetterGenshinImpact.Core.Simulator;
 using BetterGenshinImpact.Core.Simulator.Extensions;
 using BetterGenshinImpact.Helpers;
+using BetterGenshinImpact.Service.Interface;
 using BetterGenshinImpact.Service.Notification;
 using BetterGenshinImpact.Service.Notification.Model.Enum;
 using Microsoft.Extensions.Localization;
@@ -71,12 +72,12 @@ public class CheckRewardsTask
             if (done)
             {
                 Logger.LogInformation("检查每日奖励结果：{Msg}", "今日奖励已领取");
-                Notify.Event(NotificationEvent.DailyReward).Success("检查每日奖励：已领取");
+                Notify.Event(NotificationEvent.DailyReward).Success(TranslationHelper.T("检查每日奖励：已领取", MissingTextSource.Notification));
             }
             else
             {
                 Logger.LogWarning("检查每日奖励结果：{Msg}，请手动检查！", "未领取");
-                Notify.Event(NotificationEvent.DailyReward).Error("检查到每日奖励未领取，请手动查看！");
+                Notify.Event(NotificationEvent.DailyReward).Error(TranslationHelper.T("检查到每日奖励未领取，请手动查看！", MissingTextSource.Notification));
             }
             await Delay(200, ct);
             await new ReturnMainUiTask().Start(ct);

--- a/BetterGenshinImpact/GlobalUsing.cs
+++ b/BetterGenshinImpact/GlobalUsing.cs
@@ -1,1 +1,2 @@
-﻿global using MessageBox = Wpf.Ui.Violeta.Controls.MessageBox;
+global using MessageBox = Wpf.Ui.Violeta.Controls.MessageBox;
+global using Toast = BetterGenshinImpact.Helpers.BgiToast;

--- a/BetterGenshinImpact/Helpers/BgiToast.cs
+++ b/BetterGenshinImpact/Helpers/BgiToast.cs
@@ -6,16 +6,16 @@ namespace BetterGenshinImpact.Helpers;
 
 public static class BgiToast
 {
-    public static void Success(string message, int time = 2000)
+    public static void Success(string message)
         => Wpf.Ui.Violeta.Controls.Toast.Success(GetOwner(), TranslationHelper.T(message, MissingTextSource.Toast));
 
-    public static void Information(string message, int time = 2000)
+    public static void Information(string message)
         => Wpf.Ui.Violeta.Controls.Toast.Information(GetOwner(), TranslationHelper.T(message, MissingTextSource.Toast));
 
-    public static void Warning(string message, int time = 2000)
+    public static void Warning(string message)
         => Wpf.Ui.Violeta.Controls.Toast.Warning(GetOwner(), TranslationHelper.T(message, MissingTextSource.Toast));
 
-    public static void Error(string message, int time = 2000)
+    public static void Error(string message)
         => Wpf.Ui.Violeta.Controls.Toast.Error(GetOwner(), TranslationHelper.T(message, MissingTextSource.Toast));
 
     private static FrameworkElement GetOwner()

--- a/BetterGenshinImpact/Helpers/BgiToast.cs
+++ b/BetterGenshinImpact/Helpers/BgiToast.cs
@@ -1,0 +1,25 @@
+using System;
+using BetterGenshinImpact.Service.Interface;
+using System.Windows;
+
+namespace BetterGenshinImpact.Helpers;
+
+public static class BgiToast
+{
+    public static void Success(string message, int time = 2000)
+        => Wpf.Ui.Violeta.Controls.Toast.Success(GetOwner(), TranslationHelper.T(message, MissingTextSource.Toast));
+
+    public static void Information(string message, int time = 2000)
+        => Wpf.Ui.Violeta.Controls.Toast.Information(GetOwner(), TranslationHelper.T(message, MissingTextSource.Toast));
+
+    public static void Warning(string message, int time = 2000)
+        => Wpf.Ui.Violeta.Controls.Toast.Warning(GetOwner(), TranslationHelper.T(message, MissingTextSource.Toast));
+
+    public static void Error(string message, int time = 2000)
+        => Wpf.Ui.Violeta.Controls.Toast.Error(GetOwner(), TranslationHelper.T(message, MissingTextSource.Toast));
+
+    private static FrameworkElement GetOwner()
+    {
+        return Application.Current?.MainWindow ?? throw new InvalidOperationException("Main window is not available.");
+    }
+}

--- a/BetterGenshinImpact/Helpers/TranslatingSerilogLoggerProvider.cs
+++ b/BetterGenshinImpact/Helpers/TranslatingSerilogLoggerProvider.cs
@@ -66,7 +66,7 @@ public sealed class TranslatingSerilogLoggerProvider : ILoggerProvider
             }
 
             var (template, values) = ExtractTemplateAndValues(state, formatter, exception);
-            var translatedTemplate = RuntimeHelper.IsDebuggerAttached
+            var translatedTemplate = RuntimeHelper.IsDebuggerAttached || logLevel is LogLevel.Trace or LogLevel.Debug
                 ? template
                 : _translationService.Translate(template, TranslationSourceInfo.From(MissingTextSource.Log));
 

--- a/BetterGenshinImpact/Helpers/TranslationHelper.cs
+++ b/BetterGenshinImpact/Helpers/TranslationHelper.cs
@@ -1,0 +1,64 @@
+using System;
+using BetterGenshinImpact.Service.Interface;
+
+namespace BetterGenshinImpact.Helpers;
+
+public static class TranslationHelper
+{
+    public static string T(string text, MissingTextSource source = MissingTextSource.Unknown)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return text;
+        }
+
+        try
+        {
+            return App.GetService<ITranslationService>()?.Translate(text, TranslationSourceInfo.From(source)) ?? text;
+        }
+        catch
+        {
+            return text;
+        }
+    }
+
+    public static string Format(string template, MissingTextSource source, params object?[] args)
+    {
+        var translatedTemplate = T(template, source);
+        if (args.Length == 0)
+        {
+            return translatedTemplate;
+        }
+
+        var translatedArgs = new object?[args.Length];
+        for (var i = 0; i < args.Length; i++)
+        {
+            translatedArgs[i] = args[i] is string text ? T(text, source) : args[i];
+        }
+
+        try
+        {
+            return string.Format(translatedTemplate, translatedArgs);
+        }
+        catch (FormatException)
+        {
+            return translatedTemplate;
+        }
+    }
+
+    public static string TranslateMultiline(string text, MissingTextSource source)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return text;
+        }
+
+        var lines = text.Replace("\r\n", "\n").Split('\n');
+        for (var i = 0; i < lines.Length; i++)
+        {
+            lines[i] = T(lines[i], source);
+        }
+
+        return string.Join(Environment.NewLine, lines);
+    }
+}

--- a/BetterGenshinImpact/Service/Interface/ITranslationService.cs
+++ b/BetterGenshinImpact/Service/Interface/ITranslationService.cs
@@ -4,10 +4,13 @@ namespace BetterGenshinImpact.Service.Interface;
 
 public enum MissingTextSource
 {
-    Log,
-    UiStaticLiteral,
-    UiDynamicBinding,
-    Unknown
+    Log = 0,
+    UiStaticLiteral = 1,
+    UiDynamicBinding = 2,
+    Unknown = 3,
+    Notification = 4,
+    Toast = 5,
+    Dialog = 6
 }
 
 public sealed class TranslationSourceInfo

--- a/BetterGenshinImpact/Service/Notification/Model/BaseNotificationData.cs
+++ b/BetterGenshinImpact/Service/Notification/Model/BaseNotificationData.cs
@@ -103,7 +103,7 @@ public class BaseNotificationData
 
         if (Data is string text)
         {
-            Data = TranslationHelper.T(text, MissingTextSource.Notification);
+            Data = TranslationHelper.TranslateMultiline(text, MissingTextSource.Notification);
         }
     }
 }

--- a/BetterGenshinImpact/Service/Notification/Model/BaseNotificationData.cs
+++ b/BetterGenshinImpact/Service/Notification/Model/BaseNotificationData.cs
@@ -3,6 +3,8 @@ using BetterGenshinImpact.Service.Notification.Model.Enum;
 using System.Text.Json.Serialization;
 using BetterGenshinImpact.GameTask.Common;
 using BetterGenshinImpact.Service.Notification.Converter;
+using BetterGenshinImpact.Helpers;
+using BetterGenshinImpact.Service.Interface;
 using Microsoft.Extensions.Logging;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
@@ -49,6 +51,7 @@ public class BaseNotificationData
     {
         try
         {
+            TranslateForUser();
             NotificationService.Instance().NotifyAllNotifiers(this);
         }
         catch (Exception e)
@@ -89,5 +92,18 @@ public class BaseNotificationData
         Message = message + Environment.NewLine + exception.Message + Environment.NewLine + exception.StackTrace;
         Result = NotificationEventResult.Fail;
         Send();
+    }
+
+    public void TranslateForUser()
+    {
+        if (!string.IsNullOrWhiteSpace(Message))
+        {
+            Message = TranslationHelper.TranslateMultiline(Message, MissingTextSource.Notification);
+        }
+
+        if (Data is string text)
+        {
+            Data = TranslationHelper.T(text, MissingTextSource.Notification);
+        }
     }
 }

--- a/BetterGenshinImpact/Service/Notification/Model/Enum/NotificationEvent.cs
+++ b/BetterGenshinImpact/Service/Notification/Model/Enum/NotificationEvent.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using BetterGenshinImpact.Helpers;
+using BetterGenshinImpact.Service.Interface;
 
 namespace BetterGenshinImpact.Service.Notification.Model.Enum;
 
@@ -47,5 +49,5 @@ public class NotificationEvent(string code, string msg)
     }
 
     public string Code { get; private set; } = code;
-    public string Msg { get; private set; } = msg;
+    public string Msg => TranslationHelper.T(msg, MissingTextSource.Notification);
 }

--- a/BetterGenshinImpact/Service/Notification/Model/NotificationTestResult.cs
+++ b/BetterGenshinImpact/Service/Notification/Model/NotificationTestResult.cs
@@ -1,4 +1,7 @@
-﻿namespace BetterGenshinImpact.Service.Notification.Model;
+using BetterGenshinImpact.Helpers;
+using BetterGenshinImpact.Service.Interface;
+
+namespace BetterGenshinImpact.Service.Notification.Model;
 
 public class NotificationTestResult
 {
@@ -7,11 +10,19 @@ public class NotificationTestResult
 
     public static NotificationTestResult Success()
     {
-        return new NotificationTestResult { IsSuccess = true, Message = "通知成功" };
+        return new NotificationTestResult
+        {
+            IsSuccess = true,
+            Message = TranslationHelper.T("通知成功", MissingTextSource.Notification)
+        };
     }
 
     public static NotificationTestResult Error(string message)
     {
-        return new NotificationTestResult { IsSuccess = false, Message = message };
+        return new NotificationTestResult
+        {
+            IsSuccess = false,
+            Message = TranslationHelper.T(message, MissingTextSource.Notification)
+        };
     }
 }

--- a/BetterGenshinImpact/Service/Notification/NotificationService.cs
+++ b/BetterGenshinImpact/Service/Notification/NotificationService.cs
@@ -6,6 +6,8 @@ using System.Threading.Tasks;
 using BetterGenshinImpact.GameTask;
 using BetterGenshinImpact.GameTask.Common;
 using BetterGenshinImpact.GameTask.Model.Area;
+using BetterGenshinImpact.Helpers;
+using BetterGenshinImpact.Service.Interface;
 using BetterGenshinImpact.Service.Notification.Model;
 using BetterGenshinImpact.Service.Notification.Model.Enum;
 using BetterGenshinImpact.Service.Notifier;
@@ -359,6 +361,7 @@ public class NotificationService : IHostedService, IDisposable
             }
 
             var testData = CreateTestNotificationData();
+            testData.TranslateForUser();
             await notifier.SendAsync(testData);
             return NotificationTestResult.Success();
         }
@@ -368,7 +371,8 @@ public class NotificationService : IHostedService, IDisposable
         }
         catch (Exception ex)
         {
-            return NotificationTestResult.Error($"测试通知时发生未知错误: {ex.Message}");
+            return NotificationTestResult.Error(
+                TranslationHelper.Format("测试通知时发生未知错误: {0}", MissingTextSource.Notification, ex.Message));
         }
     }
 

--- a/BetterGenshinImpact/Service/ScriptService.cs
+++ b/BetterGenshinImpact/Service/ScriptService.cs
@@ -19,6 +19,7 @@ using BetterGenshinImpact.GameTask.Common.Job;
 using BetterGenshinImpact.GameTask.FarmingPlan;
 using BetterGenshinImpact.GameTask.LogParse;
 using BetterGenshinImpact.GameTask.TaskProgress;
+using BetterGenshinImpact.Helpers;
 using BetterGenshinImpact.Service.Interface;
 using BetterGenshinImpact.Service.Notification;
 using BetterGenshinImpact.Service.Notification.Model.Enum;
@@ -301,7 +302,8 @@ public partial class ScriptService : IScriptService
                         if (fisrt )
                         {
                             fisrt = false;
-                            Notify.Event(NotificationEvent.GroupStart).Success($"配置组{groupName}启动");
+                            Notify.Event(NotificationEvent.GroupStart).Success(
+                                TranslationHelper.Format("配置组{0}启动", MissingTextSource.Notification, groupName));
                         }
 
                         if (!RunnerContext.Instance.IsPreExecution &&taskProgress != null)
@@ -439,7 +441,8 @@ public partial class ScriptService : IScriptService
         {
             if (CancellationContext.Instance.IsManualStop is false)
             {
-                Notify.Event(NotificationEvent.GroupEnd).Success($"配置组{groupName}结束");
+                Notify.Event(NotificationEvent.GroupEnd).Success(
+                    TranslationHelper.Format("配置组{0}结束", MissingTextSource.Notification, groupName));
             }
         }
 

--- a/BetterGenshinImpact/View/Windows/ThemedMessageBox.xaml.cs
+++ b/BetterGenshinImpact/View/Windows/ThemedMessageBox.xaml.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Threading.Tasks;
 using System.Windows;
+using BetterGenshinImpact.Helpers;
 using BetterGenshinImpact.Helpers.Ui;
+using BetterGenshinImpact.Service.Interface;
 using Wpf.Ui.Controls;
 using MessageBoxButton = System.Windows.MessageBoxButton;
 using MessageBoxResult = System.Windows.MessageBoxResult;
@@ -129,6 +131,9 @@ public partial class ThemedMessageBox : FluentWindow
         MessageBoxResult defaultResult = MessageBoxResult.None,
         Window? owner = null)
     {
+        content = TranslationHelper.T(content, MissingTextSource.Dialog);
+        title = TranslationHelper.T(title, MissingTextSource.Dialog);
+
         var messageBox = new ThemedMessageBox
         {
             Title = title
@@ -236,30 +241,30 @@ public partial class ThemedMessageBox : FluentWindow
         switch (button)
         {
             case MessageBoxButton.OK:
-                messageBox.PrimaryButton.Content = "确定";
+                messageBox.PrimaryButton.Content = TranslationHelper.T("确定", MissingTextSource.Dialog);
                 messageBox.PrimaryButton.Visibility = Visibility.Visible;
                 break;
 
             case MessageBoxButton.OKCancel:
-                messageBox.PrimaryButton.Content = "确定";
+                messageBox.PrimaryButton.Content = TranslationHelper.T("确定", MissingTextSource.Dialog);
                 messageBox.PrimaryButton.Visibility = Visibility.Visible;
-                messageBox.SecondaryButton.Content = "取消";
+                messageBox.SecondaryButton.Content = TranslationHelper.T("取消", MissingTextSource.Dialog);
                 messageBox.SecondaryButton.Visibility = Visibility.Visible;
                 break;
 
             case MessageBoxButton.YesNo:
-                messageBox.PrimaryButton.Content = "是";
+                messageBox.PrimaryButton.Content = TranslationHelper.T("是", MissingTextSource.Dialog);
                 messageBox.PrimaryButton.Visibility = Visibility.Visible;
-                messageBox.SecondaryButton.Content = "否";
+                messageBox.SecondaryButton.Content = TranslationHelper.T("否", MissingTextSource.Dialog);
                 messageBox.SecondaryButton.Visibility = Visibility.Visible;
                 break;
 
             case MessageBoxButton.YesNoCancel:
-                messageBox.PrimaryButton.Content = "是";
+                messageBox.PrimaryButton.Content = TranslationHelper.T("是", MissingTextSource.Dialog);
                 messageBox.PrimaryButton.Visibility = Visibility.Visible;
-                messageBox.SecondaryButton.Content = "否";
+                messageBox.SecondaryButton.Content = TranslationHelper.T("否", MissingTextSource.Dialog);
                 messageBox.SecondaryButton.Visibility = Visibility.Visible;
-                messageBox.CloseButton.Content = "取消";
+                messageBox.CloseButton.Content = TranslationHelper.T("取消", MissingTextSource.Dialog);
                 messageBox.CloseButton.Visibility = Visibility.Visible;
                 break;
         }

--- a/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
@@ -575,7 +575,7 @@ public partial class OneDragonFlowViewModel : ViewModel
             _logger.LogInformation("没有一条龙任务!");
         }
 
-        Notify.Event(NotificationEvent.DragonStart).Success("一条龙启动");
+        Notify.Event(NotificationEvent.DragonStart).Success(TranslationHelper.T("一条龙启动", MissingTextSource.Notification));
         foreach (var task in taskListCopy)
         {
             if (task is { IsEnabled: true, Action: not null })
@@ -599,7 +599,7 @@ public partial class OneDragonFlowViewModel : ViewModel
                             return;
                         }
 
-                        Notify.Event(NotificationEvent.DragonStart).Success("配置组任务启动");
+                        Notify.Event(NotificationEvent.DragonStart).Success(TranslationHelper.T("配置组任务启动", MissingTextSource.Notification));
 
                         if (SelectedConfig.TaskEnabledList[task.Name])
                         {
@@ -624,7 +624,7 @@ public partial class OneDragonFlowViewModel : ViewModel
                     _logger.LogInformation("任务被取消，退出执行");
                     if (CancellationContext.Instance.IsManualStop is false)
                     {
-                        Notify.Event(NotificationEvent.DragonEnd).Success("一条龙和配置组任务结束");
+                        Notify.Event(NotificationEvent.DragonEnd).Success(TranslationHelper.T("一条龙和配置组任务结束", MissingTextSource.Notification));
                     }
                     return; // 后续的检查任务也不执行
                 }
@@ -638,7 +638,7 @@ public partial class OneDragonFlowViewModel : ViewModel
             await Task.Delay(500);
             if (CancellationContext.Instance.IsManualStop is false)
             {
-                Notify.Event(NotificationEvent.DragonEnd).Success("一条龙和配置组任务结束");
+                Notify.Event(NotificationEvent.DragonEnd).Success(TranslationHelper.T("一条龙和配置组任务结束", MissingTextSource.Notification));
             }
             _logger.LogInformation("一条龙和配置组任务结束");
 

--- a/BetterGenshinImpact/ViewModel/Pages/ScriptControlViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/ScriptControlViewModel.cs
@@ -387,7 +387,7 @@ public partial class ScriptControlViewModel : ViewModel
             {
                 Application.Current.Dispatcher.Invoke(() =>
                 {
-                    Toast.Information(status, time: 5000);
+                    Toast.Information(status);
                 });
             }
 


### PR DESCRIPTION
## Summary
- Route notification, toast, and themed message box text through the translation service
- Add translation helpers for dynamic notification text and multiline messages
- Translate OneDragon and resin summary notification messages before sending them

## Verification
- dotnet build BetterGenshinImpact.sln -c Debug

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 应用现已支持多语言国际化，覆盖通知、对话框、日志与脚本任务提示。
  * 新增吐司消息组件，支持 成功/信息/警告/错误 四种类型；日志根据 UI 语言自动启用多语言支持。

* **修复与优化**
  * 各类用户提示（通知、消息框、测试通知等）改为本地化文案，提升可读性与一致性。
  * 调整部分吐司显示时长行为以改善体验。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/babalae/better-genshin-impact/pull/3125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->