### PR TITLE
fix:一键宏停止时立即松开所有按键

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoFight/OneKeyFightTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/OneKeyFightTask.cs
@@ -1,4 +1,5 @@
 ﻿using BetterGenshinImpact.Core.Config;
+using BetterGenshinImpact.Core.Simulator;
 using BetterGenshinImpact.GameTask.AutoFight.Model;
 using BetterGenshinImpact.GameTask.AutoFight.Script;
 using BetterGenshinImpact.Model;
@@ -74,6 +75,7 @@ public class OneKeyFightTask : Singleton<OneKeyFightTask>
             else
             {
                 _cts.Cancel();
+                Simulation.ReleaseAllKey();
             }
         }
     }
@@ -89,6 +91,7 @@ public class OneKeyFightTask : Singleton<OneKeyFightTask>
         if (IsHoldOnMode())
         {
             _cts?.Cancel();
+            Simulation.ReleaseAllKey();
         }
     }
 
@@ -179,9 +182,9 @@ public class OneKeyFightTask : Singleton<OneKeyFightTask>
                     // 通用化战斗策略
                     foreach (var command in combatCommands)
                     {
+                        if (ct.IsCancellationRequested) break;
                         if (command.ActivatingRound != null && command.ActivatingRound.Count > 0 && !command.ActivatingRound.Contains(round))
                         {
-                            // 跳过强制首轮指令
                             continue;
                         }
                         command.Execute(activeAvatar);


### PR DESCRIPTION
此前一键宏运行中途取消执行时，还是会执行剩下的宏，现在取消时会立即松开所有按键

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发版说明

* **Bug Fixes**
  * 优化自动战斗任务的中止流程，确保按键状态得到正确释放
  * 加快战斗命令执行过程中的取消响应速度，提升操作中止的即时性

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/babalae/better-genshin-impact/pull/3126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->