### PR TITLE
feat: 战斗策略支持 round(n) 轮次控制

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
@@ -321,6 +321,13 @@ public class AutoFightTask : ISoloTask
                 while (!cts2.Token.IsCancellationRequested)
                 {
                     round++; // 每个完整循环视为一个回合
+                    if (timeoutStopwatch.Elapsed > fightTimeout || AutoFightSeek.RotationCount >= 6)
+                    {
+                        Logger.LogInformation(AutoFightSeek.RotationCount >= 6 ? "旋转次数达到上限，战斗结束" : "战斗超时结束");
+                        fightEndFlag = true;
+                        timeOutFlag = true;
+                        break;
+                    }
                     // 所有战斗角色都可以被取消
 
                     #region 本次战斗的跳过战斗判定
@@ -343,6 +350,7 @@ public class AutoFightTask : ISoloTask
 
                     #endregion
                     
+                    var hasExecutableCommandThisRound = false;
                     for (var i = 0; i < combatCommands.Count; i++)
                     {
                         var command = combatCommands[i];
@@ -352,6 +360,7 @@ public class AutoFightTask : ISoloTask
                         {
                             continue;
                         }
+                        hasExecutableCommandThisRound = true;
                         var lastCommand = i == 0 ? command : combatCommands[i - 1];
                         
                         #region 盾奶位技能优先功能
@@ -487,6 +496,11 @@ public class AutoFightTask : ISoloTask
                         }
                     }
 
+                    if (!hasExecutableCommandThisRound)
+                    {
+                        await Delay(50, ct);
+                        continue;
+                    }
 
                     if (fightEndFlag)
                     {

--- a/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
@@ -278,6 +278,7 @@ public class AutoFightTask : ISoloTask
         // if (await CheckFightFinish()) {
         //     return;
         // }
+        var round = 0; // 用于记录当前回合
         var fightEndFlag = false;
         var timeOutFlag = false;
         string lastFightName = "";
@@ -319,6 +320,7 @@ public class AutoFightTask : ISoloTask
                 
                 while (!cts2.Token.IsCancellationRequested)
                 {
+                    round++; // 每个完整循环视为一个回合
                     // 所有战斗角色都可以被取消
 
                     #region 本次战斗的跳过战斗判定
@@ -344,6 +346,12 @@ public class AutoFightTask : ISoloTask
                     for (var i = 0; i < combatCommands.Count; i++)
                     {
                         var command = combatCommands[i];
+                        // 按回合过滤指令
+                        if (command.ActivatingRound != null && command.ActivatingRound.Count > 0
+                            && !command.ActivatingRound.Contains(round))
+                        {
+                            continue;
+                        }
                         var lastCommand = i == 0 ? command : combatCommands[i - 1];
                         
                         #region 盾奶位技能优先功能


### PR DESCRIPTION
将此前在 (https://github.com/babalae/better-genshin-impact/pull/2597) 中为一键宏（OneKeyFightTask）实现的 round 轮次分段执行功能，扩展到 自动战斗主任务（AutoFightTask）

策略示例
芙宁娜 `e,attack(0.6) | round(1),keypress(q),wait(0.1),keypress(q) | attack(0.2) `

第1轮：执行 `e,attack(0.6) `→ 执行 `keypress(q),wait(0.1),keypress(q),attack(0.2)`

第2轮及以后：执行 `e,attack(0.6)` → 跳过 `keypress(q),wait(0.1),keypress(q)` → 执行 `attack(0.2)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 战斗系统新增“回合”调度：动作可按指定回合表自动激活，仅在指定回合执行，提高自动战斗的灵活性与精准度。
  * 当前回合支持提前检测战斗超时与回合上限，若本轮无可执行指令则短暂等待后继续下一回合，优化战斗节奏与稳定性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/babalae/better-genshin-impact/pull/3127?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->