### PR TITLE
fix: 修复 WGC HDR 下传送候选项识别失败

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoTrackPath/TpTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoTrackPath/TpTask.cs
@@ -247,6 +247,7 @@ public class TpTask
             // 直接切换地区
             await SwitchArea(MapTypesExtensions.ParseFromName(mapName).GetDescription());
         }
+
         await Delay(50, ct);
 
 
@@ -337,6 +338,7 @@ public class TpTask
                 Logger.LogInformation("传送完成，返回主界面");
                 return;
             }
+
             //增加容错，小概率情况下碰到，前面点击传送失败
             capture.Find(_assets.TeleportButtonRo, rg => rg.Click());
             await Delay(delayMs, ct);
@@ -515,9 +517,9 @@ public class TpTask
                 catch (MapPositionNotRecognizedException)
                 {
                     Logger.LogDebug("缩放后依然失败，尝试强制跃迁...");
-                    await ForceJumpToTargetArea(x, y, mapName); 
+                    await ForceJumpToTargetArea(x, y, mapName);
                     await Delay(300, ct);
-                    
+
                     try
                     {
                         mapCenterPoint = GetPositionFromBigMap(mapName);
@@ -532,9 +534,9 @@ public class TpTask
             else
             {
                 Logger.LogDebug("缩放已在最佳区间附近，直接尝试强制跃迁...");
-                await ForceJumpToTargetArea(x, y, mapName); 
+                await ForceJumpToTargetArea(x, y, mapName);
                 await Delay(300, ct);
-                
+
                 try
                 {
                     mapCenterPoint = GetPositionFromBigMap(mapName);
@@ -610,11 +612,11 @@ public class TpTask
             try
             {
                 var newCenterPoint = GetPositionFromBigMap(mapName); // 随循环更新的地图中心
-                
+
                 // 计算识别坐标与预测坐标的偏差
                 double jumpDistance = Math.Sqrt(Math.Pow(newCenterPoint.X - predictedPoint.X, 2) + Math.Pow(newCenterPoint.Y - predictedPoint.Y, 2));
                 double expectedMoveLen = Math.Sqrt(moveMouseX * moveMouseX + moveMouseY * moveMouseY) * currentZoomLevel / _tpConfig.MapScaleFactor;
-                
+
                 // 如果实际识别坐标产生超出物理可能的远距离跳跃 (比如原本只移动了50单位，但是坐标跳跃了300单位以上)
                 // 则判定为低特征区域产生的误识别（假阳性），抛出异常进入下面的盲走抓取逻辑
                 if (jumpDistance > Math.Max(200, expectedMoveLen * 2))
@@ -629,7 +631,7 @@ public class TpTask
             catch (MapPositionNotRecognizedException)
             {
                 exceptionTimes++;
-                if (exceptionTimes > 5) 
+                if (exceptionTimes > 5)
                 {
                     throw new Exception("多次中心点识别失败或异常，惯性推算失效，重新传送");
                 }
@@ -816,7 +818,7 @@ public class TpTask
                 {
                     rect = default; // 发生异常视为识别失败
                 }
-                
+
                 if (rect == default)
                 {
                     // 滚轮调整后再次识别
@@ -1042,7 +1044,7 @@ public class TpTask
         // 2. 判断是否已经点出传送按钮
         var hasTeleportButton = CheckTeleportButton(imageRegion);
         await Delay(50, ct);
-        if (hasTeleportButton) return;   // 可以传送了，结束
+        if (hasTeleportButton) return; // 可以传送了，结束
         // 3. 没点出传送按钮，且不存在外部地图关闭按钮
         // 说明只有两种可能，a. 点出来的是未激活传送点或者标点 b. 选择传送点选项列表
         var mapCloseRa1 = imageRegion.Find(_assets.MapCloseButtonRo);
@@ -1096,13 +1098,11 @@ public class TpTask
     private bool CheckMapChooseIcon(ImageRegion imageRegion)
     {
         var hasMapChooseIcon = false;
-        var isHdrCapture = TaskContext.Instance().Config.CaptureMode == CaptureModes.WindowsGraphicsCaptureHdr.ToString();
+        var isHdrCapture = TaskContext.Instance().Config.CaptureMode == nameof(CaptureModes.WindowsGraphicsCaptureHdr);
 
         // 全匹配一遍
         using var mapChooseIconRoi = imageRegion.CacheGreyMat[_assets.MapChooseIconRoi].Clone();
-        var rResultList = isHdrCapture
-            ? MatchTemplateHelper.MatchMultiPicForOnePic(mapChooseIconRoi, _assets.MapChooseIconGreyMatList, 0.7)
-            : MatchTemplateHelper.MatchMultiPicForOnePic(mapChooseIconRoi, _assets.MapChooseIconGreyMatList);
+        var rResultList = MatchTemplateHelper.MatchMultiPicForOnePic(mapChooseIconRoi, _assets.MapChooseIconGreyMatList, isHdrCapture ? 0.7 : 0.8);
         // 按高度排序
         if (rResultList.Count > 0)
         {
@@ -1114,9 +1114,8 @@ public class TpTask
                 using var ra = imageRegion.DeriveCrop(_assets.MapChooseIconRoi.X + iconRect.X + iconRect.Width, _assets.MapChooseIconRoi.Y + iconRect.Y - 8, 200, iconRect.Height + 16);
                 using var textRegion = ra.Find(new RecognitionObject
                 {
-                    // RecognitionType = RecognitionTypes.Ocr,
-                    RecognitionType = RecognitionTypes.ColorRangeAndOcr,
-                    LowerColor = isHdrCapture ? new Scalar(120, 120, 120) : new Scalar(249, 249, 249),
+                    RecognitionType = isHdrCapture ? RecognitionTypes.Ocr : RecognitionTypes.ColorRangeAndOcr,
+                    LowerColor = new Scalar(249, 249, 249), // 只取白色文字
                     UpperColor = new Scalar(255, 255, 255),
                 });
                 if (string.IsNullOrEmpty(textRegion.Text) || textRegion.Text.Length == 1)
@@ -1159,6 +1158,11 @@ public class TpTask
 
 public class MapPositionNotRecognizedException : Exception
 {
-    public MapPositionNotRecognizedException(string message) : base(message) { }
-    public MapPositionNotRecognizedException(string message, Exception innerException) : base(message, innerException) { }
+    public MapPositionNotRecognizedException(string message) : base(message)
+    {
+    }
+
+    public MapPositionNotRecognizedException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
 }

--- a/BetterGenshinImpact/GameTask/AutoTrackPath/TpTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoTrackPath/TpTask.cs
@@ -19,6 +19,7 @@ using BetterGenshinImpact.GameTask.Model.Area;
 using BetterGenshinImpact.GameTask.QuickTeleport.Assets;
 using BetterGenshinImpact.Helpers;
 using BetterGenshinImpact.Helpers.Extensions;
+using Fischless.GameCapture;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 using OpenCvSharp;
@@ -1095,9 +1096,13 @@ public class TpTask
     private bool CheckMapChooseIcon(ImageRegion imageRegion)
     {
         var hasMapChooseIcon = false;
+        var isHdrCapture = TaskContext.Instance().Config.CaptureMode == CaptureModes.WindowsGraphicsCaptureHdr.ToString();
 
         // 全匹配一遍
-        var rResultList = MatchTemplateHelper.MatchMultiPicForOnePic(imageRegion.CacheGreyMat[_assets.MapChooseIconRoi], _assets.MapChooseIconGreyMatList);
+        using var mapChooseIconRoi = imageRegion.CacheGreyMat[_assets.MapChooseIconRoi].Clone();
+        var rResultList = isHdrCapture
+            ? MatchTemplateHelper.MatchMultiPicForOnePic(mapChooseIconRoi, _assets.MapChooseIconGreyMatList, 0.7)
+            : MatchTemplateHelper.MatchMultiPicForOnePic(mapChooseIconRoi, _assets.MapChooseIconGreyMatList);
         // 按高度排序
         if (rResultList.Count > 0)
         {
@@ -1111,7 +1116,7 @@ public class TpTask
                 {
                     // RecognitionType = RecognitionTypes.Ocr,
                     RecognitionType = RecognitionTypes.ColorRangeAndOcr,
-                    LowerColor = new Scalar(249, 249, 249), // 只取白色文字
+                    LowerColor = isHdrCapture ? new Scalar(120, 120, 120) : new Scalar(249, 249, 249),
                     UpperColor = new Scalar(255, 255, 255),
                 });
                 if (string.IsNullOrEmpty(textRegion.Text) || textRegion.Text.Length == 1)

--- a/BetterGenshinImpact/GameTask/QuickTeleport/QuickTeleportTrigger.cs
+++ b/BetterGenshinImpact/GameTask/QuickTeleport/QuickTeleportTrigger.cs
@@ -126,13 +126,12 @@ internal class QuickTeleportTrigger : ITaskTrigger
     private bool CheckMapChooseIcon(CaptureContent content)
     {
         var hasMapChooseIcon = false;
-        var isHdrCapture = TaskContext.Instance().Config.CaptureMode == CaptureModes.WindowsGraphicsCaptureHdr.ToString();
+        var isHdrCapture = TaskContext.Instance().Config.CaptureMode == nameof(CaptureModes.WindowsGraphicsCaptureHdr);
 
         // 全匹配一遍
         using var mapChooseIconRoi = content.CaptureRectArea.CacheGreyMat[_assets.MapChooseIconRoi].Clone();
-        var rResultList = isHdrCapture
-            ? MatchTemplateHelper.MatchMultiPicForOnePic(mapChooseIconRoi, _assets.MapChooseIconGreyMatList, 0.7)
-            : MatchTemplateHelper.MatchMultiPicForOnePic(mapChooseIconRoi, _assets.MapChooseIconGreyMatList);
+        var rResultList = MatchTemplateHelper.MatchMultiPicForOnePic(mapChooseIconRoi, _assets.MapChooseIconGreyMatList, isHdrCapture ? 0.7 : 0.8);
+
         // 按高度排序
         if (rResultList.Count > 0)
         {
@@ -144,9 +143,8 @@ internal class QuickTeleportTrigger : ITaskTrigger
                 using var ra = content.CaptureRectArea.DeriveCrop(_assets.MapChooseIconRoi.X + iconRect.X + iconRect.Width, _assets.MapChooseIconRoi.Y + iconRect.Y - 8, 200, iconRect.Height + 16);
                 using var textRegion = ra.Find(new RecognitionObject
                 {
-                    // RecognitionType = RecognitionTypes.Ocr,
-                    RecognitionType = RecognitionTypes.ColorRangeAndOcr,
-                    LowerColor = isHdrCapture ? new Scalar(120, 120, 120) : new Scalar(249, 249, 249),
+                    RecognitionType = isHdrCapture ? RecognitionTypes.Ocr : RecognitionTypes.ColorRangeAndOcr,
+                    LowerColor = new Scalar(249, 249, 249), // 只取白色文字
                     UpperColor = new Scalar(255, 255, 255),
                 });
                 if (string.IsNullOrEmpty(textRegion.Text) || textRegion.Text.Length == 1)

--- a/BetterGenshinImpact/GameTask/QuickTeleport/QuickTeleportTrigger.cs
+++ b/BetterGenshinImpact/GameTask/QuickTeleport/QuickTeleportTrigger.cs
@@ -5,6 +5,7 @@ using BetterGenshinImpact.GameTask.Common;
 using BetterGenshinImpact.GameTask.Model.Area;
 using BetterGenshinImpact.GameTask.QuickTeleport.Assets;
 using BetterGenshinImpact.Model;
+using Fischless.GameCapture;
 using Microsoft.Extensions.Logging;
 using OpenCvSharp;
 using System;
@@ -125,9 +126,13 @@ internal class QuickTeleportTrigger : ITaskTrigger
     private bool CheckMapChooseIcon(CaptureContent content)
     {
         var hasMapChooseIcon = false;
+        var isHdrCapture = TaskContext.Instance().Config.CaptureMode == CaptureModes.WindowsGraphicsCaptureHdr.ToString();
 
         // 全匹配一遍
-        var rResultList = MatchTemplateHelper.MatchMultiPicForOnePic(content.CaptureRectArea.CacheGreyMat[_assets.MapChooseIconRoi], _assets.MapChooseIconGreyMatList);
+        using var mapChooseIconRoi = content.CaptureRectArea.CacheGreyMat[_assets.MapChooseIconRoi].Clone();
+        var rResultList = isHdrCapture
+            ? MatchTemplateHelper.MatchMultiPicForOnePic(mapChooseIconRoi, _assets.MapChooseIconGreyMatList, 0.7)
+            : MatchTemplateHelper.MatchMultiPicForOnePic(mapChooseIconRoi, _assets.MapChooseIconGreyMatList);
         // 按高度排序
         if (rResultList.Count > 0)
         {
@@ -141,7 +146,7 @@ internal class QuickTeleportTrigger : ITaskTrigger
                 {
                     // RecognitionType = RecognitionTypes.Ocr,
                     RecognitionType = RecognitionTypes.ColorRangeAndOcr,
-                    LowerColor = new Scalar(249, 249, 249), // 只取白色文字
+                    LowerColor = isHdrCapture ? new Scalar(120, 120, 120) : new Scalar(249, 249, 249),
                     UpperColor = new Scalar(255, 255, 255),
                 });
                 if (string.IsNullOrEmpty(textRegion.Text) || textRegion.Text.Length == 1)


### PR DESCRIPTION
## 概述

- 修复 `WindowsGraphicsCapture（HDR）` 且系统 HDR 开启时，地图右下角传送候选列表识别不到“传送锚点”的问题。
- BitBlt 和普通 WindowsGraphicsCapture 继续使用原来的严格识别阈值，避免影响现有稳定路径。
- 对候选图标 ROI 先 `Clone()` 再做多模板匹配，避免匹配过程涂黑缓存的灰度帧。

## 原因

传送候选列表的识别流程会先匹配候选项图标，再对右侧白色文字做 OCR。WGC HDR 截图会先经过 HDR 到 SDR 的色彩转换，白色 UI 文字和部分图标细节可能被压暗，导致原来的 `249..255` 白色文字范围和默认模板阈值在 HDR 场景下失效。

## 修改内容

当 `CaptureMode == WindowsGraphicsCaptureHdr` 时：

- 候选图标模板匹配阈值从默认值降到 `0.7`；
- 白色文字 OCR 的颜色范围从 `249..255` 放宽到 `120..255`。

其它截图模式仍保持原来的默认模板阈值和 `249..255` 文字范围。

Fixes #3133

## 验证

- 已在 WindowsGraphicsCapture（HDR）+ Windows 系统 HDR 开启的环境下手动测试通过。
- `dotnet build BetterGenshinImpact.sln -c Debug` 通过，0 个错误。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化了 HDR 捕获模式下的地图图标与选项文字识别，调整了模板匹配阈值与识别策略以提升准确性。
  * 改进了传送点/快速传送检测在不同屏幕显示模式下的稳定性与鲁棒性，减少误判。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/babalae/better-genshin-impact/pull/3134?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->