### PR TITLE
修复运行中 URL 协议参数不生效

### DIFF
--- a/BetterGenshinImpact/Helpers/CommandLineOptions.cs
+++ b/BetterGenshinImpact/Helpers/CommandLineOptions.cs
@@ -44,7 +44,7 @@ public class CommandLineOptions
         GroupNames = groupNames ?? [];
     }
 
-    internal static CommandLineOptions Parse(string[] args)
+    public static CommandLineOptions Parse(string[] args)
     {
         if (args.Length <= 1)
             return new CommandLineOptions(CommandLineAction.None);
@@ -74,6 +74,14 @@ public class CommandLineOptions
         }
 
         return new CommandLineOptions(CommandLineAction.None);
+    }
+
+    public static CommandLineOptions ParseActivationArgs(string[] args)
+    {
+        var commandLineArgs = new string[args.Length + 1];
+        commandLineArgs[0] = "BetterGI.exe";
+        Array.Copy(args, 0, commandLineArgs, 1, args.Length);
+        return Parse(commandLineArgs);
     }
 }
 

--- a/BetterGenshinImpact/Helpers/RuntimeHelper.cs
+++ b/BetterGenshinImpact/Helpers/RuntimeHelper.cs
@@ -159,7 +159,12 @@ internal static class RuntimeHelper
         try
         {
             handle = EventWaitHandle.OpenExisting(instanceName);
-            _ = TrySendSingleInstanceActivationArgs(instanceName, Environment.GetCommandLineArgs().Skip(1).ToArray());
+            string[] activationArgs = Environment.GetCommandLineArgs().Skip(1).ToArray();
+            if (!TrySendSingleInstanceActivationArgsWithRetry(instanceName, activationArgs))
+            {
+                Debug.WriteLine("Failed to forward single instance activation args.");
+            }
+
             handle.Set();
             callback?.Invoke(false);
             Environment.Exit(0xFFFF);
@@ -188,6 +193,27 @@ internal static class RuntimeHelper
     private static string GetSingleInstanceActivationPipeName(string instanceName)
     {
         return $"{instanceName}.Activation";
+    }
+
+    private static bool TrySendSingleInstanceActivationArgsWithRetry(string instanceName, string[] args)
+    {
+        const int maxAttempts = 10;
+        const int retryDelayMilliseconds = 100;
+
+        for (int attempt = 1; attempt <= maxAttempts; attempt++)
+        {
+            if (TrySendSingleInstanceActivationArgs(instanceName, args))
+            {
+                return true;
+            }
+
+            if (attempt < maxAttempts)
+            {
+                Thread.Sleep(retryDelayMilliseconds);
+            }
+        }
+
+        return false;
     }
 
     private static bool TrySendSingleInstanceActivationArgs(string instanceName, string[] args)

--- a/BetterGenshinImpact/Helpers/RuntimeHelper.cs
+++ b/BetterGenshinImpact/Helpers/RuntimeHelper.cs
@@ -4,12 +4,15 @@ using BetterGenshinImpact.Service;
 using BetterGenshinImpact.View.Windows;
 using Microsoft.Extensions.Hosting;
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
+using System.IO.Pipes;
 using System.Linq;
 using System.Security.Principal;
 using System.Text;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
@@ -22,6 +25,39 @@ internal static class RuntimeHelper
     public static bool IsElevated { get; } = GetElevated();
     public static bool IsDebuggerAttached => Debugger.IsAttached;
     public static bool IsDesignMode { get; } = GetDesignMode();
+    private static readonly object SingleInstanceActivationLock = new();
+    private static readonly Queue<string[]> PendingSingleInstanceActivationArgs = new();
+    private static EventHandler<SingleInstanceActivatedEventArgs>? _singleInstanceActivated;
+
+    public static event EventHandler<SingleInstanceActivatedEventArgs>? SingleInstanceActivated
+    {
+        add
+        {
+            List<string[]> pendingArgs = [];
+
+            lock (SingleInstanceActivationLock)
+            {
+                _singleInstanceActivated += value;
+
+                while (PendingSingleInstanceActivationArgs.Count > 0)
+                {
+                    pendingArgs.Add(PendingSingleInstanceActivationArgs.Dequeue());
+                }
+            }
+
+            foreach (string[] args in pendingArgs)
+            {
+                value?.Invoke(null, new SingleInstanceActivatedEventArgs(args));
+            }
+        }
+        remove
+        {
+            lock (SingleInstanceActivationLock)
+            {
+                _singleInstanceActivated -= value;
+            }
+        }
+    }
 
     public static bool IsDebug =>
 #if DEBUG
@@ -123,6 +159,7 @@ internal static class RuntimeHelper
         try
         {
             handle = EventWaitHandle.OpenExisting(instanceName);
+            _ = TrySendSingleInstanceActivationArgs(instanceName, Environment.GetCommandLineArgs().Skip(1).ToArray());
             handle.Set();
             callback?.Invoke(false);
             Environment.Exit(0xFFFF);
@@ -131,6 +168,7 @@ internal static class RuntimeHelper
         {
             callback?.Invoke(true);
             handle = new EventWaitHandle(false, EventResetMode.AutoReset, instanceName);
+            StartSingleInstanceActivationPipe(instanceName);
         }
 
         _ = Task.Factory.StartNew(() =>
@@ -147,6 +185,81 @@ internal static class RuntimeHelper
         }, TaskCreationOptions.LongRunning).ConfigureAwait(false);
     }
 
+    private static string GetSingleInstanceActivationPipeName(string instanceName)
+    {
+        return $"{instanceName}.Activation";
+    }
+
+    private static bool TrySendSingleInstanceActivationArgs(string instanceName, string[] args)
+    {
+        try
+        {
+            using NamedPipeClientStream pipeClient = new(".", GetSingleInstanceActivationPipeName(instanceName), PipeDirection.Out);
+            pipeClient.Connect(300);
+
+            using StreamWriter writer = new(pipeClient, new UTF8Encoding(false))
+            {
+                AutoFlush = true
+            };
+            writer.Write(JsonSerializer.Serialize(args));
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine(ex);
+            return false;
+        }
+    }
+
+    private static void StartSingleInstanceActivationPipe(string instanceName)
+    {
+        string pipeName = GetSingleInstanceActivationPipeName(instanceName);
+        _ = Task.Run(async () =>
+        {
+            while (true)
+            {
+                try
+                {
+                    using NamedPipeServerStream pipeServer = new(
+                        pipeName,
+                        PipeDirection.In,
+                        1,
+                        PipeTransmissionMode.Byte,
+                        PipeOptions.Asynchronous);
+
+                    await pipeServer.WaitForConnectionAsync().ConfigureAwait(false);
+
+                    using StreamReader reader = new(pipeServer, Encoding.UTF8);
+                    string payload = await reader.ReadToEndAsync().ConfigureAwait(false);
+                    string[] args = JsonSerializer.Deserialize<string[]>(payload) ?? [];
+                    PublishSingleInstanceActivation(args);
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine(ex);
+                }
+            }
+        });
+    }
+
+    private static void PublishSingleInstanceActivation(string[] args)
+    {
+        EventHandler<SingleInstanceActivatedEventArgs>? handler;
+
+        lock (SingleInstanceActivationLock)
+        {
+            handler = _singleInstanceActivated;
+
+            if (handler == null)
+            {
+                PendingSingleInstanceActivationArgs.Enqueue(args);
+                return;
+            }
+        }
+
+        handler.Invoke(null, new SingleInstanceActivatedEventArgs(args));
+    }
+
     public static void CheckIntegration()
     {
         if (!Directory.Exists(Global.Absolute("Assets")) || !Directory.Exists(Global.Absolute("GameTask")))
@@ -160,6 +273,11 @@ internal static class RuntimeHelper
             Environment.Exit(0xFFFF);
         }
     }
+}
+
+internal sealed class SingleInstanceActivatedEventArgs(string[] args) : EventArgs
+{
+    public string[] Args { get; } = args;
 }
 
 internal static class RuntimeExtension

--- a/BetterGenshinImpact/Service/ApplicationHostService.cs
+++ b/BetterGenshinImpact/Service/ApplicationHostService.cs
@@ -45,17 +45,29 @@ public class ApplicationHostService(IServiceProvider serviceProvider) : IHostedS
     }
 
     /// <summary>
-    /// Handles command line activation for both first launch and subsequent single-instance launches.
+    /// Handles first launch with the original page-loaded flow, and subsequent single-instance activations explicitly.
     /// </summary>
     private async Task HandleActivationAsync(CommandLineOptions cmdOptions, bool isSingleInstanceActivation)
     {
         EnsureNavigationWindow();
 
-        QueueActivationAction(async () => await RunActivationAsync(cmdOptions, isSingleInstanceActivation));
+        if (isSingleInstanceActivation)
+        {
+            QueueActivationAction(async () => await RunSingleInstanceActivationAsync(cmdOptions));
+        }
+        else
+        {
+            QueueActivationAction(() =>
+            {
+                RunFirstLaunchActivation(cmdOptions);
+                return Task.CompletedTask;
+            });
+        }
+
         await Task.CompletedTask;
     }
 
-    private async Task RunActivationAsync(CommandLineOptions cmdOptions, bool isSingleInstanceActivation)
+    private void RunFirstLaunchActivation(CommandLineOptions cmdOptions)
     {
         if (cmdOptions.HasTaskArgs)
         {
@@ -72,14 +84,6 @@ public class ApplicationHostService(IServiceProvider serviceProvider) : IHostedS
             {
                 case CommandLineAction.StartOneDragon:
                     _ = _navigationWindow.Navigate(typeof(OneDragonFlowPage));
-                    if (isSingleInstanceActivation)
-                    {
-                        OneDragonFlowViewModel? oneDragon = App.GetService<OneDragonFlowViewModel>();
-                        if (oneDragon != null)
-                        {
-                            await oneDragon.StartFromCommandLineOptionsAsync(cmdOptions);
-                        }
-                    }
                     break;
 
                 case CommandLineAction.StartGroups:
@@ -87,10 +91,7 @@ public class ApplicationHostService(IServiceProvider serviceProvider) : IHostedS
                     if (cmdOptions.GroupNames.Length > 0)
                     {
                         var scheduler = App.GetService<ScriptControlViewModel>();
-                        if (scheduler != null)
-                        {
-                            await scheduler.OnStartMultiScriptGroupWithNamesAsync(cmdOptions.GroupNames);
-                        }
+                        scheduler?.OnStartMultiScriptGroupWithNamesAsync(cmdOptions.GroupNames);
                     }
                     break;
 
@@ -99,20 +100,12 @@ public class ApplicationHostService(IServiceProvider serviceProvider) : IHostedS
                     if (cmdOptions.GroupNames.Length > 0)
                     {
                         var scheduler = App.GetService<ScriptControlViewModel>();
-                        if (scheduler != null)
-                        {
-                            await scheduler.OnStartMultiScriptTaskProgressAsync(cmdOptions.GroupNames);
-                        }
+                        scheduler?.OnStartMultiScriptTaskProgressAsync(cmdOptions.GroupNames);
                     }
                     break;
 
                 case CommandLineAction.Start:
                     _ = _navigationWindow.Navigate(typeof(HomePage));
-                    HomePageViewModel? home = App.GetService<HomePageViewModel>();
-                    if (home != null)
-                    {
-                        await home.OnStartTriggerAsync();
-                    }
                     break;
             }
         }
@@ -122,6 +115,67 @@ public class ApplicationHostService(IServiceProvider serviceProvider) : IHostedS
         }
     }
 
+    private async Task RunSingleInstanceActivationAsync(CommandLineOptions cmdOptions)
+    {
+        if (!cmdOptions.HasTaskArgs)
+        {
+            return;
+        }
+
+        _ = _navigationWindow!.Navigate(typeof(HomePage));
+
+        var scriptConfig = TaskContext.Instance().Config.ScriptConfig;
+        if (scriptConfig.AutoUpdateBeforeCommandLineRun)
+        {
+            ScriptRepoUpdater.Instance.CommandLineAutoUpdateTask =
+                Task.Run(() => ScriptRepoUpdater.Instance.AutoUpdateSubscribedScripts());
+        }
+
+        switch (cmdOptions.Action)
+        {
+            case CommandLineAction.StartOneDragon:
+                _ = _navigationWindow.Navigate(typeof(OneDragonFlowPage));
+                OneDragonFlowViewModel? oneDragon = App.GetService<OneDragonFlowViewModel>();
+                if (oneDragon != null)
+                {
+                    await oneDragon.StartFromCommandLineOptionsAsync(cmdOptions);
+                }
+                break;
+
+            case CommandLineAction.StartGroups:
+                _ = _navigationWindow.Navigate(typeof(ScriptControlPage));
+                if (cmdOptions.GroupNames.Length > 0)
+                {
+                    var scheduler = App.GetService<ScriptControlViewModel>();
+                    if (scheduler != null)
+                    {
+                        await scheduler.OnStartMultiScriptGroupWithNamesAsync(cmdOptions.GroupNames);
+                    }
+                }
+                break;
+
+            case CommandLineAction.TaskProgress:
+                _ = _navigationWindow.Navigate(typeof(ScriptControlPage));
+                if (cmdOptions.GroupNames.Length > 0)
+                {
+                    var scheduler = App.GetService<ScriptControlViewModel>();
+                    if (scheduler != null)
+                    {
+                        await scheduler.OnStartMultiScriptTaskProgressAsync(cmdOptions.GroupNames);
+                    }
+                }
+                break;
+
+            case CommandLineAction.Start:
+                _ = _navigationWindow.Navigate(typeof(HomePage));
+                HomePageViewModel? home = App.GetService<HomePageViewModel>();
+                if (home != null)
+                {
+                    await home.OnStartTriggerAsync();
+                }
+                break;
+        }
+    }
     private void EnsureNavigationWindow()
     {
         _navigationWindow ??= (serviceProvider.GetService(typeof(INavigationWindow)) as INavigationWindow)!;

--- a/BetterGenshinImpact/Service/ApplicationHostService.cs
+++ b/BetterGenshinImpact/Service/ApplicationHostService.cs
@@ -57,17 +57,13 @@ public class ApplicationHostService(IServiceProvider serviceProvider) : IHostedS
         }
         else
         {
-            QueueActivationAction(() =>
-            {
-                RunFirstLaunchActivation(cmdOptions);
-                return Task.CompletedTask;
-            });
+            QueueActivationAction(async () => await RunFirstLaunchActivationAsync(cmdOptions));
         }
 
         await Task.CompletedTask;
     }
 
-    private void RunFirstLaunchActivation(CommandLineOptions cmdOptions)
+    private async Task RunFirstLaunchActivationAsync(CommandLineOptions cmdOptions)
     {
         if (cmdOptions.HasTaskArgs)
         {
@@ -91,7 +87,10 @@ public class ApplicationHostService(IServiceProvider serviceProvider) : IHostedS
                     if (cmdOptions.GroupNames.Length > 0)
                     {
                         var scheduler = App.GetService<ScriptControlViewModel>();
-                        scheduler?.OnStartMultiScriptGroupWithNamesAsync(cmdOptions.GroupNames);
+                        if (scheduler != null)
+                        {
+                            await scheduler.OnStartMultiScriptGroupWithNamesAsync(cmdOptions.GroupNames);
+                        }
                     }
                     break;
 
@@ -100,7 +99,10 @@ public class ApplicationHostService(IServiceProvider serviceProvider) : IHostedS
                     if (cmdOptions.GroupNames.Length > 0)
                     {
                         var scheduler = App.GetService<ScriptControlViewModel>();
-                        scheduler?.OnStartMultiScriptTaskProgressAsync(cmdOptions.GroupNames);
+                        if (scheduler != null)
+                        {
+                            await scheduler.OnStartMultiScriptTaskProgressAsync(cmdOptions.GroupNames);
+                        }
                     }
                     break;
 

--- a/BetterGenshinImpact/Service/ApplicationHostService.cs
+++ b/BetterGenshinImpact/Service/ApplicationHostService.cs
@@ -1,15 +1,17 @@
-﻿using BetterGenshinImpact.View;
+using BetterGenshinImpact.Core.Script;
+using BetterGenshinImpact.GameTask;
+using BetterGenshinImpact.Helpers;
+using BetterGenshinImpact.View;
 using BetterGenshinImpact.View.Pages;
 using BetterGenshinImpact.ViewModel.Pages;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
-using BetterGenshinImpact.Core.Script;
-using BetterGenshinImpact.GameTask;
-using BetterGenshinImpact.Helpers;
+using System.Windows.Threading;
 using Wpf.Ui;
 
 namespace BetterGenshinImpact.Service;
@@ -19,6 +21,7 @@ namespace BetterGenshinImpact.Service;
 /// </summary>
 public class ApplicationHostService(IServiceProvider serviceProvider) : IHostedService
 {
+    private readonly ILogger<ApplicationHostService> _logger = App.GetLogger<ApplicationHostService>();
     private INavigationWindow? _navigationWindow;
 
     /// <summary>
@@ -27,7 +30,8 @@ public class ApplicationHostService(IServiceProvider serviceProvider) : IHostedS
     /// <param name="cancellationToken">Indicates that the start process has been aborted.</param>
     public async Task StartAsync(CancellationToken cancellationToken)
     {
-        await HandleActivationAsync();
+        RuntimeHelper.SingleInstanceActivated += OnSingleInstanceActivated;
+        await HandleActivationAsync(CommandLineOptions.Instance, false);
     }
 
     /// <summary>
@@ -36,77 +40,125 @@ public class ApplicationHostService(IServiceProvider serviceProvider) : IHostedS
     /// <param name="cancellationToken">Indicates that the shutdown process should no longer be graceful.</param>
     public async Task StopAsync(CancellationToken cancellationToken)
     {
+        RuntimeHelper.SingleInstanceActivated -= OnSingleInstanceActivated;
         await Task.CompletedTask;
     }
 
     /// <summary>
-    /// Creates main window during activation.
+    /// Handles command line activation for both first launch and subsequent single-instance launches.
     /// </summary>
-    private async Task HandleActivationAsync()
+    private async Task HandleActivationAsync(CommandLineOptions cmdOptions, bool isSingleInstanceActivation)
     {
-        if (!Application.Current.Windows.OfType<MainWindow>().Any())
+        EnsureNavigationWindow();
+
+        QueueActivationAction(async () => await RunActivationAsync(cmdOptions, isSingleInstanceActivation));
+        await Task.CompletedTask;
+    }
+
+    private async Task RunActivationAsync(CommandLineOptions cmdOptions, bool isSingleInstanceActivation)
+    {
+        if (cmdOptions.HasTaskArgs)
         {
-            _navigationWindow = (serviceProvider.GetService(typeof(INavigationWindow)) as INavigationWindow)!;
-            _navigationWindow!.ShowWindow();
+            _ = _navigationWindow!.Navigate(typeof(HomePage));
 
-            var cmdOptions = CommandLineOptions.Instance;
-
-            if (cmdOptions.HasTaskArgs)
+            var scriptConfig = TaskContext.Instance().Config.ScriptConfig;
+            if (scriptConfig.AutoUpdateBeforeCommandLineRun)
             {
-                //无论如何，先跳到主页，否则在通过参数的任务在执行完之前，不会加载快捷键
-                _ = _navigationWindow.Navigate(typeof(HomePage));
-
-                // 命令行启动时，并行更新订阅脚本（不阻塞游戏启动和导航）
-                // StartGameTask 会在游戏进入主界面后等待此 Task 完成，再开始执行任务
-                var scriptConfig = TaskContext.Instance().Config.ScriptConfig;
-                if (scriptConfig.AutoUpdateBeforeCommandLineRun)
-                {
-                    ScriptRepoUpdater.Instance.CommandLineAutoUpdateTask =
-                        Task.Run(() => ScriptRepoUpdater.Instance.AutoUpdateSubscribedScripts());
-                }
-
-                switch (cmdOptions.Action)
-                {
-                    case CommandLineAction.StartOneDragon:
-                        // 通过命令行参数启动「一条龙」 => 跳转到一条龙配置页。
-                        _ = _navigationWindow.Navigate(typeof(OneDragonFlowPage));
-                        // 后续代码在 OneDragonFlowViewModel / OnLoaded 中。
-                        break;
-
-                    case CommandLineAction.StartGroups:
-                        // 通过命令行参数启动「调度组」 => 跳转到调度器配置页。
-                        _ = _navigationWindow.Navigate(typeof(ScriptControlPage));
-                        if (cmdOptions.GroupNames.Length > 0)
-                        {
-                            var scheduler = App.GetService<ScriptControlViewModel>();
-                            scheduler?.OnStartMultiScriptGroupWithNamesAsync(cmdOptions.GroupNames);
-                        }
-                        break;
-
-                    case CommandLineAction.TaskProgress:
-                        // 通过命令行参数启动「任务进度」 => 跳转到调度器配置页。
-                        _ = _navigationWindow.Navigate(typeof(ScriptControlPage));
-                        if (cmdOptions.GroupNames.Length > 0)
-                        {
-                            var scheduler = App.GetService<ScriptControlViewModel>();
-                            scheduler?.OnStartMultiScriptTaskProgressAsync(cmdOptions.GroupNames);
-                        }
-                        break;
-
-                    case CommandLineAction.Start:
-                        // 通过命令行参数打开「启动页开关」 => 跳转到主页。
-                        _ = _navigationWindow.Navigate(typeof(HomePage));
-                        // 后续代码在 HomePageViewModel / OnLoaded 中。
-                        break;
-                }
+                ScriptRepoUpdater.Instance.CommandLineAutoUpdateTask =
+                    Task.Run(() => ScriptRepoUpdater.Instance.AutoUpdateSubscribedScripts());
             }
-            else
+
+            switch (cmdOptions.Action)
             {
-                // 通过双击程序启动 => 跳转到主页。
-                _ = _navigationWindow.Navigate(typeof(HomePage));
+                case CommandLineAction.StartOneDragon:
+                    _ = _navigationWindow.Navigate(typeof(OneDragonFlowPage));
+                    if (isSingleInstanceActivation)
+                    {
+                        OneDragonFlowViewModel? oneDragon = App.GetService<OneDragonFlowViewModel>();
+                        if (oneDragon != null)
+                        {
+                            await oneDragon.StartFromCommandLineOptionsAsync(cmdOptions);
+                        }
+                    }
+                    break;
+
+                case CommandLineAction.StartGroups:
+                    _ = _navigationWindow.Navigate(typeof(ScriptControlPage));
+                    if (cmdOptions.GroupNames.Length > 0)
+                    {
+                        var scheduler = App.GetService<ScriptControlViewModel>();
+                        if (scheduler != null)
+                        {
+                            await scheduler.OnStartMultiScriptGroupWithNamesAsync(cmdOptions.GroupNames);
+                        }
+                    }
+                    break;
+
+                case CommandLineAction.TaskProgress:
+                    _ = _navigationWindow.Navigate(typeof(ScriptControlPage));
+                    if (cmdOptions.GroupNames.Length > 0)
+                    {
+                        var scheduler = App.GetService<ScriptControlViewModel>();
+                        if (scheduler != null)
+                        {
+                            await scheduler.OnStartMultiScriptTaskProgressAsync(cmdOptions.GroupNames);
+                        }
+                    }
+                    break;
+
+                case CommandLineAction.Start:
+                    _ = _navigationWindow.Navigate(typeof(HomePage));
+                    HomePageViewModel? home = App.GetService<HomePageViewModel>();
+                    if (home != null)
+                    {
+                        await home.OnStartTriggerAsync();
+                    }
+                    break;
             }
         }
-        //
-        await Task.CompletedTask;
+        else
+        {
+            _ = _navigationWindow!.Navigate(typeof(HomePage));
+        }
+    }
+
+    private void EnsureNavigationWindow()
+    {
+        _navigationWindow ??= (serviceProvider.GetService(typeof(INavigationWindow)) as INavigationWindow)!;
+
+        if (!Application.Current.Windows.OfType<MainWindow>().Any())
+        {
+            _navigationWindow.ShowWindow();
+        }
+    }
+
+    private void OnSingleInstanceActivated(object? sender, SingleInstanceActivatedEventArgs e)
+    {
+        _ = Application.Current.Dispatcher.InvokeAsync(async () =>
+        {
+            try
+            {
+                await HandleActivationAsync(CommandLineOptions.ParseActivationArgs(e.Args), true);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Handle single instance activation failed");
+            }
+        });
+    }
+
+    private void QueueActivationAction(Func<Task> action)
+    {
+        _ = Application.Current.Dispatcher.InvokeAsync(async () =>
+        {
+            try
+            {
+                await action();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Run command line activation action failed");
+            }
+        }, DispatcherPriority.ApplicationIdle);
     }
 }

--- a/BetterGenshinImpact/ViewModel/Pages/HomePageViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/HomePageViewModel.cs
@@ -133,12 +133,7 @@ public partial class HomePageViewModel : ViewModel
 
         _autoRun = false;
 
-        // 只对纯 "start" 参数自动启动截图器
-        // startOneDragon、--startGroups 等由各自流程中的 StartGameTask 处理
-        if (CommandLineOptions.Instance.Action == CommandLineAction.Start)
-        {
-            _ = OnStartTriggerAsync();
-        }
+        // Command line activation is handled by ApplicationHostService.
     }
 
     private void OnClosed()

--- a/BetterGenshinImpact/ViewModel/Pages/HomePageViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/HomePageViewModel.cs
@@ -133,7 +133,12 @@ public partial class HomePageViewModel : ViewModel
 
         _autoRun = false;
 
-        // Command line activation is handled by ApplicationHostService.
+        // 只对纯 "start" 参数自动启动截图器
+        // startOneDragon、--startGroups 等由各自流程中的 StartGameTask 处理
+        if (CommandLineOptions.Instance.Action == CommandLineAction.Start)
+        {
+            _ = OnStartTriggerAsync();
+        }
     }
 
     private void OnClosed()

--- a/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
@@ -518,6 +518,34 @@ public partial class OneDragonFlowViewModel : ViewModel
         }
     }
 
+    public async Task StartFromCommandLineOptionsAsync(CommandLineOptions cmdOptions)
+    {
+        if (cmdOptions.Action != CommandLineAction.StartOneDragon)
+        {
+            return;
+        }
+
+        if (cmdOptions.OneDragonConfigName != null)
+        {
+            _logger.LogInformation("Command line one dragon config: {Name}", cmdOptions.OneDragonConfigName);
+            var argsOneDragonConfig = ConfigList.FirstOrDefault(x =>
+                string.Equals(x.Name, cmdOptions.OneDragonConfigName, StringComparison.Ordinal));
+            if (argsOneDragonConfig != null)
+            {
+                SelectedConfig = argsOneDragonConfig;
+                OnConfigDropDownChanged();
+            }
+            else
+            {
+                _logger.LogWarning("Command line one dragon config not found: {Name}", cmdOptions.OneDragonConfigName);
+            }
+        }
+
+        Toast.Information($"Command line one dragon: {SelectedConfig.Name}");
+        await OnOneKeyExecute();
+    }
+
+
     [RelayCommand]
     public async Task OnOneKeyExecute()
     {

--- a/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
@@ -538,10 +538,18 @@ public partial class OneDragonFlowViewModel : ViewModel
             else
             {
                 _logger.LogWarning("Command line one dragon config not found: {Name}", cmdOptions.OneDragonConfigName);
+                Toast.Warning($"未找到一条龙配置：{cmdOptions.OneDragonConfigName}");
+                return;
             }
         }
 
-        Toast.Information($"Command line one dragon: {SelectedConfig.Name}");
+        if (SelectedConfig == null)
+        {
+            _logger.LogWarning("No one dragon config is loaded for command line activation");
+            return;
+        }
+
+        Toast.Information($"命令行一条龙「{SelectedConfig.Name}」。");
         await OnOneKeyExecute();
     }
 

--- a/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
@@ -481,7 +481,7 @@ public partial class OneDragonFlowViewModel : ViewModel
     private bool _autoRun = true;
     
     [RelayCommand]
-    private void OnLoaded()
+    private async Task OnLoaded()
     {
         // 组件首次加载时运行一次。
         if (!_autoRun)
@@ -489,35 +489,9 @@ public partial class OneDragonFlowViewModel : ViewModel
             return;
         }
         _autoRun = false;
-        //
-        var cmdOptions = CommandLineOptions.Instance;
-        if (cmdOptions.Action == CommandLineAction.StartOneDragon)
-        {
-            // 通过命令行参数启动一条龙。
-            if (cmdOptions.OneDragonConfigName != null)
-            {
-                // 从命令行参数中提取一条龙配置名称。
-                _logger.LogInformation($"参数指定的一条龙配置：{cmdOptions.OneDragonConfigName}");
-                var argsOneDragonConfig = ConfigList.FirstOrDefault(x =>
-                    string.Equals(x.Name, cmdOptions.OneDragonConfigName, StringComparison.Ordinal));
-                if (argsOneDragonConfig != null)
-                {
-                    // 设定配置，配置下拉框会选定。
-                    SelectedConfig = argsOneDragonConfig;
-                    // 调用选定更新函数。
-                    OnConfigDropDownChanged();
-                }
-                else
-                {
-                    _logger.LogWarning("未找到，请检查。");
-                }
-            }
-            // 异步执行一条龙
-            Toast.Information($"命令行一条龙「{SelectedConfig.Name}」。");
-            OnOneKeyExecute();
-        }
-    }
 
+        await StartFromCommandLineOptionsAsync(CommandLineOptions.Instance);
+    }
     public async Task StartFromCommandLineOptionsAsync(CommandLineOptions cmdOptions)
     {
         if (cmdOptions.Action != CommandLineAction.StartOneDragon)

--- a/Test/BetterGenshinImpact.UnitTest/Helpers/CommandLineOptionsTests.cs
+++ b/Test/BetterGenshinImpact.UnitTest/Helpers/CommandLineOptionsTests.cs
@@ -1,0 +1,50 @@
+using BetterGenshinImpact.Helpers;
+
+namespace BetterGenshinImpact.UnitTest.Helpers;
+
+public class CommandLineOptionsTests
+{
+    [Fact]
+    public void Parse_ShouldRecognizeBetterGiStartUrl()
+    {
+        var options = CommandLineOptions.Parse(["BetterGI.exe", "bettergi://start"]);
+
+        Assert.Equal(CommandLineAction.Start, options.Action);
+        Assert.True(options.HasTaskArgs);
+    }
+
+    [Fact]
+    public void Parse_ShouldKeepStartGroupNamesInOrder()
+    {
+        var options = CommandLineOptions.Parse(["BetterGI.exe", "--startGroups", "A", "B"]);
+
+        Assert.Equal(CommandLineAction.StartGroups, options.Action);
+        Assert.Equal(["A", "B"], options.GroupNames);
+    }
+
+    [Fact]
+    public void Parse_ShouldRecognizeTaskProgressName()
+    {
+        var options = CommandLineOptions.Parse(["BetterGI.exe", "--TaskProgress", "latest"]);
+
+        Assert.Equal(CommandLineAction.TaskProgress, options.Action);
+        Assert.Equal(["latest"], options.GroupNames);
+    }
+
+    [Fact]
+    public void Parse_ShouldKeepOneDragonConfigName()
+    {
+        var options = CommandLineOptions.Parse(["BetterGI.exe", "startOneDragon", "daily"]);
+
+        Assert.Equal(CommandLineAction.StartOneDragon, options.Action);
+        Assert.Equal("daily", options.OneDragonConfigName);
+    }
+
+    [Fact]
+    public void ParseActivationArgs_ShouldParseArgumentsWithoutExecutableName()
+    {
+        var options = CommandLineOptions.ParseActivationArgs(["bettergi://start"]);
+
+        Assert.Equal(CommandLineAction.Start, options.Action);
+    }
+}


### PR DESCRIPTION
﻿## 变更说明

修复 #300 中 BetterGI 已运行时再次访问 `bettergi://start`，参数被单例逻辑吞掉的问题。

- 在单例进程检测中增加命名管道转发第二次启动参数，保留原有唤醒窗口行为。
- 保留首次启动的原有页面 `Loaded` 流程，避免改变普通启动、首次 `bettergi://start` 和首次 `startOneDragon` 的时序。
- 运行中二次激活时由主实例解析并执行参数：
  - `bettergi://start`：导航到主页并启动截图器。
  - `startOneDragon [配置名]`：导航到一条龙页并启动指定配置。
  - `--startGroups` / `--TaskProgress`：复用调度器页面的现有启动逻辑。
- 空参数二次启动只唤醒主窗口，不再强制切回主页。
- 二次激活导航投递到 Dispatcher 空闲阶段，避免窗口初始化期 `NavigationView` 内容宿主尚未初始化导致崩溃。
- 补充 `CommandLineOptions` 解析测试，覆盖 `bettergi://start`、一条龙、配置组和任务进度参数。

## 验证

- `dotnet test Test\BetterGenshinImpact.UnitTest\BetterGenshinImpact.UnitTest.csproj -c Debug -p:Platform=x64 --filter CommandLineOptionsTests` 通过。
- `dotnet build BetterGenshinImpact\BetterGenshinImpact.csproj -c Debug -p:Platform=x64 -p:RestoreDisableParallel=true -m:1` 通过。
- 手动验证：普通启动正常，不再出现启动期 `NavigationView` NRE。
- 手动验证：BetterGI 已运行时调用 `bettergi://start`，主实例执行截图器启动逻辑，未产生第二实例残留。
- 手动验证：BetterGI 已运行时调用 `startOneDragon 默认配置`，主实例进入一条龙流程并启动任务，未产生第二实例残留。

Closes #300


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 改进应用激活流程：当从外部启动同一程序时，可将参数传递给已运行实例并触发对应页面/任务启动。
  * 新增支持解析“激活参数”的入口，便于在不带可执行文件名的情况下正确识别启动指令。
* **改进**
  * “一条龙”启动逻辑改为异步入口，支持根据命令行参数选择配置并按需执行。
* **测试**
  * 新增命令行参数解析单元测试，覆盖协议与常见参数组合。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->