### PR TITLE
feat: 优化一条龙每周秘境配置与下拉选择显示

### DIFF
--- a/BetterGenshinImpact/Core/Config/OneDragonFlowConfig.cs
+++ b/BetterGenshinImpact/Core/Config/OneDragonFlowConfig.cs
@@ -46,11 +46,11 @@ public partial class OneDragonFlowConfig : ObservableObject
     [ObservableProperty]
     private int _minResinToKeep = 0;
     
-    // 领取每日奖励的好感数量
+    // 普通周日或限时奖励选项
     [ObservableProperty]
     private string _sundayEverySelectedValue = "0";
-    
-    // 领取每日奖励的好感数量
+
+    // 每周秘境的全局限时奖励选项，单日留空时使用
     [ObservableProperty]
     private string _sundaySelectedValue = "0";
     
@@ -151,6 +151,9 @@ public partial class OneDragonFlowConfig : ObservableObject
     
     [ObservableProperty]
     private string _mondayDomainName = string.Empty;
+
+    [ObservableProperty]
+    private string _mondaySelectedValue = "0";
     
     
     //周二
@@ -159,6 +162,9 @@ public partial class OneDragonFlowConfig : ObservableObject
     
     [ObservableProperty]
     private string _tuesdayDomainName = string.Empty;
+
+    [ObservableProperty]
+    private string _tuesdaySelectedValue = "0";
     
     //周三
     [ObservableProperty]
@@ -166,6 +172,9 @@ public partial class OneDragonFlowConfig : ObservableObject
     
     [ObservableProperty]
     private string _wednesdayDomainName = string.Empty;
+
+    [ObservableProperty]
+    private string _wednesdaySelectedValue = "0";
     
     //周四
     [ObservableProperty]
@@ -173,6 +182,9 @@ public partial class OneDragonFlowConfig : ObservableObject
     
     [ObservableProperty]
     private string _thursdayDomainName = string.Empty;
+
+    [ObservableProperty]
+    private string _thursdaySelectedValue = "0";
     
     //周五
     [ObservableProperty]
@@ -180,6 +192,9 @@ public partial class OneDragonFlowConfig : ObservableObject
     
     [ObservableProperty]
     private string _fridayDomainName = string.Empty;
+
+    [ObservableProperty]
+    private string _fridaySelectedValue = "0";
     
     //周六
     [ObservableProperty]
@@ -187,6 +202,9 @@ public partial class OneDragonFlowConfig : ObservableObject
     
     [ObservableProperty]
     private string _saturdayDomainName = string.Empty;
+
+    [ObservableProperty]
+    private string _saturdaySelectedValue = "0";
     
     //周日
     [ObservableProperty]
@@ -194,6 +212,9 @@ public partial class OneDragonFlowConfig : ObservableObject
 
     [ObservableProperty]
     private string _sundayDomainName = string.Empty;
+
+    [ObservableProperty]
+    private string _sundayDaySelectedValue = "0";
 
     // 完成后操作
     [ObservableProperty]
@@ -208,20 +229,35 @@ public partial class OneDragonFlowConfig : ObservableObject
             var dayOfWeek = (serverTime.Hour >= 4 ? serverTime : serverTime.AddDays(-1)).DayOfWeek;
             return dayOfWeek switch
             {
-                DayOfWeek.Monday => (MondayPartyName, MondayDomainName,SundaySelectedValue),
-                DayOfWeek.Tuesday => (TuesdayPartyName, TuesdayDomainName,SundaySelectedValue),
-                DayOfWeek.Wednesday => (WednesdayPartyName, WednesdayDomainName,SundaySelectedValue),
-                DayOfWeek.Thursday => (ThursdayPartyName, ThursdayDomainName,SundaySelectedValue),
-                DayOfWeek.Friday => (FridayPartyName, FridayDomainName,SundaySelectedValue),
-                DayOfWeek.Saturday => (SaturdayPartyName, SaturdayDomainName,SundaySelectedValue),
-                DayOfWeek.Sunday => (SundayPartyName, SundayDomainName,SundaySelectedValue),
+                DayOfWeek.Monday => (GetWeeklyPartyName(MondayPartyName), GetWeeklyDomainName(MondayDomainName), GetWeeklySelectedValue(MondaySelectedValue)),
+                DayOfWeek.Tuesday => (GetWeeklyPartyName(TuesdayPartyName), GetWeeklyDomainName(TuesdayDomainName), GetWeeklySelectedValue(TuesdaySelectedValue)),
+                DayOfWeek.Wednesday => (GetWeeklyPartyName(WednesdayPartyName), GetWeeklyDomainName(WednesdayDomainName), GetWeeklySelectedValue(WednesdaySelectedValue)),
+                DayOfWeek.Thursday => (GetWeeklyPartyName(ThursdayPartyName), GetWeeklyDomainName(ThursdayDomainName), GetWeeklySelectedValue(ThursdaySelectedValue)),
+                DayOfWeek.Friday => (GetWeeklyPartyName(FridayPartyName), GetWeeklyDomainName(FridayDomainName), GetWeeklySelectedValue(FridaySelectedValue)),
+                DayOfWeek.Saturday => (GetWeeklyPartyName(SaturdayPartyName), GetWeeklyDomainName(SaturdayDomainName), GetWeeklySelectedValue(SaturdaySelectedValue)),
+                DayOfWeek.Sunday => (GetWeeklyPartyName(SundayPartyName), GetWeeklyDomainName(SundayDomainName), GetWeeklySelectedValue(SundayDaySelectedValue)),
                 _ => (PartyName, DomainName,SundaySelectedValue)
             };
         }
         else
         {
-            return (PartyName, DomainName,SundayEverySelectedValue);
+            return (PartyName, DomainName, SundayEverySelectedValue);
         }
+    }
+
+    private string GetWeeklyPartyName(string partyName)
+    {
+        return string.IsNullOrWhiteSpace(partyName) ? PartyName : partyName;
+    }
+
+    private string GetWeeklyDomainName(string domainName)
+    {
+        return string.IsNullOrWhiteSpace(domainName) ? DomainName : domainName;
+    }
+
+    private string GetWeeklySelectedValue(string selectedValue)
+    {
+        return string.IsNullOrWhiteSpace(selectedValue) || selectedValue == "0" ? SundaySelectedValue : selectedValue;
     }
 
     public bool ShouldRunLeyLineToday()

--- a/BetterGenshinImpact/Helpers/DomainCascadingItems.cs
+++ b/BetterGenshinImpact/Helpers/DomainCascadingItems.cs
@@ -12,6 +12,31 @@ public static class DomainCascadingItems
     public static IReadOnlyList<ICascadingItem> Items =>
         _items ??= BuildItems();
 
+    private static readonly Dictionary<string, (int Order, string Text)> TalentRewardDisplays = new()
+    {
+        ["「自由」的哲学"] = (1, "「自由」(1/4)"),
+        ["「抗争」的哲学"] = (2, "「抗争」(2/5)"),
+        ["「诗文」的哲学"] = (3, "「诗文」(3/6)"),
+        ["「繁荣」的哲学"] = (1, "「繁荣」(1/4)"),
+        ["「勤劳」的哲学"] = (2, "「勤劳」(2/5)"),
+        ["「黄金」的哲学"] = (3, "「黄金」(3/6)"),
+        ["「浮世」的哲学"] = (1, "「浮世」(1/4)"),
+        ["「风雅」的哲学"] = (2, "「风雅」(2/5)"),
+        ["「天光」的哲学"] = (3, "「天光」(3/6)"),
+        ["「诤言」的哲学"] = (1, "「诤言」(1/4)"),
+        ["「巧思」的哲学"] = (2, "「巧思」(2/5)"),
+        ["「笃行」的哲学"] = (3, "「笃行」(3/6)"),
+        ["「公平」的哲学"] = (1, "「公平」(1/4)"),
+        ["「正义」的哲学"] = (2, "「正义」(2/5)"),
+        ["「秩序」的哲学"] = (3, "「秩序」(3/6)"),
+        ["「角逐」的哲学"] = (1, "「角逐」(1/4)"),
+        ["「焚燔」的哲学"] = (2, "「焚燔」(2/5)"),
+        ["「纷争」的哲学"] = (3, "「纷争」(3/6)"),
+        ["「月光」的哲学"] = (1, "「月光」(1/4)"),
+        ["「乐园」的哲学"] = (2, "「乐园」(2/5)"),
+        ["「浪迹」的哲学"] = (3, "「浪迹」(3/6)")
+    };
+
     private static IReadOnlyList<ICascadingItem> BuildItems()
     {
         return MapLazyAssets.Instance.CountryToDomains.Keys
@@ -22,11 +47,22 @@ public static class DomainCascadingItems
                     .AsEnumerable()
                     .Reverse()
                     .Select(d => (ICascadingItem)new CascadingItem(
-                        d.Name! + " | " + string.Join(" ", d.Rewards))
+                        d.Name! + " | " + FormatRewards(d.Rewards))
                     {
                         Tag = d.Name
                     })
             ))
             .ToList();
+    }
+
+    private static string FormatRewards(IEnumerable<string> rewards)
+    {
+        return string.Join(" ", rewards
+            .Select((reward, index) => TalentRewardDisplays.TryGetValue(reward, out var display)
+                ? (display.Order, Index: index, display.Text)
+                : (Order: int.MaxValue, Index: index, Text: reward))
+            .OrderBy(reward => reward.Order)
+            .ThenBy(reward => reward.Index)
+            .Select(reward => reward.Text));
     }
 }

--- a/BetterGenshinImpact/View/Behavior/DomainCascadingComboBoxBehavior.cs
+++ b/BetterGenshinImpact/View/Behavior/DomainCascadingComboBoxBehavior.cs
@@ -1,0 +1,156 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Media;
+using Wpf.Ui.Violeta.Controls;
+
+namespace BetterGenshinImpact.View.Behavior;
+
+public static class DomainCascadingComboBoxBehavior
+{
+    private static readonly DependencyProperty LastCommittedItemProperty =
+        DependencyProperty.RegisterAttached(
+            "LastCommittedItem",
+            typeof(ICascadingItem),
+            typeof(DomainCascadingComboBoxBehavior),
+            new PropertyMetadata(null));
+
+    private static readonly DependencyProperty LastCommittedTextProperty =
+        DependencyProperty.RegisterAttached(
+            "LastCommittedText",
+            typeof(string),
+            typeof(DomainCascadingComboBoxBehavior),
+            new PropertyMetadata(string.Empty));
+
+    public static readonly DependencyProperty UseFullLabelsWhenOpenProperty =
+        DependencyProperty.RegisterAttached(
+            "UseFullLabelsWhenOpen",
+            typeof(bool),
+            typeof(DomainCascadingComboBoxBehavior),
+            new PropertyMetadata(false, OnUseFullLabelsWhenOpenChanged));
+
+    public static bool GetUseFullLabelsWhenOpen(DependencyObject obj)
+    {
+        return (bool)obj.GetValue(UseFullLabelsWhenOpenProperty);
+    }
+
+    public static void SetUseFullLabelsWhenOpen(DependencyObject obj, bool value)
+    {
+        obj.SetValue(UseFullLabelsWhenOpenProperty, value);
+    }
+
+    private static void OnUseFullLabelsWhenOpenChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is not CascadingComboBox comboBox)
+            return;
+
+        comboBox.DropDownClosed -= OnDropDownClosed;
+        comboBox.DropDownOpened -= OnDropDownOpened;
+        comboBox.SelectionChanged -= OnSelectionChanged;
+        comboBox.Loaded -= OnLoaded;
+
+        if (e.NewValue is true)
+        {
+            comboBox.DropDownClosed += OnDropDownClosed;
+            comboBox.DropDownOpened += OnDropDownOpened;
+            comboBox.SelectionChanged += OnSelectionChanged;
+            comboBox.Loaded += OnLoaded;
+            comboBox.Dispatcher.BeginInvoke(() => UpdateCommittedSelection(comboBox, restoreInvalidSelection: false));
+        }
+    }
+
+    private static void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        if (sender is CascadingComboBox comboBox)
+            comboBox.Dispatcher.BeginInvoke(() => UpdateCommittedSelection(comboBox, restoreInvalidSelection: false));
+    }
+
+    private static void OnSelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (sender is CascadingComboBox comboBox)
+            comboBox.Dispatcher.BeginInvoke(() => UpdateCommittedSelection(comboBox, restoreInvalidSelection: false));
+    }
+
+    private static void OnDropDownOpened(object? sender, System.EventArgs e)
+    {
+        if (sender is CascadingComboBox comboBox)
+            comboBox.Dispatcher.BeginInvoke(() => UpdateCommittedSelection(comboBox, restoreInvalidSelection: false));
+    }
+
+    private static void OnDropDownClosed(object? sender, System.EventArgs e)
+    {
+        if (sender is CascadingComboBox comboBox)
+            comboBox.Dispatcher.BeginInvoke(() => UpdateCommittedSelection(comboBox, restoreInvalidSelection: true));
+    }
+
+    private static void UpdateCommittedSelection(CascadingComboBox comboBox, bool restoreInvalidSelection)
+    {
+        if (IsSelectableDomain(comboBox.SelectedCascadingItem))
+            CommitSelectedItem(comboBox, comboBox.SelectedCascadingItem);
+        else if (GetLastCommittedItem(comboBox) == null)
+            comboBox.SetValue(LastCommittedTextProperty, comboBox.PlaceholderText);
+        else if (restoreInvalidSelection && GetLastCommittedItem(comboBox) is { } lastCommittedItem)
+            comboBox.SetCurrentValue(CascadingComboBox.SelectedCascadingItemProperty, lastCommittedItem);
+
+        ApplySelectedPreviewBinding(comboBox);
+    }
+
+    private static bool IsSelectableDomain(ICascadingItem? item)
+    {
+        return item?.Tag is string name && !string.IsNullOrWhiteSpace(name);
+    }
+
+    private static ICascadingItem? GetLastCommittedItem(DependencyObject obj)
+    {
+        return (ICascadingItem?)obj.GetValue(LastCommittedItemProperty);
+    }
+
+    private static void CommitSelectedItem(CascadingComboBox comboBox, ICascadingItem? item)
+    {
+        if (!IsSelectableDomain(item))
+            return;
+
+        comboBox.SetValue(LastCommittedItemProperty, item);
+        comboBox.SetValue(LastCommittedTextProperty, item!.Tag as string ?? string.Empty);
+    }
+
+    private static void ApplySelectedPreviewBinding(CascadingComboBox comboBox)
+    {
+        comboBox.ApplyTemplate();
+
+        BindPreviewText(comboBox, "PART_SelectedText");
+        BindPreviewText(comboBox, "PART_SelectedValueText");
+    }
+
+    private static void BindPreviewText(CascadingComboBox comboBox, string partName)
+    {
+        if (FindVisualChild<TextBlock>(comboBox, partName) is not { } selectedText)
+            return;
+
+        BindingOperations.SetBinding(selectedText, TextBlock.TextProperty, new Binding("SelectedCascadingItem.Tag")
+        {
+            Source = comboBox,
+            Mode = BindingMode.OneWay,
+            Path = new PropertyPath("(0)", LastCommittedTextProperty),
+            TargetNullValue = comboBox.PlaceholderText,
+            FallbackValue = comboBox.PlaceholderText
+        });
+    }
+
+    private static T? FindVisualChild<T>(DependencyObject parent, string name) where T : FrameworkElement
+    {
+        var childCount = VisualTreeHelper.GetChildrenCount(parent);
+        for (var i = 0; i < childCount; i++)
+        {
+            var child = VisualTreeHelper.GetChild(parent, i);
+            if (child is T element && element.Name == name)
+                return element;
+
+            var result = FindVisualChild<T>(child, name);
+            if (result != null)
+                return result;
+        }
+
+        return null;
+    }
+}

--- a/BetterGenshinImpact/View/Converters/DomainNameToCascadingItemConverter.cs
+++ b/BetterGenshinImpact/View/Converters/DomainNameToCascadingItemConverter.cs
@@ -26,8 +26,9 @@ public class DomainNameToCascadingItemConverter : IValueConverter
 
     public object? ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
     {
-        if (value is ICascadingItem item)
-            return item.Tag as string;
-        return null;
+        if (value is ICascadingItem { Tag: string name } && !string.IsNullOrWhiteSpace(name))
+            return name;
+
+        return Binding.DoNothing;
     }
 }

--- a/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml
+++ b/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml
@@ -5,6 +5,7 @@
              xmlns:controls="clr-namespace:BetterGenshinImpact.View.Controls"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:dd="urn:gong-wpf-dragdrop"
+             xmlns:behavior="clr-namespace:BetterGenshinImpact.View.Behavior"
              xmlns:helpers="clr-namespace:BetterGenshinImpact.Helpers"
              xmlns:local="clr-namespace:BetterGenshinImpact.View.Pages"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -21,7 +22,7 @@
              FontFamily="{StaticResource TextThemeFontFamily}"
              Foreground="{DynamicResource TextFillColorPrimaryBrush}"
              mc:Ignorable="d">
-    
+
     <b:Interaction.Triggers>
         <b:EventTrigger EventName="Loaded">
             <b:InvokeCommandAction Command="{Binding LoadedCommand}" CommandParameter="{Binding}" />
@@ -463,7 +464,7 @@
                                             MaxWidth="800"
                                             Margin="20,0,36,0"
                                             Text="{Binding SelectedConfig.PartyName, Mode=TwoWay}"
-                                            PlaceholderText="填写队伍名称"
+                                            PlaceholderText="留空则不切换队伍"
                                             TextAlignment="Center"
                                             TextWrapping="Wrap" />
                             </Grid>
@@ -499,6 +500,7 @@
                                           Width="100"
                                           HorizontalAlignment="Left"
                                           Margin="10,0,10,0"
+                                          behavior:DomainCascadingComboBoxBehavior.UseFullLabelsWhenOpen="True"
                                           ItemsSource="{x:Static helpers:DomainCascadingItems.Items}"
                                           SelectedCascadingItem="{Binding SelectedConfig.DomainName, Mode=TwoWay, Converter={StaticResource DomainNameConverter}}" />
                                 <ui:TextBlock Grid.Row="0"
@@ -578,240 +580,325 @@
                                               Text="周期始于凌晨 4:00 ，如周一 4:00 至周二 3:59 刷取周一秘境" 
                                               TextWrapping="Wrap">
                                 </ui:TextBlock>
-                           
-                            <Grid Margin="16">
+
+                            <Grid Margin="20,16,20,4">
                                 <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="56" />
+                                    <ColumnDefinition Width="2*" />
+                                    <ColumnDefinition Width="3*" />
+                                    <ColumnDefinition Width="80" />
+                                </Grid.ColumnDefinitions>
+                                <ui:TextBlock Grid.Column="0"
+                                              Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                              Text="日期"
+                                              TextAlignment="Center" />
+                                <ui:TextBlock Grid.Column="1"
+                                              Margin="8,0,8,0"
+                                              Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                              HorizontalAlignment="Center"
+                                              Text="队伍"
+                                              TextAlignment="Center" />
+                                <ui:TextBlock Grid.Column="2"
+                                              Margin="8,0,8,0"
+                                              Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                              Text="秘境"
+                                              TextAlignment="Center" />
+                                <ui:TextBlock Grid.Column="3"
+                                              Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                              Text="奖励"
+                                              TextAlignment="Center" />
+                            </Grid>
+
+                            <Grid Margin="20,8,20,16">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="56" />
+                                    <ColumnDefinition Width="2*" />
+                                    <ColumnDefinition Width="3*" />
+                                    <ColumnDefinition Width="80" />
+                                </Grid.ColumnDefinitions>
+                                <ui:TextBlock Grid.Column="0"
+                                              HorizontalAlignment="Center"
+                                              Text="默认"
+                                              VerticalAlignment="Center" />
+                                <ui:TextBox Grid.Column="1"
+                                            MinWidth="0"
+                                            Margin="8,0,8,0"
+                                            Text="{Binding SelectedConfig.PartyName, Mode=TwoWay}"
+                                            TextAlignment="Center"
+                                            TextWrapping="Wrap"
+                                            PlaceholderText="留空则不切换队伍" />
+                                <vio:CascadingComboBox Grid.Column="2"
+                                          MinWidth="0"
+                                          Margin="8,0,8,0"
+                                          HorizontalAlignment="Stretch"
+                                          behavior:DomainCascadingComboBoxBehavior.UseFullLabelsWhenOpen="True"
+                                          ItemsSource="{x:Static helpers:DomainCascadingItems.Items}"
+                                          SelectedCascadingItem="{Binding SelectedConfig.DomainName, Mode=TwoWay, Converter={StaticResource DomainNameConverter}}" />
+                                <ComboBox Grid.Column="3"
+                                          MinWidth="56"
+                                          HorizontalContentAlignment="Center"
+                                          ItemsSource="{Binding SundaySelectedValueList}"
+                                          SelectedItem="{Binding SelectedConfig.SundaySelectedValue, Mode=TwoWay}" />
+                            </Grid>
+                           
+                            <Grid Margin="20,16,20,16">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="56" />
+                                    <ColumnDefinition Width="2*" />
+                                    <ColumnDefinition Width="3*" />
+                                    <ColumnDefinition Width="80" />
                                 </Grid.ColumnDefinitions>
                                 <ui:TextBlock Grid.Row="0"
                                               Grid.Column="0"
-                                              Margin="38,0,0,0"
                                               HorizontalAlignment="Center"
                                               Text="周一"
                                               VerticalAlignment="Center" />
                                 <ui:TextBox Grid.Row="0"
                                             Grid.Column="1"
-                                            MinWidth="140"
-                                            Margin="5,0,12,0"
+                                            MinWidth="0"
+                                            Margin="8,0,8,0"
                                             Text="{Binding SelectedConfig.MondayPartyName, Mode=TwoWay}"
                                             TextWrapping="Wrap"
                                             VerticalAlignment="Center"
                                             TextAlignment="Center"
-                                            PlaceholderText="填写队伍名称 " />
+                                            PlaceholderText="留空使用默认队伍" />
                                 <vio:CascadingComboBox Grid.Row="0"
                                           Grid.Column="2"
-                                          Width="100"
-                                          Margin="0,0,36,0"
+                                          MinWidth="0"
+                                          Margin="8,0,8,0"
+                                          HorizontalAlignment="Stretch"
+                                          behavior:DomainCascadingComboBoxBehavior.UseFullLabelsWhenOpen="True"
                                           ItemsSource="{x:Static helpers:DomainCascadingItems.Items}"
                                           SelectedCascadingItem="{Binding SelectedConfig.MondayDomainName, Mode=TwoWay, Converter={StaticResource DomainNameConverter}}" />
+                                <ComboBox Grid.Row="0"
+                                          Grid.Column="3"
+                                          MinWidth="56"
+                                          HorizontalContentAlignment="Center"
+                                          ItemsSource="{Binding SundaySelectedValueList}"
+                                          SelectedItem="{Binding SelectedConfig.MondaySelectedValue, Mode=TwoWay}" />
                             </Grid>
-                            <Grid Margin="16">
+                            <Grid Margin="20,16,20,16">
                                 <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="56" />
+                                    <ColumnDefinition Width="2*" />
+                                    <ColumnDefinition Width="3*" />
+                                    <ColumnDefinition Width="80" />
                                 </Grid.ColumnDefinitions>
                                 <ui:TextBlock Grid.Row="0"
                                               Grid.Column="0"
                                               FontTypography="Body"
-                                              Margin="38,0,0,0"
                                               HorizontalAlignment="Center"
                                               Text="周二"
                                               VerticalAlignment="Center" />
                                 <ui:TextBox Grid.Row="0"
                                             Grid.Column="1"
-                                            MinWidth="140"
-                                            Margin="5,0,12,0"
+                                            MinWidth="0"
+                                            Margin="8,0,8,0"
                                             Text="{Binding SelectedConfig.TuesdayPartyName, Mode=TwoWay}"
                                             TextWrapping="Wrap"
                                             VerticalAlignment="Center"
                                             TextAlignment="Center"
-                                            PlaceholderText="填写队伍名称 " />
+                                            PlaceholderText="留空使用默认队伍" />
                                 <vio:CascadingComboBox Grid.Row="0"
                                           Grid.Column="2"
-                                          Width="100"
-                                          Margin="0,0,36,0"
+                                          MinWidth="0"
+                                          Margin="8,0,8,0"
+                                          HorizontalAlignment="Stretch"
+                                          behavior:DomainCascadingComboBoxBehavior.UseFullLabelsWhenOpen="True"
                                           ItemsSource="{x:Static helpers:DomainCascadingItems.Items}"
                                           SelectedCascadingItem="{Binding SelectedConfig.TuesdayDomainName, Mode=TwoWay, Converter={StaticResource DomainNameConverter}}" />
+                                <ComboBox Grid.Row="0"
+                                          Grid.Column="3"
+                                          MinWidth="56"
+                                          HorizontalContentAlignment="Center"
+                                          ItemsSource="{Binding SundaySelectedValueList}"
+                                          SelectedItem="{Binding SelectedConfig.TuesdaySelectedValue, Mode=TwoWay}" />
                             </Grid>
-                            <Grid Margin="16">
+                            <Grid Margin="20,16,20,16">
                                 <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="56" />
+                                    <ColumnDefinition Width="2*" />
+                                    <ColumnDefinition Width="3*" />
+                                    <ColumnDefinition Width="80" />
                                 </Grid.ColumnDefinitions>
                                 <ui:TextBlock Grid.Row="0"
                                               Grid.Column="0"
-                                              Margin="38,0,0,0"
                                               HorizontalAlignment="Center"
                                               Text="周三"
                                               VerticalAlignment="Center" />
                                 <ui:TextBox Grid.Row="0"
                                             Grid.Column="1"
-                                            MinWidth="140"
-                                            Margin="5,0,12,0"
+                                            MinWidth="0"
+                                            Margin="8,0,8,0"
                                             Text="{Binding SelectedConfig.WednesdayPartyName, Mode=TwoWay}"
                                             TextWrapping="Wrap"
                                             VerticalAlignment="Center"
                                             TextAlignment="Center"
-                                            PlaceholderText="填写队伍名称 " />
+                                            PlaceholderText="留空使用默认队伍" />
                                 <vio:CascadingComboBox Grid.Row="0"
                                           Grid.Column="2"
-                                          Width="100"
-                                          Margin="0,0,36,0"
+                                          MinWidth="0"
+                                          Margin="8,0,8,0"
+                                          HorizontalAlignment="Stretch"
+                                          behavior:DomainCascadingComboBoxBehavior.UseFullLabelsWhenOpen="True"
                                           ItemsSource="{x:Static helpers:DomainCascadingItems.Items}"
                                           SelectedCascadingItem="{Binding SelectedConfig.WednesdayDomainName, Mode=TwoWay, Converter={StaticResource DomainNameConverter}}" />
+                                <ComboBox Grid.Row="0"
+                                          Grid.Column="3"
+                                          MinWidth="56"
+                                          HorizontalContentAlignment="Center"
+                                          ItemsSource="{Binding SundaySelectedValueList}"
+                                          SelectedItem="{Binding SelectedConfig.WednesdaySelectedValue, Mode=TwoWay}" />
 
                             </Grid>
-                            <Grid Margin="16">
+                            <Grid Margin="20,16,20,16">
                                 <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="56" />
+                                    <ColumnDefinition Width="2*" />
+                                    <ColumnDefinition Width="3*" />
+                                    <ColumnDefinition Width="80" />
                                 </Grid.ColumnDefinitions>
                                 <ui:TextBlock Grid.Row="0"
                                               Grid.Column="0"
-                                              Margin="38,0,0,0"
                                               HorizontalAlignment="Center"
                                               Text="周四"
                                               VerticalAlignment="Center" />
                                 <ui:TextBox Grid.Row="0"
                                             Grid.Column="1"
-                                            MinWidth="140"
-                                            Margin="5,0,12,0"
+                                            MinWidth="0"
+                                            Margin="8,0,8,0"
                                             Text="{Binding SelectedConfig.ThursdayPartyName, Mode=TwoWay}"
                                             TextWrapping="Wrap"
                                             VerticalAlignment="Center"
                                             TextAlignment="Center"
-                                            PlaceholderText="填写队伍名称 " />
+                                            PlaceholderText="留空使用默认队伍" />
                                 <vio:CascadingComboBox Grid.Row="0"
                                           Grid.Column="2"
-                                          Width="100"
-                                          Margin="0,0,36,0"
+                                          MinWidth="0"
+                                          Margin="8,0,8,0"
+                                          HorizontalAlignment="Stretch"
+                                          behavior:DomainCascadingComboBoxBehavior.UseFullLabelsWhenOpen="True"
                                           ItemsSource="{x:Static helpers:DomainCascadingItems.Items}"
                                           SelectedCascadingItem="{Binding SelectedConfig.ThursdayDomainName, Mode=TwoWay, Converter={StaticResource DomainNameConverter}}" />
+                                <ComboBox Grid.Row="0"
+                                          Grid.Column="3"
+                                          MinWidth="56"
+                                          HorizontalContentAlignment="Center"
+                                          ItemsSource="{Binding SundaySelectedValueList}"
+                                          SelectedItem="{Binding SelectedConfig.ThursdaySelectedValue, Mode=TwoWay}" />
 
                             </Grid>
-                            <Grid Margin="16">
+                            <Grid Margin="20,16,20,16">
                                 <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="56" />
+                                    <ColumnDefinition Width="2*" />
+                                    <ColumnDefinition Width="3*" />
+                                    <ColumnDefinition Width="80" />
                                 </Grid.ColumnDefinitions>
                                 <ui:TextBlock Grid.Row="0"
                                               Grid.Column="0"
-                                              Margin="38,0,0,0"
                                               HorizontalAlignment="Center"
                                               Text="周五"
                                               VerticalAlignment="Center" />
                                 <ui:TextBox Grid.Row="0"
                                             Grid.Column="1"
-                                            MinWidth="140"
-                                            Margin="5,0,12,0"
+                                            MinWidth="0"
+                                            Margin="8,0,8,0"
                                             Text="{Binding SelectedConfig.FridayPartyName, Mode=TwoWay}"
                                             TextWrapping="Wrap"
                                             VerticalAlignment="Center"
                                             TextAlignment="Center"
-                                            PlaceholderText="填写队伍名称 " />
+                                            PlaceholderText="留空使用默认队伍" />
                                 <vio:CascadingComboBox Grid.Row="0"
                                           Grid.Column="2"
-                                          Width="100"
-                                          Margin="0,0,36,0"
+                                          MinWidth="0"
+                                          Margin="8,0,8,0"
+                                          HorizontalAlignment="Stretch"
+                                          behavior:DomainCascadingComboBoxBehavior.UseFullLabelsWhenOpen="True"
                                           ItemsSource="{x:Static helpers:DomainCascadingItems.Items}"
                                           SelectedCascadingItem="{Binding SelectedConfig.FridayDomainName, Mode=TwoWay, Converter={StaticResource DomainNameConverter}}" />
+                                <ComboBox Grid.Row="0"
+                                          Grid.Column="3"
+                                          MinWidth="56"
+                                          HorizontalContentAlignment="Center"
+                                          ItemsSource="{Binding SundaySelectedValueList}"
+                                          SelectedItem="{Binding SelectedConfig.FridaySelectedValue, Mode=TwoWay}" />
 
 
                             </Grid>
-                            <Grid Margin="16">
+                            <Grid Margin="20,16,20,16">
                                 <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="56" />
+                                    <ColumnDefinition Width="2*" />
+                                    <ColumnDefinition Width="3*" />
+                                    <ColumnDefinition Width="80" />
                                 </Grid.ColumnDefinitions>
                                 <ui:TextBlock Grid.Row="0"
                                               Grid.Column="0"
-                                              Margin="38,0,0,0"
                                               HorizontalAlignment="Center"
                                               Text="周六"
                                               VerticalAlignment="Center" />
                                 <ui:TextBox Grid.Row="0"
                                             Grid.Column="1"
-                                            MinWidth="140"
-                                            Margin="5,0,12,0"
+                                            MinWidth="0"
+                                            Margin="8,0,8,0"
                                             Text="{Binding SelectedConfig.SaturdayPartyName, Mode=TwoWay}"
                                             TextWrapping="Wrap"
                                             VerticalAlignment="Center"
                                             TextAlignment="Center"
-                                            PlaceholderText="填写队伍名称 " />
+                                            PlaceholderText="留空使用默认队伍" />
                                 <vio:CascadingComboBox Grid.Row="0"
                                           Grid.Column="2"
-                                          Width="100"
-                                          Margin="0,0,36,0"
+                                          MinWidth="0"
+                                          Margin="8,0,8,0"
+                                          HorizontalAlignment="Stretch"
+                                          behavior:DomainCascadingComboBoxBehavior.UseFullLabelsWhenOpen="True"
                                           ItemsSource="{x:Static helpers:DomainCascadingItems.Items}"
                                           SelectedCascadingItem="{Binding SelectedConfig.SaturdayDomainName, Mode=TwoWay, Converter={StaticResource DomainNameConverter}}" />
+                                <ComboBox Grid.Row="0"
+                                          Grid.Column="3"
+                                          MinWidth="56"
+                                          HorizontalContentAlignment="Center"
+                                          ItemsSource="{Binding SundaySelectedValueList}"
+                                          SelectedItem="{Binding SelectedConfig.SaturdaySelectedValue, Mode=TwoWay}" />
 
                             </Grid>
-                            <Grid Margin="16">
+                            <Grid Margin="20,16,20,16">
                                 <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" />
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="56" />
+                                    <ColumnDefinition Width="2*" />
+                                    <ColumnDefinition Width="3*" />
+                                    <ColumnDefinition Width="80" />
                                 </Grid.ColumnDefinitions>
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="*" />
-                                </Grid.RowDefinitions>
                                 <ui:TextBlock Grid.Row="0"
                                               Grid.Column="0"
-                                              Margin="38,0,0,0"
                                               HorizontalAlignment="Center"
                                               Text="周日"
                                               VerticalAlignment="Center" />
                                 <ui:TextBox Grid.Row="0"
                                             Grid.Column="1"
-                                            MinWidth="140"
-                                            Margin="5,0,12,0"
+                                            MinWidth="0"
+                                            Margin="8,0,8,0"
                                             Text="{Binding SelectedConfig.SundayPartyName, Mode=TwoWay}"
                                             TextWrapping="Wrap"
                                             VerticalAlignment="Center"
                                             TextAlignment="Center"
-                                            PlaceholderText="填写队伍名称 " />
+                                            PlaceholderText="留空使用默认队伍" />
                                 <vio:CascadingComboBox Grid.Row="0"
                                           Grid.Column="2"
-                                          Width="100"
-                                          Margin="0,0,36,0"
+                                          MinWidth="0"
+                                          Margin="8,0,8,0"
+                                          HorizontalAlignment="Stretch"
+                                          behavior:DomainCascadingComboBoxBehavior.UseFullLabelsWhenOpen="True"
                                           ItemsSource="{x:Static helpers:DomainCascadingItems.Items}"
                                           SelectedCascadingItem="{Binding SelectedConfig.SundayDomainName, Mode=TwoWay, Converter={StaticResource DomainNameConverter}}" />
-                                <Border Grid.Row="1"
-                                        Grid.Column="0"
-                                        Grid.ColumnSpan="3"
-                                        Grid.RowSpan="2"
-                                        Margin="0,21,100,10"
-                                        Background="{DynamicResource ControlFillColorDefaultBrush}"
-                                        BorderBrush="{DynamicResource ControlElevationBorderBrush}"
-                                        BorderThickness="1"
-                                        CornerRadius="5"
-                                        Width="Auto"
-                                        HorizontalAlignment="Right"
-                                        Padding="10">
-                                    <ui:TextBlock FontTypography="Body"
-                                                  FontSize="13" 
-                                                  Text="周日或限时三种奖励,从上往下(1/2/3)序号:"
-                                                  TextAlignment="Justify"
-                                                  TextWrapping="Wrap" />
-                                </Border>
-                                <ComboBox Grid.Row="1"
-                                          Grid.Column="2"
-                                          Grid.RowSpan="2"
-                                          Margin="20,11,37,0"
-                                          HorizontalAlignment="Right"
+                                <ComboBox Grid.Row="0"
+                                          Grid.Column="3"
+                                          MinWidth="56"
+                                          HorizontalContentAlignment="Center"
                                           VerticalAlignment="Center"
-                                          ItemsSource="{Binding SundaySelectedValueList , Mode=TwoWay}"
-                                          SelectedItem="{Binding SelectedConfig.SundaySelectedValue, Mode=TwoWay}">
-                                </ComboBox>
+                                          ItemsSource="{Binding SundaySelectedValueList}"
+                                          SelectedItem="{Binding SelectedConfig.SundayDaySelectedValue, Mode=TwoWay}" />
                             </Grid>
                         </StackPanel>
                     </ui:CardExpander>

--- a/BetterGenshinImpact/View/Pages/TaskSettingsPage.xaml
+++ b/BetterGenshinImpact/View/Pages/TaskSettingsPage.xaml
@@ -4,6 +4,7 @@
       xmlns:b="http://schemas.microsoft.com/xaml/behaviors"
       xmlns:controls="clr-namespace:BetterGenshinImpact.View.Controls"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:behavior="clr-namespace:BetterGenshinImpact.View.Behavior"
       xmlns:helpers="clr-namespace:BetterGenshinImpact.Helpers"
       xmlns:markup="clr-namespace:BetterGenshinImpact.Markup"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -1326,6 +1327,7 @@
                               Grid.Column="1"
                               Width="180"
                               Margin="0,0,36,0"
+                              behavior:DomainCascadingComboBoxBehavior.UseFullLabelsWhenOpen="True"
                               ItemsSource="{x:Static helpers:DomainCascadingItems.Items}"
                               SelectedCascadingItem="{Binding Config.AutoDomainConfig.DomainName, Mode=TwoWay, Converter={StaticResource DomainNameConverter}}" />
                 </Grid>


### PR DESCRIPTION
- 增加每周秘境的全局队伍、秘境、奖励 fallback
- 支持按星期单独配置队伍、秘境和限时奖励
- 优化秘境下拉框显示：展开显示奖励信息，闭合仅显示秘境名
- 调整天赋秘境奖励展示顺序与日期提示
- 修复选择秘境分类时已选配置被清空的问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 支持为一周中的每一天单独配置秘境、队伍和奖励选择，提升每周秘境自动刷取的灵活性。

* **改进**
  * 将秘境配置 UI 重构为统一表格布局，增强可读性。
  * 优化秘境选择下拉展示，改进奖励排序与文本显示的稳定性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/babalae/better-genshin-impact/pull/3142?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->