### PR TITLE
fix:优化一键宏

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoFight/OneKeyFightTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/OneKeyFightTask.cs
@@ -35,6 +35,11 @@ public class OneKeyFightTask : Singleton<OneKeyFightTask>
 
     private CombatScenes? _currentCombatScenes;
     private HashSet<User32.VK> _preMacroKeys = [];
+    private bool _hasMacroSnapshot = false;
+
+    // Vanara User32.VK 枚举不含鼠标键
+    private static readonly User32.VK VK_LBUTTON = (User32.VK)0x01;
+    private static readonly User32.VK VK_RBUTTON = (User32.VK)0x02;
 
     public void KeyDown()
     {
@@ -80,7 +85,7 @@ public class OneKeyFightTask : Singleton<OneKeyFightTask>
             else
             {
                 _cts.Cancel();
-                ReleaseMacroOnlyKeys();
+                if (_hasMacroSnapshot) ReleaseMacroOnlyKeys();
             }
         }
     }
@@ -89,7 +94,7 @@ public class OneKeyFightTask : Singleton<OneKeyFightTask>
     {
         _isKeyDown = false;
         // 取消/释放放在 IsEnabled 之前，确保停止动作始终清理输入状态
-        if (IsHoldOnMode())
+        if (IsHoldOnMode() && _hasMacroSnapshot)
         {
             _cts?.Cancel();
             ReleaseMacroOnlyKeys();
@@ -278,10 +283,19 @@ public class OneKeyFightTask : Singleton<OneKeyFightTask>
                 _preMacroKeys.Add(key);
             }
         }
+        // 鼠标键不在 VK 枚举中，单独捕获
+        if ((User32.GetAsyncKeyState((int)VK_LBUTTON) & 0x8000) != 0) _preMacroKeys.Add(VK_LBUTTON);
+        if ((User32.GetAsyncKeyState((int)VK_RBUTTON) & 0x8000) != 0) _preMacroKeys.Add(VK_RBUTTON);
+        _hasMacroSnapshot = true;
     }
 
     private void ReleaseMacroOnlyKeys()
     {
+        if (!_hasMacroSnapshot)
+        {
+            return;
+        }
+
         // 用 PostMessage 释放键，避免钩子上下文中 SendInput 导致递归
         var hWnd = TaskContext.Instance().GameHandle;
         var postMsg = Simulation.PostMessage(hWnd);
@@ -292,7 +306,18 @@ public class OneKeyFightTask : Singleton<OneKeyFightTask>
                 postMsg.KeyUp(key);
             }
         }
-        postMsg.LeftButtonUp();
-        postMsg.RightButtonUp();
+        if ((User32.GetAsyncKeyState((int)VK_LBUTTON) & 0x8000) != 0 &&
+            !_preMacroKeys.Contains(VK_LBUTTON))
+        {
+            postMsg.LeftButtonUp();
+        }
+        if ((User32.GetAsyncKeyState((int)VK_RBUTTON) & 0x8000) != 0 &&
+            !_preMacroKeys.Contains(VK_RBUTTON))
+        {
+            postMsg.RightButtonUp();
+        }
+
+        _preMacroKeys.Clear();
+        _hasMacroSnapshot = false;
     }
 }

--- a/BetterGenshinImpact/GameTask/AutoFight/OneKeyFightTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/OneKeyFightTask.cs
@@ -37,9 +37,12 @@ public class OneKeyFightTask : Singleton<OneKeyFightTask>
     private HashSet<User32.VK> _preMacroKeys = [];
     private bool _hasMacroSnapshot = false;
 
-    // Vanara User32.VK 枚举不含鼠标键
+    // Vanara User32.VK 枚举不含鼠标键，与 GlobalMethod 支持范围对齐
     private static readonly User32.VK VK_LBUTTON = (User32.VK)0x01;
     private static readonly User32.VK VK_RBUTTON = (User32.VK)0x02;
+    private static readonly User32.VK VK_MBUTTON = (User32.VK)0x04;
+    private static readonly User32.VK VK_XBUTTON1 = (User32.VK)0x05;
+    private static readonly User32.VK VK_XBUTTON2 = (User32.VK)0x06;
 
     public void KeyDown()
     {
@@ -283,9 +286,12 @@ public class OneKeyFightTask : Singleton<OneKeyFightTask>
                 _preMacroKeys.Add(key);
             }
         }
-        // 鼠标键不在 VK 枚举中，单独捕获
+        // 鼠标键不在 VK 枚举中，单独捕获（与 GlobalMethod 支持范围对齐）
         if ((User32.GetAsyncKeyState((int)VK_LBUTTON) & 0x8000) != 0) _preMacroKeys.Add(VK_LBUTTON);
         if ((User32.GetAsyncKeyState((int)VK_RBUTTON) & 0x8000) != 0) _preMacroKeys.Add(VK_RBUTTON);
+        if ((User32.GetAsyncKeyState((int)VK_MBUTTON) & 0x8000) != 0) _preMacroKeys.Add(VK_MBUTTON);
+        if ((User32.GetAsyncKeyState((int)VK_XBUTTON1) & 0x8000) != 0) _preMacroKeys.Add(VK_XBUTTON1);
+        if ((User32.GetAsyncKeyState((int)VK_XBUTTON2) & 0x8000) != 0) _preMacroKeys.Add(VK_XBUTTON2);
         _hasMacroSnapshot = true;
     }
 
@@ -315,6 +321,21 @@ public class OneKeyFightTask : Singleton<OneKeyFightTask>
             !_preMacroKeys.Contains(VK_RBUTTON))
         {
             postMsg.RightButtonUp();
+        }
+        if ((User32.GetAsyncKeyState((int)VK_MBUTTON) & 0x8000) != 0 &&
+            !_preMacroKeys.Contains(VK_MBUTTON))
+        {
+            User32.PostMessage(hWnd, 0x208, IntPtr.Zero, IntPtr.Zero); // WM_MBUTTONUP
+        }
+        if ((User32.GetAsyncKeyState((int)VK_XBUTTON1) & 0x8000) != 0 &&
+            !_preMacroKeys.Contains(VK_XBUTTON1))
+        {
+            User32.PostMessage(hWnd, 0x20C, (IntPtr)0x0020, IntPtr.Zero); // WM_XBUTTONUP + MK_XBUTTON1
+        }
+        if ((User32.GetAsyncKeyState((int)VK_XBUTTON2) & 0x8000) != 0 &&
+            !_preMacroKeys.Contains(VK_XBUTTON2))
+        {
+            User32.PostMessage(hWnd, 0x20C, (IntPtr)0x0040, IntPtr.Zero); // WM_XBUTTONUP + MK_XBUTTON2
         }
 
         _preMacroKeys.Clear();

--- a/BetterGenshinImpact/GameTask/AutoFight/OneKeyFightTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/OneKeyFightTask.cs
@@ -8,9 +8,11 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Vanara.PInvoke;
 using static BetterGenshinImpact.GameTask.Common.TaskControl;
 
 namespace BetterGenshinImpact.GameTask.AutoFight;
@@ -32,6 +34,7 @@ public class OneKeyFightTask : Singleton<OneKeyFightTask>
     private DateTime _lastUpdateTime = DateTime.MinValue;
 
     private CombatScenes? _currentCombatScenes;
+    private HashSet<User32.VK> _preMacroKeys = [];
 
     public void KeyDown()
     {
@@ -53,6 +56,7 @@ public class OneKeyFightTask : Singleton<OneKeyFightTask>
         {
             if (_cts == null || _cts.Token.IsCancellationRequested)
             {
+                SnapshotPressedKeys();
                 _cts = new CancellationTokenSource();
                 _fightTask = FightTask(_cts.Token);
                 if (!_fightTask.IsCompleted)
@@ -65,6 +69,7 @@ public class OneKeyFightTask : Singleton<OneKeyFightTask>
         {
             if (_cts == null || _cts.Token.IsCancellationRequested)
             {
+                SnapshotPressedKeys();
                 _cts = new CancellationTokenSource();
                 _fightTask = FightTask(_cts.Token);
                 if (!_fightTask.IsCompleted)
@@ -75,7 +80,7 @@ public class OneKeyFightTask : Singleton<OneKeyFightTask>
             else
             {
                 _cts.Cancel();
-                Simulation.ReleaseAllKey();
+                ReleaseMacroOnlyKeys();
             }
         }
     }
@@ -83,15 +88,16 @@ public class OneKeyFightTask : Singleton<OneKeyFightTask>
     public void KeyUp()
     {
         _isKeyDown = false;
-        if (!IsEnabled())
-        {
-            return;
-        }
-
+        // 取消/释放放在 IsEnabled 之前，确保停止动作始终清理输入状态
         if (IsHoldOnMode())
         {
             _cts?.Cancel();
-            Simulation.ReleaseAllKey();
+            ReleaseMacroOnlyKeys();
+        }
+
+        if (!IsEnabled())
+        {
+            return;
         }
     }
 
@@ -257,5 +263,36 @@ public class OneKeyFightTask : Singleton<OneKeyFightTask>
     public static bool IsTickMode()
     {
         return TaskContext.Instance().Config.MacroConfig.CombatMacroHotkeyMode == TickMode;
+    }
+
+    /// <summary>
+    /// 快照宏启动前已按下的键，停止时只释放宏期间按下的键
+    /// </summary>
+    private void SnapshotPressedKeys()
+    {
+        _preMacroKeys = [];
+        foreach (User32.VK key in Enum.GetValues(typeof(User32.VK)))
+        {
+            if ((User32.GetAsyncKeyState((int)key) & 0x8000) != 0)
+            {
+                _preMacroKeys.Add(key);
+            }
+        }
+    }
+
+    private void ReleaseMacroOnlyKeys()
+    {
+        // 用 PostMessage 释放键，避免钩子上下文中 SendInput 导致递归
+        var hWnd = TaskContext.Instance().GameHandle;
+        var postMsg = Simulation.PostMessage(hWnd);
+        foreach (User32.VK key in Enum.GetValues(typeof(User32.VK)))
+        {
+            if ((User32.GetAsyncKeyState((int)key) & 0x8000) != 0 && !_preMacroKeys.Contains(key))
+            {
+                postMsg.KeyUp(key);
+            }
+        }
+        postMsg.LeftButtonUp();
+        postMsg.RightButtonUp();
     }
 }

--- a/BetterGenshinImpact/GameTask/AutoFight/OneKeyFightTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/OneKeyFightTask.cs
@@ -330,12 +330,13 @@ public class OneKeyFightTask : Singleton<OneKeyFightTask>
         if ((User32.GetAsyncKeyState((int)VK_XBUTTON1) & 0x8000) != 0 &&
             !_preMacroKeys.Contains(VK_XBUTTON1))
         {
-            User32.PostMessage(hWnd, 0x20C, (IntPtr)0x0020, IntPtr.Zero); // WM_XBUTTONUP + MK_XBUTTON1
+            User32.PostMessage(hWnd, 0x20C, (IntPtr)(0x0020 | (0x0001 << 16)), IntPtr.Zero); // LOWORD=MK_XBUTTON1, HIWORD=XBUTTON1
         }
         if ((User32.GetAsyncKeyState((int)VK_XBUTTON2) & 0x8000) != 0 &&
             !_preMacroKeys.Contains(VK_XBUTTON2))
         {
-            User32.PostMessage(hWnd, 0x20C, (IntPtr)0x0040, IntPtr.Zero); // WM_XBUTTONUP + MK_XBUTTON2
+            User32.PostMessage(hWnd, 0x20C, (IntPtr)(0x0040 | (0x0002 << 16)), IntPtr.Zero); // LOWORD=MK_XBUTTON2, HIWORD=XBUTTON2
+        }
         }
 
         _preMacroKeys.Clear();


### PR DESCRIPTION
- 快照宏启动前已按下的键，停止时仅释放宏期间按下的键（不影响事先按着的键）解决(#3145)
- ReleaseMacroOnlyKeys 改用 PostMessage 替代 SendInput，避免钩子上下文中 SendInput 触发递归死锁

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 一键战斗宏改进按键快照与释放：启动前快照当前按键，取消时仅释放宏期间新增且仍处于按下的按键（包含左右/中键与侧键），避免误释放全量按键；调整停止流程以优先基于快照执行按键释放，提升在不同触发模式下的稳定性与抗异常能力。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/babalae/better-genshin-impact/pull/3148?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->