### PR TITLE
fix: 复制配置组丢失设置

### DIFF
--- a/BetterGenshinImpact/Model/SettingItem.cs
+++ b/BetterGenshinImpact/Model/SettingItem.cs
@@ -134,6 +134,10 @@ public class SettingItem
                                 ctx[Name] = new List<string>();
                             }
                         }
+                        else if (ctx[Name] is JsonElement j2)
+                        {
+                            ctx[Name] = j2.Deserialize<List<string>>() ?? new List<string>();
+                        }
                         else if (ctx[Name] is List<object> listOfObjects)
                         {
                             ctx[Name] = listOfObjects.Select(i => (string)i).ToList();

--- a/BetterGenshinImpact/Model/SettingItem.cs
+++ b/BetterGenshinImpact/Model/SettingItem.cs
@@ -136,7 +136,12 @@ public class SettingItem
                         }
                         else if (ctx[Name] is JsonElement j2)
                         {
-                            ctx[Name] = j2.Deserialize<List<string>>() ?? new List<string>();
+                            var parsed = j2.Deserialize<List<string>>();
+                            if (parsed == null)
+                            {
+                                throw new JsonException($"Setting '{Name}' expects a JSON array of strings, but got: {j2}");
+                            }
+                            ctx[Name] = parsed;
                         }
                         else if (ctx[Name] is List<object> listOfObjects)
                         {

--- a/BetterGenshinImpact/ViewModel/Pages/ScriptControlViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/ScriptControlViewModel.cs
@@ -651,11 +651,41 @@ public partial class ScriptControlViewModel : ViewModel
                         {
                             // ignored
                         }
+
+                        // JSON 反序列化后 ExpandoObject 中的值转换回原始类型
+                        ConvertJsonElementSettings(project.JsScriptSettingsObject);
                     }
                     ScriptGroups.Add(newScriptGroup);
                 }
 
                 //WriteScriptGroup(newScriptGroup);
+            }
+        }
+    }
+
+    /// <summary>
+    /// 将 ExpandoObject 中因 JSON 序列化/反序列化产生的 JsonElement 值转换回原始类型
+    /// </summary>
+    private static void ConvertJsonElementSettings(ExpandoObject? settings)
+    {
+        if (settings is not IDictionary<string, object?> dict) return;
+
+        var keys = dict.Keys.ToList();
+        foreach (var key in keys)
+        {
+            if (dict[key] is JsonElement element)
+            {
+                dict[key] = element.ValueKind switch
+                {
+                    JsonValueKind.String => element.GetString(),
+                    JsonValueKind.True => true,
+                    JsonValueKind.False => false,
+                    JsonValueKind.Number => element.TryGetInt64(out var l) ? (object)l : element.GetDouble(),
+                    JsonValueKind.Array => element.EnumerateArray()
+                        .Select(e => e.ValueKind == JsonValueKind.String ? e.GetString()! : e.ToString())
+                        .ToList(),
+                    _ => dict[key]
+                };
             }
         }
     }

--- a/BetterGenshinImpact/ViewModel/Pages/ScriptControlViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/ScriptControlViewModel.cs
@@ -666,6 +666,23 @@ public partial class ScriptControlViewModel : ViewModel
     /// <summary>
     /// 将 ExpandoObject 中因 JSON 序列化/反序列化产生的 JsonElement 值转换回原始类型
     /// </summary>
+    private static object? ConvertJsonElementValue(JsonElement element)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.String => element.GetString(),
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            JsonValueKind.Number => element.TryGetInt64(out var l) ? l : element.GetDouble(),
+            JsonValueKind.Array => element.EnumerateArray().Select(ConvertJsonElementValue).ToList(),
+            JsonValueKind.Null => null,
+            _ => element.ToString()
+        };
+    }
+
+    /// <summary>
+    /// 将 ExpandoObject 中因 JSON 序列化/反序列化产生的 JsonElement 值转换回原始类型
+    /// </summary>
     private static void ConvertJsonElementSettings(ExpandoObject? settings)
     {
         if (settings is not IDictionary<string, object?> dict) return;
@@ -674,19 +691,7 @@ public partial class ScriptControlViewModel : ViewModel
         foreach (var key in keys)
         {
             if (dict[key] is JsonElement element)
-            {
-                dict[key] = element.ValueKind switch
-                {
-                    JsonValueKind.String => element.GetString(),
-                    JsonValueKind.True => true,
-                    JsonValueKind.False => false,
-                    JsonValueKind.Number => element.TryGetInt64(out var l) ? (object)l : element.GetDouble(),
-                    JsonValueKind.Array => element.EnumerateArray()
-                        .Select(e => e.ValueKind == JsonValueKind.String ? e.GetString()! : e.ToString())
-                        .ToList(),
-                    _ => dict[key]
-                };
-            }
+                dict[key] = ConvertJsonElementValue(element);
         }
     }
 

--- a/BetterGenshinImpact/ViewModel/Pages/ScriptControlViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/ScriptControlViewModel.cs
@@ -674,10 +674,20 @@ public partial class ScriptControlViewModel : ViewModel
             JsonValueKind.True => true,
             JsonValueKind.False => false,
             JsonValueKind.Number => element.TryGetInt64(out var l) ? l : element.GetDouble(),
-            JsonValueKind.Array => element.EnumerateArray().Select(ConvertJsonElementValue).ToList(),
+            JsonValueKind.Array => ConvertJsonArray(element),
             JsonValueKind.Null => null,
             _ => element.ToString()
         };
+    }
+
+    private static object ConvertJsonArray(JsonElement element)
+    {
+        var items = element.EnumerateArray().Select(ConvertJsonElementValue).ToList();
+        // 若全为字符串，返回强类型 List<string> 以匹配 multi-checkbox 等下游逻辑
+        if (items.All(i => i is string))
+            return items.Cast<string>().ToList();
+        // 否则返回 List<object> 以匹配现有类型检查
+        return items.Where(i => i != null).Cast<object>().ToList();
     }
 
     /// <summary>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复多选框配置从存储 JSON 读回后无法正确识别与显示的问题，确保选项能正确显示与切换
  * 改进配置复制时的数据类型还原，字符串、布尔、整数/小数与数组等在复制后保持原始类型和值，数组内空值被适当处理

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/babalae/better-genshin-impact/pull/3151?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->