### PR TITLE
feat: 在 Wine 平台，添加 Wayland 截图方式支持

### DIFF
--- a/BetterGenshinImpact/ViewModel/Pages/HomePageViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/HomePageViewModel.cs
@@ -9,6 +9,7 @@ using BetterGenshinImpact.Helpers;
 using BetterGenshinImpact.Helpers.Extensions;
 using BetterGenshinImpact.Helpers.Ui;
 using BetterGenshinImpact.Model;
+using BetterGenshinImpact.Platform.Wine;
 using BetterGenshinImpact.Service.Interface;
 using BetterGenshinImpact.View;
 using BetterGenshinImpact.View.Controls.Webview;
@@ -96,6 +97,12 @@ public partial class HomePageViewModel : ViewModel
             _inferenceDeviceTypes = _inferenceDeviceTypes
                 .Where(x => x != InferenceDeviceType.GpuDirectMl)
                 .ToArray();
+        }
+
+        // Wayland 是 Linux 下的显示协议，通过 Wine 运行本程序时才支持该捕获模式
+        if (!WinePlatformAddon.IsRunningOnWine)
+        {
+            _modeNames = _modeNames.Where(x => x.EnumName != CaptureModes.Wayland.ToString()).ToList();
         }
 
         WeakReferenceMessenger.Default.Register<PropertyChangedMessage<object>>(this, (sender, msg) =>

--- a/Fischless.GameCapture/CaptureModes.cs
+++ b/Fischless.GameCapture/CaptureModes.cs
@@ -19,4 +19,8 @@ public enum CaptureModes
     [Description("WindowsGraphicsCapture（HDR）")]
     [DefaultValue(3)]
     WindowsGraphicsCaptureHdr = 3,
+
+    [Description("Wine (Wayland)")]
+    [DefaultValue(4)]
+    Wayland = 4,
 }

--- a/Fischless.GameCapture/Fischless.GameCapture.csproj
+++ b/Fischless.GameCapture/Fischless.GameCapture.csproj
@@ -25,4 +25,7 @@
 		<PackageReference Include="System.Drawing.Common" Version="10.0.7" />
 	</ItemGroup>
 
+	<ItemGroup>
+		<EmbeddedResource Include="Wayland\screencast_daemon.py" />
+	</ItemGroup>
 </Project>

--- a/Fischless.GameCapture/GameCaptureFactory.cs
+++ b/Fischless.GameCapture/GameCaptureFactory.cs
@@ -15,6 +15,7 @@ public class GameCaptureFactory
             CaptureModes.DwmGetDxSharedSurface => new DwmSharedSurface.SharedSurfaceCapture(),
             CaptureModes.WindowsGraphicsCapture => new Graphics.GraphicsCapture(),
             CaptureModes.WindowsGraphicsCaptureHdr => new Graphics.GraphicsCapture(true),
+            CaptureModes.Wayland => new Wayland.WaylandGameCapture(),
             _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null),
         };
     }

--- a/Fischless.GameCapture/Wayland/WaylandGameCapture.cs
+++ b/Fischless.GameCapture/Wayland/WaylandGameCapture.cs
@@ -1,0 +1,216 @@
+using System.Buffers.Binary;
+using System.Diagnostics;
+using System.IO;
+using System.IO.MemoryMappedFiles;
+using System.Linq;
+using OpenCvSharp;
+
+namespace Fischless.GameCapture.Wayland;
+
+public class WaylandGameCapture : IGameCapture
+{
+    public bool IsCapturing { get; private set; }
+
+    // 文件路径必须与 Python 脚本中的定义保持一致
+    private static readonly string FramePath  = "/dev/shm/bettergi/frame.bin";
+    private static readonly string FrameTmpPath  = "/dev/shm/bettergi/frame.bin.tmp";
+    private static readonly string PidPath    = "/dev/shm/bettergi/daemon.pid";
+    private static readonly string ScriptPath = "/dev/shm/bettergi/screencast_daemon.py";
+
+    private int _daemonPid = 0;
+
+    /// <summary>
+    /// 启动截图守护进程，并等待共享内存帧文件就绪
+    /// 由于 Wayland 的限制，窗口句柄 hWnd 实际没有被使用
+    /// </summary>
+    public void Start(nint hWnd, Dictionary<string, object>? settings = null)
+    {
+        IsCapturing = false;
+
+        KillDaemon();
+
+        var name = typeof(WaylandGameCapture).Assembly.GetManifestResourceNames()
+            .FirstOrDefault(n => n.EndsWith("screencast_daemon.py"));
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            Console.Error.WriteLine("[Wayland] 未找到嵌入的 screencast_daemon.py");
+            return;
+        }
+
+        using var stream = typeof(WaylandGameCapture).Assembly.GetManifestResourceStream(name);
+        if (stream is null)
+        {
+            Console.Error.WriteLine("[Wayland] 无法打开嵌入的脚本");
+            return;
+        }
+
+        try
+        {
+            Directory.CreateDirectory("/dev/shm/bettergi");
+            using var fs = new FileStream(ScriptPath, FileMode.Create);
+            stream.CopyTo(fs);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[Wayland] 把脚本复制到 /dev/shm/bettergi 时出错: {ex.GetType().Name}: {ex.Message}");
+            return;
+        }
+
+        try
+        {
+            Process.Start(new ProcessStartInfo
+            {
+                FileName               = "/usr/bin/python3",
+                Arguments              = $"\"{ScriptPath}\"",
+                UseShellExecute        = false,
+                CreateNoWindow         = true
+            });
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[Wayland] 启动守护进程出错: {ex.Message}");
+            KillDaemon();
+            return;
+        }
+
+        // 等待 Pid 文件出现，最长等待 10 秒（200 * 50ms）
+        for (int i = 0; i < 200; i++)
+        {
+            if (File.Exists(PidPath))
+            {
+                try
+                {
+                    string pidStr = File.ReadAllText(PidPath).Trim();
+                    _daemonPid = int.Parse(pidStr);
+                    if (_daemonPid != 0) break;
+                }
+                catch { }
+            }
+            Thread.Sleep(50);
+        }
+
+        // 等待共享内存帧文件出现，最长等待 30 秒（600 * 50ms），或者守护进程退出
+        for (int i = 0; i < 600; i++)
+        {
+            if (!IsDaemonAlive())
+            {
+                return;
+            }
+            if (File.Exists(FramePath))
+            {
+                IsCapturing = true;
+                return;
+            }
+            Thread.Sleep(50);
+        }
+
+        KillDaemon();
+    }
+
+    /// <summary>
+    /// 从共享内存帧文件中读取最新的一帧并转换为 OpenCV Mat。
+    /// 帧格式：8 字节大端头（宽、高各 4 字节）+ BGR 像素数据。
+    /// </summary>
+    public Mat? Capture()
+    {
+        if (!IsCapturing) return null;
+        if (!IsDaemonAlive())
+        {
+            IsCapturing = false;
+            return null;
+        }
+
+        try
+        {
+            using var mmf = MemoryMappedFile.CreateFromFile(
+                FramePath, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
+            using var accessor = mmf.CreateViewAccessor(0, 0, MemoryMappedFileAccess.Read);
+
+            long cap = accessor.Capacity;
+            if (cap < 8) return null;
+
+            byte[] header = new byte[8];
+            accessor.ReadArray(0, header, 0, 8);
+            int w = BinaryPrimitives.ReadInt32BigEndian(header);
+            int h = BinaryPrimitives.ReadInt32BigEndian(new ReadOnlySpan<byte>(header, 4, 4));
+
+            if (w <= 0 || h <= 0 || w > 8192 || h > 8192) return null;
+
+            int size = w * h * 3;
+            if (cap < 8 + size) return null;
+
+            byte[] pixels = new byte[size];
+            accessor.ReadArray(8, pixels, 0, size);
+            return Mat.FromPixelData(h, w, MatType.CV_8UC3, pixels);
+        }
+        catch (FileNotFoundException) { return null; }
+        catch (IOException) { return null; }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[Wayland] capture: {ex.GetType().Name}: {ex.Message}");
+            return null;
+        }
+    }
+
+    public void Stop()
+    {
+        IsCapturing = false;
+        KillDaemon();
+    }
+
+    public void Dispose()
+    {
+        IsCapturing = false;
+        KillDaemon();
+    }
+
+    private bool IsDaemonAlive()
+    {
+        if (_daemonPid == 0) return false;
+        string procPath = $"/proc/{_daemonPid}";
+        return Directory.Exists(procPath);
+    }
+
+    private void KillDaemon()
+    {
+        IsCapturing = false;
+
+        if (_daemonPid != 0)
+        {
+            string pidStr = _daemonPid.ToString();
+
+            try
+            {
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName        = "/bin/kill",
+                    Arguments       = pidStr,
+                    UseShellExecute = false,
+                    CreateNoWindow  = true
+                });
+            }
+            catch { }
+
+            Thread.Sleep(50);
+
+            try
+            {
+                Process.Start(new ProcessStartInfo
+                {
+                    FileName        = "/bin/kill",
+                    Arguments       = $"-9 {pidStr}",
+                    UseShellExecute = false,
+                    CreateNoWindow  = true
+                });
+            }
+            catch { }
+        }
+
+        try { File.Delete(PidPath); } catch { }
+        try { File.Delete(FramePath); } catch { }
+        try { File.Delete(FrameTmpPath); } catch { }
+        try { File.Delete(ScriptPath); } catch { }
+
+        _daemonPid = 0;
+    }
+}

--- a/Fischless.GameCapture/Wayland/screencast_daemon.py
+++ b/Fischless.GameCapture/Wayland/screencast_daemon.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""
+BetterGI 截图守护进程，基于 Wayland PipeWire
+
+通过 D-Bus 与 xdg-desktop-portal 通信，获取屏幕/窗口的 PipeWire
+视频流，将 BGR 原始帧写入 /dev/shm 共享内存，供 Wine 下的
+BetterGI WPF 应用读取。
+
+依赖于 python3-dbus 和 python3-gi
+"""
+import sys, os, signal, struct, atexit, traceback
+from pathlib import Path
+
+loop = None
+
+SHM_DIR   = Path("/dev/shm/bettergi")
+FRAME_BIN = SHM_DIR / "frame.bin"
+FRAME_TMP = SHM_DIR / "frame.bin.tmp"
+PID_FILE  = SHM_DIR / "daemon.pid"
+
+pipeline = None
+# 请求路径 -> 回调 映射表，用于将 portal 的异步响应关联到对应的请求
+pending = {}
+session = None # ScreenCast 会话对象
+
+SHM_DIR.mkdir(parents=True, exist_ok=True)
+PID_FILE.write_text(str(os.getpid()))
+
+def cleanup():
+    if pipeline is not None:
+        pipeline.set_state(Gst.State.NULL)
+    print("python 守护进程退出", file=sys.stderr)
+
+atexit.register(cleanup)
+
+def die(msg=None, code=1):
+    if msg is not None:
+        print(f"[daemon] {msg}", file=sys.stderr)
+    if loop is not None:
+        loop.quit()
+    else:
+        sys.exit(code)
+
+try:
+    from dbus.mainloop.glib import DBusGMainLoop
+    DBusGMainLoop(set_as_default=True)
+    import dbus
+    import gi
+    gi.require_version('Gst', '1.0')
+    from gi.repository import Gst, GLib
+    Gst.init(None)
+except Exception as e:
+    die(f"请检查依赖项是否安装 {e}")
+
+def on_response(response, results, path=None):
+    """
+    全局 D-Bus 信号处理：当任意请求收到响应时，
+    根据请求路径取出 pending 中对应的回调并执行。
+    """
+    cb = pending.pop(path, None)
+    if cb is not None:
+        cb(response, dict(results))
+
+def on_closed(*args, path=None):
+    """当用户在系统层面撤销共享权限时触发"""
+    if session is None or path != session:
+        return
+    die("Portal 会话被系统或用户关闭")
+
+bus = dbus.SessionBus()
+bus.add_signal_receiver(
+    on_response,
+    signal_name="Response",
+    dbus_interface="org.freedesktop.portal.Request",
+    path_keyword="path",
+)
+bus.add_signal_receiver(
+    on_closed,
+    signal_name="Closed",
+    dbus_interface="org.freedesktop.portal.Session",
+    path_keyword="path"
+)
+
+portal = bus.get_object("org.freedesktop.portal.Desktop", "/org/freedesktop/portal/desktop")
+sc = dbus.Interface(portal, "org.freedesktop.portal.ScreenCast")
+
+def start_pipeline(node_id):
+    """
+    根据 PipeWire 节点 ID 启动 GStreamer 管道，
+    将视频流转换为 BGR 格式并通过 appsink 写入共享内存。
+    """
+    global pipeline
+
+    pipe = Gst.parse_launch(
+        f"pipewiresrc path={node_id} "
+        f"! videoconvert "
+        f"! video/x-raw,format=BGR "
+        f"! appsink name=s emit-signals=true sync=false "
+        f"  max-buffers=1 drop=true"
+    )
+    if pipe is None:
+        die("GStreamer pipeline failed")
+
+    def on_new_sample(sink):
+        """处理来自 appsink 的新采样，将帧数据写入共享内存。"""
+        try:
+            sample = sink.emit("pull-sample")
+            if not sample:
+                return Gst.FlowReturn.ERROR
+            buf = sample.get_buffer()
+            caps = sample.get_caps()
+            w = h = 0
+            if caps:
+                s2 = caps.get_structure(0)
+                _, w = s2.get_int("width")  if s2.has_field("width")  else (False, 0)
+                _, h = s2.get_int("height") if s2.has_field("height") else (False, 0)
+            ok, info = buf.map(Gst.MapFlags.READ)
+            if ok:
+                try:
+                    with FRAME_TMP.open("wb") as f:
+                        # 大端字节序写入 width 和 height
+                        # 一共 8B
+                        f.write(struct.pack("!II", w, h))
+                        f.write(info.data)
+                    FRAME_TMP.rename(FRAME_BIN)
+                finally:
+                    buf.unmap(info)
+            return Gst.FlowReturn.OK
+        except Exception:
+            traceback.print_exc(file=sys.stderr)
+            return Gst.FlowReturn.ERROR
+
+    appsink = pipe.get_by_name("s")
+    appsink.connect("new-sample", on_new_sample)
+
+    gst_bus = pipe.get_bus()
+    gst_bus.add_signal_watch()
+    gst_bus.connect("message::error", lambda _bus, msg: die(f"gst error: {msg.parse_error()[0].message}"))
+    gst_bus.connect("message::eos", lambda _bus, _msg: die(code=0))
+
+    pipe.set_state(Gst.State.PLAYING)
+    pipeline = pipe
+    print(f"管道已在节点 {node_id} 上启动", file=sys.stderr)
+
+def on_started(response, results):
+    """ScreenCast Start 方法回调，提取第一个流的节点 ID 并启动管道。"""
+    if response == 0:
+        streams = results.get("streams", [])
+        if not streams:
+            die("未从 portal 返回任何流")
+        node_id = str(streams[0][0])
+        start_pipeline(node_id)
+    else:
+        die(f"启动失败，响应代码: {response}")
+
+def on_selected(response, results):
+    """用户选择捕获源后的回调，调用 Start 启动流传输。"""
+    global session
+    if response == 0:
+        h = sc.Start(session, "", {})
+        pending[h] = on_started
+    else:
+        die(f"源选择失败或被取消，响应代码: {response}")
+
+def on_created(response, results):
+    """CreateSession 回调，保存会话句柄并弹出源选择对话框。"""
+    global session
+    if response == 0:
+        session = results["session_handle"]
+        h = sc.SelectSources(
+            session,
+            {
+                "types":       dbus.UInt32(3),   # 屏幕 | 窗口
+                "multiple":    False,
+            },
+        )
+        pending[h] = on_selected
+    else:
+        die(f"创建会话失败，响应代码: {response}")
+
+def init():
+    h = sc.CreateSession({"session_handle_token": "bettergi"})
+    pending[h] = on_created
+
+    def _on_timeout():
+        if h in pending:
+            pending.pop(h)
+            die("Portal 请求超时（选择窗口）")
+        return GLib.SOURCE_REMOVE
+    GLib.timeout_add_seconds(30, _on_timeout)
+
+def handle_exit_signal(signum, frame):
+    """信号处理函数，在主线程中安全退出。"""
+    GLib.idle_add(die, None, 0, priority=GLib.PRIORITY_HIGH)
+
+for sig in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+    signal.signal(sig, handle_exit_signal)
+
+if __name__ == "__main__":
+    loop = GLib.MainLoop()
+    GLib.idle_add(init)
+    loop.run()


### PR DESCRIPTION
## 描述

增加了应用在运行于 wayland 下的 wine 平台的兼容性支持。
此前由于 wayland 的限制， bitblt 无法截屏。

## 修改内容

添加了在 wayland 下的截图方式。仅当检测到运行在 wine 中时启用。

## 测试环境

* **OS**: Gentoo Linux
* **Kernel**: Linux 6.18.32-gentoo-r3
* **WM/DE**: GNOME 48 (Wayland)
* **CPU**: 12th Gen Intel® Core™ i7-12800H
* **GPU**: Intel® Iris® Xe Graphics (ADL GT2)
* **屏幕分辨率**: 1920 $\times$ 1080 (16 : 9)
* **Wine Version**: Spritz-Wine-TKG 11.9-1

完全运行在 wayland 下时，需要添加环境变量 `DISPALY=` 。
否则 wine 仅会运行在 `XWayland` 中

## 使用说明

首先需要选择 Wayland 截图方式，名称为 `Wine (Wayland)`
在 bettergi 中选择进程窗口后，还会弹出系统对话框。
在后一个系统对话框需要手动选择原神的窗口。

## 测试结果

正常截图和运行。
由于 wayland 的限制， mask 窗口完全失效，但是实际上是运行正常的。
可以在终端看到应用的输出。





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 增加原生 Wayland 捕获支持，可在 Wayland 桌面下进行游戏画面采集。
  * 内置并随程序打包了用于 Wayland 捕获的守护进程脚本，用于帧传输与共享内存同步。
* **改进**
  * 优化 Wine 检测：在 Wine 环境下保留并启用 Wayland 捕获选项以提升兼容性与稳定性。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/babalae/better-genshin-impact/pull/3164?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->