### PR TITLE
fix: 修复ClearScript桥接取消异常导致的错误日志

### DIFF
--- a/BetterGenshinImpact/App.xaml.cs
+++ b/BetterGenshinImpact/App.xaml.cs
@@ -309,6 +309,11 @@ public partial class App : Application
                 return true;
             }
 
+            if (ex is ObjectDisposedException ode && ode.ObjectName?.Contains("V8Script") == true)
+            {
+                return true;
+            }
+
             ex = ex.InnerException;
         }
 

--- a/BetterGenshinImpact/Core/Script/Dependence/AutoPathingScript.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/AutoPathingScript.cs
@@ -1,8 +1,9 @@
 using System;
-using BetterGenshinImpact.GameTask.AutoPathing;
-using BetterGenshinImpact.GameTask.AutoPathing.Model;
+using System.Threading;
 using System.Threading.Tasks;
 using BetterGenshinImpact.Core.Config;
+using BetterGenshinImpact.GameTask.AutoPathing;
+using BetterGenshinImpact.GameTask.AutoPathing.Model;
 using BetterGenshinImpact.GameTask.Common;
 using Microsoft.Extensions.Logging;
 
@@ -34,6 +35,10 @@ public class AutoPathingScript
 
             await pathExecutor.Pathing(task);
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception e)
         {
             TaskControl.Logger.LogDebug(e,"执行地图追踪时候发生错误");
@@ -47,6 +52,10 @@ public class AutoPathingScript
         {
             var json = await new LimitedFile(_rootPath).ReadText(path);
             await Run(json);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception e)
         {

--- a/BetterGenshinImpact/Core/Script/Dependence/KeyMouseHook.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/KeyMouseHook.cs
@@ -54,18 +54,38 @@ public class KeyMouseHook: IDisposable
     /// <param name="eventType">事件类型描述</param>
     private void HandleCallbackException(Exception ex, string eventType)
     {
+        bool isCanceled = ex is OperationCanceledException
+            || (ex is ScriptEngineException see && IsTaskCanceledInside(see));
+
         if (ex is ScriptEngineException scriptEx)
         {
-            _logger.LogError("执行{eventType}JS回调时发生错误：{scriptEx.Message}，清除所有回调",eventType, scriptEx.Message); 
-            _logger.LogDebug("{scriptEx}",scriptEx);
+            if (!isCanceled)
+            {
+                _logger.LogError("执行{eventType}JS回调时发生错误：{scriptEx.Message}，清除所有回调",eventType, scriptEx.Message);
+                _logger.LogDebug("{scriptEx}",scriptEx);
+            }
         }
         else
         {
-            _logger.LogError("执行{eventType}回调时发生错误:{ex.Message}，清除所有回调,如果此异常出现在JS脚本结束时,请在JS脚本结束前手动调用Dispose()方法",eventType,ex.Message);
-            _logger.LogDebug("{ex}",ex);
+            if (!isCanceled)
+            {
+                _logger.LogError("执行{eventType}回调时发生错误:{ex.Message}，清除所有回调,如果此异常出现在JS脚本结束时,请在JS脚本结束前手动调用Dispose()方法",eventType,ex.Message);
+                _logger.LogDebug("{ex}",ex);
+            }
         }
 
         Dispose();
+    }
+
+    private static bool IsTaskCanceledInside(Exception ex)
+    {
+        var inner = ex.InnerException;
+        while (inner != null)
+        {
+            if (inner is OperationCanceledException) return true;
+            inner = inner.InnerException;
+        }
+        return false;
     }
     
     /// <summary>

--- a/BetterGenshinImpact/GameTask/TaskRunner.cs
+++ b/BetterGenshinImpact/GameTask/TaskRunner.cs
@@ -94,7 +94,7 @@ public class TaskRunner
         }
         catch (Exception e)
         {
-            if (IsTaskCanceledInside(e))
+            if (e is OperationCanceledException || IsTaskCanceledInside(e))
             {
                 if (RunnerContext.Instance.IsContinuousRunGroup)
                 {
@@ -188,11 +188,11 @@ public class TaskRunner
 
     private static bool IsTaskCanceledInside(Exception ex)
     {
-        var inner = ex.InnerException;
-        while (inner != null)
+        Exception? current = ex;
+        while (current != null)
         {
-            if (inner is OperationCanceledException) return true;
-            inner = inner.InnerException;
+            if (current is OperationCanceledException) return true;
+            current = current.InnerException;
         }
         return false;
     }

--- a/BetterGenshinImpact/GameTask/TaskRunner.cs
+++ b/BetterGenshinImpact/GameTask/TaskRunner.cs
@@ -94,9 +94,19 @@ public class TaskRunner
         }
         catch (Exception e)
         {
-            Notify.Event(NotificationEvent.TaskError).Error("任务执行异常", e);
-            _logger.LogError(e.Message);
-            _logger.LogDebug(e.StackTrace);
+            if (IsTaskCanceledInside(e))
+            {
+                if (RunnerContext.Instance.IsContinuousRunGroup)
+                {
+                    throw;
+                }
+            }
+            else
+            {
+                Notify.Event(NotificationEvent.TaskError).Error("任务执行异常", e);
+                _logger.LogError(e.Message);
+                _logger.LogDebug(e.StackTrace);
+            }
         }
         finally
         {
@@ -168,12 +178,23 @@ public class TaskRunner
                 }
             }
         });
-        VisionContext.Instance().DrawContent.ClearAll(); 
-        
+        VisionContext.Instance().DrawContent.ClearAll();
+
         // 激活原神窗口
         var maskWindow = MaskWindow.Instance();
         SystemControl.ActivateWindow();
         maskWindow.Invoke(maskWindow.Show);
+    }
+
+    private static bool IsTaskCanceledInside(Exception ex)
+    {
+        var inner = ex.InnerException;
+        while (inner != null)
+        {
+            if (inner is OperationCanceledException) return true;
+            inner = inner.InnerException;
+        }
+        return false;
     }
 
     public void End()

--- a/BetterGenshinImpact/Service/ScriptService.cs
+++ b/BetterGenshinImpact/Service/ScriptService.cs
@@ -23,6 +23,7 @@ using BetterGenshinImpact.Service.Interface;
 using BetterGenshinImpact.Service.Notification;
 using BetterGenshinImpact.Service.Notification.Model.Enum;
 using BetterGenshinImpact.ViewModel.Pages;
+using Microsoft.ClearScript;
 using Microsoft.Extensions.Logging;
 
 namespace BetterGenshinImpact.Service;
@@ -359,10 +360,20 @@ public partial class ScriptService : IScriptService
                                 _logger.LogInformation("取消执行配置组: {Msg}", e.Message);
                                 throw;
                             }
+                            catch (OperationCanceledException)
+                            {
+                                throw;
+                            }
                             catch (Exception e)
                             {
-                                _logger.LogDebug(e, "执行脚本时发生异常");
+                                if (IsTaskCanceledInside(e))
+                                {
+                                    _logger.LogInformation("取消执行");
+                                    throw;
+                                }
+
                                 _logger.LogError("执行脚本时发生异常: {Msg}", e.Message);
+                                _logger.LogDebug(e, "执行脚本时发生异常");
                                 if (!RunnerContext.Instance.IsPreExecution && taskProgress != null && taskProgress.CurrentScriptGroupProjectInfo != null)
                                 {
                                     taskProgress.CurrentScriptGroupProjectInfo.Status = 2;
@@ -556,6 +567,24 @@ public partial class ScriptService : IScriptService
         }
 
         return codeList;
+    }
+
+    /// <summary>
+    /// 检查 ScriptEngineException 的内部异常链中是否包含 TaskCanceledException，
+    /// 用于处理 ClearScript Task-Promise 桥接将取消异常包装为 ScriptEngineException 的情况
+    /// </summary>
+    private static bool IsTaskCanceledInside(Exception ex)
+    {
+        var inner = ex.InnerException;
+        while (inner != null)
+        {
+            if (inner is OperationCanceledException)
+            {
+                return true;
+            }
+            inner = inner.InnerException;
+        }
+        return false;
     }
 
     private bool HasTimerOperation(IEnumerable<string> codeList)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 更准确地区分“取消”与真实错误，脚本执行被取消时不再误报为错误
  * 优化异常链识别，处理被包装的取消异常场景并在适当情况下继续抛出
  * 将特定 V8Script 释放相关异常视为可忽略，减少噪声日志
  * 改进任务与钩子清理流程，提升稳定性和可靠性
<!-- end of auto-generated comment: release notes by coderabbit.ai -->