### PR TITLE
fix(state_machine): 区分状态转场等待与当前节点重试

### DIFF
--- a/BetterGenshinImpact/GameTask/Common/StateMachine/README.md
+++ b/BetterGenshinImpact/GameTask/Common/StateMachine/README.md
@@ -117,7 +117,7 @@ private async Task<StateHandlerResult> HandleEventMenu(BvPage page)
 
 | 返回值 | 框架行为 | 典型场景 |
 | --- | --- | --- |
-| `Success` | 动作完成，框架等待当前状态的邻接状态出现；若转场超时，会占用当前状态的 retry 预算 | 点击按钮、发送交互键后等待页面切换 |
+| `Success` | 动作完成，框架等待当前状态的邻接状态出现；如果源状态在动作生效窗口内持续可见，会触发当前状态 retry | 点击按钮、发送交互键后等待页面切换 |
 | `Wait` | 不计 retry，直接进入下一轮检测 | 加载中、动画中、当前状态无需动作 |
 | `Retry` | 当前状态 retry 次数加一，超限后抛异常 | 按钮没找到、OCR 暂时失败、动作没法确认 |
 | `Fail` | 立即抛异常 | 配置错误、关键条件不满足、无法恢复 |
@@ -155,7 +155,7 @@ RegisterStateTransitions(
 - 当前状态有邻接关系时，框架只检测邻接状态。
 - 每个注册的状态转移必须至少有一个邻接状态；结束节点不要注册状态转移。
 - 邻接状态不能包含自身，注册时会直接抛异常。
-- 如果需要在同一页面重试，不要写自环，应该让 Handler 返回 `Retry` 或 `Success` 后转场超时进入 retry。
+- 如果需要在同一页面重试，不要写自环，应该让 Handler 返回 `Retry`，或让 `Success` 后的源状态保持超时触发 retry。
 - `Success` 状态必须有合理的下一跳，否则等待邻接状态会失败并消耗 retry。
 
 候选状态顺序会影响检测优先级。更具体、更不容易误判的状态应放在前面。
@@ -207,7 +207,7 @@ private async Task<StateHandlerResult> HandleTargetPage(BvPage page)
 retry 预算会被两类事件消耗：
 
 - Handler 返回 `Retry`。
-- Handler 返回 `Success`，但等待邻接状态转换超时。
+- Handler 返回 `Success` 后，源状态持续可见并达到动作生效窗口上限。
 
 状态变化后 retry 计数和 retry 计时都会重置。
 
@@ -227,13 +227,22 @@ retry 预算会被两类事件消耗：
 
 例如“找不到活动入口”和“交互秘境入口后没法确认是否已经选中”属于同一类问题：动作可重复，但最终只能靠后续状态检测确认。这类节点更适合设置 `RetryTimeout`。
 
-## 转场超时
+## 转场等待
 
-`DefaultTransitionTimeout` 表示：Handler 返回 `Success` 后，如果仍然停留在原状态，最多等多久。默认是 3000ms。
+`DefaultTransitionTimeout` 表示：Handler 返回 `Success` 后，源状态持续可见多久才认为本次动作没有生效。默认是 3000ms。达到这个窗口上限后，状态机会触发当前状态 retry。
 
-`DefaultIntermediateTransitionTimeout` 表示：如果界面已经离开原状态，但还没到任何邻接目标，最多允许中间态持续多久。默认是 120000ms。这个设计是为了避免游戏加载、传送、黑屏等中间态被短转场超时误判。
+`DefaultIntermediateTransitionTimeout` 表示：如果界面已经离开源状态，但还没到任何邻接目标，最多允许中间态持续多久。默认是 120000ms。这个设计是为了避免游戏加载、传送、黑屏等中间态被短动作窗口误判成当前状态 retry。
 
-可以在节点上覆盖转场超时：
+转场等待会按 `DefaultDetectionInterval` 持续轮询“邻接目标状态 + 源状态”，不会做全量状态检测。这样可以避免 `MainWorld` 这类宽泛状态在秘境入口、地图等场景误命中，导致当前节点本该 retry 的动作被误判成中间态。
+
+等待期间按下面的规则计时：
+
+- 检测到邻接目标状态：立即转换成功。
+- 检测到源状态：说明动作还没有触发转场，动作生效窗口继续计时，中间态长超时重置。
+- 源状态和邻接目标都没检测到：说明可能处于加载、黑屏、动画等中间态，动作生效窗口重置，中间态长超时继续计时。
+- 中间态长超时：直接抛出中间态转换超时异常，不计入当前源状态的 retry 预算。
+
+可以在节点上覆盖动作生效窗口：
 
 ```csharp
 [StateHandler(MyState.TeleportMap, TransitionTimeout = 10000)]
@@ -264,7 +273,7 @@ if (CurrentStateRetryCount > 3)
 | `CurrentStateRetryTimeout` | 当前状态的时间上限，使用次数策略时为 null |
 | `CurrentStateRetryUsesTimeout` | 当前状态是否使用时间策略 |
 | `CurrentStateRetryInterval` | 当前状态 retry 后的循环间隔 |
-| `CurrentStateTransitionTimeout` | 当前状态等待邻接状态的转场超时 |
+| `CurrentStateTransitionTimeout` | 当前状态源状态保持多久后触发 retry |
 
 这些属性都是只读保护属性，节点不能直接改框架内部计数。
 

--- a/BetterGenshinImpact/GameTask/Common/StateMachine/README.md
+++ b/BetterGenshinImpact/GameTask/Common/StateMachine/README.md
@@ -273,7 +273,7 @@ if (CurrentStateRetryCount > 3)
 | `CurrentStateRetryTimeout` | 当前状态的时间上限，使用次数策略时为 null |
 | `CurrentStateRetryUsesTimeout` | 当前状态是否使用时间策略 |
 | `CurrentStateRetryInterval` | 当前状态 retry 后的循环间隔 |
-| `CurrentStateTransitionTimeout` | 当前状态源状态保持多久后触发 retry |
+| `CurrentStateTransitionTimeout` | 仅在当前状态 Handler 返回 `Success` 后生效；从 `Success` 返回后开始计时，源状态持续可见超过此时长会触发 retry |
 
 这些属性都是只读保护属性，节点不能直接改框架内部计数。
 

--- a/BetterGenshinImpact/GameTask/Common/StateMachine/StateMachineBase.cs
+++ b/BetterGenshinImpact/GameTask/Common/StateMachine/StateMachineBase.cs
@@ -18,7 +18,7 @@ using static TaskControl;
 public enum StateHandlerResult
 {
     /// <summary>
-    /// 成功：操作完成，状态机自动等待邻接状态转换；转场超时会占用当前状态的重试次数
+    /// 成功：操作完成，状态机自动等待邻接状态转换；源状态持续可见超过动作生效窗口后触发当前状态重试
     /// </summary>
     Success,
 
@@ -81,7 +81,7 @@ public sealed class StateHandlerAttribute(object state) : Attribute
     public int RetryInterval { get; set; } = -1;
 
     /// <summary>
-    /// 当前状态 Handler 返回 Success 后等待邻接状态转换的超时时间（毫秒）。
+    /// 当前状态 Handler 返回 Success 后，源状态持续可见多久才触发当前状态重试（毫秒）。
     /// </summary>
     public int TransitionTimeout { get; set; } = -1;
 }
@@ -116,6 +116,20 @@ public sealed class UnknownStateHandlerAttribute : Attribute
 /// </summary>
 public abstract class StateMachineBase<TState, TContext> where TState : struct, Enum
 {
+    private enum StateTransitionWaitStatus
+    {
+        ReachedTarget,
+        RetryCurrentState,
+        IntermediateTimeout
+    }
+
+    private readonly struct StateTransitionWaitResult(StateTransitionWaitStatus status, TState state = default)
+    {
+        public StateTransitionWaitStatus Status { get; } = status;
+
+        public TState State { get; } = state;
+    }
+
     /// <summary>
     /// 由子类实现以提供 Logger
     /// </summary>
@@ -154,7 +168,7 @@ public abstract class StateMachineBase<TState, TContext> where TState : struct, 
     protected int CurrentStateRetryInterval { get; private set; }
 
     /// <summary>
-    /// 当前状态 Handler 返回 Success 后等待邻接状态转换的超时时间（毫秒）。
+    /// 当前状态 Handler 返回 Success 后，源状态持续可见多久才触发当前状态重试（毫秒）。
     /// </summary>
     protected int CurrentStateTransitionTimeout { get; private set; }
 
@@ -191,7 +205,7 @@ public abstract class StateMachineBase<TState, TContext> where TState : struct, 
     private readonly Dictionary<TState, int> _stateRetryIntervals = new();
 
     /// <summary>
-    /// 状态转换超时表 - 未注册时使用默认状态转换超时
+    /// 源状态保持超时表 - 未注册时使用默认源状态保持超时
     /// </summary>
     private readonly Dictionary<TState, int> _stateTransitionTimeouts = new();
 
@@ -206,7 +220,7 @@ public abstract class StateMachineBase<TState, TContext> where TState : struct, 
     protected virtual int DefaultDetectionInterval => 300;
 
     /// <summary>
-    /// 默认状态转换超时（毫秒）
+    /// 默认源状态保持超时（毫秒）
     /// </summary>
     protected virtual int DefaultTransitionTimeout => 3000;
 
@@ -534,13 +548,13 @@ public abstract class StateMachineBase<TState, TContext> where TState : struct, 
     }
 
     /// <summary>
-    /// 注册指定状态 Handler 返回 Success 后等待邻接状态转换的超时时间。
+    /// 注册指定状态 Handler 返回 Success 后，源状态持续可见多久才触发当前状态重试。
     /// </summary>
     protected void RegisterStateTransitionTimeout(TState state, int timeoutMs)
     {
         if (timeoutMs <= 0)
         {
-            throw new ArgumentOutOfRangeException(nameof(timeoutMs), "状态转换超时时间必须大于 0");
+            throw new ArgumentOutOfRangeException(nameof(timeoutMs), "源状态保持超时时间必须大于 0");
         }
 
         _stateTransitionTimeouts[state] = timeoutMs;
@@ -617,7 +631,7 @@ public abstract class StateMachineBase<TState, TContext> where TState : struct, 
     /// <param name="targetStates">目标状态（到达任一即停止）</param>
     /// <param name="maxIterations">最大迭代次数（防止无限循环）</param>
     /// <param name="maxRetries">默认单个状态最大重试次数，可通过 RegisterStateRetryLimit 覆盖指定状态</param>
-    /// <exception cref="InvalidOperationException">Handler 返回 Fail、重试超限、转场超时超限或达到最大迭代次数时抛出</exception>
+    /// <exception cref="InvalidOperationException">Handler 返回 Fail、重试超限、中间态等待超时或达到最大迭代次数时抛出</exception>
     protected async Task RunStateMachineUntil(TContext context, TState[] targetStates, int maxIterations = 1000, int maxRetries = 5)
     {
         Logger.LogInformation("========== 状态机启动，目标状态：{Targets} ==========",
@@ -671,17 +685,22 @@ public abstract class StateMachineBase<TState, TContext> where TState : struct, 
                 switch (result)
                 {
                     case StateHandlerResult.Success:
-                        // 成功：等待邻接状态转换；转场超时视为当前状态的一次重试
-                        var nextState = await EnsureNextStateTransition(transitionTimeout);
-                        if (EqualityComparer<TState>.Default.Equals(nextState, default))
+                        // 成功：等待邻接状态转换；源状态持续可见超过动作生效窗口时触发当前状态重试
+                        var transitionResult = await WaitNextStateTransition(transitionTimeout);
+                        switch (transitionResult.Status)
                         {
-                            RecordStateRetry("等待邻接状态转换超时", retryPolicy, stateRetryStopwatch);
-                            nextLoopInterval = retryInterval;
-                        }
-                        else
-                        {
-                            CurrentStateRetryCount = 0; // 成功转换后重置重试计数
-                            stateRetryStopwatch.Restart();
+                            case StateTransitionWaitStatus.ReachedTarget:
+                                CurrentStateRetryCount = 0; // 成功转换后重置重试计数
+                                stateRetryStopwatch.Restart();
+                                break;
+
+                            case StateTransitionWaitStatus.RetryCurrentState:
+                                RecordStateRetry("源状态持续可见，触发当前状态重试", retryPolicy, stateRetryStopwatch);
+                                nextLoopInterval = retryInterval;
+                                break;
+
+                            case StateTransitionWaitStatus.IntermediateTimeout:
+                                throw new InvalidOperationException($"状态 {CurrentState} 等待中间态转换超时");
                         }
                         break;
 
@@ -831,21 +850,21 @@ public abstract class StateMachineBase<TState, TContext> where TState : struct, 
     /// <summary>
     /// 等待任一目标状态出现（内部方法）
     /// </summary>
-    /// <param name="expectedStates">可接受的目标状态数组</param>
+    /// <param name="observedStates">可观察状态数组，应包含源状态和可接受的目标状态</param>
     /// <param name="timeoutMs">超时时间（毫秒）</param>
-    /// <returns>转换到的状态，如果超时则返回 default</returns>
-    private async Task<TState> EnsureAnyStateTransition(TState[] expectedStates, int? timeoutMs = null)
+    /// <returns>转换等待结果</returns>
+    private async Task<StateTransitionWaitResult> WaitAnyStateTransition(TState[] observedStates, int? timeoutMs = null)
     {
         var timeout = timeoutMs ?? DefaultTransitionTimeout;
         var sourceState = CurrentState;
-        var transitionTargetStates = expectedStates
+        var transitionTargetStates = observedStates
             .Where(state => !EqualityComparer<TState>.Default.Equals(state, sourceState))
             .ToArray();
 
         if (transitionTargetStates.Length == 0)
         {
             Logger.LogWarning("状态 {State} 没有可等待的非自身邻接状态", sourceState);
-            return default;
+            return new StateTransitionWaitResult(StateTransitionWaitStatus.RetryCurrentState);
         }
 
         var sourceVisibleStopwatch = Stopwatch.StartNew();
@@ -857,17 +876,16 @@ public abstract class StateMachineBase<TState, TContext> where TState : struct, 
         {
             _ct.ThrowIfCancellationRequested();
 
-            // 只检测期望的状态
-            var currentState = DetectStateAmong(transitionTargetStates);
+            // 只检测目标状态和源状态
+            var currentState = DetectStateAmong(observedStates);
             if (transitionTargetStates.Contains(currentState))
             {
                 CurrentState = currentState;
                 Logger.LogDebug("状态转换成功：{State}", currentState);
-                return currentState;
+                return new StateTransitionWaitResult(StateTransitionWaitStatus.ReachedTarget, currentState);
             }
 
-            var detectedState = DetectCurrentState();
-            if (EqualityComparer<TState>.Default.Equals(detectedState, sourceState))
+            if (EqualityComparer<TState>.Default.Equals(currentState, sourceState))
             {
                 intermediateStopwatch.Restart();
             }
@@ -881,15 +899,16 @@ public abstract class StateMachineBase<TState, TContext> where TState : struct, 
 
         if (sourceVisibleStopwatch.ElapsedMilliseconds >= timeout)
         {
-            Logger.LogWarning("状态转换超时，期望任一：{Expected}，当前仍停留在原状态：{Current}",
-                string.Join(",", transitionTargetStates), sourceState);
+            Logger.LogWarning("源状态 {State} 持续可见超过 {Timeout} ms，触发当前状态重试，期望任一：{Expected}",
+                sourceState, timeout, string.Join(",", transitionTargetStates));
+            return new StateTransitionWaitResult(StateTransitionWaitStatus.RetryCurrentState);
         }
         else
         {
-            Logger.LogWarning("状态转换超时，期望任一：{Expected}，中间态等待超过 {Timeout} ms，当前：{Current}",
-                string.Join(",", transitionTargetStates), intermediateTimeout, DetectCurrentState());
+            Logger.LogWarning("中间态等待超过 {Timeout} ms，期望任一：{Expected}",
+                intermediateTimeout, string.Join(",", transitionTargetStates));
+            return new StateTransitionWaitResult(StateTransitionWaitStatus.IntermediateTimeout);
         }
-        return default;
     }
 
     /// <summary>
@@ -897,17 +916,33 @@ public abstract class StateMachineBase<TState, TContext> where TState : struct, 
     /// 自动使用当前状态注册的邻接状态作为期望状态
     /// </summary>
     /// <param name="timeoutMs">超时时间（毫秒）</param>
-    /// <returns>转换到的状态，如果没有注册邻接状态则返回 default</returns>
-    protected async Task<TState> EnsureNextStateTransition(int? timeoutMs = null)
+    /// <returns>转换等待结果</returns>
+    private async Task<StateTransitionWaitResult> WaitNextStateTransition(int? timeoutMs = null)
     {
         var possibleStates = GetPossibleNextStates();
         if (possibleStates == null || possibleStates.Length == 0)
         {
             Logger.LogWarning("当前状态 {State} 没有注册邻接状态，无法确定期望状态", CurrentState);
-            return default;
+            return new StateTransitionWaitResult(StateTransitionWaitStatus.RetryCurrentState);
         }
 
-        return await EnsureAnyStateTransition(possibleStates, timeoutMs);
+        var observedStates = possibleStates
+            .Concat(new[] { CurrentState })
+            .Distinct()
+            .ToArray();
+        return await WaitAnyStateTransition(observedStates, timeoutMs);
+    }
+
+    /// <summary>
+    /// 等待转换到邻接状态（使用状态转换关系）
+    /// 自动使用当前状态注册的邻接状态作为期望状态
+    /// </summary>
+    /// <param name="timeoutMs">超时时间（毫秒）</param>
+    /// <returns>转换到的状态，如果没有注册邻接状态或等待超时则返回 default</returns>
+    protected async Task<TState> EnsureNextStateTransition(int? timeoutMs = null)
+    {
+        var result = await WaitNextStateTransition(timeoutMs);
+        return result.Status == StateTransitionWaitStatus.ReachedTarget ? result.State : default;
     }
 
     #endregion

--- a/BetterGenshinImpact/GameTask/Common/StateMachine/StateMachineBase.cs
+++ b/BetterGenshinImpact/GameTask/Common/StateMachine/StateMachineBase.cs
@@ -938,7 +938,7 @@ public abstract class StateMachineBase<TState, TContext> where TState : struct, 
     /// 自动使用当前状态注册的邻接状态作为期望状态
     /// </summary>
     /// <param name="timeoutMs">超时时间（毫秒）</param>
-    /// <returns>转换到的状态，如果没有注册邻接状态或等待超时则返回 default</returns>
+    /// <returns>转换到的状态；没有注册邻接状态、源状态保持超时或中间态等待超时时返回 default</returns>
     protected async Task<TState> EnsureNextStateTransition(int? timeoutMs = null)
     {
         var result = await WaitNextStateTransition(timeoutMs);


### PR DESCRIPTION
- 转场等待仅检测源状态和邻接目标，避免宽泛状态误命中
- 区分目标命中、源状态保持超时和中间态超时
- 源状态持续可见时触发当前节点重试，中间态长等不占用 retry 预算
- 更新状态机文档说明动作生效窗口和中间态等待语义

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **文档**
  * 澄清并扩展了状态机中“成功”“重试”与“转换等待”的语义说明，新增关于同页面重试规则和等待行为的说明以及相关超时说明。

* **改进**
  * 优化了状态转换等待与重试处理流程，增加更细化的等待/重置/超时判定与示例，提升任务执行稳定性与状态转换准确性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->