### PR TITLE
fix: HDR模式下传送选项文字识别失败

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoTrackPath/TpTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoTrackPath/TpTask.cs
@@ -1114,8 +1114,9 @@ public class TpTask
                 using var ra = imageRegion.DeriveCrop(_assets.MapChooseIconRoi.X + iconRect.X + iconRect.Width, _assets.MapChooseIconRoi.Y + iconRect.Y - 8, 200, iconRect.Height + 16);
                 using var textRegion = ra.Find(new RecognitionObject
                 {
-                    RecognitionType = isHdrCapture ? RecognitionTypes.Ocr : RecognitionTypes.ColorRangeAndOcr,
-                    LowerColor = new Scalar(249, 249, 249), // 只取白色文字
+                    // RecognitionType = RecognitionTypes.Ocr,
+                    RecognitionType = RecognitionTypes.ColorRangeAndOcr,
+                    LowerColor = isHdrCapture ? new Scalar(235, 235, 235) : new Scalar(249, 249, 249),
                     UpperColor = new Scalar(255, 255, 255),
                 });
                 if (string.IsNullOrEmpty(textRegion.Text) || textRegion.Text.Length == 1)

--- a/BetterGenshinImpact/GameTask/QuickTeleport/QuickTeleportTrigger.cs
+++ b/BetterGenshinImpact/GameTask/QuickTeleport/QuickTeleportTrigger.cs
@@ -143,8 +143,9 @@ internal class QuickTeleportTrigger : ITaskTrigger
                 using var ra = content.CaptureRectArea.DeriveCrop(_assets.MapChooseIconRoi.X + iconRect.X + iconRect.Width, _assets.MapChooseIconRoi.Y + iconRect.Y - 8, 200, iconRect.Height + 16);
                 using var textRegion = ra.Find(new RecognitionObject
                 {
-                    RecognitionType = isHdrCapture ? RecognitionTypes.Ocr : RecognitionTypes.ColorRangeAndOcr,
-                    LowerColor = new Scalar(249, 249, 249), // 只取白色文字
+                    // RecognitionType = RecognitionTypes.Ocr,
+                    RecognitionType = RecognitionTypes.ColorRangeAndOcr,
+                    LowerColor = isHdrCapture ? new Scalar(235, 235, 235) : new Scalar(249, 249, 249),
                     UpperColor = new Scalar(255, 255, 255),
                 });
                 if (string.IsNullOrEmpty(textRegion.Text) || textRegion.Text.Length == 1)


### PR DESCRIPTION
## 问题

WGC HDR 捕获模式下，传送点选项中的白色文字无法被检测到，导致快捷传送和大地图传送功能失效。

### 根因分析

**1. 颜色阈值过紧**

实测 WGC HDR 下白色文字颜色：
- 正常情况约 **#F7F7F7**（RGB 247, 247, 247）
- 极端情况（游戏注册表未开 HDR 但使用了 WGC HDR 截图器）约 **#F0F0F0**（RGB 240, 240, 240）

实测当前代码 SDR 阈值 `LowerColor = Scalar(249, 249, 249)` 连 247 都兜不住，更不用说 240。
看起来我在 #3134 中的阈值相关代码没有被保留，在bgi更新之后我发现自动传送再次无法正常使用，故重新发起pr。

**2. 纯 OCR 在 HDR 下误检严重**

当前 HDR 模式使用的是 `RecognitionTypes.Ocr`（无颜色预过滤），直接对地图背景做 OCR，复杂背景下误检率极高，基本不可用。

## 修复

两个文件统一策略：

```csharp
// 始终使用 ColorRangeAndOcr，根据捕获模式动态调整阈值
RecognitionType = RecognitionTypes.ColorRangeAndOcr,
LowerColor = isHdrCapture ? new Scalar(235, 235, 235) : new Scalar(249, 249, 249),
UpperColor = new Scalar(255, 255, 255),
```
Fixes #3133 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化了传送点/地图选项的识别逻辑，在 HDR 与非 HDR 截图模式下使用更稳定的文字识别过滤阈值。
  * 提升了不同画面模式下的识别一致性，减少选项识别失败或误判。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->