### PR TITLE
fix: HTML遮罩在不同DPI下位置不一致

### DIFF
--- a/BetterGenshinImpact/View/HtmlMaskWindow.xaml.cs
+++ b/BetterGenshinImpact/View/HtmlMaskWindow.xaml.cs
@@ -11,6 +11,7 @@ using static Vanara.PInvoke.User32;
 using BetterGenshinImpact.Core.Script.Dependence;
 using BetterGenshinImpact.GameTask;
 using BetterGenshinImpact.GameTask.Common;
+using BetterGenshinImpact.Helpers;
 using Microsoft.Extensions.Logging;
 using Microsoft.Web.WebView2.Core;
 
@@ -434,12 +435,13 @@ public partial class HtmlMaskWindow : Window
             var currentRect = SystemControl.GetCaptureRect(gameHandle);
             if (currentRect.Width <= 0 || currentRect.Height <= 0) return;
 
+            var dpiScale = DpiHelper.GetScale(gameHandle);
             Dispatcher.Invoke(() =>
             {
-                Left = currentRect.Left;
-                Top = currentRect.Top;
-                Width = currentRect.Width;
-                Height = currentRect.Height;
+                Left = currentRect.Left / dpiScale.X;
+                Top = currentRect.Top / dpiScale.Y;
+                Width = currentRect.Width / dpiScale.X;
+                Height = currentRect.Height / dpiScale.Y;
             });
         }
         catch (Exception ex)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 发布说明

* **错误修复**
  * 修复遮罩窗口在高DPI显示器上的位置和尺寸显示问题，确保窗口能够正确自适配不同DPI缩放设置。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->