### PR TITLE
适配 Starward 全屏自定义分辨率捕获坐标空间

### DIFF
--- a/BetterGenshinImpact/App.xaml.cs
+++ b/BetterGenshinImpact/App.xaml.cs
@@ -9,6 +9,7 @@ using BetterGenshinImpact.Core.Recognition.OCR;
 using BetterGenshinImpact.Core.Recognition.ONNX;
 using BetterGenshinImpact.GameTask;
 using BetterGenshinImpact.Helpers;
+using BetterGenshinImpact.Helpers.DpiAwareness;
 using BetterGenshinImpact.Helpers.Extensions;
 using BetterGenshinImpact.Helpers.Win32;
 using BetterGenshinImpact.Hutao;
@@ -211,6 +212,7 @@ public partial class App : Application
     /// </summary>
     protected override async void OnStartup(StartupEventArgs e)
     {
+        DpiAwarenessInitializer.InitializeSystemAware();
         Process.GetCurrentProcess().PriorityClass = ProcessPriorityClass.Normal;
         // Wine 平台适配
         WinePlatformAddon.ApplyApplicationConfig();

--- a/BetterGenshinImpact/AssemblyInfo.cs
+++ b/BetterGenshinImpact/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 using System.Windows;
 using System.Windows.Media;
 
-[assembly: DisableDpiAwareness]
 [assembly: ThemeInfo(ResourceDictionaryLocation.None, ResourceDictionaryLocation.SourceAssembly)]

--- a/BetterGenshinImpact/GameTask/AutoMusicGame/AutoMusicGameTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoMusicGame/AutoMusicGameTask.cs
@@ -60,7 +60,7 @@ public class AutoMusicGameTask(AutoMusicGameParam taskParam) : ISoloTask
             var taskList = new List<Task>();
 
             // 计算按键位置
-            var gameCaptureRegion = CaptureToRectArea();
+            using var gameCaptureRegion = CaptureToRectArea();
 
             foreach (var keyValuePair in _keyX)
             {

--- a/BetterGenshinImpact/GameTask/AutoMusicGame/AutoMusicGameTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoMusicGame/AutoMusicGameTask.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using BetterGenshinImpact.GameTask.Model;
 using BetterGenshinImpact.Helpers;
 using Vanara.PInvoke;
 using static BetterGenshinImpact.GameTask.Common.TaskControl;
@@ -244,9 +245,62 @@ public class AutoMusicGameTask(AutoMusicGameParam taskParam) : ISoloTask
 
     public static void LogScreenResolution()
     {
-        AssertUtils.CheckGameResolution("自动音游");
+        CheckAutoMusicGameResolution();
 
         Logger.LogInformation("{Name}：回到游戏主界面时记得关闭自动音游任务！", "千音雅集");
         Logger.LogWarning("{Name}：默认的样式“轻漾涟漪”是{No}的！需要手动完成几首曲目获得{Money}千音币后兑换并使用胡桃样式“{Hutao}”！", "千音雅集", "不可用", 600, "疏影引蝶映梅红");
+    }
+
+    public static RECT GetEffectiveGameScreenSizeFromRawCaptureRect(RECT rawCaptureRect)
+    {
+        var contentSpace = CaptureGeometry.FromRawCaptureRect(rawCaptureRect).ContentSpace;
+        return new RECT(0, 0, contentSpace.Width, contentSpace.Height);
+    }
+
+    public static RECT GetEffectiveGameScreenSizeFromSystemInfo(ISystemInfo systemInfo)
+    {
+        return systemInfo.GameScreenSize;
+    }
+
+    private static void CheckAutoMusicGameResolution()
+    {
+        var (effectiveGameScreenSize, rawCaptureRect, source) = ResolveAutoMusicGameResolution();
+        if (!AssertUtils.IsGameResolution16X9(effectiveGameScreenSize))
+        {
+            Logger.LogError(
+                "游戏窗口分辨率不是 16:9 ！当前有效内容区为 {Width}x{Height}，原始捕获区域为 {RawWidth}x{RawHeight}，来源 {Source}，非 16:9 分辨率的游戏无法正常使用自动音游功能 !",
+                effectiveGameScreenSize.Width,
+                effectiveGameScreenSize.Height,
+                rawCaptureRect.Width,
+                rawCaptureRect.Height,
+                source);
+            throw new Exception("游戏窗口分辨率不是 16:9");
+        }
+
+        if (rawCaptureRect.Width != effectiveGameScreenSize.Width || rawCaptureRect.Height != effectiveGameScreenSize.Height)
+        {
+            Logger.LogInformation(
+                "自动音游使用有效内容区 {Width}x{Height}（原始捕获 {RawWidth}x{RawHeight}，来源 {Source}）",
+                effectiveGameScreenSize.Width,
+                effectiveGameScreenSize.Height,
+                rawCaptureRect.Width,
+                rawCaptureRect.Height,
+                source);
+        }
+    }
+
+    private static (RECT EffectiveGameScreenSize, RECT RawCaptureRect, string Source) ResolveAutoMusicGameResolution()
+    {
+        var taskContext = TaskContext.Instance();
+        if (taskContext is { IsInitialized: true, SystemInfo: not null })
+        {
+            var systemInfo = taskContext.SystemInfo;
+            var rawCaptureRect = systemInfo.CaptureGeometry?.RawCaptureRect
+                                 ?? new RECT(0, 0, systemInfo.GameScreenSize.Width, systemInfo.GameScreenSize.Height);
+            return (GetEffectiveGameScreenSizeFromSystemInfo(systemInfo), rawCaptureRect, "SystemInfo");
+        }
+
+        var rawCaptureRectFromWindow = SystemControl.GetCaptureRect(taskContext.GameHandle);
+        return (GetEffectiveGameScreenSizeFromRawCaptureRect(rawCaptureRectFromWindow), rawCaptureRectFromWindow, "RawCaptureRect");
     }
 }

--- a/BetterGenshinImpact/GameTask/CaptureContent.cs
+++ b/BetterGenshinImpact/GameTask/CaptureContent.cs
@@ -1,7 +1,8 @@
-﻿using BetterGenshinImpact.GameTask.Model.Area;
-using System;
 using BetterGenshinImpact.GameTask.Common.BgiVision;
+using BetterGenshinImpact.GameTask.Model.Area;
 using OpenCvSharp;
+using System;
+using System.Collections.Generic;
 
 namespace BetterGenshinImpact.GameTask;
 
@@ -18,7 +19,8 @@ public class CaptureContent : IDisposable
     public int FrameRate => (int)(1000 / TimerInterval);
 
     public ImageRegion CaptureRectArea { get; }
-    
+    private readonly List<ImageRegion> _ownedRegions = [];
+
     public GameUiCategory CurrentGameUiCategory;
 
     public CaptureContent(Mat image, int frameIndex, double interval)
@@ -26,9 +28,20 @@ public class CaptureContent : IDisposable
         FrameIndex = frameIndex;
         TimerInterval = interval;
         var systemInfo = TaskContext.Instance().SystemInfo;
+        var geometry = systemInfo.CaptureGeometry;
 
-        var gameCaptureRegion = systemInfo.DesktopRectArea.Derive(image, systemInfo.CaptureAreaRect.X, systemInfo.CaptureAreaRect.Y);
-        CaptureRectArea = gameCaptureRegion.DeriveTo1080P();
+        var rawCaptureRegion = systemInfo.DesktopRectArea.Derive(image, geometry.RawCaptureRect.X, geometry.RawCaptureRect.Y);
+        AddOwnedRegion(rawCaptureRegion);
+
+        ImageRegion contentRegion = rawCaptureRegion;
+        if (!geometry.ContentSpace.Equals(geometry.CaptureSpace))
+        {
+            contentRegion = rawCaptureRegion.DeriveCrop(geometry.ContentSpace);
+            AddOwnedRegion(contentRegion);
+        }
+
+        CaptureRectArea = contentRegion.DeriveTo1080P();
+        AddOwnedRegion(CaptureRectArea);
     }
 
     /// <summary>
@@ -38,11 +51,24 @@ public class CaptureContent : IDisposable
     public CaptureContent(ImageRegion ra)
     {
         CaptureRectArea = ra;
+        AddOwnedRegion(ra);
     }
 
     public void Dispose()
     {
-        CaptureRectArea.Dispose();
+        for (var i = _ownedRegions.Count - 1; i >= 0; i--)
+        {
+            _ownedRegions[i].Dispose();
+        }
+
         GC.SuppressFinalize(this);
+    }
+
+    private void AddOwnedRegion(ImageRegion region)
+    {
+        if (!_ownedRegions.Contains(region))
+        {
+            _ownedRegions.Add(region);
+        }
     }
 }

--- a/BetterGenshinImpact/GameTask/GameTaskManager.cs
+++ b/BetterGenshinImpact/GameTask/GameTaskManager.cs
@@ -213,7 +213,12 @@ internal class GameTaskManager
                 assetScale = 1;
             }
 
-            mat = ResizeHelper.Resize(mat, assetScale);
+            var resizedMat = ResizeHelper.Resize(mat, assetScale);
+            if (!ReferenceEquals(resizedMat, mat))
+            {
+                mat.Dispose();
+                mat = resizedMat;
+            }
         }
 
         return mat;

--- a/BetterGenshinImpact/GameTask/GameTaskManager.cs
+++ b/BetterGenshinImpact/GameTask/GameTaskManager.cs
@@ -17,7 +17,9 @@ using BetterGenshinImpact.GameTask.Placeholder;
 using BetterGenshinImpact.GameTask.QuickSereniteaPot.Assets;
 using BetterGenshinImpact.GameTask.QuickTeleport.Assets;
 using BetterGenshinImpact.View.Drawable;
+using Microsoft.Extensions.Logging;
 using OpenCvSharp;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
@@ -31,6 +33,8 @@ namespace BetterGenshinImpact.GameTask;
 
 internal class GameTaskManager
 {
+    private static readonly ILogger<GameTaskManager> Logger = App.GetLogger<GameTaskManager>();
+
     public static ConcurrentDictionary<string, ITaskTrigger>? TriggerDictionary { get; set; }
 
     /// <summary>
@@ -189,12 +193,34 @@ internal class GameTaskManager
             throw new FileNotFoundException($"未找到{featName}中的{assertName}文件");
         }
 
-        var mat = Mat.FromStream(File.OpenRead(filePath), flags);
+        using var assetStream = File.OpenRead(filePath);
+        var mat = Mat.FromStream(assetStream, flags);
+        if (mat.Empty())
+        {
+            throw new InvalidDataException($"读取素材图片失败: {filePath}");
+        }
+
         if (systemInfo.GameScreenSize.Width != 1920)
         {
-            mat = ResizeHelper.Resize(mat, systemInfo.AssetScale);
+            var assetScale = systemInfo.AssetScale;
+            if (!IsValidScale(assetScale))
+            {
+                Logger.LogWarning(
+                    "素材缩放比例无效，使用 1 跳过缩放。当前内容尺寸: {W}x{H}, AssetScale: {AssetScale}",
+                    systemInfo.GameScreenSize.Width,
+                    systemInfo.GameScreenSize.Height,
+                    assetScale);
+                assetScale = 1;
+            }
+
+            mat = ResizeHelper.Resize(mat, assetScale);
         }
 
         return mat;
+    }
+
+    private static bool IsValidScale(double scale)
+    {
+        return scale > 0 && !double.IsNaN(scale) && !double.IsInfinity(scale);
     }
 }

--- a/BetterGenshinImpact/GameTask/Model/Area/GameCaptureRegion.cs
+++ b/BetterGenshinImpact/GameTask/Model/Area/GameCaptureRegion.cs
@@ -58,26 +58,6 @@ public class GameCaptureRegion(Mat mat, int initX, int initY, Region? owner = nu
     // }
 
     /// <summary>
-    /// 游戏窗口初始截图大于1080P的统一转换到1080P
-    /// </summary>
-    /// <returns></returns>
-    public ImageRegion DeriveTo1080P()
-    {
-        if (Width <= 1920)
-        {
-            return this;
-        }
-
-        var scale = Width / 1920d;
-
-        var newMat = new Mat();
-        Cv2.Resize(SrcMat, newMat, new Size(1920, Height / scale));
-        Dispose();
-        return new ImageRegion(newMat, 0, 0, this, new ScaleConverter(scale));
-        // return new ImageRegion(newMat, 0, 0, this, new TranslationConverter(0, 0));
-    }
-
-    /// <summary>
     /// 静态方法,在游戏窗体捕获区域维度进行点击
     /// </summary>
     /// <param name="posFunc">
@@ -88,25 +68,25 @@ public class GameCaptureRegion(Mat mat, int initX, int initY, Region? owner = nu
     /// </param>
     public static void GameRegionClick(Func<Size, double, (double, double)> posFunc)
     {
-        var captureAreaRect = TaskContext.Instance().SystemInfo.CaptureAreaRect;
-        var assetScale = TaskContext.Instance().SystemInfo.ScaleTo1080PRatio;
-        var (cx, cy) = posFunc(new Size(captureAreaRect.Width, captureAreaRect.Height), assetScale);
-        DesktopRegion.DesktopRegionClick(captureAreaRect.X + cx, captureAreaRect.Y + cy);
+        var contentRect = TaskContext.Instance().SystemInfo.CaptureAreaRect;
+        var scaleTo1080P = TaskContext.Instance().SystemInfo.ScaleTo1080PRatio;
+        var (cx, cy) = posFunc(new Size(contentRect.Width, contentRect.Height), scaleTo1080P);
+        DesktopRegion.DesktopRegionClick(contentRect.X + cx, contentRect.Y + cy);
     }
 
     public static void GameRegionMove(Func<Size, double, (double, double)> posFunc)
     {
-        var captureAreaRect = TaskContext.Instance().SystemInfo.CaptureAreaRect;
-        var assetScale = TaskContext.Instance().SystemInfo.ScaleTo1080PRatio;
-        var (cx, cy) = posFunc(new Size(captureAreaRect.Width, captureAreaRect.Height), assetScale);
-        DesktopRegion.DesktopRegionMove(captureAreaRect.X + cx, captureAreaRect.Y + cy);
+        var contentRect = TaskContext.Instance().SystemInfo.CaptureAreaRect;
+        var scaleTo1080P = TaskContext.Instance().SystemInfo.ScaleTo1080PRatio;
+        var (cx, cy) = posFunc(new Size(contentRect.Width, contentRect.Height), scaleTo1080P);
+        DesktopRegion.DesktopRegionMove(contentRect.X + cx, contentRect.Y + cy);
     }
 
     public static void GameRegionMoveBy(Func<Size, double, (double, double)> deltaFunc)
     {
-        var captureAreaRect = TaskContext.Instance().SystemInfo.CaptureAreaRect;
-        var assetScale = TaskContext.Instance().SystemInfo.ScaleTo1080PRatio;
-        var (dx, dy) = deltaFunc(new Size(captureAreaRect.Width, captureAreaRect.Height), assetScale);
+        var contentRect = TaskContext.Instance().SystemInfo.CaptureAreaRect;
+        var scaleTo1080P = TaskContext.Instance().SystemInfo.ScaleTo1080PRatio;
+        var (dx, dy) = deltaFunc(new Size(contentRect.Width, contentRect.Height), scaleTo1080P);
         DesktopRegion.DesktopRegionMoveBy(dx, dy);
     }
 

--- a/BetterGenshinImpact/GameTask/Model/Area/GameCaptureRegion.cs
+++ b/BetterGenshinImpact/GameTask/Model/Area/GameCaptureRegion.cs
@@ -68,25 +68,25 @@ public class GameCaptureRegion(Mat mat, int initX, int initY, Region? owner = nu
     /// </param>
     public static void GameRegionClick(Func<Size, double, (double, double)> posFunc)
     {
-        var contentRect = TaskContext.Instance().SystemInfo.CaptureAreaRect;
-        var scaleTo1080P = TaskContext.Instance().SystemInfo.ScaleTo1080PRatio;
-        var (cx, cy) = posFunc(new Size(contentRect.Width, contentRect.Height), scaleTo1080P);
-        DesktopRegion.DesktopRegionClick(contentRect.X + cx, contentRect.Y + cy);
+        var captureAreaRect = TaskContext.Instance().SystemInfo.CaptureAreaRect;
+        var assetScale = TaskContext.Instance().SystemInfo.ScaleTo1080PRatio;
+        var (cx, cy) = posFunc(new Size(captureAreaRect.Width, captureAreaRect.Height), assetScale);
+        DesktopRegion.DesktopRegionClick(captureAreaRect.X + cx, captureAreaRect.Y + cy);
     }
 
     public static void GameRegionMove(Func<Size, double, (double, double)> posFunc)
     {
-        var contentRect = TaskContext.Instance().SystemInfo.CaptureAreaRect;
-        var scaleTo1080P = TaskContext.Instance().SystemInfo.ScaleTo1080PRatio;
-        var (cx, cy) = posFunc(new Size(contentRect.Width, contentRect.Height), scaleTo1080P);
-        DesktopRegion.DesktopRegionMove(contentRect.X + cx, contentRect.Y + cy);
+        var captureAreaRect = TaskContext.Instance().SystemInfo.CaptureAreaRect;
+        var assetScale = TaskContext.Instance().SystemInfo.ScaleTo1080PRatio;
+        var (cx, cy) = posFunc(new Size(captureAreaRect.Width, captureAreaRect.Height), assetScale);
+        DesktopRegion.DesktopRegionMove(captureAreaRect.X + cx, captureAreaRect.Y + cy);
     }
 
     public static void GameRegionMoveBy(Func<Size, double, (double, double)> deltaFunc)
     {
-        var contentRect = TaskContext.Instance().SystemInfo.CaptureAreaRect;
-        var scaleTo1080P = TaskContext.Instance().SystemInfo.ScaleTo1080PRatio;
-        var (dx, dy) = deltaFunc(new Size(contentRect.Width, contentRect.Height), scaleTo1080P);
+        var captureAreaRect = TaskContext.Instance().SystemInfo.CaptureAreaRect;
+        var assetScale = TaskContext.Instance().SystemInfo.ScaleTo1080PRatio;
+        var (dx, dy) = deltaFunc(new Size(captureAreaRect.Width, captureAreaRect.Height), assetScale);
         DesktopRegion.DesktopRegionMoveBy(dx, dy);
     }
 

--- a/BetterGenshinImpact/GameTask/Model/Area/ImageRegion.cs
+++ b/BetterGenshinImpact/GameTask/Model/Area/ImageRegion.cs
@@ -96,6 +96,22 @@ public class ImageRegion : Region
         return DeriveCrop(rect.X, rect.Y, rect.Width, rect.Height);
     }
 
+    /// <summary>
+    /// 游戏内容区大于 1080P 标准宽度时统一缩放到 1920 宽。
+    /// </summary>
+    public ImageRegion DeriveTo1080P()
+    {
+        if (Width <= 1920)
+        {
+            return this;
+        }
+
+        var scale = Width / 1920d;
+        var newMat = new Mat();
+        Cv2.Resize(SrcMat, newMat, new OpenCvSharp.Size(1920, (int)Math.Round(Height / scale)));
+        return new ImageRegion(newMat, 0, 0, this, new ScaleConverter(scale));
+    }
+
     // public ImageRegion Derive(Mat mat, int x, int y)
     // {
     //     return new ImageRegion(mat, x, y, this, new TranslationConverter(x, y));

--- a/BetterGenshinImpact/GameTask/Model/CaptureGeometry.cs
+++ b/BetterGenshinImpact/GameTask/Model/CaptureGeometry.cs
@@ -1,0 +1,61 @@
+using OpenCvSharp;
+using Vanara.PInvoke;
+
+namespace BetterGenshinImpact.GameTask.Model;
+
+public sealed class CaptureGeometry
+{
+    private const int ContentAspectWidth = 16;
+    private const int ContentAspectHeight = 9;
+
+    private CaptureGeometry(RECT rawCaptureRect, Rect captureSpace, RECT contentRect, Rect contentSpace)
+    {
+        RawCaptureRect = rawCaptureRect;
+        CaptureSpace = captureSpace;
+        ContentRect = contentRect;
+        ContentSpace = contentSpace;
+    }
+
+    public RECT RawCaptureRect { get; }
+
+    public Rect CaptureSpace { get; }
+
+    public RECT ContentRect { get; }
+
+    public Rect ContentSpace { get; }
+
+    public static CaptureGeometry FromRawCaptureRect(RECT rawCaptureRect)
+    {
+        var captureSpace = new Rect(0, 0, rawCaptureRect.Width, rawCaptureRect.Height);
+        var contentSpace = CalculateContentSpace(captureSpace);
+        var contentRect = new RECT(
+            rawCaptureRect.Left + contentSpace.X,
+            rawCaptureRect.Top + contentSpace.Y,
+            rawCaptureRect.Left + contentSpace.X + contentSpace.Width,
+            rawCaptureRect.Top + contentSpace.Y + contentSpace.Height);
+
+        return new CaptureGeometry(rawCaptureRect, captureSpace, contentRect, contentSpace);
+    }
+
+    public static Rect CalculateContentSpace(Rect captureSpace)
+    {
+        if (captureSpace.Width <= 0 || captureSpace.Height <= 0)
+        {
+            return new Rect(captureSpace.X, captureSpace.Y, 0, 0);
+        }
+
+        var width = captureSpace.Width;
+        var height = captureSpace.Height;
+        var widthLimitedByHeight = height * ContentAspectWidth / ContentAspectHeight;
+
+        if (widthLimitedByHeight <= width)
+        {
+            var x = captureSpace.X + (width - widthLimitedByHeight) / 2;
+            return new Rect(x, captureSpace.Y, widthLimitedByHeight, height);
+        }
+
+        var heightLimitedByWidth = width * ContentAspectHeight / ContentAspectWidth;
+        var y = captureSpace.Y + (height - heightLimitedByWidth) / 2;
+        return new Rect(captureSpace.X, y, width, heightLimitedByWidth);
+    }
+}

--- a/BetterGenshinImpact/GameTask/Model/CaptureGeometry.cs
+++ b/BetterGenshinImpact/GameTask/Model/CaptureGeometry.cs
@@ -24,6 +24,12 @@ public sealed class CaptureGeometry
 
     public Rect ContentSpace { get; }
 
+    public bool HasValidContentSpace =>
+        CaptureSpace.Width > 0
+        && CaptureSpace.Height > 0
+        && ContentSpace.Width > 0
+        && ContentSpace.Height > 0;
+
     public static CaptureGeometry FromRawCaptureRect(RECT rawCaptureRect)
     {
         var captureSpace = new Rect(0, 0, rawCaptureRect.Width, rawCaptureRect.Height);

--- a/BetterGenshinImpact/GameTask/Model/ISystemInfo.cs
+++ b/BetterGenshinImpact/GameTask/Model/ISystemInfo.cs
@@ -38,12 +38,12 @@ namespace BetterGenshinImpact.GameTask.Model
         /// <summary>
         /// 捕获内容区，排除全屏黑边后和实际游戏画面一致
         /// </summary>
-        public RECT CaptureAreaRect { get; }
+        public RECT CaptureAreaRect { get; set; }
 
         /// <summary>
         /// 捕获内容区，大于1080P则为1920x1080
         /// </summary>
-        public Rect ScaleMax1080PCaptureRect { get; }
+        public Rect ScaleMax1080PCaptureRect { get; set; }
 
         public CaptureGeometry CaptureGeometry { get; }
 

--- a/BetterGenshinImpact/GameTask/Model/ISystemInfo.cs
+++ b/BetterGenshinImpact/GameTask/Model/ISystemInfo.cs
@@ -36,15 +36,18 @@ namespace BetterGenshinImpact.GameTask.Model
         public double ScaleTo1080PRatio { get; }
 
         /// <summary>
-        /// 捕获窗口区域 和实际游戏画面一致
-        /// CaptureAreaRect = GameScreenSize or GameWindowRect
+        /// 捕获内容区，排除全屏黑边后和实际游戏画面一致
         /// </summary>
-        public RECT CaptureAreaRect { get; set; }
+        public RECT CaptureAreaRect { get; }
 
         /// <summary>
-        /// 捕获窗口区域 大于1080P则为1920x1080
+        /// 捕获内容区，大于1080P则为1920x1080
         /// </summary>
-        public Rect ScaleMax1080PCaptureRect { get; set; }
+        public Rect ScaleMax1080PCaptureRect { get; }
+
+        public CaptureGeometry CaptureGeometry { get; }
+
+        public void UpdateCaptureGeometry(RECT rawCaptureRect);
 
         public Process GameProcess { get; }
 

--- a/BetterGenshinImpact/GameTask/Model/SystemInfo.cs
+++ b/BetterGenshinImpact/GameTask/Model/SystemInfo.cs
@@ -40,12 +40,12 @@ namespace BetterGenshinImpact.GameTask.Model
         /// <summary>
         /// 捕获内容区，排除全屏黑边后和实际游戏画面一致
         /// </summary>
-        public RECT CaptureAreaRect { get; private set; }
+        public RECT CaptureAreaRect { get; set; }
 
         /// <summary>
         /// 捕获内容区，大于1080P则为1920x1080
         /// </summary>
-        public Rect ScaleMax1080PCaptureRect { get; private set; }
+        public Rect ScaleMax1080PCaptureRect { get; set; }
 
         public CaptureGeometry CaptureGeometry { get; private set; } = null!;
 

--- a/BetterGenshinImpact/GameTask/Model/SystemInfo.cs
+++ b/BetterGenshinImpact/GameTask/Model/SystemInfo.cs
@@ -18,35 +18,36 @@ namespace BetterGenshinImpact.GameTask.Model
         /// <summary>
         /// 游戏窗口内分辨率
         /// </summary>
-        public RECT GameScreenSize { get; }
+        public RECT GameScreenSize { get; private set; }
 
         /// <summary>
         /// 以1080P为标准的素材缩放比例,不会大于1
         /// 与 ZoomOutMax1080PRatio 相等
         /// </summary>
-        public double AssetScale { get; } = 1;
+        public double AssetScale { get; private set; } = 1;
 
         /// <summary>
         /// 游戏区域比1080P缩小的比例
         /// 最大值为1
         /// </summary>
-        public double ZoomOutMax1080PRatio { get; } = 1;
+        public double ZoomOutMax1080PRatio { get; private set; } = 1;
 
         /// <summary>
         /// 捕获游戏区域缩放至1080P的比例
         /// </summary>
-        public double ScaleTo1080PRatio { get; }
+        public double ScaleTo1080PRatio { get; private set; }
 
         /// <summary>
-        /// 捕获窗口区域 和实际游戏画面一致
-        /// CaptureAreaRect = GameScreenSize or GameWindowRect
+        /// 捕获内容区，排除全屏黑边后和实际游戏画面一致
         /// </summary>
-        public RECT CaptureAreaRect { get; set; }
+        public RECT CaptureAreaRect { get; private set; }
 
         /// <summary>
-        /// 捕获窗口区域 大于1080P则为1920x1080
+        /// 捕获内容区，大于1080P则为1920x1080
         /// </summary>
-        public Rect ScaleMax1080PCaptureRect { get; set; }
+        public Rect ScaleMax1080PCaptureRect { get; private set; }
+
+        public CaptureGeometry CaptureGeometry { get; private set; } = null!;
 
         public Process GameProcess { get; }
 
@@ -72,31 +73,37 @@ namespace BetterGenshinImpact.GameTask.Model
                 throw new ArgumentException("游戏窗口不能最小化");
             }
 
-            // 注意截图区域要和游戏窗口实际区域一致
-            // todo 窗口移动后？
-            GameScreenSize = SystemControl.GetGameScreenRect(hWnd);
+            UpdateCaptureGeometry(SystemControl.GetCaptureRect(hWnd));
             if (GameScreenSize.Width < 800 || GameScreenSize.Height < 600)
             {
                 throw new ArgumentException("游戏窗口分辨率不得小于 800x600 ！");
             }
+        }
 
-            // 0.28 改动，素材缩放比例不可以超过 1，也就是图像识别时分辨率大于 1920x1080 的情况下直接进行缩放
+        public void UpdateCaptureGeometry(RECT rawCaptureRect)
+        {
+            CaptureGeometry = BetterGenshinImpact.GameTask.Model.CaptureGeometry.FromRawCaptureRect(rawCaptureRect);
+            CaptureAreaRect = CaptureGeometry.ContentRect;
+            GameScreenSize = new RECT(0, 0, CaptureGeometry.ContentSpace.Width, CaptureGeometry.ContentSpace.Height);
+
+            AssetScale = 1;
+            ZoomOutMax1080PRatio = 1;
             if (GameScreenSize.Width < 1920)
             {
                 ZoomOutMax1080PRatio = GameScreenSize.Width / 1920d;
                 AssetScale = ZoomOutMax1080PRatio;
             }
+
             ScaleTo1080PRatio = GameScreenSize.Width / 1920d; // 1080P 为标准
 
-            CaptureAreaRect = SystemControl.GetCaptureRect(hWnd);
-            if (CaptureAreaRect.Width > 1920)
+            if (GameScreenSize.Width > 1920)
             {
-                var scale = CaptureAreaRect.Width / 1920d;
-                ScaleMax1080PCaptureRect = new Rect(CaptureAreaRect.X, CaptureAreaRect.Y, 1920, (int)(CaptureAreaRect.Height / scale));
+                var scale = GameScreenSize.Width / 1920d;
+                ScaleMax1080PCaptureRect = new Rect(0, 0, 1920, (int)(GameScreenSize.Height / scale));
             }
             else
             {
-                ScaleMax1080PCaptureRect = new Rect(CaptureAreaRect.X, CaptureAreaRect.Y, CaptureAreaRect.Width, CaptureAreaRect.Height);
+                ScaleMax1080PCaptureRect = new Rect(0, 0, GameScreenSize.Width, GameScreenSize.Height);
             }
         }
     }

--- a/BetterGenshinImpact/GameTask/Model/SystemInfo.cs
+++ b/BetterGenshinImpact/GameTask/Model/SystemInfo.cs
@@ -82,7 +82,13 @@ namespace BetterGenshinImpact.GameTask.Model
 
         public void UpdateCaptureGeometry(RECT rawCaptureRect)
         {
-            CaptureGeometry = BetterGenshinImpact.GameTask.Model.CaptureGeometry.FromRawCaptureRect(rawCaptureRect);
+            var geometry = BetterGenshinImpact.GameTask.Model.CaptureGeometry.FromRawCaptureRect(rawCaptureRect);
+            if (!geometry.HasValidContentSpace)
+            {
+                return;
+            }
+
+            CaptureGeometry = geometry;
             CaptureAreaRect = CaptureGeometry.ContentRect;
             GameScreenSize = new RECT(0, 0, CaptureGeometry.ContentSpace.Width, CaptureGeometry.ContentSpace.Height);
 

--- a/BetterGenshinImpact/GameTask/TaskTriggerDispatcher.cs
+++ b/BetterGenshinImpact/GameTask/TaskTriggerDispatcher.cs
@@ -1,4 +1,5 @@
 using BetterGenshinImpact.Core.Config;
+using BetterGenshinImpact.Core.Recognition.OpenCv;
 using BetterGenshinImpact.GameTask.Common;
 using BetterGenshinImpact.Helpers;
 using BetterGenshinImpact.View;
@@ -484,7 +485,7 @@ namespace BetterGenshinImpact.GameTask
                 }
 
                 _gameRect = new RECT(currentRect);
-                TaskContext.Instance().SystemInfo.CaptureAreaRect = currentRect;
+                TaskContext.Instance().SystemInfo.UpdateCaptureGeometry(currentRect);
                 MaskWindow.Instance().RefreshPosition();
                 HtmlMaskWindow.UpdateAllPositions();
                 return true;
@@ -543,11 +544,13 @@ namespace BetterGenshinImpact.GameTask
                 var savePath = Global.Absolute($@"log\screenshot\{name}");
                 if (TaskContext.Instance().Config.CommonConfig.ScreenshotUidCoverEnabled)
                 {
+                    var geometry = TaskContext.Instance().SystemInfo.CaptureGeometry;
                     var assetScale = TaskContext.Instance().SystemInfo.ScaleTo1080PRatio;
-                    var rect = new Rect((int)(mat.Width - MaskWindowConfig.UidCoverRightBottomRect.X * assetScale),
-                        (int)(mat.Height - MaskWindowConfig.UidCoverRightBottomRect.Y * assetScale),
+                    var rect = new Rect(
+                        (int)(geometry.ContentSpace.X + geometry.ContentSpace.Width - MaskWindowConfig.UidCoverRightBottomRect.X * assetScale),
+                        (int)(geometry.ContentSpace.Y + geometry.ContentSpace.Height - MaskWindowConfig.UidCoverRightBottomRect.Y * assetScale),
                         (int)(MaskWindowConfig.UidCoverRightBottomRect.Width * assetScale),
-                        (int)(MaskWindowConfig.UidCoverRightBottomRect.Height * assetScale));
+                        (int)(MaskWindowConfig.UidCoverRightBottomRect.Height * assetScale)).ClampTo(mat);
                     mat.Rectangle(rect, Scalar.White, -1);
                     Cv2.ImWrite(savePath, mat);
                 }

--- a/BetterGenshinImpact/GameTask/TaskTriggerDispatcher.cs
+++ b/BetterGenshinImpact/GameTask/TaskTriggerDispatcher.cs
@@ -468,7 +468,13 @@ namespace BetterGenshinImpact.GameTask
         {
             var hWnd = TaskContext.Instance().GameHandle;
             var currentRect = SystemControl.GetCaptureRect(hWnd);
-            if (_gameRect == RECT.Empty)
+            if (SizeIsInvalid(currentRect))
+            {
+                _logger.LogDebug("跳过无效游戏窗口捕获区域同步: {W}x{H}", currentRect.Width, currentRect.Height);
+                return true;
+            }
+
+            if (_gameRect == RECT.Empty || SizeIsInvalid(_gameRect))
             {
                 _gameRect = new RECT(currentRect);
             }
@@ -476,7 +482,7 @@ namespace BetterGenshinImpact.GameTask
             {
                 // 后面大概可以取消掉这个判断，支持随意移动变化窗口 —— 不支持 需要考虑的问题太多了
                 if ((_gameRect.Width != currentRect.Width || _gameRect.Height != currentRect.Height)
-                    && !SizeIsZero(_gameRect) && !SizeIsZero(currentRect))
+                    && !SizeIsInvalid(_gameRect) && !SizeIsInvalid(currentRect))
                 {
                     _logger.LogError("► 游戏窗口大小发生变化 {W}x{H}->{CW}x{CH}, 自动重启截图器中...", _gameRect.Width, _gameRect.Height, currentRect.Width, currentRect.Height);
                     UiTaskStopTickEvent?.Invoke(null, EventArgs.Empty);
@@ -494,9 +500,9 @@ namespace BetterGenshinImpact.GameTask
             return false;
         }
 
-        private bool SizeIsZero(RECT rect)
+        private bool SizeIsInvalid(RECT rect)
         {
-            return rect.Width == 0 || rect.Height == 0;
+            return rect.Width <= 0 || rect.Height <= 0;
         }
 
         private void WinEventCallback(User32.HWINEVENTHOOK hWinEventHook, uint @event, HWND hwnd, int idObject, int idChild, uint dwEventThread, uint dwmsEventTime)

--- a/BetterGenshinImpact/Helpers/AssertUtils.cs
+++ b/BetterGenshinImpact/Helpers/AssertUtils.cs
@@ -2,6 +2,7 @@
 using BetterGenshinImpact.GameTask;
 using BetterGenshinImpact.GameTask.Common;
 using Microsoft.Extensions.Logging;
+using Vanara.PInvoke;
 
 namespace BetterGenshinImpact.Helpers;
 
@@ -22,11 +23,19 @@ public class AssertUtils
     /// </summary>
     public static void CheckGameResolution(string msg = "")
     {
-        var gameScreenSize = SystemControl.GetGameScreenRect(TaskContext.Instance().GameHandle);
-        if (gameScreenSize.Width * 9 != gameScreenSize.Height * 16)
+        var taskContext = TaskContext.Instance();
+        var gameScreenSize = taskContext is { IsInitialized: true, SystemInfo: not null }
+            ? taskContext.SystemInfo.GameScreenSize
+            : SystemControl.GetGameScreenRect(taskContext.GameHandle);
+        if (!IsGameResolution16X9(gameScreenSize))
         {
             TaskControl.Logger.LogError("游戏窗口分辨率不是 16:9 ！当前分辨率为 {Width}x{Height} , 非 16:9 分辨率的游戏无法正常使用{Msg}功能 !", gameScreenSize.Width, gameScreenSize.Height, msg);
             throw new Exception("游戏窗口分辨率不是 16:9");
         }
+    }
+
+    public static bool IsGameResolution16X9(RECT gameScreenSize)
+    {
+        return gameScreenSize.Width * 9 == gameScreenSize.Height * 16;
     }
 }

--- a/BetterGenshinImpact/Helpers/AssertUtils.cs
+++ b/BetterGenshinImpact/Helpers/AssertUtils.cs
@@ -36,6 +36,8 @@ public class AssertUtils
 
     public static bool IsGameResolution16X9(RECT gameScreenSize)
     {
-        return gameScreenSize.Width * 9 == gameScreenSize.Height * 16;
+        return gameScreenSize.Width > 0
+               && gameScreenSize.Height > 0
+               && gameScreenSize.Width * 9 == gameScreenSize.Height * 16;
     }
 }

--- a/BetterGenshinImpact/Helpers/DpiAwareness/DpiAwarenessController.cs
+++ b/BetterGenshinImpact/Helpers/DpiAwareness/DpiAwarenessController.cs
@@ -3,7 +3,6 @@ using System.Diagnostics;
 using System.Windows;
 using System.Windows.Interop;
 using System.Windows.Media;
-using BetterGenshinImpact.Platform.Wine;
 using Vanara.PInvoke;
 
 namespace BetterGenshinImpact.Helpers.DpiAwareness;
@@ -18,31 +17,6 @@ internal class DpiAwarenessController
     private HwndSource? hwndSource;
     private HWND? hwnd;
     private double currentDpiRatio;
-
-    static DpiAwarenessController()
-    {
-        if (WinePlatformAddon.IsRunningOnWine)
-        {
-            try
-            {
-                SHCore
-                    .SetProcessDpiAwareness(
-                        SHCore.PROCESS_DPI_AWARENESS.PROCESS_PER_MONITOR_DPI_AWARE
-                    )
-                    .ThrowIfFailed();
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Debug.WriteLine(
-                    $"Failed to set DPI awareness in Wine: {ex.Message}"
-                );
-            }
-        }
-        else{
-          SHCore
-              .SetProcessDpiAwareness(SHCore.PROCESS_DPI_AWARENESS.PROCESS_PER_MONITOR_DPI_AWARE);
-        }
-    }
 
     /// <summary>
     /// 构造一个新的高分辨率适配器

--- a/BetterGenshinImpact/Helpers/DpiAwareness/DpiAwarenessInitializer.cs
+++ b/BetterGenshinImpact/Helpers/DpiAwareness/DpiAwarenessInitializer.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Diagnostics;
+using Vanara.PInvoke;
+
+namespace BetterGenshinImpact.Helpers.DpiAwareness;
+
+internal static class DpiAwarenessInitializer
+{
+    private static bool _initialized;
+
+    public static void InitializeSystemAware()
+    {
+        if (_initialized)
+        {
+            return;
+        }
+
+        _initialized = true;
+
+        try
+        {
+            SHCore
+                .SetProcessDpiAwareness(SHCore.PROCESS_DPI_AWARENESS.PROCESS_SYSTEM_DPI_AWARE)
+                .ThrowIfFailed();
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Failed to set system DPI awareness: {ex.Message}");
+        }
+    }
+}

--- a/BetterGenshinImpact/View/HtmlMaskWindow.xaml.cs
+++ b/BetterGenshinImpact/View/HtmlMaskWindow.xaml.cs
@@ -432,7 +432,9 @@ public partial class HtmlMaskWindow : Window
             var gameHandle = TaskContext.Instance().GameHandle;
             if (gameHandle == IntPtr.Zero) return;
 
-            var currentRect = SystemControl.GetCaptureRect(gameHandle);
+            var currentRect = TaskContext.Instance().IsInitialized
+                ? TaskContext.Instance().SystemInfo.CaptureAreaRect
+                : SystemControl.GetCaptureRect(gameHandle);
             if (currentRect.Width <= 0 || currentRect.Height <= 0) return;
 
             var dpiScale = DpiHelper.GetScale(gameHandle);

--- a/BetterGenshinImpact/View/MaskWindow.xaml.cs
+++ b/BetterGenshinImpact/View/MaskWindow.xaml.cs
@@ -107,7 +107,9 @@ public partial class MaskWindow : Window
 
     public void RefreshPositionForNormal()
     {
-        var currentRect = SystemControl.GetCaptureRect(TaskContext.Instance().GameHandle);
+        var currentRect = TaskContext.Instance().IsInitialized
+            ? TaskContext.Instance().SystemInfo.CaptureAreaRect
+            : SystemControl.GetCaptureRect(TaskContext.Instance().GameHandle);
 
         Invoke(() =>
         {

--- a/Test/BetterGenshinImpact.UnitTest/GameTaskTests/CaptureGeometryTests.cs
+++ b/Test/BetterGenshinImpact.UnitTest/GameTaskTests/CaptureGeometryTests.cs
@@ -1,4 +1,5 @@
 using BetterGenshinImpact.GameTask;
+using BetterGenshinImpact.GameTask.AutoMusicGame;
 using BetterGenshinImpact.GameTask.Model;
 using BetterGenshinImpact.GameTask.Model.Area;
 using BetterGenshinImpact.Helpers;
@@ -62,6 +63,26 @@ public class CaptureGeometryTests
         var systemInfo = new FakeSystemInfo(new RECT(0, 0, 1920, 1080), 1);
 
         RunWithInitializedSystemInfo(systemInfo, () => AssertUtils.CheckGameResolution("自动音游"));
+    }
+
+    [Fact]
+    public void AutoMusicGameResolution_UsesSystemInfoContentSize()
+    {
+        var systemInfo = new FakeSystemInfo(new RECT(0, 0, 2560, 1600), 1);
+
+        var effectiveGameScreenSize = AutoMusicGameTask.GetEffectiveGameScreenSizeFromSystemInfo(systemInfo);
+
+        Assert.Equal(new RECT(0, 0, 2560, 1440), effectiveGameScreenSize);
+        Assert.True(AssertUtils.IsGameResolution16X9(effectiveGameScreenSize));
+    }
+
+    [Fact]
+    public void AutoMusicGameResolution_CalculatesContentSizeFromRawCaptureRect()
+    {
+        var effectiveGameScreenSize = AutoMusicGameTask.GetEffectiveGameScreenSizeFromRawCaptureRect(new RECT(0, 0, 2560, 1600));
+
+        Assert.Equal(new RECT(0, 0, 2560, 1440), effectiveGameScreenSize);
+        Assert.True(AssertUtils.IsGameResolution16X9(effectiveGameScreenSize));
     }
 
     [Fact]

--- a/Test/BetterGenshinImpact.UnitTest/GameTaskTests/CaptureGeometryTests.cs
+++ b/Test/BetterGenshinImpact.UnitTest/GameTaskTests/CaptureGeometryTests.cs
@@ -100,12 +100,14 @@ public class CaptureGeometryTests
         Assert.Equal(new Rect(0, 0, 1920, 1080), systemInfo.ScaleMax1080PCaptureRect);
     }
 
-    [Fact]
-    public void IsGameResolution16X9_ReturnsFalseWhenDerivedContentSizeIsNot16x9()
+    [Theory]
+    [InlineData(0, 0, false)]
+    [InlineData(0, 1080, false)]
+    [InlineData(1000, 1000, false)]
+    [InlineData(1920, 1080, true)]
+    public void IsGameResolution16X9_ValidatesPositive16x9Size(int width, int height, bool expected)
     {
-        var systemInfo = new FakeSystemInfo(new RECT(0, 0, 1000, 1000), 1);
-
-        Assert.False(AssertUtils.IsGameResolution16X9(systemInfo.GameScreenSize));
+        Assert.Equal(expected, AssertUtils.IsGameResolution16X9(new RECT(0, 0, width, height)));
     }
 
     [Fact]

--- a/Test/BetterGenshinImpact.UnitTest/GameTaskTests/CaptureGeometryTests.cs
+++ b/Test/BetterGenshinImpact.UnitTest/GameTaskTests/CaptureGeometryTests.cs
@@ -1,0 +1,45 @@
+using BetterGenshinImpact.GameTask.Model;
+using BetterGenshinImpact.GameTask.Model.Area;
+using BetterGenshinImpact.UnitTest.GameTaskTests.AutoFishingTests;
+using OpenCvSharp;
+using Vanara.PInvoke;
+
+namespace BetterGenshinImpact.UnitTest.GameTaskTests;
+
+public class CaptureGeometryTests
+{
+    [Theory]
+    [InlineData(1920, 1080, 0, 0, 1920, 1080)]
+    [InlineData(2560, 1600, 0, 80, 2560, 1440)]
+    [InlineData(1280, 800, 0, 40, 1280, 720)]
+    [InlineData(3440, 1440, 440, 0, 2560, 1440)]
+    public void FromRawCaptureRect_CalculatesCentered16x9ContentSpace(
+        int rawWidth,
+        int rawHeight,
+        int expectedX,
+        int expectedY,
+        int expectedWidth,
+        int expectedHeight)
+    {
+        var geometry = CaptureGeometry.FromRawCaptureRect(new RECT(0, 0, rawWidth, rawHeight));
+
+        Assert.Equal(new Rect(0, 0, rawWidth, rawHeight), geometry.CaptureSpace);
+        Assert.Equal(new Rect(expectedX, expectedY, expectedWidth, expectedHeight), geometry.ContentSpace);
+        Assert.Equal(new RECT(expectedX, expectedY, expectedX + expectedWidth, expectedY + expectedHeight), geometry.ContentRect);
+    }
+
+    [Fact]
+    public void ScaledContentRegion_Converts1080PPointBackToDesktopPoint()
+    {
+        var rawMat = new Mat(1600, 2560, MatType.CV_8UC3);
+        var desktopRegion = new DesktopRegion(2560, 1600, new FakeMouseSimulator());
+        using var rawRegion = desktopRegion.Derive(rawMat, 0, 0);
+        using var contentRegion = rawRegion.DeriveCrop(new Rect(0, 80, 2560, 1440));
+        using var scaledRegion = contentRegion.DeriveTo1080P();
+
+        var (x, y) = scaledRegion.ConvertPositionToDesktopRegion(960, 540);
+
+        Assert.Equal(1280, x);
+        Assert.Equal(800, y);
+    }
+}

--- a/Test/BetterGenshinImpact.UnitTest/GameTaskTests/CaptureGeometryTests.cs
+++ b/Test/BetterGenshinImpact.UnitTest/GameTaskTests/CaptureGeometryTests.cs
@@ -1,6 +1,9 @@
+using BetterGenshinImpact.GameTask;
 using BetterGenshinImpact.GameTask.Model;
 using BetterGenshinImpact.GameTask.Model.Area;
+using BetterGenshinImpact.Helpers;
 using BetterGenshinImpact.UnitTest.GameTaskTests.AutoFishingTests;
+using System;
 using OpenCvSharp;
 using Vanara.PInvoke;
 
@@ -41,5 +44,68 @@ public class CaptureGeometryTests
 
         Assert.Equal(1280, x);
         Assert.Equal(800, y);
+    }
+
+    [Fact]
+    public void CheckGameResolution_UsesContentSizeWhenTaskContextInitialized()
+    {
+        var systemInfo = new FakeSystemInfo(new RECT(0, 0, 2560, 1600), 1);
+
+        RunWithInitializedSystemInfo(systemInfo, () => AssertUtils.CheckGameResolution("自动音游"));
+
+        Assert.Equal(new RECT(0, 0, 2560, 1440), systemInfo.GameScreenSize);
+    }
+
+    [Fact]
+    public void CheckGameResolution_AllowsNative16x9Capture()
+    {
+        var systemInfo = new FakeSystemInfo(new RECT(0, 0, 1920, 1080), 1);
+
+        RunWithInitializedSystemInfo(systemInfo, () => AssertUtils.CheckGameResolution("自动音游"));
+    }
+
+    [Fact]
+    public void IsGameResolution16X9_ReturnsFalseWhenDerivedContentSizeIsNot16x9()
+    {
+        var systemInfo = new FakeSystemInfo(new RECT(0, 0, 1000, 1000), 1);
+
+        Assert.False(AssertUtils.IsGameResolution16X9(systemInfo.GameScreenSize));
+    }
+
+    [Fact]
+    public void ScaledContentRegion_Converts1080PMusicPointBackToRawGameCapturePoint()
+    {
+        var rawMat = new Mat(1600, 2560, MatType.CV_8UC3);
+        var desktopRegion = new DesktopRegion(2560, 1600, new FakeMouseSimulator());
+        using var rawRegion = desktopRegion.Derive(rawMat, 0, 0);
+        using var contentRegion = rawRegion.DeriveCrop(new Rect(0, 80, 2560, 1440));
+        using var scaledRegion = contentRegion.DeriveTo1080P();
+
+        var (x, y) = scaledRegion.ConvertPositionToGameCaptureRegion(960, 921);
+
+        Assert.Equal(1280, x);
+        Assert.Equal(1308, y);
+    }
+
+    private static void RunWithInitializedSystemInfo(ISystemInfo systemInfo, Action action)
+    {
+        var taskContext = TaskContext.Instance();
+        var originalIsInitialized = taskContext.IsInitialized;
+        var originalGameHandle = taskContext.GameHandle;
+        var originalSystemInfo = taskContext.SystemInfo;
+
+        try
+        {
+            taskContext.IsInitialized = true;
+            taskContext.GameHandle = IntPtr.Zero;
+            taskContext.SystemInfo = systemInfo;
+            action();
+        }
+        finally
+        {
+            taskContext.IsInitialized = originalIsInitialized;
+            taskContext.GameHandle = originalGameHandle;
+            taskContext.SystemInfo = originalSystemInfo;
+        }
     }
 }

--- a/Test/BetterGenshinImpact.UnitTest/GameTaskTests/CaptureGeometryTests.cs
+++ b/Test/BetterGenshinImpact.UnitTest/GameTaskTests/CaptureGeometryTests.cs
@@ -86,6 +86,21 @@ public class CaptureGeometryTests
     }
 
     [Fact]
+    public void UpdateCaptureGeometry_IgnoresInvalidRawCaptureRect()
+    {
+        var systemInfo = new FakeSystemInfo(new RECT(0, 0, 2560, 1600), 1);
+        var originalGeometry = systemInfo.CaptureGeometry;
+
+        systemInfo.UpdateCaptureGeometry(new RECT(0, 0, 0, 0));
+
+        Assert.Same(originalGeometry, systemInfo.CaptureGeometry);
+        Assert.Equal(new RECT(0, 0, 2560, 1440), systemInfo.GameScreenSize);
+        Assert.Equal(new RECT(0, 80, 2560, 1520), systemInfo.CaptureAreaRect);
+        Assert.Equal(1, systemInfo.AssetScale);
+        Assert.Equal(new Rect(0, 0, 1920, 1080), systemInfo.ScaleMax1080PCaptureRect);
+    }
+
+    [Fact]
     public void IsGameResolution16X9_ReturnsFalseWhenDerivedContentSizeIsNot16x9()
     {
         var systemInfo = new FakeSystemInfo(new RECT(0, 0, 1000, 1000), 1);

--- a/Test/BetterGenshinImpact.UnitTest/GameTaskTests/FakeSystemInfo.cs
+++ b/Test/BetterGenshinImpact.UnitTest/GameTaskTests/FakeSystemInfo.cs
@@ -33,7 +33,13 @@ namespace BetterGenshinImpact.UnitTest.GameTaskTests
 
         public void UpdateCaptureGeometry(RECT rawCaptureRect)
         {
-            CaptureGeometry = BetterGenshinImpact.GameTask.Model.CaptureGeometry.FromRawCaptureRect(rawCaptureRect);
+            var geometry = BetterGenshinImpact.GameTask.Model.CaptureGeometry.FromRawCaptureRect(rawCaptureRect);
+            if (!geometry.HasValidContentSpace)
+            {
+                return;
+            }
+
+            CaptureGeometry = geometry;
             CaptureAreaRect = CaptureGeometry.ContentRect;
             GameScreenSize = new RECT(0, 0, CaptureGeometry.ContentSpace.Width, CaptureGeometry.ContentSpace.Height);
 

--- a/Test/BetterGenshinImpact.UnitTest/GameTaskTests/FakeSystemInfo.cs
+++ b/Test/BetterGenshinImpact.UnitTest/GameTaskTests/FakeSystemInfo.cs
@@ -25,9 +25,9 @@ namespace BetterGenshinImpact.UnitTest.GameTaskTests
 
         public double ScaleTo1080PRatio { get; private set; }
 
-        public RECT CaptureAreaRect { get; private set; }
+        public RECT CaptureAreaRect { get; set; }
 
-        public Rect ScaleMax1080PCaptureRect { get; private set; } = new Rect(0, 0, 1920, 1080);
+        public Rect ScaleMax1080PCaptureRect { get; set; } = new Rect(0, 0, 1920, 1080);
 
         public CaptureGeometry CaptureGeometry { get; private set; } = null!;
 

--- a/Test/BetterGenshinImpact.UnitTest/GameTaskTests/FakeSystemInfo.cs
+++ b/Test/BetterGenshinImpact.UnitTest/GameTaskTests/FakeSystemInfo.cs
@@ -2,11 +2,7 @@ using BetterGenshinImpact.GameTask.Model;
 using BetterGenshinImpact.GameTask.Model.Area;
 using OpenCvSharp;
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Vanara.PInvoke;
 
 namespace BetterGenshinImpact.UnitTest.GameTaskTests
@@ -16,29 +12,51 @@ namespace BetterGenshinImpact.UnitTest.GameTaskTests
         public FakeSystemInfo(RECT gameScreenSize, double assetScale)
         {
             DesktopRectArea = new(gameScreenSize.Width, gameScreenSize.Height);
+            UpdateCaptureGeometry(new RECT(0, 0, gameScreenSize.Width, gameScreenSize.Height));
+        }
 
-            GameScreenSize = gameScreenSize;
-            // 0.28 改动，素材缩放比例不可以超过 1，也就是图像识别时分辨率大于 1920x1080 的情况下直接进行缩放
+        public System.Drawing.Size DisplaySize => throw new NotImplementedException();
+
+        public RECT GameScreenSize { get; private set; }
+
+        public double AssetScale { get; private set; } = 1;
+
+        public double ZoomOutMax1080PRatio { get; private set; } = 1;
+
+        public double ScaleTo1080PRatio { get; private set; }
+
+        public RECT CaptureAreaRect { get; private set; }
+
+        public Rect ScaleMax1080PCaptureRect { get; private set; } = new Rect(0, 0, 1920, 1080);
+
+        public CaptureGeometry CaptureGeometry { get; private set; } = null!;
+
+        public void UpdateCaptureGeometry(RECT rawCaptureRect)
+        {
+            CaptureGeometry = BetterGenshinImpact.GameTask.Model.CaptureGeometry.FromRawCaptureRect(rawCaptureRect);
+            CaptureAreaRect = CaptureGeometry.ContentRect;
+            GameScreenSize = new RECT(0, 0, CaptureGeometry.ContentSpace.Width, CaptureGeometry.ContentSpace.Height);
+
+            AssetScale = 1;
+            ZoomOutMax1080PRatio = 1;
             if (GameScreenSize.Width < 1920)
             {
                 ZoomOutMax1080PRatio = GameScreenSize.Width / 1920d;
                 AssetScale = ZoomOutMax1080PRatio;
             }
-            ScaleTo1080PRatio = GameScreenSize.Width / 1920d; // 1080P 为标准
+
+            ScaleTo1080PRatio = GameScreenSize.Width / 1920d;
+
+            if (GameScreenSize.Width > 1920)
+            {
+                var scale = GameScreenSize.Width / 1920d;
+                ScaleMax1080PCaptureRect = new Rect(0, 0, 1920, (int)(GameScreenSize.Height / scale));
+            }
+            else
+            {
+                ScaleMax1080PCaptureRect = new Rect(0, 0, GameScreenSize.Width, GameScreenSize.Height);
+            }
         }
-
-        public System.Drawing.Size DisplaySize => throw new NotImplementedException();
-
-        public RECT GameScreenSize { get; }
-
-        public double AssetScale { get; } = 1;
-
-        public double ZoomOutMax1080PRatio { get; }
-
-        public double ScaleTo1080PRatio { get; }
-
-        public RECT CaptureAreaRect { get ; set ; }
-        public Rect ScaleMax1080PCaptureRect { get; set; } = new Rect(0, 0, 1920, 1080);
 
         public Process GameProcess => throw new NotImplementedException();
 


### PR DESCRIPTION
## 变更内容
- 建立 SystemAware DPI 捕获基线，避免 DPI-unaware 场景下只看到虚拟尺寸。
- 新增 CaptureGeometry/CaptureSpace/ContentRect/ContentSpace，按 raw capture 居中最大 16:9 内容区建立识别空间。
- 将捕获、区域映射、点击回推、遮罩窗口和截图 UID 遮盖对齐到有效游戏内容区。
- 修复自动音游/千音雅集在 Starward 全屏黑边场景下误判非 16:9 的问题。
- 防止停止任务时无效 0x0 捕获区域污染 SystemInfo 并导致素材缩放 OpenCV 异常。

## 验证
- dotnet test Test\BetterGenshinImpact.UnitTest\BetterGenshinImpact.UnitTest.csproj -c Debug --filter FullyQualifiedName~CaptureGeometryTests
- dotnet build BetterGenshinImpact.sln -c Debug

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新增功能**
  * 改进了应用启动时的 DPI 适配初始化。
  * 增强了游戏屏幕捕获区域的几何计算，自动检测并适配 16:9 内容区域。
  * 完善了分辨率验证与缩放逻辑，更好地支持不同屏幕分辨率。

* **bug 修复**
  * 优化了高分辨率屏幕下的 1080P 缩放处理。
  * 改进了资源释放管理，减少内存占用。
  * 修正了自动音游模式下的分辨率检测。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->