### PR TITLE
fix: 修复自动幽境危战切换队伍有可能切错boss

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoStygianOnslaught/AutoStygianOnslaughtTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoStygianOnslaught/AutoStygianOnslaughtTask.cs
@@ -1055,7 +1055,8 @@ public class AutoStygianOnslaughtTask : StateMachineBase<StygianState, BvPage>, 
 
                     for (int j = 0; j < 5; j++)
                     {
-                        foundTeam.Click();
+                        // 点击队伍名称右侧区域，避免面板关闭后重复点击落到左侧 Boss 图标。
+                        foundTeam.ClickTo(foundTeam.Width / 2 + 250, foundTeam.Height / 2);
                         await Delay(200, _ct);
                     }
                     Logger.LogInformation($"{Name}：已选择队伍 {fightTeamName}");


### PR DESCRIPTION
issue https://github.com/babalae/better-genshin-impact/issues/3057

其实本质是在因为在这个页面
<img width="2560" height="1440" alt="PixPin_2026-06-19_09-52-08" src="https://github.com/user-attachments/assets/084cf20a-5463-466d-80a7-7383540744c1" />

选择队伍的时候。会进行五次点击。
<img width="2560" height="1381" alt="PixPin_2026-06-19_09-50-36" src="https://github.com/user-attachments/assets/2dd85dec-c3bd-43cc-9319-5ed2500f63f3" />

难道是为了防止没点到？我不太清楚什么原因。所以我保险起见，只是把点击位置往右偏移了，让额外的几次点击点不到 boss

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug修复**
  * 修复了自动深境螺旋任务中预设队伍选择的点击问题。改进了队伍选择交互的准确性，防止了在特定场景下可能出现的误操作。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->