### PR TITLE
refactor(script group): 避免脚本运行时污染配置组对象

### DIFF
--- a/BetterGenshinImpact/Core/Script/Group/ScriptGroupProject.cs
+++ b/BetterGenshinImpact/Core/Script/Group/ScriptGroupProject.cs
@@ -220,7 +220,8 @@ public partial class ScriptGroupProject : ObservableObject
             CleanInvalidSettingsValues();
 
             var pathingPartyConfig = GroupInfo?.Config.PathingConfig;
-            await Project.ExecuteAsync(JsScriptSettingsObject, pathingPartyConfig);
+            var runtimeSettings = CloneJsScriptSettingsObject(JsScriptSettingsObject);
+            await Project.ExecuteAsync(runtimeSettings, pathingPartyConfig);
         }
         else if (Type == "KeyMouse")
         {
@@ -338,6 +339,28 @@ public partial class ScriptGroupProject : ObservableObject
     partial void OnScheduleChanged(string value)
     {
         OnPropertyChanged(nameof(ScheduleDesc));
+    }
+
+    /// <summary>
+    /// 创建 JS 脚本运行期配置副本，避免脚本修改 settings 时污染配置组对象。
+    /// </summary>
+    private static ExpandoObject CloneJsScriptSettingsObject(ExpandoObject source)
+    {
+        var clone = new ExpandoObject();
+        var sourceDict = (IDictionary<string, object?>)source;
+        var cloneDict = (IDictionary<string, object?>)clone;
+
+        foreach (var (key, value) in sourceDict)
+        {
+            cloneDict[key] = value switch
+            {
+                List<string> stringList => new List<string>(stringList),
+                List<object> objectList => new List<object>(objectList),
+                _ => value
+            };
+        }
+
+        return clone;
     }
 
     /// <summary>

--- a/BetterGenshinImpact/Core/Script/Group/ScriptGroupProject.cs
+++ b/BetterGenshinImpact/Core/Script/Group/ScriptGroupProject.cs
@@ -346,18 +346,27 @@ public partial class ScriptGroupProject : ObservableObject
     /// </summary>
     private static ExpandoObject CloneJsScriptSettingsObject(ExpandoObject source)
     {
+        static object? CloneValue(object? value)
+        {
+            return value switch
+            {
+                null => null,
+                string => value,
+                ValueType => value,
+                ExpandoObject expandoObject => CloneJsScriptSettingsObject(expandoObject),
+                List<string> stringList => new List<string>(stringList),
+                List<object> objectList => objectList.Select(CloneValue).ToList(),
+                _ => value
+            };
+        }
+
         var clone = new ExpandoObject();
         var sourceDict = (IDictionary<string, object?>)source;
         var cloneDict = (IDictionary<string, object?>)clone;
 
         foreach (var (key, value) in sourceDict)
         {
-            cloneDict[key] = value switch
-            {
-                List<string> stringList => new List<string>(stringList),
-                List<object> objectList => new List<object>(objectList),
-                _ => value
-            };
+            cloneDict[key] = CloneValue(value);
         }
 
         return clone;


### PR DESCRIPTION
详见#3216
--------------------------
新增CloneJsScriptSettingsObject方法创建运行期配置副本，防止脚本修改settings后影响原配置组对象


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 版本更新说明

* **Bug 修复**
  * 加强脚本执行时的配置隔离：在运行 JavaScript 脚本前，会为脚本配置生成可独立使用的运行副本，避免运行过程中对配置的修改影响其他脚本或后续执行。
  * 提升复杂配置的处理一致性（如嵌套对象与列表），降低因共享引用导致的异常行为风险。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->