### PR TITLE
fix:将settings持久化保存时机调整到JS脚本运行结束

### DIFF
--- a/BetterGenshinImpact/Service/ScriptService.cs
+++ b/BetterGenshinImpact/Service/ScriptService.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using BetterGenshinImpact.Core.Config;
 using BetterGenshinImpact.Core.Script;
 using BetterGenshinImpact.Core.Script.Dependence;
 using BetterGenshinImpact.Core.Script.Group;
@@ -524,7 +525,15 @@ public partial class ScriptService : IScriptService
 
             _logger.LogInformation("→ 开始执行JS脚本: {Name}", project.Name);
             if (RunnerContext.Instance.IsPreExecution) _logger.LogInformation("此任务为优先执行任务！");
-            await project.Run();
+            var hasSettingsBeforeRun = project.JsScriptSettingsObject != null;
+            try
+            {
+                await project.Run();
+            }
+            finally
+            {
+                SaveScriptGroupAfterJsRun(project, hasSettingsBeforeRun);
+            }
         }
         else if (project.Type == "KeyMouse")
         {
@@ -543,6 +552,32 @@ public partial class ScriptService : IScriptService
             _logger.LogInformation("→ 开始执行shell: {Name}", project.Name);
             if (RunnerContext.Instance.IsPreExecution) _logger.LogInformation("此任务为优先执行任务！");
             await project.Run();
+        }
+    }
+
+    private void SaveScriptGroupAfterJsRun(ScriptGroupProject project, bool hasSettingsBeforeRun)
+    {
+        if (!hasSettingsBeforeRun)
+        {
+            project.JsScriptSettingsObject = null;
+            return;
+        }
+
+        var scriptGroup = project.GroupInfo!;
+        try
+        {
+            var scriptGroupPath = Global.Absolute(@"User\ScriptGroup");
+            if (!Directory.Exists(scriptGroupPath))
+            {
+                Directory.CreateDirectory(scriptGroupPath);
+            }
+
+            var file = Path.Combine(scriptGroupPath, $"{scriptGroup.Name}.json");
+            File.WriteAllText(file, scriptGroup.ToJson());
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "保存JS脚本配置组失败: {GroupName}", scriptGroup.Name);
         }
     }
 


### PR DESCRIPTION
详细见#3216

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新特性**
  * 脚本执行完成后，系统现在会自动保存配置数据。
  * 优化了配置信息的持久化存储机制，确保脚本组设置能够被正确保留。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->