### PR TITLE
feat: 取消一键强化宏的点击详情菜单动作

### DIFF
--- a/BetterGenshinImpact/GameTask/Macro/QuickEnhanceArtifactMacro.cs
+++ b/BetterGenshinImpact/GameTask/Macro/QuickEnhanceArtifactMacro.cs
@@ -27,12 +27,6 @@ public class QuickEnhanceArtifactMacro
         // 强化 1760x1020
         GameCaptureRegion.GameRegion1080PPosClick(1760, 1020);
         Thread.Sleep(100 + config.EnhanceWaitDelay);
-        // 详情菜单 150x150
-        GameCaptureRegion.GameRegion1080PPosClick(150, 150);
-        Thread.Sleep(100);
-        // 强化菜单 150x220
-        GameCaptureRegion.GameRegion1080PPosClick(150, 220);
-        Thread.Sleep(100);
         // 移动回快捷放入 #30
         GameCaptureRegion.GameRegion1080PPosMove(1760, 770);
     }


### PR DESCRIPTION
此功能是为了跳过早期版本原神每次强化时弹出的强化结果对话框，后来原神取消了对话框，因此不必再进行额外点击

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **优化功能**
  * 优化快速强化圣遗物的交互流程，简化点击步骤，提高操作效率
  * 调整强化等待时间计算方式，支持自定义延迟配置

<!-- end of auto-generated comment: release notes by coderabbit.ai -->