### PR TITLE
fix:AutoDomain适配新版本快捷键改动

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoDomain/AutoDomainTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoDomain/AutoDomainTask.cs
@@ -330,17 +330,6 @@ public class AutoDomainTask : ISoloTask<Dictionary<string, int>>
                     throw new Exception("请检查是否在秘境门前");
                 }
 
-                var menu = await NewRetry.WaitForElementAppear(
-                    GetConfirmRa("单人挑战"),
-                    () => Simulation.SendInput.Keyboard.KeyPress(AutoPickAssets.Instance.PickVk),
-                    _ct,
-                    20,
-                    500
-                );
-                if (!menu)
-                {
-                    throw new Exception("请检查是否已进入秘境页面");
-                }
             }
             else
             {
@@ -371,12 +360,19 @@ public class AutoDomainTask : ISoloTask<Dictionary<string, int>>
     {
         var fightAssets = AutoFightAssets.Instance;
 
-        var menuFound = await NewRetry.WaitForElementAppear(
-            GetConfirmRa("单人挑战"),
+        await NewRetry.WaitForElementDisappear(
+            AutoPickAssets.Instance.PickRo,
             () => Simulation.SendInput.Keyboard.KeyPress(AutoPickAssets.Instance.PickVk),
             _ct,
-            10,
-            1000
+            20,
+            500
+        );
+        var menuFound = await NewRetry.WaitForElementAppear(
+            GetConfirmRa("单人挑战"),
+            null,//只等待,不执行操作
+            _ct,
+            20,
+            500
         );
         if (!menuFound)
         {


### PR DESCRIPTION
老版本在tpDomain中已经进 `秘境入口` 了，然后在` 秘境入口` 界面又尝试按F进了一次，但`切换队伍`界面不会响应二次F所以没问题

新版本支持F键快捷`开始挑战`就会直接进副本。

改动：
 - 删除冗余进副本操作，tpDomain的行为从 `进到秘境入口界面` 改为 `停在副本门口`

 - EnterDomain 改为尝试按F直到F交互消失，然后再等`单人挑战`按钮出现。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化了秘境进入流程中的确认界面等待逻辑，减少因误判或重复点击导致的卡流程问题。
  * 当无法在秘境门前识别到入口时，会直接提示检查当前位置，避免继续执行无效操作。
  * 调整了“单人挑战”确认框的等待方式，使后续进入队伍与开始挑战的流程更稳定。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->