### PR TITLE
feat:新增合成功能

### DIFF
--- a/BetterGenshinImpact/Core/Script/Dependence/Dispatcher.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/Dispatcher.cs
@@ -18,6 +18,7 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Dynamic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using BetterGenshinImpact.GameTask.AutoFight;
@@ -280,16 +281,15 @@ public class Dispatcher
                     GridScreenName gridScreenName = ScriptObjectConverter.GetValue((ScriptObject)soloTask.Config, "gridScreenName", (GridScreenName?)null) ?? throw new Exception("gridScreenName为空或错误");
                     string? itemName = ScriptObjectConverter.GetValue((ScriptObject)soloTask.Config, "itemName", (string?)null);
                     IEnumerable<string>? itemNames = ScriptObjectConverter.GetValue<string>((ScriptObject)soloTask.Config, "itemNames");
-                    if (itemName != null && itemNames != null)
+                    CountInventoryItemParam param = new()
                     {
-                        throw new ArgumentException($"参数{nameof(itemName)}和{nameof(itemNames)}不能同时使用");
-                    }
-                    if (itemName == null && itemNames == null)
-                    {
-                        throw new ArgumentException($"参数{nameof(itemName)}和{nameof(itemNames)}不能同时为空");
-                    }
-                    var result = await new CountInventoryItem(gridScreenName, itemName, itemNames).Start(cancellationToken);
-                    if (itemName != null)
+                        GridScreenName = gridScreenName,
+                        ItemName = itemName,
+                        ItemNames = itemNames?.ToList() ?? []
+                    };
+
+                    var result = await new CountInventoryItem(param).Start(cancellationToken);
+                    if (param.ItemName != null)
                     {
                         return result;
                     }
@@ -354,7 +354,7 @@ public class Dispatcher
         CancellationToken cancellationToken = customCt ?? CancellationContext.Instance.Cts.Token;
         return await new AutoBossTask(param).Start(cancellationToken);
     }
-  
+
     /// <summary>  
     /// 运行自动战斗任务
     /// </summary>  
@@ -388,22 +388,55 @@ public class Dispatcher
         CancellationToken cancellationToken = customCt ?? CancellationContext.Instance.Cts.Token;  
         await new AutoLeyLineOutcropTask(param).Start(cancellationToken);  
     }
-    
-        
+
+
     /// <summary>  
     /// 运行自动幽境危战任务
     /// </summary>  
     /// <param name="param">自动幽境危战任务参数</param>  
     /// <param name="customCt">自定义取消令牌</param>  
     /// <returns></returns>  
-    public async Task RunAutoStygianOnslaughtTask(AutoStygianOnslaughtParam param, CancellationToken? customCt = null)  
-    {  
-        if (param == null)  
-        {  
-            throw new ArgumentNullException(nameof(param), "自动幽境危战任务参数不能为空");  
-        }  
-  
-        CancellationToken cancellationToken = customCt ?? CancellationContext.Instance.Cts.Token;  
-        await new AutoStygianOnslaughtTask(param).Start(cancellationToken);  
+    public async Task RunAutoStygianOnslaughtTask(AutoStygianOnslaughtParam param, CancellationToken? customCt = null)
+    {
+        if (param == null)
+        {
+            throw new ArgumentNullException(nameof(param), "自动幽境危战任务参数不能为空");
+        }
+
+        CancellationToken cancellationToken = customCt ?? CancellationContext.Instance.Cts.Token;
+        await new AutoStygianOnslaughtTask(param).Start(cancellationToken);
+    }
+    
+    /// <summary>
+    /// 运行背包物品计数任务。
+    /// </summary>
+    /// <param name="param">背包物品计数参数。</param>
+    /// <param name="customCt">自定义取消令牌。</param>
+    /// <returns>单物品返回数量；多物品返回名称到数量的脚本对象。</returns>
+    public async Task<object?> RunCountInventoryItemTask(CountInventoryItemParam param, CancellationToken? customCt = null)
+    {
+        if (param == null)
+        {
+            throw new ArgumentNullException(nameof(param), "背包物品计数参数不能为空");
+        }
+
+        CancellationToken cancellationToken = customCt ?? CancellationContext.Instance.Cts.Token;
+        object result = await new CountInventoryItem(param).Start(cancellationToken);
+
+        if (param.ItemName != null)
+        {
+            return result;
+        }
+        else
+        {
+            dynamic expando = new ExpandoObject();
+            var expandoDict = (IDictionary<string, object>)expando;
+            foreach (var kvp in (Dictionary<string, int>)result)
+            {
+                expandoDict[kvp.Key] = kvp.Value;
+            }
+
+            return expandoDict;
+        }
     }
 }

--- a/BetterGenshinImpact/Core/Script/Dependence/Genshin.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/Genshin.cs
@@ -362,6 +362,18 @@ public class Genshin
     }
 
     /// <summary>
+    /// 在当前已打开的合成界面中合成指定材料。
+    /// </summary>
+    /// <param name="materialName">目标成品材料名。</param>
+    /// <param name="count">目标合成次数，必须大于 0。</param>
+    /// <param name="materialType">材料筛选类型；为空时从物品模型 CSV 中读取。</param>
+    /// <returns>合成执行结果。</returns>
+    public async Task<CraftMaterialResult> CraftMaterial(string materialName, int count, string? materialType = null)
+    {
+        return await new CraftMaterialTask(materialName, count, materialType).Start(CancellationContext.Instance.Cts.Token);
+    }
+
+    /// <summary>
     /// 返回主界面
     /// </summary>
     /// <returns></returns>

--- a/BetterGenshinImpact/Core/Script/Dependence/Genshin.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/Genshin.cs
@@ -365,12 +365,12 @@ public class Genshin
     /// 在当前已打开的合成界面中合成指定材料。
     /// </summary>
     /// <param name="materialName">目标成品材料名。</param>
-    /// <param name="count">目标合成次数，必须大于 0。</param>
+    /// <param name="quantity">目标合成个数，必须大于 0。</param>
     /// <param name="materialType">材料筛选类型；为空时从物品模型 CSV 中读取。</param>
     /// <returns>合成执行结果。</returns>
-    public async Task<CraftMaterialResult> CraftMaterial(string materialName, int count, string? materialType = null)
+    public async Task<CraftMaterialResult> CraftMaterial(string materialName, int quantity, string? materialType = null)
     {
-        return await new CraftMaterialTask(materialName, count, materialType).Start(CancellationContext.Instance.Cts.Token);
+        return await new CraftMaterialTask(materialName, quantity, materialType).Start(CancellationContext.Instance.Cts.Token);
     }
 
     /// <summary>

--- a/BetterGenshinImpact/Core/Script/EngineExtend.cs
+++ b/BetterGenshinImpact/Core/Script/EngineExtend.cs
@@ -10,6 +10,7 @@ using OpenCvSharp;
 using BetterGenshinImpact.Core.Recognition;
 using BetterGenshinImpact.GameTask.Model.Area;
 using BetterGenshinImpact.Core.Script.Utils;
+using BetterGenshinImpact.GameTask.Common.Job;
 using BetterGenshinImpact.GameTask.AutoDomain;
 using BetterGenshinImpact.GameTask.AutoBoss;
 using BetterGenshinImpact.GameTask.AutoFight;
@@ -17,6 +18,7 @@ using BetterGenshinImpact.GameTask.AutoFight.Model;
 using BetterGenshinImpact.GameTask.AutoLeyLineOutcrop;
 using BetterGenshinImpact.GameTask.AutoSkip;
 using BetterGenshinImpact.GameTask.AutoStygianOnslaught;
+using BetterGenshinImpact.GameTask.Model.GameUI;
 
 namespace BetterGenshinImpact.Core.Script;
 
@@ -76,6 +78,9 @@ public class EngineExtend
         
         engine.AddHostType("AutoDomainParam", typeof(AutoDomainParam));  
         engine.AddHostType("AutoBossParam", typeof(AutoBossParam));
+        engine.AddHostType("CountInventoryItemParam", typeof(CountInventoryItemParam));
+        engine.AddHostType("GridScreenName", typeof(GridScreenName));
+        engine.AddHostType("ItemIconRecognitionMode", typeof(ItemIconRecognitionMode));
         engine.AddHostType("AutoFightParam", typeof(AutoFightParam)); 
         engine.AddHostType("AutoLeyLineOutcropParam", typeof(AutoLeyLineOutcropParam));
         engine.AddHostType("AutoStygianOnslaughtParam", typeof(AutoStygianOnslaughtParam));

--- a/BetterGenshinImpact/GameTask/Common/Job/CountInventoryItem.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/CountInventoryItem.cs
@@ -1,19 +1,16 @@
 using BetterGenshinImpact.Core.Recognition.OCR;
 using BetterGenshinImpact.Core.Simulator;
 using BetterGenshinImpact.GameTask.AutoArtifactSalvage;
-using BetterGenshinImpact.GameTask.GetGridIcons;
 using BetterGenshinImpact.GameTask.Model.Area;
 using BetterGenshinImpact.GameTask.Model.GameUI;
 using BetterGenshinImpact.View.Drawable;
 using BetterGenshinImpact.Helpers;
 using Fischless.WindowsInput;
 using Microsoft.Extensions.Logging;
-using Microsoft.ML.OnnxRuntime;
 using OpenCvSharp;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using BetterGenshinImpact.Core.Script.Dependence;
@@ -29,25 +26,22 @@ namespace BetterGenshinImpact.GameTask.Common.Job
         private CancellationToken ct;
         private readonly GridScreenName gridScreenName;
         private readonly string? itemName;
-        private readonly IEnumerable<string>? itemNames;
+        private readonly IReadOnlyCollection<string>? itemNames;
+        private readonly ItemIconRecognitionMode iconRecognitionMode;
 
-        public CountInventoryItem(GridScreenName gridScreenName, string? itemName = null, IEnumerable<string>? itemNames = null)
+        public CountInventoryItem(CountInventoryItemParam param)
         {
-            this.gridScreenName = gridScreenName;
-            if (itemName != null && itemNames != null)
+            if (param == null)
             {
-                throw new ArgumentException($"参数{nameof(itemName)}和{nameof(itemNames)}不能同时使用");
+                throw new ArgumentNullException(nameof(param));
             }
-            if (itemName == null && itemNames == null)
-            {
-                throw new ArgumentException($"参数{nameof(itemName)}和{nameof(itemNames)}不能同时为空");
-            }
-            if (itemNames != null && !itemNames.Any())
-            {
-                throw new ArgumentException($"参数{nameof(itemNames)}不能为空序列");
-            }
-            this.itemName = itemName;
-            this.itemNames = itemNames;
+
+            param.Validate();
+
+            this.gridScreenName = param.GridScreenName;
+            this.itemName = param.ItemName;
+            this.itemNames = param.GetItemNamesOrNull()?.ToList();
+            this.iconRecognitionMode = param.IconRecognitionMode;
         }
 
         public async Task<object> Start(CancellationToken ct)
@@ -65,21 +59,26 @@ namespace BetterGenshinImpact.GameTask.Common.Job
             await new ReturnMainUiTask().Start(ct);
             await AutoArtifactSalvageTask.OpenInventory(this.gridScreenName, input, logger, this.ct);
 
-            using InferenceSession session = GridIconsAccuracyTestTask.LoadModel(out Dictionary<string, float[]> prototypes);
+            using IItemIconRecognizer iconRecognizer = ItemIconRecognizerFactory.Create(this.iconRecognitionMode);
 
             object result;
             if (this.itemName != null)
             {
-                result = await FindOne(session, prototypes);
+                result = await FindOne(iconRecognizer);
             }
             else
             {
-                result = await FindMulti(session, prototypes);
+                result = await FindMulti(iconRecognizer);
             }
 
             await new ReturnMainUiTask().Start(ct);
 
             return result;
+        }
+
+        private GridParams CreateGridParams()
+        {
+            return GridParams.Templates[this.gridScreenName];
         }
 
         private async Task PreScrollToBottomForWeaponOre()
@@ -95,16 +94,16 @@ namespace BetterGenshinImpact.GameTask.Common.Job
             {
                 GlobalMethod.LeftButtonUp();
             }
-            var gridScroller = new GridScroller(GridParams.Templates[gridScreenName], logger, input, ct);
+            var gridScroller = new GridScroller(CreateGridParams(), logger, input, ct);
             while (await gridScroller.TryVerticalScollDown((src, columns) => GridScreen.GridEnumerator.GetGridItems(src, columns)))
             {
                 await TaskControl.Delay(300, ct);
             }
         }
 
-        private async Task<int> FindOne(InferenceSession session, Dictionary<string, float[]> prototypes)
+        private async Task<int> FindOne(IItemIconRecognizer iconRecognizer)
         {
-            GridScreen gridScreen = new GridScreen(GridParams.Templates[this.gridScreenName], logger, ct);
+            GridScreen gridScreen = new GridScreen(CreateGridParams(), logger, ct);
             gridScreen.OnAfterTurnToNewPage += GridScreen.DrawItemsAfterTurnToNewPage;
             gridScreen.OnBeforeScroll += () => VisionContext.Instance().DrawContent.ClearAll();
             int? count = null;
@@ -120,26 +119,15 @@ namespace BetterGenshinImpact.GameTask.Common.Job
                 await foreach ((ImageRegion pageRegion, Rect itemRect) in gridScreen)
                 {
                     using ImageRegion itemRegion = pageRegion.DeriveCrop(itemRect);
-                    using Mat icon = itemRegion.SrcMat.GetGridIcon();
-                    var result = GridIconsAccuracyTestTask.Infer(icon, session, prototypes);
-                    if (result.Item1 == null)
+                    string? predName = RecognizeItemName(itemRegion, iconRecognizer);
+                    if (predName == null)
                     {
                         continue;
                     }
-                    string predName = result.Item1;
+
                     if (predName == this.itemName!)
                     {
-                        string ocrText = itemRegion.SrcMat.GetGridItemIconText(OcrFactory.Paddle);
-                        string numStr = StringUtils.ConvertFullWidthNumToHalfWidth(ocrText);
-                        if (int.TryParse(numStr, out int num))
-                        {
-                            count = num;
-                        }
-                        else
-                        {
-                            logger.LogWarning("无法识别数量：{text}", numStr);
-                            count = -2;
-                        }
+                        count = ReadItemCount(itemRegion);
                         break;
                     }
                 }
@@ -156,12 +144,12 @@ namespace BetterGenshinImpact.GameTask.Common.Job
             return count.Value;
         }
 
-        private async Task<Dictionary<string, int>> FindMulti(InferenceSession session, Dictionary<string, float[]> prototypes)
+        private async Task<Dictionary<string, int>> FindMulti(IItemIconRecognizer iconRecognizer)
         {
             Dictionary<string, int> itemsCountDic = new Dictionary<string, int>();
             List<string> notFoundItemNames = this.itemNames!.ToList();
 
-            GridScreen gridScreen = new GridScreen(GridParams.Templates[this.gridScreenName], logger, ct);
+            GridScreen gridScreen = new GridScreen(CreateGridParams(), logger, ct);
             gridScreen.OnAfterTurnToNewPage += GridScreen.DrawItemsAfterTurnToNewPage;
             gridScreen.OnBeforeScroll += () => VisionContext.Instance().DrawContent.ClearAll();
             try
@@ -175,27 +163,15 @@ namespace BetterGenshinImpact.GameTask.Common.Job
                 await foreach ((ImageRegion pageRegion, Rect itemRect) in gridScreen)
                 {
                     using ImageRegion itemRegion = pageRegion.DeriveCrop(itemRect);
-                    using Mat icon = itemRegion.SrcMat.GetGridIcon();
-                    var result = GridIconsAccuracyTestTask.Infer(icon, session, prototypes);
-                    if (result.Item1 == null)
+                    string? predName = RecognizeItemName(itemRegion, iconRecognizer);
+                    if (predName == null)
                     {
                         continue;
                     }
-                    string predName = result.Item1;
+
                     if (this.itemNames!.Contains(predName) && !itemsCountDic!.ContainsKey(predName))
                     {
-                        int count;
-                        string ocrText = itemRegion.SrcMat.GetGridItemIconText(OcrFactory.Paddle);
-                        string numStr = StringUtils.ConvertFullWidthNumToHalfWidth(ocrText);
-                        if (int.TryParse(numStr, out int num))
-                        {
-                            count = num;
-                        }
-                        else
-                        {
-                            logger.LogWarning("无法识别数量：{text}", numStr);
-                            count = -2;
-                        }
+                        int count = ReadItemCount(itemRegion);
 
                         if (!itemsCountDic!.TryAdd(predName, count))
                         {
@@ -221,6 +197,25 @@ namespace BetterGenshinImpact.GameTask.Common.Job
                 logger.LogInformation("没有找到{name}", String.Join(", ", notFoundItemNames));
             }
             return itemsCountDic;
+        }
+
+        private static string? RecognizeItemName(ImageRegion itemRegion, IItemIconRecognizer iconRecognizer)
+        {
+            using Mat icon = itemRegion.SrcMat.GetGridIcon();
+            return iconRecognizer.Recognize(icon);
+        }
+
+        private int ReadItemCount(ImageRegion itemRegion)
+        {
+            string ocrText = itemRegion.SrcMat.GetGridItemIconText(OcrFactory.Paddle);
+            string numStr = StringUtils.ConvertFullWidthNumToHalfWidth(ocrText);
+            if (int.TryParse(numStr, out int num))
+            {
+                return num;
+            }
+
+            logger.LogWarning("无法识别数量：{text}", numStr);
+            return -2;
         }
 
         async Task ISoloTask.Start(CancellationToken ct)

--- a/BetterGenshinImpact/GameTask/Common/Job/CountInventoryItemParam.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/CountInventoryItemParam.cs
@@ -1,0 +1,58 @@
+using BetterGenshinImpact.GameTask.Model.GameUI;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BetterGenshinImpact.GameTask.Common.Job;
+
+/// <summary>
+/// 背包物品计数任务参数。
+/// </summary>
+public class CountInventoryItemParam
+{
+    public GridScreenName GridScreenName { get; set; }
+
+    public string? ItemName { get; set; }
+
+    public List<string> ItemNames { get; set; } = [];
+
+    public ItemIconRecognitionMode IconRecognitionMode { get; set; } = ItemIconRecognitionMode.GridIcon;
+
+    /// <summary>
+    /// 供脚本创建后逐项赋值；参数校验在任务消费参数时执行。
+    /// </summary>
+    public CountInventoryItemParam()
+    {
+    }
+
+    public IEnumerable<string>? GetItemNamesOrNull()
+    {
+        return ItemNames.Count > 0 ? ItemNames : null;
+    }
+
+    public void Validate()
+    {
+        ItemNames ??= [];
+        bool hasItemName = !string.IsNullOrWhiteSpace(ItemName);
+        bool hasItemNames = ItemNames.Count > 0;
+        if (!hasItemName)
+        {
+            ItemName = null;
+        }
+
+        if (hasItemName && hasItemNames)
+        {
+            throw new ArgumentException($"参数{nameof(ItemName)}和{nameof(ItemNames)}不能同时使用");
+        }
+
+        if (!hasItemName && !hasItemNames)
+        {
+            throw new ArgumentException($"参数{nameof(ItemName)}和{nameof(ItemNames)}不能同时为空");
+        }
+
+        if (ItemNames.Any(string.IsNullOrWhiteSpace))
+        {
+            throw new ArgumentException($"参数{nameof(ItemNames)}不能包含空名称");
+        }
+    }
+}

--- a/BetterGenshinImpact/GameTask/Common/Job/CraftMaterialTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/CraftMaterialTask.cs
@@ -87,10 +87,6 @@ public class CraftMaterialResult
 /// </summary>
 public class CraftMaterialTask
 {
-    private const int MaxSearchPages = 5;
-    private const int SliderStartX = 1173;
-    private const int SliderY = 672;
-
     private static readonly Regex PositiveIntRegex = new(@"\d+", RegexOptions.Compiled);
     private static readonly Regex FractionRegex = new(@"(\d+)\s*/\s*(\d+)", RegexOptions.Compiled);
     private static readonly Lazy<Dictionary<string, string>> MaterialTypes = new(LoadMaterialTypes);
@@ -313,12 +309,12 @@ public class CraftMaterialTask
     /// 查找并选中目标材料，失败时抛出异常。
     /// </summary>
     /// <returns>异步任务。</returns>
-    /// <exception cref="InvalidOperationException">前 5 页未找到目标材料时抛出。</exception>
+    /// <exception cref="InvalidOperationException">未找到目标材料时抛出。</exception>
     private async Task FindAndSelectMaterial()
     {
         if (!await TryFindAndSelectMaterial())
         {
-            throw new InvalidOperationException($"前 {MaxSearchPages} 页未找到材料：{_materialName}");
+            throw new InvalidOperationException($"未找到材料：{_materialName}");
         }
     }
 
@@ -328,26 +324,15 @@ public class CraftMaterialTask
     /// <returns>找到并选中目标材料时返回 true。</returns>
     private async Task<bool> TryFindAndSelectMaterial()
     {
-        var pageIndex = 0;
-        var shouldStop = false;
         using ItemRecognizer itemRecognizer = new();
         GridScreen gridScreen = new(GridParams.Templates[GridScreenName.Crafting], _logger, _ct);
-        gridScreen.OnAfterTurnToNewPage += data =>
-        {
-            pageIndex++;
-            GridScreen.DrawItemsAfterTurnToNewPage(data);
-        };
+        gridScreen.OnAfterTurnToNewPage += GridScreen.DrawItemsAfterTurnToNewPage;
         gridScreen.OnBeforeScroll += () => VisionContext.Instance().DrawContent.ClearAll();
 
         try
         {
             await foreach ((ImageRegion pageRegion, Rect itemRect) in gridScreen)
             {
-                if (pageIndex > MaxSearchPages || shouldStop)
-                {
-                    break;
-                }
-
                 using ImageRegion itemRegion = pageRegion.DeriveCrop(itemRect);
                 using Mat icon = itemRegion.SrcMat.GetGridIcon();
                 var candidate = itemRecognizer.Match(icon);
@@ -365,7 +350,6 @@ public class CraftMaterialTask
                     continue;
                 }
 
-                shouldStop = true;
                 return true;
             }
         }
@@ -383,7 +367,7 @@ public class CraftMaterialTask
     /// <returns>详情区包含目标材料名时返回 true。</returns>
     private bool ConfirmSelectedMaterial()
     {
-        return ContainsText(Rect1080(1040, 90, 760, 175), _materialName);
+        return ContainsText(Rect1080(1139, 112, 401, 39), _materialName);
     }
 
     /// <summary>
@@ -472,7 +456,7 @@ public class CraftMaterialTask
     /// <returns>识别到的当前合成个数；失败时返回 0。</returns>
     private int ReadCurrentCraftQuantity()
     {
-        var text = StringUtils.ConvertFullWidthNumToHalfWidth(ReadOcrText(Rect1080(1220, 600, 300, 85)));
+        var text = StringUtils.ConvertFullWidthNumToHalfWidth(ReadOcrText(Rect1080(1248, 615, 221, 34)));
         return ReadFirstPositiveInt(text);
     }
 
@@ -482,14 +466,14 @@ public class CraftMaterialTask
     /// <returns>最大可合成个数；识别失败时返回 0。</returns>
     private int ReadMaxCraftQuantity()
     {
-        var maxText = StringUtils.ConvertFullWidthNumToHalfWidth(ReadOcrText(Rect1080(1500, 625, 135, 90)));
+        var maxText = StringUtils.ConvertFullWidthNumToHalfWidth(ReadOcrText(Rect1080(1522, 653, 72, 32)));
         var maxQuantity = ReadFirstPositiveInt(maxText);
         if (maxQuantity > 0)
         {
             return maxQuantity;
         }
 
-        var materialText = StringUtils.ConvertFullWidthNumToHalfWidth(ReadOcrText(Rect1080(815, 742, 1055, 215)));
+        var materialText = StringUtils.ConvertFullWidthNumToHalfWidth(ReadOcrText(Rect1080(933, 912, 561, 33)));
         var counts = FractionRegex.Matches(materialText)
             .Select(match =>
             {
@@ -526,8 +510,12 @@ public class CraftMaterialTask
     /// <returns>异步任务。</returns>
     private async Task DragSliderToRatio(double ratio)
     {
-        var x = SliderStartX + (1521 - SliderStartX) * Math.Clamp(ratio, 0d, 1d);
-        GameCaptureRegion.GameRegion1080PPosMove(SliderStartX, SliderY);
+        const int sliderStartX = 1173;
+        const int sliderEndX = 1521;
+        const int sliderY = 672;
+
+        var x = sliderStartX + (sliderEndX - sliderStartX) * Math.Clamp(ratio, 0d, 1d);
+        GameCaptureRegion.GameRegion1080PPosMove(sliderStartX, sliderY);
         await Delay(80, _ct);
         _input.Mouse.LeftButtonDown();
         try
@@ -535,8 +523,8 @@ public class CraftMaterialTask
             const int steps = 12;
             for (int step = 0; step <= steps; step++)
             {
-                var currentX = SliderStartX + (x - SliderStartX) * step / steps;
-                GameCaptureRegion.GameRegion1080PPosMove(currentX, SliderY);
+                var currentX = sliderStartX + (x - sliderStartX) * step / steps;
+                GameCaptureRegion.GameRegion1080PPosMove(currentX, sliderY);
                 await Delay(25, _ct);
             }
         }

--- a/BetterGenshinImpact/GameTask/Common/Job/CraftMaterialTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/CraftMaterialTask.cs
@@ -1,0 +1,604 @@
+using BetterGenshinImpact.Core.BgiVision;
+using BetterGenshinImpact.Core.Config;
+using BetterGenshinImpact.Core.Simulator;
+using BetterGenshinImpact.GameTask.Common.Reward;
+using BetterGenshinImpact.GameTask.GetGridIcons;
+using BetterGenshinImpact.GameTask.Model.Area;
+using BetterGenshinImpact.GameTask.Model.GameUI;
+using BetterGenshinImpact.Helpers;
+using BetterGenshinImpact.View.Drawable;
+using Fischless.WindowsInput;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualBasic.FileIO;
+using OpenCvSharp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using static BetterGenshinImpact.GameTask.Common.TaskControl;
+
+namespace BetterGenshinImpact.GameTask.Common.Job;
+
+/// <summary>
+/// 合成指定材料的执行结果。
+/// </summary>
+public class CraftMaterialResult
+{
+    /// <summary>
+    /// 是否成功完成合成。
+    /// </summary>
+    public bool Success { get; set; }
+
+    /// <summary>
+    /// 目标材料名。
+    /// </summary>
+    public string MaterialName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 目标合成次数。
+    /// </summary>
+    public int TargetCount { get; set; }
+
+    /// <summary>
+    /// 实际设置到界面的合成次数。
+    /// </summary>
+    public int ActualCount { get; set; }
+
+    /// <summary>
+    /// 本次使用的材料筛选类型。
+    /// </summary>
+    public string MaterialType { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 创建成功结果。
+    /// </summary>
+    /// <param name="materialName">目标材料名。</param>
+    /// <param name="targetCount">目标合成次数。</param>
+    /// <param name="actualCount">实际设置次数。</param>
+    /// <param name="materialType">材料筛选类型。</param>
+    /// <returns>成功结果。</returns>
+    public static CraftMaterialResult CreateSuccess(string materialName, int targetCount, int actualCount, string materialType)
+    {
+        return new CraftMaterialResult
+        {
+            Success = true,
+            MaterialName = materialName,
+            TargetCount = targetCount,
+            ActualCount = actualCount,
+            MaterialType = materialType
+        };
+    }
+
+}
+
+/// <summary>
+/// 当前合成界面内按材料名自动合成材料。
+/// </summary>
+public class CraftMaterialTask
+{
+    private const int MaxSearchPages = 5;
+    private const int SliderStartX = 1173;
+    private const int SliderY = 672;
+
+    private static readonly Regex PositiveIntRegex = new(@"\d+", RegexOptions.Compiled);
+    private static readonly Regex FractionRegex = new(@"(\d+)\s*/\s*(\d+)", RegexOptions.Compiled);
+    private static readonly Lazy<Dictionary<string, string>> MaterialTypes = new(LoadMaterialTypes);
+    private static readonly GridParams CraftingGridParams = new(new Rect(48, 193, 696, 762), 5, 3, 40, 28, 0.024);
+
+    private readonly ILogger<CraftMaterialTask> _logger = App.GetLogger<CraftMaterialTask>();
+    private readonly InputSimulator _input = Simulation.SendInput;
+    private readonly RewardIconMatcher _iconMatcher = new();
+    private readonly string _materialName;
+    private readonly int _targetCount;
+    private readonly string? _materialType;
+    private BvPage? _page;
+    private CancellationToken _ct;
+
+    /// <summary>
+    /// 当前任务使用的 BvPage 实例。
+    /// </summary>
+    /// <exception cref="InvalidOperationException">任务尚未启动时抛出。</exception>
+    private BvPage Page => _page ?? throw new InvalidOperationException("CraftMaterialTask 尚未初始化 BvPage。");
+
+    /// <summary>
+    /// 创建当前合成界面自动合成任务。
+    /// </summary>
+    /// <param name="materialName">目标材料名。</param>
+    /// <param name="targetCount">目标合成次数。</param>
+    /// <param name="materialType">材料筛选类型；为空时从物品 CSV 读取。</param>
+    public CraftMaterialTask(string materialName, int targetCount, string? materialType = null)
+    {
+        _materialName = materialName?.Trim() ?? string.Empty;
+        _targetCount = targetCount;
+        _materialType = string.IsNullOrWhiteSpace(materialType) ? null : materialType.Trim();
+    }
+
+    /// <summary>
+    /// 执行合成任务。
+    /// </summary>
+    /// <param name="ct">取消令牌。</param>
+    /// <returns>合成执行结果。</returns>
+    /// <exception cref="ArgumentException">材料名为空时抛出。</exception>
+    /// <exception cref="ArgumentOutOfRangeException">合成次数小于等于 0 时抛出。</exception>
+    /// <exception cref="InvalidOperationException">合成界面、材料筛选、材料搜索或数量设置失败时抛出。</exception>
+    public async Task<CraftMaterialResult> Start(CancellationToken ct)
+    {
+        _ct = ct;
+        _page = new BvPage(ct);
+        ValidateArguments();
+
+        var materialType = ResolveMaterialType();
+        EnsureInCraftingUi();
+
+        _logger.LogInformation("开始合成材料：{MaterialName}，目标次数：{Count}，筛选类型：{MaterialType}", _materialName, _targetCount, materialType);
+
+        await SelectMaterialType(materialType);
+        await FindAndSelectMaterial();
+        var adjustedCount = await SetCraftCount(_targetCount);
+
+        await SubmitCraftAndClaimResult();
+
+        _logger.LogInformation("材料 {MaterialName} 合成完成，次数：{Count}", _materialName, adjustedCount);
+        return CraftMaterialResult.CreateSuccess(_materialName, _targetCount, adjustedCount, materialType);
+    }
+
+    /// <summary>
+    /// 校验任务构造参数。
+    /// </summary>
+    /// <exception cref="ArgumentException">材料名为空时抛出。</exception>
+    /// <exception cref="ArgumentOutOfRangeException">合成次数小于等于 0 时抛出。</exception>
+    private void ValidateArguments()
+    {
+        if (string.IsNullOrWhiteSpace(_materialName))
+        {
+            throw new ArgumentException("材料名不能为空。", nameof(_materialName));
+        }
+
+        if (_targetCount <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(_targetCount), _targetCount, "合成次数必须大于 0。");
+        }
+    }
+
+    /// <summary>
+    /// 解析材料筛选类型，优先使用调用方显式传入的类型。
+    /// </summary>
+    /// <returns>材料筛选类型。</returns>
+    /// <exception cref="InvalidOperationException">未传入材料类型且 CSV 中没有对应材料类型时抛出。</exception>
+    private string ResolveMaterialType()
+    {
+        if (!string.IsNullOrWhiteSpace(_materialType))
+        {
+            return _materialType;
+        }
+
+        if (MaterialTypes.Value.TryGetValue(_materialName, out var materialType) && !string.IsNullOrWhiteSpace(materialType))
+        {
+            return materialType;
+        }
+
+        throw new InvalidOperationException($"未找到材料 {_materialName} 的材料类型，请传入 materialType 或检查 item.csv。");
+    }
+
+    /// <summary>
+    /// 从物品原型 CSV 读取材料类型映射。
+    /// </summary>
+    /// <returns>材料名到材料类型的映射。</returns>
+    private static Dictionary<string, string> LoadMaterialTypes()
+    {
+        var path = Global.Absolute(@"Assets\Model\ItemV2\item.csv");
+        var result = new Dictionary<string, string>();
+
+        using var parser = new TextFieldParser(path, Encoding.UTF8)
+        {
+            TextFieldType = FieldType.Delimited,
+            HasFieldsEnclosedInQuotes = true,
+            TrimWhiteSpace = false
+        };
+        parser.SetDelimiters(",");
+
+        var headers = parser.ReadFields()!;
+
+        int nameIndex = FindHeaderIndex(headers, "item_name");
+        int typeIndex = FindHeaderIndex(headers, "material_type", "materialType", "item_type", "itemType", "material_category", "category");
+
+        while (!parser.EndOfData)
+        {
+            var columns = parser.ReadFields()!;
+            var name = columns[nameIndex].Trim();
+            var materialType = columns[typeIndex].Trim();
+            if (!string.IsNullOrWhiteSpace(name) && !string.IsNullOrWhiteSpace(materialType))
+            {
+                result[name] = materialType;
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// 查找 CSV 表头中第一个匹配的列索引。
+    /// </summary>
+    /// <param name="headers">CSV 表头。</param>
+    /// <param name="candidates">可接受的列名候选。</param>
+    /// <returns>匹配到的列索引；未找到时返回 -1。</returns>
+    private static int FindHeaderIndex(string[] headers, params string[] candidates)
+    {
+        for (int i = 0; i < headers.Length; i++)
+        {
+            var header = headers[i]?.Trim();
+            if (candidates.Any(candidate => string.Equals(header, candidate, StringComparison.OrdinalIgnoreCase)))
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    /// <summary>
+    /// 确认当前界面是合成界面。
+    /// </summary>
+    /// <exception cref="InvalidOperationException">当前不在合成界面时抛出。</exception>
+    private void EnsureInCraftingUi()
+    {
+        if (!IsInCraftingUi())
+        {
+            throw new InvalidOperationException("请先打开合成界面。");
+        }
+    }
+
+    /// <summary>
+    /// 判断当前是否处于合成界面。
+    /// </summary>
+    /// <returns>处于合成界面时返回 true。</returns>
+    private bool IsInCraftingUi()
+    {
+        return ContainsText(Rect1080(40, 960, 720, 105), "筛选")
+               && ContainsText(Rect1080(0, 0, 260, 95), "合成");
+    }
+
+    /// <summary>
+    /// 选择材料筛选类型，失败时抛出异常。
+    /// </summary>
+    /// <param name="materialType">材料筛选类型。</param>
+    /// <returns>异步任务。</returns>
+    /// <exception cref="InvalidOperationException">未找到或无法点击筛选类型时抛出。</exception>
+    private async Task SelectMaterialType(string materialType)
+    {
+        if (!await TrySelectMaterialType(materialType))
+        {
+            throw new InvalidOperationException($"未能选择材料筛选类型：{materialType}");
+        }
+    }
+
+    /// <summary>
+    /// 在筛选弹窗中选择指定材料类型。
+    /// </summary>
+    /// <param name="materialType">材料筛选类型。</param>
+    /// <returns>选择成功时返回 true。</returns>
+    private async Task<bool> TrySelectMaterialType(string materialType)
+    {
+        try
+        {
+        
+            var confirmation = await Page.GetByText(materialType, Rect1080(165, 1000, 279, 34)).TryWaitFor(300);
+            if (confirmation.Count > 0)
+            {
+                return true;
+            }
+
+            await Page.GetByText("筛选", Rect1080(90, 1000, 60, 33)).Click(3000);
+            await Page.GetByText(materialType, Rect1080(35, 124, 243, 615)).Click(5000);
+    
+
+            throw new TimeoutException($"识别文字[{materialType}]在 10 次筛选后仍未确认！");
+        }
+        catch (TimeoutException e)
+        {
+            _logger.LogWarning("选择材料筛选类型 {MaterialType} 超时：{Message}", materialType, e.Message);
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// 查找并选中目标材料，失败时抛出异常。
+    /// </summary>
+    /// <returns>异步任务。</returns>
+    /// <exception cref="InvalidOperationException">前 5 页未找到目标材料时抛出。</exception>
+    private async Task FindAndSelectMaterial()
+    {
+        if (!await TryFindAndSelectMaterial())
+        {
+            throw new InvalidOperationException($"前 {MaxSearchPages} 页未找到材料：{_materialName}");
+        }
+    }
+
+    /// <summary>
+    /// 在合成列表中用图标模型查找并选中目标材料。
+    /// </summary>
+    /// <returns>找到并选中目标材料时返回 true。</returns>
+    private async Task<bool> TryFindAndSelectMaterial()
+    {
+        var pageIndex = 0;
+        var shouldStop = false;
+        GridScreen gridScreen = new(CraftingGridParams, _logger, _ct);
+        gridScreen.OnAfterTurnToNewPage += data =>
+        {
+            pageIndex++;
+            GridScreen.DrawItemsAfterTurnToNewPage(data);
+        };
+        gridScreen.OnBeforeScroll += () => VisionContext.Instance().DrawContent.ClearAll();
+
+        try
+        {
+            await foreach ((ImageRegion pageRegion, Rect itemRect) in gridScreen)
+            {
+                if (pageIndex > MaxSearchPages || shouldStop)
+                {
+                    break;
+                }
+
+                using ImageRegion itemRegion = pageRegion.DeriveCrop(itemRect);
+                using Mat icon = itemRegion.SrcMat.GetGridIcon();
+                var candidate = _iconMatcher.Match(icon);
+                if (candidate.Score < 0.75 || candidate.Name != _materialName)
+                {
+                    continue;
+                }
+
+                itemRegion.Click();
+                await Delay(500, _ct);
+
+                if (!ConfirmSelectedMaterial())
+                {
+                    _logger.LogWarning("模型识别到 {Name}，但详情区未确认同名材料，继续搜索。", _materialName);
+                    continue;
+                }
+
+                shouldStop = true;
+                return true;
+            }
+        }
+        finally
+        {
+            VisionContext.Instance().DrawContent.ClearAll();
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// 通过右侧详情区 OCR 确认当前选中材料是否为目标材料。
+    /// </summary>
+    /// <returns>详情区包含目标材料名时返回 true。</returns>
+    private bool ConfirmSelectedMaterial()
+    {
+        return ContainsText(Rect1080(1040, 90, 760, 175), _materialName);
+    }
+
+    /// <summary>
+    /// 设置合成次数并校验最终数量。
+    /// </summary>
+    /// <param name="targetCount">目标合成次数。</param>
+    /// <returns>最终校验到的合成次数。</returns>
+    /// <exception cref="InvalidOperationException">最大可合成次数、当前合成次数读取失败，材料不足或最终数量不匹配时抛出。</exception>
+    private async Task<int> SetCraftCount(int targetCount)
+    {
+        var addButton = (X: 1614, Y: 672);
+        var reduceButton = (X: 1074, Y: 672);
+
+        var maxCount = ReadMaxCraftCount();
+        if (maxCount <= 0)
+        {
+            throw new InvalidOperationException("未能识别最大可合成次数。");
+        }
+
+        if (targetCount > maxCount)
+        {
+            throw new InvalidOperationException($"材料不足以合成指定数量，目标 {targetCount}，当前最多可合成 {maxCount}。");
+        }
+
+        if (maxCount == 1)
+        {
+            return 1;
+        }
+
+        await DragSliderToRatio(0);
+        await Delay(250, _ct);
+
+        var ratio = Math.Clamp((targetCount - 1d) / (maxCount - 1d), 0d, 1d);
+        await DragSliderToRatio(ratio);
+        await Delay(350, _ct);
+
+        var actualCount = ReadCurrentCraftCount();
+        if (actualCount <= 0)
+        {
+            throw new InvalidOperationException("未能读取当前合成次数。");
+        }
+
+        if (Math.Abs(actualCount - targetCount) > 30)
+        {
+            await DragSliderToRatio(ratio);
+            await Delay(350, _ct);
+            actualCount = ReadCurrentCraftCount();
+            if (actualCount <= 0 || Math.Abs(actualCount - targetCount) > 30)
+            {
+                throw new InvalidOperationException($"滑块调整合成次数后校验失败，目标 {targetCount}，当前 {actualCount}。");
+            }
+        }
+
+        while (actualCount < targetCount)
+        {
+            GameCaptureRegion.GameRegion1080PPosClick(addButton.X, addButton.Y);
+            await Delay(60, _ct);
+            actualCount++;
+        }
+
+        while (actualCount > targetCount)
+        {
+            GameCaptureRegion.GameRegion1080PPosClick(reduceButton.X, reduceButton.Y);
+            await Delay(60, _ct);
+            actualCount--;
+        }
+
+        await Delay(200, _ct);
+        var verifiedCount = ReadCurrentCraftCount();
+        if (verifiedCount <= 0)
+        {
+            throw new InvalidOperationException("最终合成次数读取失败。");
+        }
+
+        if (verifiedCount != targetCount)
+        {
+            throw new InvalidOperationException($"最终合成次数与目标不一致，目标 {targetCount}，当前 {verifiedCount}。");
+        }
+
+        return verifiedCount;
+    }
+
+    /// <summary>
+    /// 读取右侧当前合成次数。
+    /// </summary>
+    /// <returns>识别到的当前合成次数；失败时返回 0。</returns>
+    private int ReadCurrentCraftCount()
+    {
+        var text = StringUtils.ConvertFullWidthNumToHalfWidth(ReadOcrText(Rect1080(1220, 600, 300, 85)));
+        return ReadFirstPositiveInt(text);
+    }
+
+    /// <summary>
+    /// 读取当前材料最大可合成次数。
+    /// </summary>
+    /// <returns>最大可合成次数；识别失败时返回 0。</returns>
+    private int ReadMaxCraftCount()
+    {
+        var maxText = StringUtils.ConvertFullWidthNumToHalfWidth(ReadOcrText(Rect1080(1500, 625, 135, 90)));
+        var maxCount = ReadFirstPositiveInt(maxText);
+        if (maxCount > 0)
+        {
+            return maxCount;
+        }
+
+        var materialText = StringUtils.ConvertFullWidthNumToHalfWidth(ReadOcrText(Rect1080(815, 742, 1055, 215)));
+        var counts = FractionRegex.Matches(materialText)
+            .Select(match =>
+            {
+                var owned = StringUtils.TryParseInt(match.Groups[1].Value, 0);
+                var required = StringUtils.TryParseInt(match.Groups[2].Value, 0);
+                return required > 0 ? owned / required : 0;
+            })
+            .Where(value => value > 0)
+            .ToList();
+
+        return counts.Count > 0 ? counts.Min() : 0;
+    }
+
+    /// <summary>
+    /// 从文本中读取第一个正整数。
+    /// </summary>
+    /// <param name="text">待解析文本。</param>
+    /// <returns>第一个正整数；没有数字时返回 0。</returns>
+    private static int ReadFirstPositiveInt(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return 0;
+        }
+
+        var match = PositiveIntRegex.Match(StringUtils.RemoveAllSpace(text));
+        return match.Success ? StringUtils.TryParseInt(match.Value, 0) : 0;
+    }
+
+    /// <summary>
+    /// 将合成数量滑块拖动到指定比例位置。
+    /// </summary>
+    /// <param name="ratio">滑块比例，0 表示最左侧，1 表示最右侧。</param>
+    /// <returns>异步任务。</returns>
+    private async Task DragSliderToRatio(double ratio)
+    {
+        var x = SliderStartX + (1521 - SliderStartX) * Math.Clamp(ratio, 0d, 1d);
+        GameCaptureRegion.GameRegion1080PPosMove(SliderStartX, SliderY);
+        await Delay(80, _ct);
+        _input.Mouse.LeftButtonDown();
+        try
+        {
+            const int steps = 12;
+            for (int step = 0; step <= steps; step++)
+            {
+                var currentX = SliderStartX + (x - SliderStartX) * step / steps;
+                GameCaptureRegion.GameRegion1080PPosMove(currentX, SliderY);
+                await Delay(25, _ct);
+            }
+        }
+        finally
+        {
+            _input.Mouse.LeftButtonUp();
+        }
+    }
+
+    /// <summary>
+    /// 提交合成并按顺序确认合成消耗与产物获得弹窗。
+    /// </summary>
+    /// <returns>异步任务。</returns>
+    /// <exception cref="InvalidOperationException">合成提交或任一确认按钮未能识别点击时抛出。</exception>
+    private async Task SubmitCraftAndClaimResult()
+    {
+        try
+        {   //分别是右下角合成按钮，弹窗确认合成按钮，弹窗产物确认按钮
+            await Page.GetByText("合成", Rect1080(1588, 967, 332, 113)).Click(5000);
+            await Page.GetByText("确认", Rect1080(980, 725, 370, 70)).Click(5000);
+            await Page.GetByText("确认", Rect1080(790, 875, 340, 65)).Click(5000);
+        }
+        catch (TimeoutException e)
+        {
+            throw new InvalidOperationException("合成提交与确认流程失败。", e);
+        }
+    }
+
+    /// <summary>
+    /// 读取指定区域内的 OCR 文本。
+    /// </summary>
+    /// <param name="rect">待识别区域。</param>
+    /// <returns>按从上到下、从左到右顺序拼接的 OCR 文本。</returns>
+    private string ReadOcrText(Rect rect)
+    {
+        return string.Concat(Page.Ocr(rect)
+            .OrderBy(region => region.Y)
+            .ThenBy(region => region.X)
+            .Select(region => region.Text));
+    }
+
+    /// <summary>
+    /// 判断指定区域内是否包含目标文本。
+    /// </summary>
+    /// <param name="rect">待识别区域。</param>
+    /// <param name="text">目标文本。</param>
+    /// <returns>包含目标文本时返回 true。</returns>
+    private bool ContainsText(Rect rect, string text)
+    {
+        var normalizedText = StringUtils.RemoveAllSpace(ReadOcrText(rect));
+        return normalizedText.Contains(StringUtils.RemoveAllSpace(text), StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// 将 1080P 基准矩形转换为当前截图尺寸矩形。
+    /// </summary>
+    /// <param name="x">1080P 基准左上角 X。</param>
+    /// <param name="y">1080P 基准左上角 Y。</param>
+    /// <param name="width">1080P 基准宽度。</param>
+    /// <param name="height">1080P 基准高度。</param>
+    /// <returns>当前截图尺寸下的矩形。</returns>
+    private static Rect Rect1080(int x, int y, int width, int height)
+    {
+        var scale = TaskContext.Instance().SystemInfo.AssetScale;
+        return new Rect(
+            (int)Math.Round(x * scale),
+            (int)Math.Round(y * scale),
+            (int)Math.Round(width * scale),
+            (int)Math.Round(height * scale));
+    }
+}

--- a/BetterGenshinImpact/GameTask/Common/Job/CraftMaterialTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/CraftMaterialTask.cs
@@ -481,7 +481,6 @@ public class CraftMaterialTask
                 var required = StringUtils.TryParseInt(match.Groups[2].Value, 0);
                 return required > 0 ? owned / required : 0;
             })
-            .Where(value => value > 0)
             .ToList();
 
         return counts.Count > 0 ? counts.Min() : 0;

--- a/BetterGenshinImpact/GameTask/Common/Job/CraftMaterialTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/CraftMaterialTask.cs
@@ -94,11 +94,9 @@ public class CraftMaterialTask
     private static readonly Regex PositiveIntRegex = new(@"\d+", RegexOptions.Compiled);
     private static readonly Regex FractionRegex = new(@"(\d+)\s*/\s*(\d+)", RegexOptions.Compiled);
     private static readonly Lazy<Dictionary<string, string>> MaterialTypes = new(LoadMaterialTypes);
-    private static readonly GridParams CraftingGridParams = new(new Rect(48, 193, 696, 762), 5, 3, 40, 28, 0.024);
 
     private readonly ILogger<CraftMaterialTask> _logger = App.GetLogger<CraftMaterialTask>();
     private readonly InputSimulator _input = Simulation.SendInput;
-    private readonly RewardIconMatcher _iconMatcher = new();
     private readonly string _materialName;
     private readonly int _targetQuantity;
     private readonly string? _materialType;
@@ -332,7 +330,8 @@ public class CraftMaterialTask
     {
         var pageIndex = 0;
         var shouldStop = false;
-        GridScreen gridScreen = new(CraftingGridParams, _logger, _ct);
+        using ItemRecognizer itemRecognizer = new();
+        GridScreen gridScreen = new(GridParams.Templates[GridScreenName.Crafting], _logger, _ct);
         gridScreen.OnAfterTurnToNewPage += data =>
         {
             pageIndex++;
@@ -351,7 +350,7 @@ public class CraftMaterialTask
 
                 using ImageRegion itemRegion = pageRegion.DeriveCrop(itemRect);
                 using Mat icon = itemRegion.SrcMat.GetGridIcon();
-                var candidate = _iconMatcher.Match(icon);
+                var candidate = itemRecognizer.Match(icon);
                 if (candidate.Score < 0.75 || candidate.Name != _materialName)
                 {
                     continue;

--- a/BetterGenshinImpact/GameTask/Common/Job/CraftMaterialTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/CraftMaterialTask.cs
@@ -208,7 +208,7 @@ public class CraftMaterialTask
         var headers = parser.ReadFields()!;
 
         int nameIndex = FindHeaderIndex(headers, "item_name");
-        int typeIndex = FindHeaderIndex(headers, "material_type", "materialType", "item_type", "itemType", "material_category", "category");
+        int typeIndex = FindHeaderIndex(headers, "material_type");
 
         while (!parser.EndOfData)
         {

--- a/BetterGenshinImpact/GameTask/Common/Job/CraftMaterialTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/CraftMaterialTask.cs
@@ -38,14 +38,14 @@ public class CraftMaterialResult
     public string MaterialName { get; set; } = string.Empty;
 
     /// <summary>
-    /// 目标合成次数。
+    /// 目标合成个数。
     /// </summary>
-    public int TargetCount { get; set; }
+    public int TargetQuantity { get; set; }
 
     /// <summary>
-    /// 实际设置到界面的合成次数。
+    /// 实际设置到界面的合成个数。
     /// </summary>
-    public int ActualCount { get; set; }
+    public int ActualQuantity { get; set; }
 
     /// <summary>
     /// 本次使用的材料筛选类型。
@@ -53,22 +53,30 @@ public class CraftMaterialResult
     public string MaterialType { get; set; } = string.Empty;
 
     /// <summary>
+    /// 本次合成产物汇总。
+    /// </summary>
+    public List<RewardItem> Rewards { get; set; } = [];
+
+    /// <summary>
     /// 创建成功结果。
     /// </summary>
     /// <param name="materialName">目标材料名。</param>
-    /// <param name="targetCount">目标合成次数。</param>
-    /// <param name="actualCount">实际设置次数。</param>
+    /// <param name="targetQuantity">目标合成个数。</param>
+    /// <param name="actualQuantity">实际设置个数。</param>
     /// <param name="materialType">材料筛选类型。</param>
+    /// <param name="rewards">本次合成产物汇总。</param>
     /// <returns>成功结果。</returns>
-    public static CraftMaterialResult CreateSuccess(string materialName, int targetCount, int actualCount, string materialType)
+    public static CraftMaterialResult CreateSuccess(string materialName, int targetQuantity, int actualQuantity, string materialType,
+        List<RewardItem> rewards)
     {
         return new CraftMaterialResult
         {
             Success = true,
             MaterialName = materialName,
-            TargetCount = targetCount,
-            ActualCount = actualCount,
-            MaterialType = materialType
+            TargetQuantity = targetQuantity,
+            ActualQuantity = actualQuantity,
+            MaterialType = materialType,
+            Rewards = rewards
         };
     }
 
@@ -92,7 +100,7 @@ public class CraftMaterialTask
     private readonly InputSimulator _input = Simulation.SendInput;
     private readonly RewardIconMatcher _iconMatcher = new();
     private readonly string _materialName;
-    private readonly int _targetCount;
+    private readonly int _targetQuantity;
     private readonly string? _materialType;
     private BvPage? _page;
     private CancellationToken _ct;
@@ -107,12 +115,12 @@ public class CraftMaterialTask
     /// 创建当前合成界面自动合成任务。
     /// </summary>
     /// <param name="materialName">目标材料名。</param>
-    /// <param name="targetCount">目标合成次数。</param>
+    /// <param name="targetQuantity">目标合成个数。</param>
     /// <param name="materialType">材料筛选类型；为空时从物品 CSV 读取。</param>
-    public CraftMaterialTask(string materialName, int targetCount, string? materialType = null)
+    public CraftMaterialTask(string materialName, int targetQuantity, string? materialType = null)
     {
         _materialName = materialName?.Trim() ?? string.Empty;
-        _targetCount = targetCount;
+        _targetQuantity = targetQuantity;
         _materialType = string.IsNullOrWhiteSpace(materialType) ? null : materialType.Trim();
     }
 
@@ -122,7 +130,7 @@ public class CraftMaterialTask
     /// <param name="ct">取消令牌。</param>
     /// <returns>合成执行结果。</returns>
     /// <exception cref="ArgumentException">材料名为空时抛出。</exception>
-    /// <exception cref="ArgumentOutOfRangeException">合成次数小于等于 0 时抛出。</exception>
+    /// <exception cref="ArgumentOutOfRangeException">合成个数小于等于 0 时抛出。</exception>
     /// <exception cref="InvalidOperationException">合成界面、材料筛选、材料搜索或数量设置失败时抛出。</exception>
     public async Task<CraftMaterialResult> Start(CancellationToken ct)
     {
@@ -133,23 +141,26 @@ public class CraftMaterialTask
         var materialType = ResolveMaterialType();
         EnsureInCraftingUi();
 
-        _logger.LogInformation("开始合成材料：{MaterialName}，目标次数：{Count}，筛选类型：{MaterialType}", _materialName, _targetCount, materialType);
+        _logger.LogInformation("开始合成材料：{MaterialName}，目标个数：{Quantity}，筛选类型：{MaterialType}", _materialName, _targetQuantity, materialType);
 
         await SelectMaterialType(materialType);
         await FindAndSelectMaterial();
-        var adjustedCount = await SetCraftCount(_targetCount);
+        var adjustedQuantity = await SetCraftQuantity(_targetQuantity);
 
-        await SubmitCraftAndClaimResult();
+        var rewards = await SubmitCraftAndClaimResult(adjustedQuantity);
 
-        _logger.LogInformation("材料 {MaterialName} 合成完成，次数：{Count}", _materialName, adjustedCount);
-        return CraftMaterialResult.CreateSuccess(_materialName, _targetCount, adjustedCount, materialType);
+        _logger.LogInformation("材料 {MaterialName} 合成完成，实际设置个数：{Quantity}，产物：{Rewards}",
+            _materialName,
+            adjustedQuantity,
+            FormatRewards(rewards));
+        return CraftMaterialResult.CreateSuccess(_materialName, _targetQuantity, adjustedQuantity, materialType, rewards);
     }
 
     /// <summary>
     /// 校验任务构造参数。
     /// </summary>
     /// <exception cref="ArgumentException">材料名为空时抛出。</exception>
-    /// <exception cref="ArgumentOutOfRangeException">合成次数小于等于 0 时抛出。</exception>
+    /// <exception cref="ArgumentOutOfRangeException">合成个数小于等于 0 时抛出。</exception>
     private void ValidateArguments()
     {
         if (string.IsNullOrWhiteSpace(_materialName))
@@ -157,9 +168,9 @@ public class CraftMaterialTask
             throw new ArgumentException("材料名不能为空。", nameof(_materialName));
         }
 
-        if (_targetCount <= 0)
+        if (_targetQuantity <= 0)
         {
-            throw new ArgumentOutOfRangeException(nameof(_targetCount), _targetCount, "合成次数必须大于 0。");
+            throw new ArgumentOutOfRangeException(nameof(_targetQuantity), _targetQuantity, "合成个数必须大于 0。");
         }
     }
 
@@ -284,18 +295,14 @@ public class CraftMaterialTask
     {
         try
         {
-        
             var confirmation = await Page.GetByText(materialType, Rect1080(165, 1000, 279, 34)).TryWaitFor(300);
             if (confirmation.Count > 0)
             {
                 return true;
             }
-
             await Page.GetByText("筛选", Rect1080(90, 1000, 60, 33)).Click(3000);
             await Page.GetByText(materialType, Rect1080(35, 124, 243, 615)).Click(5000);
-    
-
-            throw new TimeoutException($"识别文字[{materialType}]在 10 次筛选后仍未确认！");
+            return true;
         }
         catch (TimeoutException e)
         {
@@ -381,28 +388,28 @@ public class CraftMaterialTask
     }
 
     /// <summary>
-    /// 设置合成次数并校验最终数量。
+    /// 设置本次合成个数并校验最终数量。
     /// </summary>
-    /// <param name="targetCount">目标合成次数。</param>
-    /// <returns>最终校验到的合成次数。</returns>
-    /// <exception cref="InvalidOperationException">最大可合成次数、当前合成次数读取失败，材料不足或最终数量不匹配时抛出。</exception>
-    private async Task<int> SetCraftCount(int targetCount)
+    /// <param name="targetQuantity">目标合成个数。</param>
+    /// <returns>最终校验到的合成个数。</returns>
+    /// <exception cref="InvalidOperationException">最大可合成个数、当前合成个数读取失败，材料不足或最终数量不匹配时抛出。</exception>
+    private async Task<int> SetCraftQuantity(int targetQuantity)
     {
         var addButton = (X: 1614, Y: 672);
         var reduceButton = (X: 1074, Y: 672);
 
-        var maxCount = ReadMaxCraftCount();
-        if (maxCount <= 0)
+        var maxQuantity = ReadMaxCraftQuantity();
+        if (maxQuantity <= 0)
         {
-            throw new InvalidOperationException("未能识别最大可合成次数。");
+            throw new InvalidOperationException("未能识别最大可合成个数。");
         }
 
-        if (targetCount > maxCount)
+        if (targetQuantity > maxQuantity)
         {
-            throw new InvalidOperationException($"材料不足以合成指定数量，目标 {targetCount}，当前最多可合成 {maxCount}。");
+            throw new InvalidOperationException($"材料不足以合成指定个数，目标 {targetQuantity}，当前最多可合成 {maxQuantity}。");
         }
 
-        if (maxCount == 1)
+        if (maxQuantity == 1)
         {
             return 1;
         }
@@ -410,77 +417,77 @@ public class CraftMaterialTask
         await DragSliderToRatio(0);
         await Delay(250, _ct);
 
-        var ratio = Math.Clamp((targetCount - 1d) / (maxCount - 1d), 0d, 1d);
+        var ratio = Math.Clamp((targetQuantity - 1d) / (maxQuantity - 1d), 0d, 1d);
         await DragSliderToRatio(ratio);
         await Delay(350, _ct);
 
-        var actualCount = ReadCurrentCraftCount();
-        if (actualCount <= 0)
+        var actualQuantity = ReadCurrentCraftQuantity();
+        if (actualQuantity <= 0)
         {
-            throw new InvalidOperationException("未能读取当前合成次数。");
+            throw new InvalidOperationException("未能读取当前合成个数。");
         }
 
-        if (Math.Abs(actualCount - targetCount) > 30)
+        if (Math.Abs(actualQuantity - targetQuantity) > 30)
         {
             await DragSliderToRatio(ratio);
             await Delay(350, _ct);
-            actualCount = ReadCurrentCraftCount();
-            if (actualCount <= 0 || Math.Abs(actualCount - targetCount) > 30)
+            actualQuantity = ReadCurrentCraftQuantity();
+            if (actualQuantity <= 0 || Math.Abs(actualQuantity - targetQuantity) > 30)
             {
-                throw new InvalidOperationException($"滑块调整合成次数后校验失败，目标 {targetCount}，当前 {actualCount}。");
+                throw new InvalidOperationException($"滑块调整合成个数后校验失败，目标 {targetQuantity}，当前 {actualQuantity}。");
             }
         }
 
-        while (actualCount < targetCount)
+        while (actualQuantity < targetQuantity)
         {
             GameCaptureRegion.GameRegion1080PPosClick(addButton.X, addButton.Y);
             await Delay(60, _ct);
-            actualCount++;
+            actualQuantity++;
         }
 
-        while (actualCount > targetCount)
+        while (actualQuantity > targetQuantity)
         {
             GameCaptureRegion.GameRegion1080PPosClick(reduceButton.X, reduceButton.Y);
             await Delay(60, _ct);
-            actualCount--;
+            actualQuantity--;
         }
 
         await Delay(200, _ct);
-        var verifiedCount = ReadCurrentCraftCount();
-        if (verifiedCount <= 0)
+        var verifiedQuantity = ReadCurrentCraftQuantity();
+        if (verifiedQuantity <= 0)
         {
-            throw new InvalidOperationException("最终合成次数读取失败。");
+            throw new InvalidOperationException("最终合成个数读取失败。");
         }
 
-        if (verifiedCount != targetCount)
+        if (verifiedQuantity != targetQuantity)
         {
-            throw new InvalidOperationException($"最终合成次数与目标不一致，目标 {targetCount}，当前 {verifiedCount}。");
+            throw new InvalidOperationException($"最终合成个数与目标不一致，目标 {targetQuantity}，当前 {verifiedQuantity}。");
         }
 
-        return verifiedCount;
+        return verifiedQuantity;
     }
 
     /// <summary>
-    /// 读取右侧当前合成次数。
+    /// 读取右侧当前合成个数。
     /// </summary>
-    /// <returns>识别到的当前合成次数；失败时返回 0。</returns>
-    private int ReadCurrentCraftCount()
+    /// <returns>识别到的当前合成个数；失败时返回 0。</returns>
+    private int ReadCurrentCraftQuantity()
     {
         var text = StringUtils.ConvertFullWidthNumToHalfWidth(ReadOcrText(Rect1080(1220, 600, 300, 85)));
         return ReadFirstPositiveInt(text);
     }
 
     /// <summary>
-    /// 读取当前材料最大可合成次数。
+    /// 读取当前材料最大可合成个数。
     /// </summary>
-    /// <returns>最大可合成次数；识别失败时返回 0。</returns>
-    private int ReadMaxCraftCount()
+    /// <returns>最大可合成个数；识别失败时返回 0。</returns>
+    private int ReadMaxCraftQuantity()
     {
         var maxText = StringUtils.ConvertFullWidthNumToHalfWidth(ReadOcrText(Rect1080(1500, 625, 135, 90)));
-        var maxCount = ReadFirstPositiveInt(maxText);
-        if (maxCount > 0)
+        var maxQuantity = ReadFirstPositiveInt(maxText);
+        if (maxQuantity > 0)
         {
-            return maxCount;
+            return maxQuantity;
         }
 
         var materialText = StringUtils.ConvertFullWidthNumToHalfWidth(ReadOcrText(Rect1080(815, 742, 1055, 215)));
@@ -543,20 +550,79 @@ public class CraftMaterialTask
     /// <summary>
     /// 提交合成并按顺序确认合成消耗与产物获得弹窗。
     /// </summary>
-    /// <returns>异步任务。</returns>
+    /// <param name="actualQuantity">实际合成个数。</param>
+    /// <returns>本次合成产物汇总。</returns>
     /// <exception cref="InvalidOperationException">合成提交或任一确认按钮未能识别点击时抛出。</exception>
-    private async Task SubmitCraftAndClaimResult()
+    private async Task<List<RewardItem>> SubmitCraftAndClaimResult(int actualQuantity)
     {
         try
-        {   //分别是右下角合成按钮，弹窗确认合成按钮，弹窗产物确认按钮
+        {
+            var rewards = CreateDefaultCraftRewards(actualQuantity);
+
+            // 分别是右下角合成按钮、弹窗确认合成按钮、弹窗产物确认按钮。
             await Page.GetByText("合成", Rect1080(1588, 967, 332, 113)).Click(5000);
             await Page.GetByText("确认", Rect1080(980, 725, 370, 70)).Click(5000);
-            await Page.GetByText("确认", Rect1080(790, 875, 340, 65)).Click(5000);
+
+            var resultConfirmButtons = await Page.GetByText("确认", Rect1080(790, 875, 340, 65)).WaitFor(5000);
+            rewards = RecognizeCraftRewards(actualQuantity);
+
+            resultConfirmButtons.First().Click();
+            return rewards;
         }
         catch (TimeoutException e)
         {
             throw new InvalidOperationException("合成提交与确认流程失败。", e);
         }
+    }
+
+    /// <summary>
+    /// 识别产物弹窗中的实际合成产物，失败时回退为默认产物。
+    /// </summary>
+    /// <param name="actualQuantity">实际合成个数。</param>
+    /// <returns>识别到的产物汇总。</returns>
+    private List<RewardItem> RecognizeCraftRewards(int actualQuantity)
+    {
+        try
+        {
+            var rewardSummary = RewardResultRecognizer.Instance.RecognizeMultiPage(1);
+            var rewards = rewardSummary
+                .Where(pair => pair.Value > 0)
+                .Select((pair, index) => new RewardItem(pair.Key, -1, pair.Value, index))
+                .ToList();
+
+            if (rewards.Count > 0)
+            {
+                return rewards;
+            }
+
+            _logger.LogWarning("合成产物识别结果为空，已回退为默认产物。");
+        }
+        catch (Exception e)
+        {
+            _logger.LogWarning(e, "合成产物识别失败，已回退为默认产物。");
+        }
+
+        return CreateDefaultCraftRewards(actualQuantity);
+    }
+
+    /// <summary>
+    /// 创建产物识别失败时的默认合成产物。
+    /// </summary>
+    /// <param name="actualQuantity">实际合成个数。</param>
+    /// <returns>默认合成产物汇总。</returns>
+    private List<RewardItem> CreateDefaultCraftRewards(int actualQuantity)
+    {
+        return [new RewardItem(_materialName, -1, actualQuantity, 0)];
+    }
+
+    /// <summary>
+    /// 格式化产物汇总日志文本。
+    /// </summary>
+    /// <param name="rewards">产物汇总。</param>
+    /// <returns>用于日志输出的产物文本。</returns>
+    private static string FormatRewards(IEnumerable<RewardItem> rewards)
+    {
+        return string.Join(", ", rewards.Select(reward => reward.ToString()));
     }
 
     /// <summary>

--- a/BetterGenshinImpact/GameTask/Common/Job/ItemIconRecognitionMode.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/ItemIconRecognitionMode.cs
@@ -1,0 +1,7 @@
+namespace BetterGenshinImpact.GameTask.Common.Job;
+
+public enum ItemIconRecognitionMode
+{
+    GridIcon,
+    Item
+}

--- a/BetterGenshinImpact/GameTask/Common/Job/ItemIconRecognizer.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/ItemIconRecognizer.cs
@@ -1,4 +1,5 @@
 using BetterGenshinImpact.Core.Config;
+using BetterGenshinImpact.GameTask.GetGridIcons;
 using Microsoft.ML.OnnxRuntime;
 using Microsoft.ML.OnnxRuntime.Tensors;
 using Microsoft.VisualBasic.FileIO;
@@ -9,28 +10,65 @@ using System.IO;
 using System.Linq;
 using System.Text;
 
-namespace BetterGenshinImpact.GameTask.Common.Reward;
+namespace BetterGenshinImpact.GameTask.Common.Job;
 
 /// <summary>
-/// 奖励图标 ONNX 匹配候选。
+/// 物品图标 ONNX 匹配候选。
 /// </summary>
 /// <param name="Name">候选名称。</param>
 /// <param name="Score">匹配分数。</param>
 /// <param name="QualityLevel">候选稀有度；未知或不支持时为 -1。</param>
-internal sealed record RewardIconCandidate(string Name, double Score, int QualityLevel)
+internal sealed record ItemIconCandidate(string Name, double Score, int QualityLevel)
 {
     /// <summary>
     /// 无有效匹配时的空候选。
     /// </summary>
-    public static readonly RewardIconCandidate Empty = new(string.Empty, double.MinValue, -1);
+    public static readonly ItemIconCandidate Empty = new(string.Empty, double.MinValue, -1);
 }
 
-/// <summary>
-/// 奖励图标 embedding 匹配器。
-/// </summary>
-internal sealed class RewardIconMatcher
+internal interface IItemIconRecognizer : IDisposable
+{
+    string? Recognize(Mat icon);
+}
+
+internal static class ItemIconRecognizerFactory
+{
+    public static IItemIconRecognizer Create(ItemIconRecognitionMode mode)
+    {
+        return mode switch
+        {
+            ItemIconRecognitionMode.GridIcon => new GridIconRecognizer(),
+            ItemIconRecognitionMode.Item => new ItemRecognizer(),
+            _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, "不支持的物品图标识别模式")
+        };
+    }
+}
+
+internal sealed class GridIconRecognizer : IItemIconRecognizer
+{
+    private readonly InferenceSession _session;
+    private readonly Dictionary<string, float[]> _prototypes;
+
+    public GridIconRecognizer()
+    {
+        _session = GridIconsAccuracyTestTask.LoadModel(out _prototypes);
+    }
+
+    public string? Recognize(Mat icon)
+    {
+        return GridIconsAccuracyTestTask.Infer(icon, _session, _prototypes).Item1;
+    }
+
+    public void Dispose()
+    {
+        _session.Dispose();
+    }
+}
+
+internal sealed class ItemRecognizer : IItemIconRecognizer
 {
     private const int InputSize = 125;
+    private const double MatchThreshold = 0.75;
 
     private readonly InferenceSession _session;
     private readonly List<IconPrototype> _prototypes;
@@ -45,21 +83,21 @@ internal sealed class RewardIconMatcher
     private sealed record IconPrototype(string Name, int QualityLevel, bool IsRelic, float[] Embedding);
 
     /// <summary>
-    /// 初始化奖励图标模型和原型表。
+    /// 初始化物品图标模型和原型表。
     /// </summary>
-    internal RewardIconMatcher()
+    internal ItemRecognizer()
     {
         _session = new InferenceSession(Global.Absolute(@"Assets\Model\ItemV2\item.onnx"));
         _prototypes = LoadIconPrototypes();
     }
 
     /// <summary>
-    /// 返回奖励图标模型的最高分匹配结果。
+    /// 返回物品图标模型的最高分匹配结果。
     /// </summary>
     /// <param name="mat">125×125 的 BGR 图标图像。</param>
     /// <returns>最高分图标候选。</returns>
     /// <exception cref="ArgumentOutOfRangeException">图标尺寸不是 125×125。</exception>
-    internal RewardIconCandidate Match(Mat mat)
+    internal ItemIconCandidate Match(Mat mat)
     {
         if (mat.Size().Width != InputSize || mat.Size().Height != InputSize)
         {
@@ -83,7 +121,7 @@ internal sealed class RewardIconMatcher
         using var results = _session.Run(inputs);
         var embedding = results.First(r => r.Name == "embedding");
         float[] feature = embedding.AsEnumerable<float>().ToArray();
-        NormalizeVectorInPlace(feature, "奖励图标模型特征向量");
+        NormalizeVectorInPlace(feature, "物品图标模型特征向量");
 
         return _prototypes
             // 每个原型与模型特征做点积；两侧都已 L2 归一化，点积即余弦相似度。
@@ -103,17 +141,28 @@ internal sealed class RewardIconMatcher
                     Score = score
                 };
             })
-            // 圣遗物需要保留同名不同星级；其它奖励不支持稀有度检测。
+            // 圣遗物需要保留同名不同星级；其它物品不支持稀有度检测。
             .GroupBy(c => new
             {
                 c.Name,
                 QualityLevel = c.IsRelic ? c.QualityLevel : -1
             })
-            // 每个显示名只保留最高分原型作为该奖励得分。
+            // 每个显示名只保留最高分原型作为该物品得分。
             .Select(g => g.OrderByDescending(c => c.Score).First())
             .OrderByDescending(c => c.Score)
-            .Select(c => new RewardIconCandidate(c.Name, c.Score, c.IsRelic ? c.QualityLevel : -1))
-            .FirstOrDefault() ?? RewardIconCandidate.Empty;
+            .Select(c => new ItemIconCandidate(c.Name, c.Score, c.IsRelic ? c.QualityLevel : -1))
+            .FirstOrDefault() ?? ItemIconCandidate.Empty;
+    }
+
+    public string? Recognize(Mat icon)
+    {
+        var candidate = Match(icon);
+        return candidate.Score >= MatchThreshold ? candidate.Name : null;
+    }
+
+    public void Dispose()
+    {
+        _session.Dispose();
     }
 
     /// <summary>
@@ -168,7 +217,7 @@ internal sealed class RewardIconMatcher
         int totalFloats = bytes.Length / sizeof(float);
         float[] flatData = new float[totalFloats];
         Buffer.BlockCopy(bytes, 0, flatData, 0, bytes.Length);
-        NormalizeVectorInPlace(flatData, $"奖励图标原型向量 {name}");
+        NormalizeVectorInPlace(flatData, $"物品图标原型向量 {name}");
         return new IconPrototype(name, qualityLevel, isRelic, flatData);
     }
 

--- a/BetterGenshinImpact/GameTask/Common/Reward/RewardResultRecognizer.cs
+++ b/BetterGenshinImpact/GameTask/Common/Reward/RewardResultRecognizer.cs
@@ -2,6 +2,7 @@ using BetterGenshinImpact.Core.Config;
 using BetterGenshinImpact.Core.Recognition.OCR;
 using BetterGenshinImpact.Core.Simulator;
 using BetterGenshinImpact.GameTask.Common;
+using BetterGenshinImpact.GameTask.Common.Job;
 using BetterGenshinImpact.GameTask.Model.Area;
 using BetterGenshinImpact.GameTask.Model.GameUI;
 using BetterGenshinImpact.Helpers;
@@ -24,7 +25,7 @@ public class RewardResultRecognizer
     private static readonly Lazy<RewardResultRecognizer> _instance = new(() => new RewardResultRecognizer());
     public static RewardResultRecognizer Instance => _instance.Value;
 
-    private readonly RewardIconMatcher _iconMatcher;
+    private readonly ItemRecognizer _itemRecognizer;
     private readonly ILogger<RewardResultRecognizer> _logger = App.GetLogger<RewardResultRecognizer>();
     private static readonly Scalar RewardMaskLower = new(0, 0, 190);
     private static readonly Scalar RewardMaskUpper = new(179, 20, 249);
@@ -46,7 +47,7 @@ public class RewardResultRecognizer
 
     private RewardResultRecognizer()
     {
-        _iconMatcher = new RewardIconMatcher();
+        _itemRecognizer = new ItemRecognizer();
     }
 
     /// <summary>
@@ -363,17 +364,17 @@ public class RewardResultRecognizer
     /// <param name="cardMat">奖励卡片图像。</param>
     /// <param name="cardIdx">卡片序号。</param>
     /// <returns>图标候选结果。</returns>
-    private RewardIconCandidate RecognizeIcon(Mat cardMat, int cardIdx)
+    private ItemIconCandidate RecognizeIcon(Mat cardMat, int cardIdx)
     {
         try
         {
             using Mat icon = cardMat.GetGridIcon(); // 归一化为 125×125
-            return _iconMatcher.Match(icon);
+            return _itemRecognizer.Match(icon);
         }
         catch (Exception ex)
         {
             _logger.LogDebug(ex, "奖励识别：卡片 {CardIndex} 图标识别异常，已忽略", cardIdx);
-            return RewardIconCandidate.Empty;
+            return ItemIconCandidate.Empty;
         }
     }
 

--- a/BetterGenshinImpact/GameTask/Model/GameUI/GridParams.cs
+++ b/BetterGenshinImpact/GameTask/Model/GameUI/GridParams.cs
@@ -38,7 +38,8 @@ namespace BetterGenshinImpact.GameTask.Model.GameUI
             { GridScreenName.Quest, weapons },
             { GridScreenName.PreciousItems, weapons },
             { GridScreenName.Furnishings, weapons },
-            { GridScreenName.ArtifactSalvage, new GridParams(new Rect(48, 106, 1267, 768), 9, 3, 40, 28, 0.018)}
+            { GridScreenName.ArtifactSalvage, new GridParams(new Rect(48, 106, 1267, 768), 9, 3, 40, 28, 0.018) },
+            { GridScreenName.Crafting, new GridParams(new Rect(45, 170, 705, 790), 5, 3, 40, 32, 0.024)}
         }.ToFrozenDictionary();
     }
 }

--- a/BetterGenshinImpact/GameTask/Model/GameUI/GridScreen.cs
+++ b/BetterGenshinImpact/GameTask/Model/GameUI/GridScreen.cs
@@ -1,3 +1,4 @@
+using BetterGenshinImpact.Core.Recognition.OpenCv;
 using BetterGenshinImpact.Core.Simulator;
 using BetterGenshinImpact.GameTask.Common;
 using BetterGenshinImpact.GameTask.Model.Area;
@@ -327,13 +328,15 @@ namespace BetterGenshinImpact.GameTask.Model.GameUI
             /// <returns></returns>
             public static IEnumerable<GridCell> PostProcess(Mat mat, IEnumerable<Rect> rects, int threshold)
             {
-                if (!rects.Any())
+                List<Rect> rectList = rects.ToList();
+                if (!rectList.Any())
                 {
                     return [];
                 }
                 // 根据聚簇结果补漏……
-                List<GridCell> cells = GridCell.ClusterToCells(rects, threshold).ToList();
+                List<GridCell> cells = GridCell.ClusterToCells(rectList, threshold).ToList();
                 GridCell.FillMissingGridCells(ref cells);
+                FillExtraBottomRow(mat, ref cells);
 
                 // 在末尾处有可能补多了，把底部颜色不符的丢掉……  // PS：群友有直接用底部颜色进行识别的，效果不错
                 var result = cells.ToList();
@@ -356,6 +359,95 @@ namespace BetterGenshinImpact.GameTask.Model.GameUI
                 }
 
                 return result;
+            }
+
+            /// <summary>
+            /// 当已有网格行下方仍有足够空间时，按当前行距和列距额外推断一行幻影格子。
+            /// 推断出的格子会在后续流程中继续通过 <see cref="IsCorrectBottomColor(Mat, int)"/> 做底部颜色校验。
+            /// </summary>
+            /// <param name="mat">当前网格 ROI 图像。</param>
+            /// <param name="cells">当前已识别和已补齐的网格格子。</param>
+            private static void FillExtraBottomRow(Mat mat, ref List<GridCell> cells)
+            {
+                if (cells.Count <= 0)
+                {
+                    return;
+                }
+
+                var rows = cells
+                    .GroupBy(c => c.RowNum)
+                    .Select(g => new
+                    {
+                        RowNum = g.Key,
+                        Y = g.Average(c => c.Rect.Y),
+                        Height = g.Average(c => c.Rect.Height)
+                    })
+                    .OrderBy(row => row.RowNum)
+                    .ToList();
+                if (rows.Count < 2)
+                {
+                    return;
+                }
+
+                var rowSpacings = rows
+                    .Zip(rows.Skip(1), (previous, next) => next.Y - previous.Y - previous.Height)
+                    .Where(spacing => spacing >= 0)
+                    .ToList();
+                if (rowSpacings.Count == 0)
+                {
+                    return;
+                }
+
+                double avgWidth = cells.Average(c => c.Rect.Width);
+                double avgHeight = cells.Average(c => c.Rect.Height);
+                double avgRowSpacing = rowSpacings.Average();
+                var lastRow = rows[^1];
+                double nextY = lastRow.Y + lastRow.Height + avgRowSpacing;
+                if (nextY + avgHeight > mat.Rows)
+                {
+                    return;
+                }
+
+                double avgColSpacing;
+                {
+                    var colSpacings = new List<double>();
+                    foreach (var row in cells.GroupBy(c => c.RowNum))
+                    {
+                        foreach (var pair in row.OrderBy(c => c.ColNum).Zip(row.OrderBy(c => c.ColNum).Skip(1)))
+                        {
+                            if (pair.Second.ColNum != pair.First.ColNum + 1)
+                            {
+                                continue;
+                            }
+
+                            double spacing = pair.Second.Rect.X - pair.First.Rect.X - pair.First.Rect.Width;
+                            if (spacing >= 0)
+                            {
+                                colSpacings.Add(spacing);
+                            }
+                        }
+                    }
+
+                    avgColSpacing = colSpacings.Count == 0 ? 0 : colSpacings.Average();
+                }
+
+                double avgLeft = cells.Average(c => c.Rect.X - (avgWidth + avgColSpacing) * c.ColNum);
+                int rowNum = cells.Max(c => c.RowNum) + 1;
+                int maxColNum = cells.Max(c => c.ColNum);
+                for (int colNum = 0; colNum <= maxColNum; colNum++)
+                {
+                    int x = (int)Math.Round(avgLeft + (avgWidth + avgColSpacing) * colNum, MidpointRounding.AwayFromZero);
+                    int y = (int)Math.Round(nextY, MidpointRounding.AwayFromZero);
+                    int width = (int)Math.Round(avgWidth, MidpointRounding.AwayFromZero);
+                    int height = (int)Math.Round(avgHeight, MidpointRounding.AwayFromZero);
+                    GridCell cell = new GridCell(new Rect(x, y, width, height))
+                    {
+                        ColNum = colNum,
+                        RowNum = rowNum,
+                        IsPhantom = true
+                    };
+                    cells.Add(cell);
+                }
             }
 
             public async ValueTask<bool> MoveNextAsync()
@@ -455,13 +547,27 @@ namespace BetterGenshinImpact.GameTask.Model.GameUI
 
                 Scalar bgrColor = new Scalar(0xdc, 0xe5, 0xe9);
 
-                // 计算区域的平均颜色
-                Scalar meanColor = Cv2.Mean(image);
+                //在合成台沿用时，名字太长会影响颜色比较，这里将名字区域从矩形中扣掉，只用剩下的口字型边框来比较颜色。
+                using Mat mask = new Mat(image.Size(), MatType.CV_8UC1, new Scalar(255));
+                Rect ignoredRect = new Rect(6, 0, 113, 21).ClampTo(image);
+                if (ignoredRect.Width > 0 && ignoredRect.Height > 0)
+                {
+                    using Mat ignoredMask = mask.SubMat(ignoredRect);
+                    ignoredMask.SetTo(0);
+                }
+
+                if (Cv2.CountNonZero(mask) == 0)
+                {
+                    return false;
+                }
+
+                // 忽略文字主区域后，使用剩余底部背景计算平均颜色。
+                Scalar meanColor = Cv2.Mean(image, mask);
 
                 // 计算平均颜色与目标颜色的差异
                 double diff = Math.Abs(meanColor.Val0 - bgrColor.Val0) +
-                             Math.Abs(meanColor.Val1 - bgrColor.Val1) +
-                             Math.Abs(meanColor.Val2 - bgrColor.Val2);
+                              Math.Abs(meanColor.Val1 - bgrColor.Val1) +
+                              Math.Abs(meanColor.Val2 - bgrColor.Val2);
 
                 return diff <= tolerance * 3;
             }

--- a/BetterGenshinImpact/GameTask/Model/GameUI/GridScreenName.cs
+++ b/BetterGenshinImpact/GameTask/Model/GameUI/GridScreenName.cs
@@ -28,6 +28,8 @@ namespace BetterGenshinImpact.GameTask.Model.GameUI
         [Description("圣遗物分解")]
         ArtifactSalvage,
         [Description("圣遗物套装筛选")]
-        ArtifactSetFilter
+        ArtifactSetFilter,
+        [Description("合成")]
+        Crafting
     }
 }


### PR DESCRIPTION
增加在合成台界面的合成功能，
```C#
    public async Task<CraftMaterialResult> CraftMaterial(string materialName, int count, string? materialType = null)
    {
        return await new CraftMaterialTask(materialName, count, materialType).Start(CancellationContext.Instance.Cts.Token);
    }
```
JS示例：`genshin.craftMaterial("史莱姆清",1,"角色与武器培养素材")`
必须已经在合成台界面，参数中 `材料类型` 可选，但csv文件还没更新，目前属于必填。
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **新功能**
  * 新增“合成材料”自动处理：按材料名与数量执行合成，并返回成功状态、目标/实际数量及产物汇总信息。
  * 背包物品统计支持单个/多个物品查询；多物品结果可直接以动态对象方式读取。
  * 新增图标识别模式（网格/物品），用于调整背包物品识别方式。
* **改进**
  * 更新物品/奖励图标识别实现，提升识别稳定性。
  * 扩展“合成”界面的网格配置与网格补全/底部校验逻辑。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->