### PR TITLE
feat：添加角色网格图标识别，添加更换角色的方法

### DIFF
--- a/BetterGenshinImpact/Core/Recognition/ONNX/BgiOnnxModel.cs
+++ b/BetterGenshinImpact/Core/Recognition/ONNX/BgiOnnxModel.cs
@@ -62,6 +62,12 @@ public class BgiOnnxModel
         Register("BgiQClassify", @"Assets\Model\Common\q_classify_sim.onnx");
 
     /// <summary>
+    /// 队伍配置角色头像识别模型
+    /// </summary>
+    public static readonly BgiOnnxModel AvatarGridIcon =
+        Register("AvatarGridIcon", @"Assets\Model\AvatarGridIcon\avatar.onnx");
+
+    /// <summary>
     /// Silero 人声检测模型
     /// </summary>
     public static readonly BgiOnnxModel SileroVad =

--- a/BetterGenshinImpact/Core/Script/Dependence/Genshin.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/Genshin.cs
@@ -314,9 +314,8 @@ public class Genshin
         {
             return await new SwitchCharacterStateMachineTask().Start(slot1, slot2, slot3, slot4, CancellationContext.Instance.Cts.Token);
         }
-        catch (Exception ex)
+        catch (PartySetupFailedException)
         {
-            _logger.LogError("{Message}", ex.Message);
             return false;
         }
     }

--- a/BetterGenshinImpact/Core/Script/Dependence/Genshin.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/Genshin.cs
@@ -16,12 +16,14 @@ using BetterGenshinImpact.GameTask.Common.Map.Maps.Base;
 using BetterGenshinImpact.GameTask.Common.Exceptions;
 using BetterGenshinImpact.GameTask.Common.Map.Maps;
 using BetterGenshinImpact.Helpers.Extensions;
+using Microsoft.Extensions.Logging;
 
 namespace BetterGenshinImpact.Core.Script.Dependence;
 
 public class Genshin
 {
     private RECT captureAreaRect = TaskContext.Instance().SystemInfo.CaptureAreaRect;
+    private readonly ILogger<Genshin> _logger = App.GetLogger<Genshin>();
 
     /// <summary>
     /// 游戏宽度
@@ -302,19 +304,20 @@ public class Genshin
     /// <param name="slot4">4 号位角色名。</param>
     /// <returns>完成保存并返回主界面返回 true；参数无效、目标角色未找到或流程失败返回 false。</returns>
     /// <remarks>
-    /// 参数为 null 或空字符串表示跳过对应槽位。
-    /// 调用示例：<c>await genshin.SwitchCharacter("胡桃", "夜兰", null, "钟离");</c>
+    /// 每个槽位都必须传入字符串，空字符串表示跳过对应槽位。
+    /// 调用示例：<c>await genshin.SwitchCharacter("胡桃", "夜兰", "", "钟离");</c>
     /// 该方法表示重组队伍槽位角色，不是按数字键切换当前出战角色。
     /// </remarks>
-    public async Task<bool> SwitchCharacter(string? slot1 = null, string? slot2 = null, string? slot3 = null, string? slot4 = null)
+    public async Task<bool> SwitchCharacter(string slot1, string slot2, string slot3, string slot4)
     {
         try
         {
             return await new SwitchCharacterStateMachineTask().Start(slot1, slot2, slot3, slot4, CancellationContext.Instance.Cts.Token);
         }
-        catch (PartySetupFailedException)
+        catch (Exception ex)
         {
-            return false;//释放失败状态给调用方，否则失败后会退出任务。
+            _logger.LogError("{Message}", ex.Message);
+            return false;
         }
     }
 

--- a/BetterGenshinImpact/Core/Script/Dependence/Genshin.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/Genshin.cs
@@ -304,11 +304,11 @@ public class Genshin
     /// <param name="slot4">4 号位角色名。</param>
     /// <returns>完成保存并返回主界面返回 true；参数无效、目标角色未找到或流程失败返回 false。</returns>
     /// <remarks>
-    /// 每个槽位都必须传入字符串，空字符串表示跳过对应槽位。
+    /// 未传入的槽位默认跳过；空字符串表示跳过对应槽位。
     /// 调用示例：<c>await genshin.SwitchCharacter("胡桃", "夜兰", "", "钟离");</c>
     /// 该方法表示重组队伍槽位角色，不是按数字键切换当前出战角色。
     /// </remarks>
-    public async Task<bool> SwitchCharacter(string slot1, string slot2, string slot3, string slot4)
+    public async Task<bool> SwitchCharacter(string slot1 = "", string slot2 = "", string slot3 = "", string slot4 = "")
     {
         try
         {

--- a/BetterGenshinImpact/Core/Script/Dependence/Genshin.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/Genshin.cs
@@ -287,12 +287,37 @@ public class Genshin
         {
             return await new SwitchPartyTask().Start(partyName, CancellationContext.Instance.Cts.Token);
         }
-        catch (PartySetupFailedException ex)
+        catch (PartySetupFailedException)
         {
-            return false;//释放失败状态到JS，否则失败后会退出任务。
+            return false;//释放失败状态给调用方，否则失败后会退出任务。
         }
     }
-    
+
+    /// <summary>
+    /// 按槽位重组当前队伍角色。
+    /// </summary>
+    /// <param name="slot1">1 号位角色名。</param>
+    /// <param name="slot2">2 号位角色名。</param>
+    /// <param name="slot3">3 号位角色名。</param>
+    /// <param name="slot4">4 号位角色名。</param>
+    /// <returns>完成保存并返回主界面返回 true；参数无效、目标角色未找到或流程失败返回 false。</returns>
+    /// <remarks>
+    /// 参数为 null 或空字符串表示跳过对应槽位。
+    /// 调用示例：<c>await genshin.SwitchCharacter("胡桃", "夜兰", null, "钟离");</c>
+    /// 该方法表示重组队伍槽位角色，不是按数字键切换当前出战角色。
+    /// </remarks>
+    public async Task<bool> SwitchCharacter(string? slot1 = null, string? slot2 = null, string? slot3 = null, string? slot4 = null)
+    {
+        try
+        {
+            return await new SwitchCharacterStateMachineTask().Start(slot1, slot2, slot3, slot4, CancellationContext.Instance.Cts.Token);
+        }
+        catch (PartySetupFailedException)
+        {
+            return false;//释放失败状态给调用方，否则失败后会退出任务。
+        }
+    }
+
     /// <summary>
     /// 清除当前调度器的队伍缓存
     /// </summary>

--- a/BetterGenshinImpact/GameTask/AutoFight/Assets/combat_avatar.json
+++ b/BetterGenshinImpact/GameTask/AutoFight/Assets/combat_avatar.json
@@ -50,7 +50,8 @@
   {
     "alias": [
       "奇偶(男)",
-      "MannequinBoy"
+      "MannequinBoy",
+      "奇偶·男性"
     ],
     "id": "10000117",
     "name": "奇偶(男)",
@@ -60,7 +61,8 @@
   {
     "alias": [
       "奇偶(女)",
-      "MannequinGirl"
+      "MannequinGirl",
+      "奇偶·女性"
     ],
     "id": "10000118",
     "name": "奇偶(女)",

--- a/BetterGenshinImpact/GameTask/Common/Job/AvatarGridIconRecognizer.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/AvatarGridIconRecognizer.cs
@@ -1,0 +1,186 @@
+using BetterGenshinImpact.Core.Config;
+using BetterGenshinImpact.Core.Recognition.ONNX;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.ML.OnnxRuntime;
+using Microsoft.ML.OnnxRuntime.Tensors;
+using Microsoft.VisualBasic.FileIO;
+using OpenCvSharp;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace BetterGenshinImpact.GameTask.Common.Job;
+
+/// <summary>
+/// 队伍配置角色头像模型识别候选。
+/// </summary>
+/// <param name="CharacterName">角色标准名称。</param>
+/// <param name="ElementType">角色元素类型，来自 avatar.csv 的 element_type。</param>
+/// <param name="Score">候选与输入头像 embedding 的余弦相似度。</param>
+internal sealed record AvatarGridIconCandidate(string CharacterName, string ElementType, double Score)
+{
+    /// <summary>
+    /// 未匹配到有效候选时使用的空结果。
+    /// </summary>
+    public static readonly AvatarGridIconCandidate Empty = new(string.Empty, string.Empty, double.MinValue);
+}
+
+/// <summary>
+/// 队伍配置角色头像识别器。
+/// </summary>
+/// <remarks>
+/// 使用 <c>Assets\Model\AvatarGridIcon\avatar.onnx</c> 提取头像特征，
+/// 再与 <c>Assets\Model\AvatarGridIcon\avatar.csv</c> 中的角色原型向量做余弦相似度识别。
+/// </remarks>
+internal sealed class AvatarGridIconRecognizer : IDisposable
+{
+    private const int InputSize = 115;
+    private const string PrototypePath = @"Assets\Model\AvatarGridIcon\avatar.csv";
+
+    private readonly InferenceSession _session;
+    private readonly List<AvatarPrototype> _prototypes;
+
+    private sealed record AvatarPrototype(string CharacterName, string ElementType, string WeaponName, float[] Embedding);
+
+    /// <summary>
+    /// 初始化头像 ONNX 模型会话并加载角色头像原型表。
+    /// </summary>
+    public AvatarGridIconRecognizer()
+    {
+        _session = App.ServiceProvider.GetRequiredService<BgiOnnxFactory>()
+            .CreateInferenceSession(BgiOnnxModel.AvatarGridIcon);
+        _prototypes = LoadPrototypes();
+    }
+
+    /// <summary>
+    /// 识别一个队伍配置角色头像格子，返回相似度最高的角色候选。
+    /// </summary>
+    /// <param name="mat">角色头像格子裁剪图，BGR 格式；方法内部会 resize 到 115x115。</param>
+    /// <returns>按角色名聚合后的最高分识别候选。</returns>
+    public AvatarGridIconCandidate Recognize(Mat mat)
+    {
+        using Mat resized = mat.Resize(new Size(InputSize, InputSize));
+        using Mat rgb = resized.CvtColor(ColorConversionCodes.BGR2RGB);
+        var tensor = new DenseTensor<float>(new[] { 1, 3, InputSize, InputSize });
+        for (int y = 0; y < rgb.Height; y++)
+        {
+            for (int x = 0; x < rgb.Width; x++)
+            {
+                var pixel = rgb.At<Vec3b>(y, x);
+                tensor[0, 0, y, x] = (pixel[0] / 255f - 0.5f) / 0.5f;
+                tensor[0, 1, y, x] = (pixel[1] / 255f - 0.5f) / 0.5f;
+                tensor[0, 2, y, x] = (pixel[2] / 255f - 0.5f) / 0.5f;
+            }
+        }
+
+        var inputs = new List<NamedOnnxValue> { NamedOnnxValue.CreateFromTensor("input_image", tensor) };
+        using var results = _session.Run(inputs);
+        float[] feature = results.First(r => r.Name == "embedding").AsEnumerable<float>().ToArray();
+        NormalizeVectorInPlace(feature);
+
+        return _prototypes
+            // 两侧 embedding 都已 L2 归一化，点积即余弦相似度。
+            .Select(prototype =>
+            {
+                double score = 0;
+                for (int i = 0; i < feature.Length; i++)
+                {
+                    score += prototype.Embedding[i] * feature[i];
+                }
+
+                return new AvatarGridIconCandidate(prototype.CharacterName, prototype.ElementType, score);
+            })
+            .GroupBy(candidate => candidate.CharacterName)
+            .Select(group => group.OrderByDescending(candidate => candidate.Score).First())
+            .OrderByDescending(candidate => candidate.Score)
+            .FirstOrDefault() ?? AvatarGridIconCandidate.Empty;
+    }
+
+    /// <summary>
+    /// 获取指定角色的元素类型，用于队伍配置界面的元素筛选。
+    /// </summary>
+    /// <param name="characterName">角色标准名称。</param>
+    /// <returns>角色元素类型。</returns>
+    public string GetElementType(string characterName)
+    {
+        return _prototypes.First(prototype => prototype.CharacterName == characterName).ElementType;
+    }
+
+    /// <summary>
+    /// 获取指定角色的武器名称，用于队伍配置界面的武器筛选。
+    /// </summary>
+    /// <param name="characterName">角色标准名称。</param>
+    /// <returns>角色武器名称。</returns>
+    public string GetWeaponName(string characterName)
+    {
+        return _prototypes.First(prototype => prototype.CharacterName == characterName).WeaponName;
+    }
+
+    /// <summary>
+    /// 从 avatar.csv 加载角色头像原型向量。
+    /// </summary>
+    /// <returns>角色头像原型列表。</returns>
+    private static List<AvatarPrototype> LoadPrototypes()
+    {
+        using var parser = new TextFieldParser(Global.Absolute(PrototypePath), Encoding.UTF8)
+        {
+            TextFieldType = FieldType.Delimited,
+            HasFieldsEnclosedInQuotes = true,
+            TrimWhiteSpace = false
+        };
+        parser.SetDelimiters(",");
+
+        var headers = parser.ReadFields()!;
+        int characterNameIndex = Array.FindIndex(headers, h => string.Equals(h?.Trim(), "character_name", StringComparison.OrdinalIgnoreCase));
+        int elementTypeIndex = Array.FindIndex(headers, h => string.Equals(h?.Trim(), "element_type", StringComparison.OrdinalIgnoreCase));
+        int weaponTypeIndex = Array.FindIndex(headers, h => string.Equals(h?.Trim(), "weapon_type", StringComparison.OrdinalIgnoreCase));
+        int embeddingIndex = Array.FindIndex(headers, h => string.Equals(h?.Trim(), "embedding", StringComparison.OrdinalIgnoreCase));
+
+        List<AvatarPrototype> prototypes = [];
+        while (!parser.EndOfData)
+        {
+            var columns = parser.ReadFields()!;
+            var bytes = Convert.FromBase64String(columns[embeddingIndex].Trim());
+            int totalFloats = bytes.Length / sizeof(float);
+            float[] embedding = new float[totalFloats];
+            Buffer.BlockCopy(bytes, 0, embedding, 0, bytes.Length);
+            NormalizeVectorInPlace(embedding);
+            prototypes.Add(new AvatarPrototype(
+                columns[characterNameIndex].Trim(),
+                columns[elementTypeIndex].Trim(),
+                columns[weaponTypeIndex].Trim(),
+                embedding));
+        }
+
+        return prototypes;
+    }
+
+    /// <summary>
+    /// 对 embedding 向量执行 L2 归一化，便于后续用点积计算余弦相似度。
+    /// </summary>
+    /// <param name="vector">待归一化的向量。</param>
+    private static void NormalizeVectorInPlace(float[] vector)
+    {
+        double norm2 = 0;
+        foreach (float value in vector)
+        {
+            norm2 += (double)value * value;
+        }
+
+        double norm = Math.Sqrt(norm2);
+        for (int i = 0; i < vector.Length; i++)
+        {
+            vector[i] = (float)(vector[i] / norm);
+        }
+    }
+
+    /// <summary>
+    /// 释放 ONNX 推理会话。
+    /// </summary>
+    public void Dispose()
+    {
+        _session.Dispose();
+    }
+}

--- a/BetterGenshinImpact/GameTask/Common/Job/AvatarGridIconRecognizer.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/AvatarGridIconRecognizer.cs
@@ -14,7 +14,7 @@ using System.Text;
 namespace BetterGenshinImpact.GameTask.Common.Job;
 
 /// <summary>
-/// 队伍配置角色头像模型识别候选。
+/// 角色头像模型识别候选。
 /// </summary>
 /// <param name="CharacterName">角色标准名称。</param>
 /// <param name="ElementType">角色元素类型，来自 avatar.csv 的 element_type。</param>
@@ -28,7 +28,7 @@ internal sealed record AvatarGridIconCandidate(string CharacterName, string Elem
 }
 
 /// <summary>
-/// 队伍配置角色头像识别器。
+/// 角色头像识别器。
 /// </summary>
 /// <remarks>
 /// 使用 <c>Assets\Model\AvatarGridIcon\avatar.onnx</c> 提取头像特征，
@@ -55,7 +55,7 @@ internal sealed class AvatarGridIconRecognizer : IDisposable
     }
 
     /// <summary>
-    /// 识别一个队伍配置角色头像格子，返回相似度最高的角色候选。
+    /// 识别一个角色格子，返回相似度最高的角色候选。
     /// </summary>
     /// <param name="mat">角色头像格子裁剪图，BGR 格式；方法内部会 resize 到 115x115。</param>
     /// <returns>按角色名聚合后的最高分识别候选。</returns>
@@ -99,7 +99,7 @@ internal sealed class AvatarGridIconRecognizer : IDisposable
     }
 
     /// <summary>
-    /// 获取指定角色的元素类型，用于队伍配置界面的元素筛选。
+    /// 获取指定角色的元素类型
     /// </summary>
     /// <param name="characterName">角色标准名称。</param>
     /// <returns>角色元素类型。</returns>
@@ -109,7 +109,7 @@ internal sealed class AvatarGridIconRecognizer : IDisposable
     }
 
     /// <summary>
-    /// 获取指定角色的武器名称，用于队伍配置界面的武器筛选。
+    /// 获取指定角色的武器名称
     /// </summary>
     /// <param name="characterName">角色标准名称。</param>
     /// <returns>角色武器名称。</returns>

--- a/BetterGenshinImpact/GameTask/Common/Job/SwitchCharacterStateMachineTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/SwitchCharacterStateMachineTask.cs
@@ -42,7 +42,6 @@ public enum SwitchCharacterState
     ClearFilter, //清除当前筛选条件
     VerifyRoleInSlot, //确认角色已进入目标槽位
     ClearMisplacedRole, //清理进入非目标槽位的角色
-    PrepareRefillRole, //准备原队角色补位
     SaveConfiguration, //保存当前队伍配置
     ReturnMainUi, //返回主界面
     Completed //任务已完成
@@ -72,15 +71,11 @@ public sealed class SwitchCharacterStateMachineTask : StateMachineBase<SwitchCha
     private List<TargetRole> _targetRoles = [];
     private List<TeamSlotSnapshot> _initialSlots = [];
     private HashSet<int> _slotsToClear = [];
-    private Queue<TargetRole> _rolesToSelect = new();
-    private Queue<string> _refillCandidates = new();
-    private List<int> _sourceClearedSlots = [];
-    private Queue<int> _fillSlots = new();
+    private Queue<SelectionPlanItem> _selectionPlan = new();
     private TargetRole? _currentRole;
     private bool _currentRoleIsRefill;
     private int _currentRoleAttempt;
     private bool _currentAvatarFound;
-    private bool _fillSlotsInitialized;
     private bool _clearCombatScenesAfterReturn;
     private string? _pendingFilterElementType;
     private string? _pendingFilterWeaponType;
@@ -116,6 +111,14 @@ public sealed class SwitchCharacterStateMachineTask : StateMachineBase<SwitchCha
 
     private sealed record TeamSlotSnapshot(int Slot, string? Name, bool IsSelected, Rect? CardRect);
 
+    private sealed record SelectionPlanItem(TargetRole Role, bool IsRefill);
+
+    private sealed record SwitchPlanBuildResult(
+        bool Success,
+        HashSet<int> SlotsToClear,
+        List<SelectionPlanItem> SelectionPlan,
+        string? FailureReason);
+
     private AvatarGridIconRecognizer Recognizer =>
         _recognizer ?? throw new InvalidOperationException("切换角色：头像识别器未初始化");
 
@@ -138,23 +141,22 @@ public sealed class SwitchCharacterStateMachineTask : StateMachineBase<SwitchCha
             (SwitchCharacterState.QuickTeamList, [
                 SwitchCharacterState.BuildSwitchPlan,
                 SwitchCharacterState.FindAndClickAvatar,
-                SwitchCharacterState.PrepareRefillRole,
                 SwitchCharacterState.SaveConfiguration,
                 SwitchCharacterState.ReturnMainUi
             ]),
             (SwitchCharacterState.BuildSwitchPlan, [SwitchCharacterState.ClearSelectedRoles, SwitchCharacterState.ReturnMainUi]),
             (SwitchCharacterState.ClearSelectedRoles, [SwitchCharacterState.PrepareNextRole]),
-            (SwitchCharacterState.PrepareNextRole, [SwitchCharacterState.OpenFilterPanel, SwitchCharacterState.PrepareRefillRole]),
+            (SwitchCharacterState.PrepareNextRole, [SwitchCharacterState.OpenFilterPanel, SwitchCharacterState.SaveConfiguration]),
             (SwitchCharacterState.OpenFilterPanel, [
                 SwitchCharacterState.ReturnMainUi,
                 SwitchCharacterState.FilterPanel,
-                SwitchCharacterState.PrepareRefillRole
+                SwitchCharacterState.PrepareNextRole
             ]),
             (SwitchCharacterState.FilterPanel, [
                 SwitchCharacterState.ReturnMainUi,
                 SwitchCharacterState.SelectElementFilter,
                 SwitchCharacterState.SelectWeaponFilter,
-                SwitchCharacterState.PrepareRefillRole
+                SwitchCharacterState.PrepareNextRole
             ]),
             (SwitchCharacterState.SelectElementFilter, [
                 SwitchCharacterState.ReturnMainUi,
@@ -171,21 +173,19 @@ public sealed class SwitchCharacterStateMachineTask : StateMachineBase<SwitchCha
             (SwitchCharacterState.FindAndClickAvatar, [SwitchCharacterState.ClearFilter]),
             (SwitchCharacterState.ClearFilter, [
                 SwitchCharacterState.VerifyRoleInSlot,
-                SwitchCharacterState.PrepareRefillRole,
+                SwitchCharacterState.PrepareNextRole,
                 SwitchCharacterState.ReturnMainUi
             ]),
             (SwitchCharacterState.VerifyRoleInSlot, [
                 SwitchCharacterState.PrepareNextRole,
                 SwitchCharacterState.ClearMisplacedRole,
-                SwitchCharacterState.PrepareRefillRole,
                 SwitchCharacterState.ReturnMainUi
             ]),
             (SwitchCharacterState.ClearMisplacedRole, [
                 SwitchCharacterState.OpenFilterPanel,
-                SwitchCharacterState.PrepareRefillRole,
+                SwitchCharacterState.PrepareNextRole,
                 SwitchCharacterState.ReturnMainUi
             ]),
-            (SwitchCharacterState.PrepareRefillRole, [SwitchCharacterState.OpenFilterPanel, SwitchCharacterState.SaveConfiguration]),
             (SwitchCharacterState.SaveConfiguration, [SwitchCharacterState.ReturnMainUi]),
             (SwitchCharacterState.ReturnMainUi, [SwitchCharacterState.Completed])
         );
@@ -249,15 +249,11 @@ public sealed class SwitchCharacterStateMachineTask : StateMachineBase<SwitchCha
         _targetRoles = roles.ToList();
         _initialSlots = [];
         _slotsToClear = [];
-        _rolesToSelect = new Queue<TargetRole>();
-        _refillCandidates = new Queue<string>();
-        _sourceClearedSlots = [];
-        _fillSlots = new Queue<int>();
+        _selectionPlan = new Queue<SelectionPlanItem>();
         _currentRole = null;
         _currentRoleIsRefill = false;
         _currentRoleAttempt = 0;
         _currentAvatarFound = false;
-        _fillSlotsInitialized = false;
         _clearCombatScenesAfterReturn = false;
         _pendingFilterElementType = null;
         _pendingFilterWeaponType = null;
@@ -315,7 +311,7 @@ public sealed class SwitchCharacterStateMachineTask : StateMachineBase<SwitchCha
             }
 
             _currentRole = null;
-            _workflowState = SwitchCharacterState.PrepareRefillRole;
+            _workflowState = SwitchCharacterState.PrepareNextRole;
             return StateHandlerResult.Success;
         }
 
@@ -423,18 +419,6 @@ public sealed class SwitchCharacterStateMachineTask : StateMachineBase<SwitchCha
     private bool DetectClearMisplacedRole(ImageRegion capture)
     {
         return IsWorkflowQuickTeamState(capture, SwitchCharacterState.ClearMisplacedRole)
-               && !IsFilterApplied(capture);
-    }
-
-    /// <summary>
-    /// 检测补位准备状态。
-    /// </summary>
-    /// <param name="capture">当前截图。</param>
-    /// <returns>快速编队列表中等待准备补位时返回 true。</returns>
-    [StateDetector(SwitchCharacterState.PrepareRefillRole, Order = 19)]
-    private bool DetectPrepareRefillRole(ImageRegion capture)
-    {
-        return IsWorkflowQuickTeamState(capture, SwitchCharacterState.PrepareRefillRole)
                && !IsFilterApplied(capture);
     }
 
@@ -771,7 +755,6 @@ public sealed class SwitchCharacterStateMachineTask : StateMachineBase<SwitchCha
         {
             SwitchCharacterState.BuildSwitchPlan
                 or SwitchCharacterState.FindAndClickAvatar
-                or SwitchCharacterState.PrepareRefillRole
                 or SwitchCharacterState.SaveConfiguration
                 or SwitchCharacterState.ReturnMainUi => Task.FromResult(StateHandlerResult.Success),
             _ => Task.FromResult(StateHandlerResult.Fail)
@@ -787,8 +770,16 @@ public sealed class SwitchCharacterStateMachineTask : StateMachineBase<SwitchCha
     private async Task<StateHandlerResult> HandleBuildSwitchPlan(BvPage page)
     {
         _initialSlots = await RecognizeTeamSlots(Recognizer, _ct);
-        var rolesToSelect = GetRolesToSelect(_targetRoles, _initialSlots);
-        if (rolesToSelect.Count == 0)
+        var plan = BuildSelectionPlan(_targetRoles, _initialSlots);
+        if (!plan.Success)
+        {
+            _logger.LogError("切换角色：{Reason}", plan.FailureReason);
+            _result = false;
+            _workflowState = SwitchCharacterState.ReturnMainUi;
+            return StateHandlerResult.Success;
+        }
+
+        if (plan.SelectionPlan.Count == 0)
         {
             _logger.LogInformation("切换角色：目标角色已在指定槽位");
             _result = true;
@@ -797,20 +788,12 @@ public sealed class SwitchCharacterStateMachineTask : StateMachineBase<SwitchCha
             return StateHandlerResult.Success;
         }
 
-        _slotsToClear = GetSlotsToClear(rolesToSelect, _initialSlots);
-        _refillCandidates = GetRefillCandidates(_initialSlots, _slotsToClear, _targetRoles);
-        _sourceClearedSlots = _slotsToClear
-            .Except(rolesToSelect.Select(role => role.Slot))
-            .OrderBy(slot => slot)
-            .ToList();
-        _rolesToSelect = new Queue<TargetRole>(rolesToSelect);
-        _fillSlots = new Queue<int>();
-        _fillSlotsInitialized = false;
+        _slotsToClear = plan.SlotsToClear;
+        _selectionPlan = new Queue<SelectionPlanItem>(plan.SelectionPlan);
 
-        _logger.LogInformation("切换角色：需要取消槽位 {SlotsToClear}，目标角色数 {TargetCount}，补位候选数 {RefillCount}",
+        _logger.LogInformation("切换角色：需要取消槽位 {SlotsToClear}，选择计划 {Plan}",
             string.Join(",", _slotsToClear.OrderBy(slot => slot)),
-            _rolesToSelect.Count,
-            _refillCandidates.Count);
+            string.Join(",", plan.SelectionPlan.Select(item => $"{item.Role.Slot}.{item.Role.Name}{(item.IsRefill ? "(补位)" : string.Empty)}")));
 
         _workflowState = SwitchCharacterState.ClearSelectedRoles;
         return StateHandlerResult.Success;
@@ -833,18 +816,19 @@ public sealed class SwitchCharacterStateMachineTask : StateMachineBase<SwitchCha
     /// 准备下一个目标角色。
     /// </summary>
     /// <param name="page">页面操作对象。</param>
-    /// <returns>存在目标角色时进入筛选流程；目标角色耗尽时进入补位流程。</returns>
+    /// <returns>存在计划项时进入筛选流程；计划耗尽时进入保存流程。</returns>
     [StateHandler(SwitchCharacterState.PrepareNextRole, RetryTimeout = 12000, RetryInterval = 300, TransitionTimeout = 3000)]
     private Task<StateHandlerResult> HandlePrepareNextRole(BvPage page)
     {
-        if (_rolesToSelect.Count == 0)
+        if (_selectionPlan.Count == 0)
         {
             _currentRole = null;
-            _workflowState = SwitchCharacterState.PrepareRefillRole;
+            _workflowState = SwitchCharacterState.SaveConfiguration;
             return Task.FromResult(StateHandlerResult.Success);
         }
 
-        SetCurrentRole(_rolesToSelect.Dequeue(), isRefill: false);
+        var item = _selectionPlan.Dequeue();
+        SetCurrentRole(item.Role, item.IsRefill);
         _workflowState = SwitchCharacterState.OpenFilterPanel;
         return Task.FromResult(StateHandlerResult.Success);
     }
@@ -883,7 +867,7 @@ public sealed class SwitchCharacterStateMachineTask : StateMachineBase<SwitchCha
                 }
 
                 _currentRole = null;
-                _workflowState = SwitchCharacterState.PrepareRefillRole;
+                _workflowState = SwitchCharacterState.PrepareNextRole;
                 return Task.FromResult(StateHandlerResult.Success);
             }
 
@@ -1030,7 +1014,7 @@ public sealed class SwitchCharacterStateMachineTask : StateMachineBase<SwitchCha
         {
             _logger.LogWarning("切换角色：未找到补位角色 {Name}，保留空位", _currentRole.Name);
             _currentRole = null;
-            _workflowState = SwitchCharacterState.PrepareRefillRole;
+            _workflowState = SwitchCharacterState.PrepareNextRole;
             return Task.FromResult(StateHandlerResult.Success);
         }
 
@@ -1059,9 +1043,7 @@ public sealed class SwitchCharacterStateMachineTask : StateMachineBase<SwitchCha
         {
             _logger.LogInformation("切换角色：{Name} 已进入 {Slot} 号位", _currentRole.Name, _currentRole.Slot);
             _currentRole = null;
-            _workflowState = _currentRoleIsRefill
-                ? SwitchCharacterState.PrepareRefillRole
-                : SwitchCharacterState.PrepareNextRole;
+            _workflowState = SwitchCharacterState.PrepareNextRole;
             return StateHandlerResult.Success;
         }
 
@@ -1069,7 +1051,7 @@ public sealed class SwitchCharacterStateMachineTask : StateMachineBase<SwitchCha
         {
             _logger.LogWarning("切换角色：补位角色 {Name} 未进入槽位 {Slot}，保留空位", _currentRole.Name, _currentRole.Slot);
             _currentRole = null;
-            _workflowState = SwitchCharacterState.PrepareRefillRole;
+            _workflowState = SwitchCharacterState.PrepareNextRole;
             return StateHandlerResult.Success;
         }
 
@@ -1105,41 +1087,6 @@ public sealed class SwitchCharacterStateMachineTask : StateMachineBase<SwitchCha
         SetCurrentRoleFilter(_currentRole);
         _workflowState = SwitchCharacterState.OpenFilterPanel;
         return StateHandlerResult.Success;
-    }
-
-    /// <summary>
-    /// 准备本次被清出的原队角色补位。
-    /// </summary>
-    /// <param name="page">页面操作对象。</param>
-    /// <returns>有补位任务时进入筛选流程；无补位任务时进入保存状态。</returns>
-    [StateHandler(SwitchCharacterState.PrepareRefillRole, RetryTimeout = 12000, RetryInterval = 300, TransitionTimeout = 3000)]
-    private Task<StateHandlerResult> HandlePrepareRefillRole(BvPage page)
-    {
-        if (!_fillSlotsInitialized)
-        {
-            _fillSlots = new Queue<int>(_sourceClearedSlots.OrderBy(slot => slot));
-            _fillSlotsInitialized = true;
-        }
-
-        while (_fillSlots.Count > 0)
-        {
-            if (_refillCandidates.Count == 0)
-            {
-                _logger.LogInformation("切换角色：补位候选已耗尽，剩余空槽保留为空");
-                _workflowState = SwitchCharacterState.SaveConfiguration;
-                return Task.FromResult(StateHandlerResult.Success);
-            }
-
-            var slot = _fillSlots.Dequeue();
-            var candidate = _refillCandidates.Dequeue();
-            _logger.LogInformation("切换角色：使用原队角色 {Name} 补位到槽位 {Slot}", candidate, slot);
-            SetCurrentRole(CreateTargetRole(slot, candidate), isRefill: true);
-            _workflowState = SwitchCharacterState.OpenFilterPanel;
-            return Task.FromResult(StateHandlerResult.Success);
-        }
-
-        _workflowState = SwitchCharacterState.SaveConfiguration;
-        return Task.FromResult(StateHandlerResult.Success);
     }
 
     /// <summary>
@@ -1353,6 +1300,68 @@ public sealed class SwitchCharacterStateMachineTask : StateMachineBase<SwitchCha
         }
 
         return candidates;
+    }
+
+    /// <summary>
+    /// 构建按槽位从小到大执行的角色选择计划。
+    /// </summary>
+    /// <param name="roles">目标槽位角色列表。</param>
+    /// <param name="initialSlots">当前已选角色快照。</param>
+    /// <returns>清空槽位和选择计划；前置空槽无法补齐时返回失败。</returns>
+    private static SwitchPlanBuildResult BuildSelectionPlan(
+        IReadOnlyCollection<TargetRole> roles,
+        IReadOnlyCollection<TeamSlotSnapshot> initialSlots)
+    {
+        var rolesToSelect = GetRolesToSelect(roles, initialSlots);
+        if (rolesToSelect.Count == 0)
+        {
+            return new SwitchPlanBuildResult(true, [], [], null);
+        }
+
+        HashSet<int> slotsToClear = GetSlotsToClear(rolesToSelect, initialSlots);
+        Queue<string> refillCandidates = GetRefillCandidates(initialSlots, slotsToClear, roles);
+        var targetBySlot = rolesToSelect.ToDictionary(role => role.Slot);
+        var slotOccupants = Enumerable.Range(1, 4)
+            .ToDictionary(
+                slot => slot,
+                slot => slotsToClear.Contains(slot)
+                    ? null
+                    : initialSlots.FirstOrDefault(snapshot => snapshot.Slot == slot)?.Name);
+
+        List<SelectionPlanItem> plan = [];
+        int maxTargetSlot = rolesToSelect.Max(role => role.Slot);
+        for (int slot = 1; slot <= maxTargetSlot; slot++)
+        {
+            if (targetBySlot.TryGetValue(slot, out var targetRole))
+            {
+                plan.Add(new SelectionPlanItem(targetRole, IsRefill: false));
+                slotOccupants[slot] = targetRole.Name;
+                continue;
+            }
+
+            if (!string.IsNullOrEmpty(slotOccupants[slot]))
+            {
+                continue;
+            }
+
+            bool hasLaterTarget = targetBySlot.Keys.Any(targetSlot => targetSlot > slot);
+            if (!hasLaterTarget)
+            {
+                continue;
+            }
+
+            if (!refillCandidates.TryDequeue(out var refillName))
+            {
+                string failureReason = $"目标槽位 {maxTargetSlot} 前存在无法补齐的空槽 {slot}，请同时指定前置槽位";
+                return new SwitchPlanBuildResult(false, slotsToClear, plan, failureReason);
+            }
+
+            var refillRole = CreateTargetRole(slot, refillName);
+            plan.Add(new SelectionPlanItem(refillRole, IsRefill: true));
+            slotOccupants[slot] = refillRole.Name;
+        }
+
+        return new SwitchPlanBuildResult(true, slotsToClear, plan, null);
     }
 
     /// <summary>

--- a/BetterGenshinImpact/GameTask/Common/Job/SwitchCharacterStateMachineTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/SwitchCharacterStateMachineTask.cs
@@ -1289,7 +1289,8 @@ public sealed class SwitchCharacterStateMachineTask : StateMachineBase<SwitchCha
 
         List<SelectionPlanItem> plan = [];
         int maxTargetSlot = rolesToSelect.Max(role => role.Slot);
-        for (int slot = 1; slot <= maxTargetSlot; slot++)
+        int maxAffectedSlot = Math.Max(maxTargetSlot, slotsToClear.Max());
+        for (int slot = 1; slot <= maxAffectedSlot; slot++)
         {
             if (targetBySlot.TryGetValue(slot, out var targetRole))
             {
@@ -1303,8 +1304,10 @@ public sealed class SwitchCharacterStateMachineTask : StateMachineBase<SwitchCha
                 continue;
             }
 
-            bool hasLaterTarget = targetBySlot.Keys.Any(targetSlot => targetSlot > slot);
-            if (!hasLaterTarget)
+            bool shouldRefill = slotsToClear.Contains(slot)
+                                || targetBySlot.Keys.Any(targetSlot => targetSlot > slot)
+                                || slotsToClear.Any(slotToClear => slotToClear > slot);
+            if (!shouldRefill)
             {
                 continue;
             }

--- a/BetterGenshinImpact/GameTask/Common/Job/SwitchCharacterStateMachineTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/SwitchCharacterStateMachineTask.cs
@@ -6,6 +6,7 @@ using BetterGenshinImpact.Core.Simulator.Extensions;
 using BetterGenshinImpact.GameTask.AutoFight.Config;
 using BetterGenshinImpact.GameTask.AutoTrackPath;
 using BetterGenshinImpact.GameTask.Common.BgiVision;
+using BetterGenshinImpact.GameTask.Common.Exceptions;
 using BetterGenshinImpact.GameTask.Common.StateMachine;
 using BetterGenshinImpact.GameTask.Model.Area;
 using BetterGenshinImpact.GameTask.Model.GameUI;
@@ -66,7 +67,6 @@ public sealed class SwitchCharacterStateMachineTask : StateMachineBase<SwitchCha
     private readonly double _assetScale = TaskContext.Instance().SystemInfo.AssetScale;
 
     private SwitchCharacterState _workflowState;
-    private bool _result;
     private AvatarGridIconRecognizer? _recognizer;
     private List<TargetRole> _targetRoles = [];
     private List<TeamSlotSnapshot> _initialSlots = [];
@@ -194,22 +194,23 @@ public sealed class SwitchCharacterStateMachineTask : StateMachineBase<SwitchCha
     /// <summary>
     /// 按槽位切换当前队伍角色。
     /// </summary>
-    /// <param name="slot1">1 号槽位角色名；为空、空白或 null 时跳过。</param>
-    /// <param name="slot2">2 号槽位角色名；为空、空白或 null 时跳过。</param>
-    /// <param name="slot3">3 号槽位角色名；为空、空白或 null 时跳过。</param>
-    /// <param name="slot4">4 号槽位角色名；为空、空白或 null 时跳过。</param>
+    /// <param name="slot1">1 号槽位角色名。</param>
+    /// <param name="slot2">2 号槽位角色名。</param>
+    /// <param name="slot3">3 号槽位角色名。</param>
+    /// <param name="slot4">4 号槽位角色名。</param>
     /// <param name="ct">取消令牌。</param>
     /// <returns>完成保存并返回主界面返回 true；参数无效、目标角色未找到或流程失败返回 false。</returns>
-    public async Task<bool> Start(string? slot1, string? slot2, string? slot3, string? slot4, CancellationToken ct)
+    /// <remarks>slot1-slot4 均需传入字符串；空字符串或空白字符串表示跳过对应槽位。</remarks>
+    public async Task<bool> Start(string slot1, string slot2, string slot3, string slot4, CancellationToken ct)
     {
         Initialize(ct, SwitchCharacterState.Unknown);
         var page = new BvPage(ct);
+        string[] slots = [slot1, slot2, slot3, slot4];
 
-        var roles = ParseRoles([slot1, slot2, slot3, slot4]);
+        var roles = ParseRoles(slots);
         if (roles.Count == 0 || HasConflictingRoleTargets(roles))
         {
-            _logger.LogError("切换角色：未指定角色或同一实际角色被指定到多个槽位");
-            return false;
+            throw new PartySetupFailedException("切换角色：未指定角色或同一实际角色被指定到多个槽位");
         }
 
         ResetWorkflow(roles);
@@ -219,18 +220,7 @@ public sealed class SwitchCharacterStateMachineTask : StateMachineBase<SwitchCha
         try
         {
             await RunStateMachineUntil(page, SwitchCharacterState.Completed);
-            return _result;
-        }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "切换角色：状态机流程失败");
-            // 调试状态机问题时保留当前界面，避免失败后自动返回主界面。
-            // await TryReturnMainUi(ct);
-            return false;
+            return true;
         }
         finally
         {
@@ -245,7 +235,6 @@ public sealed class SwitchCharacterStateMachineTask : StateMachineBase<SwitchCha
     private void ResetWorkflow(IReadOnlyList<TargetRole> roles)
     {
         _workflowState = SwitchCharacterState.BuildSwitchPlan;
-        _result = false;
         _targetRoles = roles.ToList();
         _initialSlots = [];
         _slotsToClear = [];
@@ -315,18 +304,7 @@ public sealed class SwitchCharacterStateMachineTask : StateMachineBase<SwitchCha
             return StateHandlerResult.Success;
         }
 
-        if (exception == null)
-        {
-            _logger.LogError("{Message}", message);
-        }
-        else
-        {
-            _logger.LogError(exception, "{Message}", message);
-        }
-
-        _result = false;
-        _workflowState = SwitchCharacterState.ReturnMainUi;
-        return StateHandlerResult.Success;
+        throw new PartySetupFailedException(exception == null ? message : $"{message}，{exception.Message}");
     }
 
     #region 状态检测器
@@ -773,16 +751,12 @@ public sealed class SwitchCharacterStateMachineTask : StateMachineBase<SwitchCha
         var plan = BuildSelectionPlan(_targetRoles, _initialSlots);
         if (!plan.Success)
         {
-            _logger.LogError("切换角色：{Reason}", plan.FailureReason);
-            _result = false;
-            _workflowState = SwitchCharacterState.ReturnMainUi;
-            return StateHandlerResult.Success;
+            throw new PartySetupFailedException($"切换角色：{plan.FailureReason}");
         }
 
         if (plan.SelectionPlan.Count == 0)
         {
             _logger.LogInformation("切换角色：目标角色已在指定槽位");
-            _result = true;
             _clearCombatScenesAfterReturn = false;
             _workflowState = SwitchCharacterState.ReturnMainUi;
             return StateHandlerResult.Success;
@@ -971,9 +945,7 @@ public sealed class SwitchCharacterStateMachineTask : StateMachineBase<SwitchCha
     {
         if (_currentRole == null)
         {
-            _result = false;
-            _workflowState = SwitchCharacterState.ReturnMainUi;
-            return StateHandlerResult.Success;
+            throw new PartySetupFailedException("切换角色：当前角色状态为空");
         }
 
         _currentAvatarFound = await FindAndClickAvatar(_currentRole, Recognizer, _ct);
@@ -999,9 +971,7 @@ public sealed class SwitchCharacterStateMachineTask : StateMachineBase<SwitchCha
 
         if (_currentRole == null)
         {
-            _result = false;
-            _workflowState = SwitchCharacterState.ReturnMainUi;
-            return Task.FromResult(StateHandlerResult.Success);
+            throw new PartySetupFailedException("切换角色：当前角色状态为空");
         }
 
         if (_currentAvatarFound)
@@ -1018,10 +988,7 @@ public sealed class SwitchCharacterStateMachineTask : StateMachineBase<SwitchCha
             return Task.FromResult(StateHandlerResult.Success);
         }
 
-        _logger.LogError("切换角色：未找到目标角色 {Name}", _currentRole.Name);
-        _result = false;
-        _workflowState = SwitchCharacterState.ReturnMainUi;
-        return Task.FromResult(StateHandlerResult.Success);
+        throw new PartySetupFailedException($"切换角色：未找到目标角色 {_currentRole.Name}");
     }
 
     /// <summary>
@@ -1034,9 +1001,7 @@ public sealed class SwitchCharacterStateMachineTask : StateMachineBase<SwitchCha
     {
         if (_currentRole == null)
         {
-            _result = false;
-            _workflowState = SwitchCharacterState.ReturnMainUi;
-            return StateHandlerResult.Success;
+            throw new PartySetupFailedException("切换角色：当前角色状态为空");
         }
 
         if (await WaitForRoleInSlot(_currentRole, Recognizer, _ct))
@@ -1061,10 +1026,7 @@ public sealed class SwitchCharacterStateMachineTask : StateMachineBase<SwitchCha
             return StateHandlerResult.Success;
         }
 
-        _logger.LogError("切换角色：未能将目标角色 {Name} 放入槽位 {Slot}", _currentRole.Name, _currentRole.Slot);
-        _result = false;
-        _workflowState = SwitchCharacterState.ReturnMainUi;
-        return StateHandlerResult.Success;
+        throw new PartySetupFailedException($"切换角色：未能将目标角色 {_currentRole.Name} 放入槽位 {_currentRole.Slot}");
     }
 
     /// <summary>
@@ -1077,9 +1039,7 @@ public sealed class SwitchCharacterStateMachineTask : StateMachineBase<SwitchCha
     {
         if (_currentRole == null)
         {
-            _result = false;
-            _workflowState = SwitchCharacterState.ReturnMainUi;
-            return StateHandlerResult.Success;
+            throw new PartySetupFailedException("切换角色：当前角色状态为空");
         }
 
         await ClearMisplacedRole(_currentRole, Recognizer, _ct);
@@ -1103,7 +1063,6 @@ public sealed class SwitchCharacterStateMachineTask : StateMachineBase<SwitchCha
             return Task.FromResult(StateHandlerResult.Retry);
         }
 
-        _result = true;
         _clearCombatScenesAfterReturn = true;
         return Task.FromResult(StateHandlerResult.Success);
     }
@@ -1117,7 +1076,7 @@ public sealed class SwitchCharacterStateMachineTask : StateMachineBase<SwitchCha
     private async Task<StateHandlerResult> HandleReturnMainUi(BvPage page)
     {
         await _returnMainUiTask.Start(_ct);
-        if (_result && _clearCombatScenesAfterReturn)
+        if (_clearCombatScenesAfterReturn)
         {
             RunnerContext.Instance.ClearCombatScenes();
         }
@@ -1129,16 +1088,16 @@ public sealed class SwitchCharacterStateMachineTask : StateMachineBase<SwitchCha
     #endregion
 
     /// <summary>
-    /// 解析四个槽位参数，跳过空槽位并转换角色名。
+    /// 解析四个槽位参数，跳过空字符串槽位并转换角色名。
     /// </summary>
     /// <param name="slots">1-4 号槽位角色名。</param>
     /// <returns>目标槽位角色列表。</returns>
-    private static List<TargetRole> ParseRoles(IReadOnlyList<string?> slots)
+    private static List<TargetRole> ParseRoles(IReadOnlyList<string> slots)
     {
         List<TargetRole> roles = [];
         for (int i = 0; i < slots.Count; i++)
         {
-            var name = slots[i]?.Trim();
+            var name = slots[i].Trim();
             if (string.IsNullOrEmpty(name))
             {
                 continue;
@@ -1608,22 +1567,6 @@ public sealed class SwitchCharacterStateMachineTask : StateMachineBase<SwitchCha
             {
                 region.Dispose();
             }
-        }
-    }
-
-    /// <summary>
-    /// 尝试返回主界面，失败时仅记录日志。
-    /// </summary>
-    /// <param name="ct">取消令牌。</param>
-    private async Task TryReturnMainUi(CancellationToken ct)
-    {
-        try
-        {
-            await _returnMainUiTask.Start(ct);
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            _logger.LogDebug(ex, "切换角色：返回主界面失败");
         }
     }
 

--- a/BetterGenshinImpact/GameTask/Common/Job/SwitchCharacterStateMachineTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/SwitchCharacterStateMachineTask.cs
@@ -1,0 +1,1660 @@
+using BetterGenshinImpact.Core.BgiVision;
+using BetterGenshinImpact.Core.Recognition;
+using BetterGenshinImpact.Core.Recognition.OCR;
+using BetterGenshinImpact.Core.Simulator;
+using BetterGenshinImpact.Core.Simulator.Extensions;
+using BetterGenshinImpact.GameTask.AutoFight.Config;
+using BetterGenshinImpact.GameTask.AutoTrackPath;
+using BetterGenshinImpact.GameTask.Common.BgiVision;
+using BetterGenshinImpact.GameTask.Common.StateMachine;
+using BetterGenshinImpact.GameTask.Model.Area;
+using BetterGenshinImpact.GameTask.Model.GameUI;
+using Microsoft.Extensions.Logging;
+using OpenCvSharp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using static BetterGenshinImpact.GameTask.Common.TaskControl;
+
+namespace BetterGenshinImpact.GameTask.Common.Job;
+
+/// <summary>
+/// 切换队伍角色任务的状态机状态。
+/// </summary>
+public enum SwitchCharacterState
+{
+    Unknown, //未识别到可处理的界面
+    MainUi, //主界面
+    PartyConfigUnavailablePrompt, //当前状态不可进行队伍配置的提示界面
+    PartyConfigPage, //队伍配置界面
+    QuickTeamList, //快速编队角色列表界面
+    FilterPanel, //角色筛选面板
+    SelectElementFilter, //选择元素筛选项
+    SelectWeaponFilter, //选择武器筛选项
+    ConfirmFilterPanel, //确认筛选面板
+    BuildSwitchPlan, //构建本次切换计划
+    ClearSelectedRoles, //取消本次需要替换的已选角色
+    PrepareNextRole, //准备下一个目标角色
+    OpenFilterPanel, //打开筛选面板
+    FindAndClickAvatar, //查找并点击目标头像
+    ClearFilter, //清除当前筛选条件
+    VerifyRoleInSlot, //确认角色已进入目标槽位
+    ClearMisplacedRole, //清理进入非目标槽位的角色
+    PrepareRefillRole, //准备原队角色补位
+    SaveConfiguration, //保存当前队伍配置
+    ReturnMainUi, //返回主界面
+    Completed //任务已完成
+}
+
+/// <summary>
+/// 按指定槽位重组当前队伍角色的状态机版本。
+/// </summary>
+/// <remarks>
+/// 状态机负责界面流转和队伍业务步骤，任务入口仅初始化上下文并等待最终状态。
+/// </remarks>
+public sealed class SwitchCharacterStateMachineTask : StateMachineBase<SwitchCharacterState, BvPage>
+{
+    private const double MatchThreshold = 0.7;
+    private const string TravelerAliasName = "旅行者";
+    private const string PlayerBoyName = "空";
+    private const string PlayerGirlName = "荧";
+    private const string SwordWeaponType = "单手剑";
+
+    private readonly ILogger<SwitchCharacterStateMachineTask> _logger = App.GetLogger<SwitchCharacterStateMachineTask>();
+    private readonly ReturnMainUiTask _returnMainUiTask = new();
+    private readonly double _assetScale = TaskContext.Instance().SystemInfo.AssetScale;
+
+    private SwitchCharacterState _workflowState;
+    private bool _result;
+    private AvatarGridIconRecognizer? _recognizer;
+    private List<TargetRole> _targetRoles = [];
+    private List<TeamSlotSnapshot> _initialSlots = [];
+    private HashSet<int> _slotsToClear = [];
+    private Queue<TargetRole> _rolesToSelect = new();
+    private Queue<string> _refillCandidates = new();
+    private List<int> _sourceClearedSlots = [];
+    private Queue<int> _fillSlots = new();
+    private TargetRole? _currentRole;
+    private bool _currentRoleIsRefill;
+    private int _currentRoleAttempt;
+    private bool _currentAvatarFound;
+    private bool _fillSlotsInitialized;
+    private bool _clearCombatScenesAfterReturn;
+    private string? _pendingFilterElementType;
+    private string? _pendingFilterWeaponType;
+
+    /// <summary>
+    /// 状态机日志对象。
+    /// </summary>
+    protected override ILogger Logger => _logger;
+
+    private sealed record TargetRole(
+        int Slot,
+        string Name,
+        string[] CandidateNames,
+        string[] ConflictNames,
+        bool SkipElementFilter,
+        string? ForcedWeaponType)
+    {
+        /// <summary>
+        /// 用于读取角色配置的首选实际角色名。
+        /// </summary>
+        public string PrimaryCandidateName => CandidateNames[0];
+
+        /// <summary>
+        /// 判断识别到的角色名是否满足当前目标。
+        /// </summary>
+        /// <param name="characterName">识别到的角色名。</param>
+        /// <returns>角色名属于当前目标候选时返回 true。</returns>
+        public bool Matches(string? characterName)
+        {
+            return characterName != null && CandidateNames.Contains(characterName, StringComparer.Ordinal);
+        }
+    }
+
+    private sealed record TeamSlotSnapshot(int Slot, string? Name, bool IsSelected, Rect? CardRect);
+
+    private AvatarGridIconRecognizer Recognizer =>
+        _recognizer ?? throw new InvalidOperationException("切换角色：头像识别器未初始化");
+
+    /// <summary>
+    /// 初始化状态机版本的角色切换任务。
+    /// </summary>
+    public SwitchCharacterStateMachineTask()
+    {
+        RegisterStateMethodsByAttribute();
+        RegisterStateTransitions(
+            (SwitchCharacterState.Unknown, [
+                SwitchCharacterState.MainUi,
+                SwitchCharacterState.PartyConfigUnavailablePrompt,
+                SwitchCharacterState.PartyConfigPage,
+                SwitchCharacterState.QuickTeamList
+            ]),
+            (SwitchCharacterState.MainUi, [SwitchCharacterState.PartyConfigUnavailablePrompt, SwitchCharacterState.PartyConfigPage]),
+            (SwitchCharacterState.PartyConfigUnavailablePrompt, [SwitchCharacterState.MainUi, SwitchCharacterState.PartyConfigPage]),
+            (SwitchCharacterState.PartyConfigPage, [SwitchCharacterState.QuickTeamList]),
+            (SwitchCharacterState.QuickTeamList, [
+                SwitchCharacterState.BuildSwitchPlan,
+                SwitchCharacterState.FindAndClickAvatar,
+                SwitchCharacterState.PrepareRefillRole,
+                SwitchCharacterState.SaveConfiguration,
+                SwitchCharacterState.ReturnMainUi
+            ]),
+            (SwitchCharacterState.BuildSwitchPlan, [SwitchCharacterState.ClearSelectedRoles, SwitchCharacterState.ReturnMainUi]),
+            (SwitchCharacterState.ClearSelectedRoles, [SwitchCharacterState.PrepareNextRole]),
+            (SwitchCharacterState.PrepareNextRole, [SwitchCharacterState.OpenFilterPanel, SwitchCharacterState.PrepareRefillRole]),
+            (SwitchCharacterState.OpenFilterPanel, [
+                SwitchCharacterState.ReturnMainUi,
+                SwitchCharacterState.FilterPanel,
+                SwitchCharacterState.PrepareRefillRole
+            ]),
+            (SwitchCharacterState.FilterPanel, [
+                SwitchCharacterState.ReturnMainUi,
+                SwitchCharacterState.SelectElementFilter,
+                SwitchCharacterState.SelectWeaponFilter,
+                SwitchCharacterState.PrepareRefillRole
+            ]),
+            (SwitchCharacterState.SelectElementFilter, [
+                SwitchCharacterState.ReturnMainUi,
+                SwitchCharacterState.SelectWeaponFilter
+            ]),
+            (SwitchCharacterState.SelectWeaponFilter, [
+                SwitchCharacterState.ReturnMainUi,
+                SwitchCharacterState.ConfirmFilterPanel
+            ]),
+            (SwitchCharacterState.ConfirmFilterPanel, [
+                SwitchCharacterState.ReturnMainUi,
+                SwitchCharacterState.FindAndClickAvatar
+            ]),
+            (SwitchCharacterState.FindAndClickAvatar, [SwitchCharacterState.ClearFilter]),
+            (SwitchCharacterState.ClearFilter, [
+                SwitchCharacterState.VerifyRoleInSlot,
+                SwitchCharacterState.PrepareRefillRole,
+                SwitchCharacterState.ReturnMainUi
+            ]),
+            (SwitchCharacterState.VerifyRoleInSlot, [
+                SwitchCharacterState.PrepareNextRole,
+                SwitchCharacterState.ClearMisplacedRole,
+                SwitchCharacterState.PrepareRefillRole,
+                SwitchCharacterState.ReturnMainUi
+            ]),
+            (SwitchCharacterState.ClearMisplacedRole, [
+                SwitchCharacterState.OpenFilterPanel,
+                SwitchCharacterState.PrepareRefillRole,
+                SwitchCharacterState.ReturnMainUi
+            ]),
+            (SwitchCharacterState.PrepareRefillRole, [SwitchCharacterState.OpenFilterPanel, SwitchCharacterState.SaveConfiguration]),
+            (SwitchCharacterState.SaveConfiguration, [SwitchCharacterState.ReturnMainUi]),
+            (SwitchCharacterState.ReturnMainUi, [SwitchCharacterState.Completed])
+        );
+    }
+
+    /// <summary>
+    /// 按槽位切换当前队伍角色。
+    /// </summary>
+    /// <param name="slot1">1 号槽位角色名；为空、空白或 null 时跳过。</param>
+    /// <param name="slot2">2 号槽位角色名；为空、空白或 null 时跳过。</param>
+    /// <param name="slot3">3 号槽位角色名；为空、空白或 null 时跳过。</param>
+    /// <param name="slot4">4 号槽位角色名；为空、空白或 null 时跳过。</param>
+    /// <param name="ct">取消令牌。</param>
+    /// <returns>完成保存并返回主界面返回 true；参数无效、目标角色未找到或流程失败返回 false。</returns>
+    public async Task<bool> Start(string? slot1, string? slot2, string? slot3, string? slot4, CancellationToken ct)
+    {
+        Initialize(ct, SwitchCharacterState.Unknown);
+        var page = new BvPage(ct);
+
+        var roles = ParseRoles([slot1, slot2, slot3, slot4]);
+        if (roles.Count == 0 || HasConflictingRoleTargets(roles))
+        {
+            _logger.LogError("切换角色：未指定角色或同一实际角色被指定到多个槽位");
+            return false;
+        }
+
+        ResetWorkflow(roles);
+        using var recognizer = new AvatarGridIconRecognizer();
+        _recognizer = recognizer;
+
+        try
+        {
+            await RunStateMachineUntil(page, SwitchCharacterState.Completed);
+            return _result;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "切换角色：状态机流程失败");
+            // 调试状态机问题时保留当前界面，避免失败后自动返回主界面。
+            // await TryReturnMainUi(ct);
+            return false;
+        }
+        finally
+        {
+            _recognizer = null;
+        }
+    }
+
+    /// <summary>
+    /// 重置本次运行的工作流上下文。
+    /// </summary>
+    /// <param name="roles">解析后的目标角色。</param>
+    private void ResetWorkflow(IReadOnlyList<TargetRole> roles)
+    {
+        _workflowState = SwitchCharacterState.BuildSwitchPlan;
+        _result = false;
+        _targetRoles = roles.ToList();
+        _initialSlots = [];
+        _slotsToClear = [];
+        _rolesToSelect = new Queue<TargetRole>();
+        _refillCandidates = new Queue<string>();
+        _sourceClearedSlots = [];
+        _fillSlots = new Queue<int>();
+        _currentRole = null;
+        _currentRoleIsRefill = false;
+        _currentRoleAttempt = 0;
+        _currentAvatarFound = false;
+        _fillSlotsInitialized = false;
+        _clearCombatScenesAfterReturn = false;
+        _pendingFilterElementType = null;
+        _pendingFilterWeaponType = null;
+    }
+
+    /// <summary>
+    /// 设置当前待处理角色，并初始化筛选条件。
+    /// </summary>
+    /// <param name="role">待处理角色。</param>
+    /// <param name="isRefill">是否为补位角色。</param>
+    private void SetCurrentRole(TargetRole role, bool isRefill)
+    {
+        _currentRole = role;
+        _currentRoleIsRefill = isRefill;
+        _currentRoleAttempt = 1;
+        _currentAvatarFound = false;
+        SetCurrentRoleFilter(role);
+    }
+
+    /// <summary>
+    /// 设置当前角色所需的筛选条件。
+    /// </summary>
+    /// <param name="role">待处理角色。</param>
+    private void SetCurrentRoleFilter(TargetRole role)
+    {
+        _pendingFilterElementType = role.SkipElementFilter ? null : Recognizer.GetElementType(role.PrimaryCandidateName);
+        _pendingFilterWeaponType = role.ForcedWeaponType ?? Recognizer.GetWeaponName(role.PrimaryCandidateName);
+        _logger.LogInformation("切换角色：{Slot}. {Name}，武器：{Weapon}，元素筛选：{ElementFilter}",
+            role.Slot,
+            role.Name,
+            _pendingFilterWeaponType,
+            _pendingFilterElementType ?? "跳过");
+    }
+
+    /// <summary>
+    /// 当前角色失败时决定跳过补位或中止目标流程。
+    /// </summary>
+    /// <param name="message">日志消息。</param>
+    /// <param name="exception">可选异常。</param>
+    /// <returns>状态处理结果。</returns>
+    private StateHandlerResult SkipRefillOrAbortTarget(string message, Exception? exception = null)
+    {
+        _pendingFilterElementType = null;
+        _pendingFilterWeaponType = null;
+
+        if (_currentRoleIsRefill)
+        {
+            if (exception == null)
+            {
+                _logger.LogWarning("{Message}，跳过补位角色 {Name}", message, _currentRole?.Name);
+            }
+            else
+            {
+                _logger.LogWarning(exception, "{Message}，跳过补位角色 {Name}", message, _currentRole?.Name);
+            }
+
+            _currentRole = null;
+            _workflowState = SwitchCharacterState.PrepareRefillRole;
+            return StateHandlerResult.Success;
+        }
+
+        if (exception == null)
+        {
+            _logger.LogError("{Message}", message);
+        }
+        else
+        {
+            _logger.LogError(exception, "{Message}", message);
+        }
+
+        _result = false;
+        _workflowState = SwitchCharacterState.ReturnMainUi;
+        return StateHandlerResult.Success;
+    }
+
+    #region 状态检测器
+
+    /// <summary>
+    /// 检测构建切换计划状态。
+    /// </summary>
+    /// <param name="capture">当前截图。</param>
+    /// <returns>快速编队列表中等待构建计划时返回 true。</returns>
+    [StateDetector(SwitchCharacterState.BuildSwitchPlan, Order = 11)]
+    private bool DetectBuildSwitchPlan(ImageRegion capture)
+    {
+        return IsWorkflowQuickTeamState(capture, SwitchCharacterState.BuildSwitchPlan);
+    }
+
+    /// <summary>
+    /// 检测取消已选角色状态。
+    /// </summary>
+    /// <param name="capture">当前截图。</param>
+    /// <returns>快速编队列表中等待取消选择时返回 true。</returns>
+    [StateDetector(SwitchCharacterState.ClearSelectedRoles, Order = 12)]
+    private bool DetectClearSelectedRoles(ImageRegion capture)
+    {
+        return IsWorkflowQuickTeamState(capture, SwitchCharacterState.ClearSelectedRoles);
+    }
+
+    /// <summary>
+    /// 检测准备目标角色状态。
+    /// </summary>
+    /// <param name="capture">当前截图。</param>
+    /// <returns>快速编队列表中等待准备目标角色时返回 true。</returns>
+    [StateDetector(SwitchCharacterState.PrepareNextRole, Order = 13)]
+    private bool DetectPrepareNextRole(ImageRegion capture)
+    {
+        return IsWorkflowQuickTeamState(capture, SwitchCharacterState.PrepareNextRole)
+               && !IsFilterApplied(capture);
+    }
+
+    /// <summary>
+    /// 检测打开筛选面板状态。
+    /// </summary>
+    /// <param name="capture">当前截图。</param>
+    /// <returns>快速编队列表中等待打开筛选面板时返回 true。</returns>
+    [StateDetector(SwitchCharacterState.OpenFilterPanel, Order = 14)]
+    private bool DetectOpenFilterPanel(ImageRegion capture)
+    {
+        return IsWorkflowQuickTeamState(capture, SwitchCharacterState.OpenFilterPanel);
+    }
+
+    /// <summary>
+    /// 检测头像查找状态。
+    /// </summary>
+    /// <param name="capture">当前截图。</param>
+    /// <returns>快速编队列表中等待查找头像时返回 true。</returns>
+    [StateDetector(SwitchCharacterState.FindAndClickAvatar, Order = 15)]
+    private bool DetectFindAndClickAvatar(ImageRegion capture)
+    {
+        return IsWorkflowQuickTeamState(capture, SwitchCharacterState.FindAndClickAvatar);
+    }
+
+    /// <summary>
+    /// 检测清除筛选状态。
+    /// </summary>
+    /// <param name="capture">当前截图。</param>
+    /// <returns>快速编队列表中等待清除筛选时返回 true。</returns>
+    [StateDetector(SwitchCharacterState.ClearFilter, Order = 16)]
+    private bool DetectClearFilter(ImageRegion capture)
+    {
+        return IsWorkflowQuickTeamState(capture, SwitchCharacterState.ClearFilter);
+    }
+
+    /// <summary>
+    /// 检测槽位确认状态。
+    /// </summary>
+    /// <param name="capture">当前截图。</param>
+    /// <returns>快速编队列表中等待确认槽位时返回 true。</returns>
+    [StateDetector(SwitchCharacterState.VerifyRoleInSlot, Order = 17)]
+    private bool DetectVerifyRoleInSlot(ImageRegion capture)
+    {
+        return IsWorkflowQuickTeamState(capture, SwitchCharacterState.VerifyRoleInSlot)
+               && !IsFilterApplied(capture);
+    }
+
+    /// <summary>
+    /// 检测误选清理状态。
+    /// </summary>
+    /// <param name="capture">当前截图。</param>
+    /// <returns>快速编队列表中等待清理误选角色时返回 true。</returns>
+    [StateDetector(SwitchCharacterState.ClearMisplacedRole, Order = 18)]
+    private bool DetectClearMisplacedRole(ImageRegion capture)
+    {
+        return IsWorkflowQuickTeamState(capture, SwitchCharacterState.ClearMisplacedRole)
+               && !IsFilterApplied(capture);
+    }
+
+    /// <summary>
+    /// 检测补位准备状态。
+    /// </summary>
+    /// <param name="capture">当前截图。</param>
+    /// <returns>快速编队列表中等待准备补位时返回 true。</returns>
+    [StateDetector(SwitchCharacterState.PrepareRefillRole, Order = 19)]
+    private bool DetectPrepareRefillRole(ImageRegion capture)
+    {
+        return IsWorkflowQuickTeamState(capture, SwitchCharacterState.PrepareRefillRole)
+               && !IsFilterApplied(capture);
+    }
+
+    /// <summary>
+    /// 检测保存配置状态。
+    /// </summary>
+    /// <param name="capture">当前截图。</param>
+    /// <returns>快速编队列表中等待保存配置时返回 true。</returns>
+    [StateDetector(SwitchCharacterState.SaveConfiguration, Order = 20)]
+    private bool DetectSaveConfiguration(ImageRegion capture)
+    {
+        return IsWorkflowQuickTeamState(capture, SwitchCharacterState.SaveConfiguration)
+               && !IsFilterApplied(capture);
+    }
+
+    /// <summary>
+    /// 检测返回主界面状态。
+    /// </summary>
+    /// <param name="capture">当前截图。</param>
+    /// <returns>当前工作流需要返回主界面时返回 true。</returns>
+    [StateDetector(SwitchCharacterState.ReturnMainUi, Order = 21)]
+    private bool DetectReturnMainUi(ImageRegion capture)
+    {
+        if (_workflowState == SwitchCharacterState.SaveConfiguration)
+        {
+            return !IsQuickTeamList(capture) && (IsPartyConfigPage(capture) || Bv.IsInMainUi(capture));
+        }
+
+        return _workflowState == SwitchCharacterState.ReturnMainUi
+               && (IsQuickTeamList(capture) || IsFilterPanel(capture) || IsPartyConfigPage(capture) || Bv.IsInMainUi(capture));
+    }
+
+    /// <summary>
+    /// 检测元素筛选项选择状态。
+    /// </summary>
+    /// <param name="capture">当前截图。</param>
+    /// <returns>筛选面板中等待选择元素筛选项时返回 true。</returns>
+    [StateDetector(SwitchCharacterState.SelectElementFilter, Order = 22)]
+    private bool DetectSelectElementFilter(ImageRegion capture)
+    {
+        return _workflowState == SwitchCharacterState.SelectElementFilter && IsFilterPanel(capture);
+    }
+
+    /// <summary>
+    /// 检测武器筛选项选择状态。
+    /// </summary>
+    /// <param name="capture">当前截图。</param>
+    /// <returns>筛选面板中等待选择武器筛选项时返回 true。</returns>
+    [StateDetector(SwitchCharacterState.SelectWeaponFilter, Order = 23)]
+    private bool DetectSelectWeaponFilter(ImageRegion capture)
+    {
+        if (!IsFilterPanel(capture))
+        {
+            return false;
+        }
+
+        return _workflowState == SwitchCharacterState.SelectWeaponFilter
+               || (_workflowState == SwitchCharacterState.SelectElementFilter
+                   && IsFilterTagSelected(capture, _pendingFilterElementType));
+    }
+
+    /// <summary>
+    /// 检测确认筛选面板状态。
+    /// </summary>
+    /// <param name="capture">当前截图。</param>
+    /// <returns>武器筛选标签已出现、正在确认筛选面板或确认后面板尚未关闭时返回 true。</returns>
+    [StateDetector(SwitchCharacterState.ConfirmFilterPanel, Order = 24)]
+    private bool DetectConfirmFilterPanel(ImageRegion capture)
+    {
+        if (!IsFilterPanel(capture))
+        {
+            return false;
+        }
+
+        return _workflowState == SwitchCharacterState.ConfirmFilterPanel
+               || (_workflowState == SwitchCharacterState.SelectWeaponFilter
+                   && IsFilterTagSelected(capture, _pendingFilterWeaponType))
+               || (CurrentState == SwitchCharacterState.ConfirmFilterPanel
+                   && _workflowState == SwitchCharacterState.FindAndClickAvatar);
+    }
+
+    /// <summary>
+    /// 检测筛选面板。
+    /// </summary>
+    /// <param name="capture">当前截图。</param>
+    /// <returns>识别到确认筛选按钮返回 true。</returns>
+    [StateDetector(SwitchCharacterState.FilterPanel, Order = 30)]
+    private bool DetectFilterPanel(ImageRegion capture)
+    {
+        return IsFilterPanel(capture);
+    }
+
+    /// <summary>
+    /// 检测快速编队角色列表。
+    /// </summary>
+    /// <param name="capture">当前截图。</param>
+    /// <returns>识别到元素共鸣文字返回 true；确认筛选完成后才允许回到角色列表。</returns>
+    [StateDetector(SwitchCharacterState.QuickTeamList, Order = 40)]
+    private bool DetectQuickTeamList(ImageRegion capture)
+    {
+        if (!IsQuickTeamList(capture))
+        {
+            return false;
+        }
+
+        if (CurrentState == SwitchCharacterState.ConfirmFilterPanel)
+        {
+            return _workflowState == SwitchCharacterState.FindAndClickAvatar && !IsFilterPanel(capture);
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// 检测不可进行队伍配置提示。
+    /// </summary>
+    /// <param name="capture">当前截图。</param>
+    /// <returns>识别到提示文字返回 true。</returns>
+    [StateDetector(SwitchCharacterState.PartyConfigUnavailablePrompt, Order = 50)]
+    private bool DetectPartyConfigUnavailablePrompt(ImageRegion capture)
+    {
+        return ContainsText(capture, "当前状态不可进行队伍配置", Rect1080(806, 198, 314, 37));
+    }
+
+    /// <summary>
+    /// 检测队伍配置界面。
+    /// </summary>
+    /// <param name="capture">当前截图。</param>
+    /// <returns>识别到队伍配置标题返回 true。</returns>
+    [StateDetector(SwitchCharacterState.PartyConfigPage, Order = 60)]
+    private bool DetectPartyConfigPage(ImageRegion capture)
+    {
+        return IsPartyConfigPage(capture);
+    }
+
+    /// <summary>
+    /// 检测任务完成状态。
+    /// </summary>
+    /// <param name="capture">当前截图。</param>
+    /// <returns>工作流已完成且处于主界面时返回 true。</returns>
+    [StateDetector(SwitchCharacterState.Completed, Order = 80)]
+    private bool DetectCompleted(ImageRegion capture)
+    {
+        return _workflowState == SwitchCharacterState.Completed && Bv.IsInMainUi(capture);
+    }
+
+    /// <summary>
+    /// 检测主界面。
+    /// </summary>
+    /// <param name="capture">当前截图。</param>
+    /// <returns>处于主界面返回 true。</returns>
+    [StateDetector(SwitchCharacterState.MainUi, Order = 90)]
+    private bool DetectMainUi(ImageRegion capture)
+    {
+        return Bv.IsInMainUi(capture);
+    }
+
+    /// <summary>
+    /// 判断截图是否为快速编队角色列表。
+    /// </summary>
+    /// <param name="capture">当前截图。</param>
+    /// <returns>识别到元素共鸣文字返回 true。</returns>
+    private bool IsQuickTeamList(ImageRegion capture)
+    {
+        return ContainsText(capture, "元素共鸣", Rect1080(1655, 32, 106, 30));
+    }
+
+    /// <summary>
+    /// 判断截图是否为筛选面板。
+    /// </summary>
+    /// <param name="capture">当前截图。</param>
+    /// <returns>识别到确认筛选按钮返回 true。</returns>
+    private bool IsFilterPanel(ImageRegion capture)
+    {
+        return ContainsText(capture, "确认筛选", Rect1080(360, 999, 128, 40));
+    }
+
+    /// <summary>
+    /// 判断截图是否为队伍配置界面。
+    /// </summary>
+    /// <param name="capture">当前截图。</param>
+    /// <returns>识别到队伍配置标题返回 true。</returns>
+    private bool IsPartyConfigPage(ImageRegion capture)
+    {
+        return ContainsText(capture, "队伍配置", Rect1080(119, 30, 108, 37));
+    }
+
+    /// <summary>
+    /// 判断筛选面板底部是否已出现指定筛选标签。
+    /// </summary>
+    /// <param name="capture">当前截图。</param>
+    /// <param name="text">筛选标签文本。</param>
+    /// <returns>筛选标签已出现返回 true。</returns>
+    private bool IsFilterTagSelected(ImageRegion capture, string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return false;
+        }
+
+        var ocrTexts = OcrFilterTags(capture);
+        var matched = ocrTexts.Any(ocrText => ocrText.Contains(text, StringComparison.Ordinal));
+        _logger.LogDebug("切换角色：筛选标签 OCR=[{OcrTexts}]，目标={Text}，matched={Matched}",
+            string.Join("|", ocrTexts),
+            text,
+            matched);
+        return matched;
+    }
+
+    /// <summary>
+    /// 对底部已选筛选标签做黑字二值化后 OCR，减少半透明标签栏下层文字干扰。
+    /// </summary>
+    /// <param name="capture">当前截图。</param>
+    /// <returns>识别到的筛选标签文本。</returns>
+    private List<string> OcrFilterTags(ImageRegion capture)
+    {
+        using var tagRegion = capture.DeriveCrop(GetFilterTagsRoi());
+        using var hsv = tagRegion.SrcMat.CvtColor(ColorConversionCodes.BGR2HSV);
+        using var darkMask = new Mat();
+        Cv2.InRange(hsv, new Scalar(0, 0, 0), new Scalar(180, 95, 120), darkMask);
+
+        using var binary = new Mat(tagRegion.SrcMat.Size(), MatType.CV_8UC3, Scalar.White);
+        binary.SetTo(Scalar.Black, darkMask);
+
+        var result = OcrFactory.Paddle.OcrResult(binary);
+        return result.Regions
+            .OrderBy(region => region.Rect.Center.Y)
+            .ThenBy(region => region.Rect.Center.X)
+            .Select(region => region.Text)
+            .ToList();
+    }
+
+    /// <summary>
+    /// 判断当前角色列表是否仍应用了筛选条件。
+    /// </summary>
+    /// <param name="capture">当前截图。</param>
+    /// <returns>识别到清除按钮返回 true。</returns>
+    private bool IsFilterApplied(ImageRegion capture)
+    {
+        return ContainsText(capture, "清除", Rect1080(699, 922, 55, 31));
+    }
+
+    /// <summary>
+    /// 判断当前截图是否可执行指定快速编队业务状态。
+    /// </summary>
+    /// <param name="capture">当前截图。</param>
+    /// <param name="state">期望业务状态。</param>
+    /// <returns>内部状态匹配且位于快速编队列表时返回 true。</returns>
+    private bool IsWorkflowQuickTeamState(ImageRegion capture, SwitchCharacterState state)
+    {
+        if (_workflowState != state || !IsQuickTeamList(capture))
+        {
+            return false;
+        }
+
+        if (CurrentState == SwitchCharacterState.ConfirmFilterPanel
+            && state == SwitchCharacterState.FindAndClickAvatar)
+        {
+            return !IsFilterPanel(capture);
+        }
+
+        return true;
+    }
+
+    #endregion
+
+    #region 状态处理器
+
+    /// <summary>
+    /// 处理未识别界面。
+    /// </summary>
+    /// <param name="page">页面操作对象。</param>
+    /// <returns>返回主界面后等待状态检测。</returns>
+    [StateHandler(SwitchCharacterState.Unknown, RetryTimes = 3, RetryInterval = 500, TransitionTimeout = 6000)]
+    private async Task<StateHandlerResult> HandleUnknownState(BvPage page)
+    {
+        _logger.LogWarning("切换角色：当前界面未识别，尝试返回主界面");
+        await _returnMainUiTask.Start(_ct);
+        return StateHandlerResult.Success;
+    }
+
+    /// <summary>
+    /// 处理主界面。
+    /// </summary>
+    /// <param name="page">页面操作对象。</param>
+    /// <returns>触发打开队伍配置后返回 Success。</returns>
+    [StateHandler(SwitchCharacterState.MainUi, RetryTimeout = 15000, RetryInterval = 500, TransitionTimeout = 7000)]
+    private async Task<StateHandlerResult> HandleMainUi(BvPage page)
+    {
+        Simulation.SendInput.SimulateAction(GIActions.OpenPartySetupScreen);
+        await Delay(2000, _ct);
+        return StateHandlerResult.Success;
+    }
+
+    /// <summary>
+    /// 处理不可进行队伍配置提示。
+    /// </summary>
+    /// <param name="page">页面操作对象。</param>
+    /// <returns>传送到七天神像后返回 Success。</returns>
+    [StateHandler(SwitchCharacterState.PartyConfigUnavailablePrompt, RetryTimes = 2, TransitionTimeout = 30000)]
+    private async Task<StateHandlerResult> HandlePartyConfigUnavailablePrompt(BvPage page)
+    {
+        _logger.LogWarning("切换角色：当前状态不可进行队伍配置，传送到七天神像后重试");
+        await new TpTask(_ct).TpToStatueOfTheSeven();
+        return StateHandlerResult.Success;
+    }
+
+    /// <summary>
+    /// 处理队伍配置界面。
+    /// </summary>
+    /// <param name="page">页面操作对象。</param>
+    /// <returns>点击快速编队按钮返回 Success；未找到按钮返回 Retry。</returns>
+    [StateHandler(SwitchCharacterState.PartyConfigPage, RetryTimeout = 10000, RetryInterval = 500, TransitionTimeout = 6000)]
+    private Task<StateHandlerResult> HandlePartyConfigPage(BvPage page)
+    {
+        if (!TryClickText(page, "快速编队", Rect1080(1294, 1003, 126, 32)))
+        {
+            _logger.LogWarning("切换角色：未找到快速编队按钮");
+            return Task.FromResult(StateHandlerResult.Retry);
+        }
+
+        return Task.FromResult(StateHandlerResult.Success);
+    }
+
+    /// <summary>
+    /// 处理快速编队角色列表。
+    /// </summary>
+    /// <param name="page">页面操作对象。</param>
+    /// <returns>当前工作流已有待执行状态时返回 Success。</returns>
+    [StateHandler(SwitchCharacterState.QuickTeamList, RetryTimeout = 12000, RetryInterval = 300, TransitionTimeout = 6000)]
+    private Task<StateHandlerResult> HandleQuickTeamList(BvPage page)
+    {
+        return _workflowState switch
+        {
+            SwitchCharacterState.BuildSwitchPlan
+                or SwitchCharacterState.FindAndClickAvatar
+                or SwitchCharacterState.PrepareRefillRole
+                or SwitchCharacterState.SaveConfiguration
+                or SwitchCharacterState.ReturnMainUi => Task.FromResult(StateHandlerResult.Success),
+            _ => Task.FromResult(StateHandlerResult.Fail)
+        };
+    }
+
+    /// <summary>
+    /// 构建本次切换计划。
+    /// </summary>
+    /// <param name="page">页面操作对象。</param>
+    /// <returns>计划构建完成返回 Success。</returns>
+    [StateHandler(SwitchCharacterState.BuildSwitchPlan, RetryTimeout = 12000, RetryInterval = 300, TransitionTimeout = 3000)]
+    private async Task<StateHandlerResult> HandleBuildSwitchPlan(BvPage page)
+    {
+        _initialSlots = await RecognizeTeamSlots(Recognizer, _ct);
+        var rolesToSelect = GetRolesToSelect(_targetRoles, _initialSlots);
+        if (rolesToSelect.Count == 0)
+        {
+            _logger.LogInformation("切换角色：目标角色已在指定槽位");
+            _result = true;
+            _clearCombatScenesAfterReturn = false;
+            _workflowState = SwitchCharacterState.ReturnMainUi;
+            return StateHandlerResult.Success;
+        }
+
+        _slotsToClear = GetSlotsToClear(rolesToSelect, _initialSlots);
+        _refillCandidates = GetRefillCandidates(_initialSlots, _slotsToClear, _targetRoles);
+        _sourceClearedSlots = _slotsToClear
+            .Except(rolesToSelect.Select(role => role.Slot))
+            .OrderBy(slot => slot)
+            .ToList();
+        _rolesToSelect = new Queue<TargetRole>(rolesToSelect);
+        _fillSlots = new Queue<int>();
+        _fillSlotsInitialized = false;
+
+        _logger.LogInformation("切换角色：需要取消槽位 {SlotsToClear}，目标角色数 {TargetCount}，补位候选数 {RefillCount}",
+            string.Join(",", _slotsToClear.OrderBy(slot => slot)),
+            _rolesToSelect.Count,
+            _refillCandidates.Count);
+
+        _workflowState = SwitchCharacterState.ClearSelectedRoles;
+        return StateHandlerResult.Success;
+    }
+
+    /// <summary>
+    /// 取消本次计划涉及的已选角色。
+    /// </summary>
+    /// <param name="page">页面操作对象。</param>
+    /// <returns>取消完成返回 Success。</returns>
+    [StateHandler(SwitchCharacterState.ClearSelectedRoles, RetryTimeout = 12000, RetryInterval = 300, TransitionTimeout = 3000)]
+    private async Task<StateHandlerResult> HandleClearSelectedRoles(BvPage page)
+    {
+        await ClearSelectedRoles(_initialSlots, _slotsToClear, _ct);
+        _workflowState = SwitchCharacterState.PrepareNextRole;
+        return StateHandlerResult.Success;
+    }
+
+    /// <summary>
+    /// 准备下一个目标角色。
+    /// </summary>
+    /// <param name="page">页面操作对象。</param>
+    /// <returns>存在目标角色时进入筛选流程；目标角色耗尽时进入补位流程。</returns>
+    [StateHandler(SwitchCharacterState.PrepareNextRole, RetryTimeout = 12000, RetryInterval = 300, TransitionTimeout = 3000)]
+    private Task<StateHandlerResult> HandlePrepareNextRole(BvPage page)
+    {
+        if (_rolesToSelect.Count == 0)
+        {
+            _currentRole = null;
+            _workflowState = SwitchCharacterState.PrepareRefillRole;
+            return Task.FromResult(StateHandlerResult.Success);
+        }
+
+        SetCurrentRole(_rolesToSelect.Dequeue(), isRefill: false);
+        _workflowState = SwitchCharacterState.OpenFilterPanel;
+        return Task.FromResult(StateHandlerResult.Success);
+    }
+
+    /// <summary>
+    /// 打开筛选面板。
+    /// </summary>
+    /// <param name="page">页面操作对象。</param>
+    /// <returns>点击筛选入口后返回 Success。</returns>
+    [StateHandler(SwitchCharacterState.OpenFilterPanel, RetryTimeout = 9000, RetryInterval = 300, TransitionTimeout = 4000)]
+    private Task<StateHandlerResult> HandleOpenFilterPanel(BvPage page)
+    {
+        GameCaptureRegion.GameRegion1080PPosClick(66, 46);
+        return Task.FromResult(StateHandlerResult.Success);
+    }
+
+    /// <summary>
+    /// 处理筛选面板。
+    /// </summary>
+    /// <param name="page">页面操作对象。</param>
+    /// <returns>根据当前角色筛选需求进入元素或武器筛选状态。</returns>
+    [StateHandler(SwitchCharacterState.FilterPanel, RetryTimeout = 12000, RetryInterval = 300, TransitionTimeout = 6000)]
+    private Task<StateHandlerResult> HandleFilterPanel(BvPage page)
+    {
+        if (string.IsNullOrWhiteSpace(_pendingFilterWeaponType))
+        {
+            if (_currentRoleIsRefill)
+            {
+                _logger.LogWarning("切换角色：补位角色 {Name} 缺少武器筛选项，跳过当前补位", _currentRole?.Name);
+                _pendingFilterElementType = null;
+                _pendingFilterWeaponType = null;
+
+                if (!TryClickText(page, "确认筛选", Rect1080(360, 999, 128, 40)))
+                {
+                    return Task.FromResult(StateHandlerResult.Retry);
+                }
+
+                _currentRole = null;
+                _workflowState = SwitchCharacterState.PrepareRefillRole;
+                return Task.FromResult(StateHandlerResult.Success);
+            }
+
+            return Task.FromResult(SkipRefillOrAbortTarget("切换角色：筛选面板缺少武器筛选项"));
+        }
+
+        _workflowState = string.IsNullOrWhiteSpace(_pendingFilterElementType)
+            ? SwitchCharacterState.SelectWeaponFilter
+            : SwitchCharacterState.SelectElementFilter;
+        return Task.FromResult(StateHandlerResult.Success);
+    }
+
+    /// <summary>
+    /// 选择元素筛选项。
+    /// </summary>
+    /// <param name="page">页面操作对象。</param>
+    /// <returns>已选择或无需选择元素时进入武器筛选；找不到选项时返回 Retry。</returns>
+    [StateHandler(SwitchCharacterState.SelectElementFilter, RetryTimeout = 12000, RetryInterval = 300, TransitionTimeout = 3000)]
+    private Task<StateHandlerResult> HandleSelectElementFilter(BvPage page)
+    {
+        if (string.IsNullOrWhiteSpace(_pendingFilterElementType))
+        {
+            _workflowState = SwitchCharacterState.SelectWeaponFilter;
+            return Task.FromResult(StateHandlerResult.Success);
+        }
+
+        using var capture = CaptureToRectArea();
+        if (IsFilterTagSelected(capture, _pendingFilterElementType))
+        {
+            _workflowState = SwitchCharacterState.SelectWeaponFilter;
+            return Task.FromResult(StateHandlerResult.Success);
+        }
+
+        if (!TryClickText(page, _pendingFilterElementType, GetElementFilterOptionsRoi()))
+        {
+            _logger.LogWarning("切换角色：未找到元素筛选项 {Text}", _pendingFilterElementType);
+            return Task.FromResult(StateHandlerResult.Retry);
+        }
+
+        return Task.FromResult(StateHandlerResult.Success);
+    }
+
+    /// <summary>
+    /// 选择武器筛选项。
+    /// </summary>
+    /// <param name="page">页面操作对象。</param>
+    /// <returns>已选择武器时进入确认筛选；找不到选项时返回 Retry。</returns>
+    [StateHandler(SwitchCharacterState.SelectWeaponFilter, RetryTimeout = 12000, RetryInterval = 300, TransitionTimeout = 3000)]
+    private Task<StateHandlerResult> HandleSelectWeaponFilter(BvPage page)
+    {
+        _workflowState = SwitchCharacterState.SelectWeaponFilter;
+        if (string.IsNullOrWhiteSpace(_pendingFilterWeaponType))
+        {
+            return Task.FromResult(SkipRefillOrAbortTarget("切换角色：筛选面板缺少武器筛选项"));
+        }
+
+        using var capture = CaptureToRectArea();
+        if (IsFilterTagSelected(capture, _pendingFilterWeaponType))
+        {
+            _workflowState = SwitchCharacterState.ConfirmFilterPanel;
+            return Task.FromResult(StateHandlerResult.Success);
+        }
+
+        if (!TryClickText(page, _pendingFilterWeaponType, GetWeaponFilterOptionsRoi()))
+        {
+            _logger.LogWarning("切换角色：未找到武器筛选项 {Text}", _pendingFilterWeaponType);
+            return Task.FromResult(StateHandlerResult.Retry);
+        }
+
+        return Task.FromResult(StateHandlerResult.Success);
+    }
+
+    /// <summary>
+    /// 确认筛选面板。
+    /// </summary>
+    /// <param name="page">页面操作对象。</param>
+    /// <returns>点击确认筛选后返回 Success；找不到按钮时返回 Retry。</returns>
+    [StateHandler(SwitchCharacterState.ConfirmFilterPanel, RetryTimeout = 12000, RetryInterval = 300, TransitionTimeout = 6000)]
+    private Task<StateHandlerResult> HandleConfirmFilterPanel(BvPage page)
+    {
+        _workflowState = SwitchCharacterState.ConfirmFilterPanel;
+        if (!TryClickText(page, "确认筛选", Rect1080(360, 999, 128, 40)))
+        {
+            _logger.LogWarning("切换角色：未找到确认筛选按钮");
+            return Task.FromResult(StateHandlerResult.Retry);
+        }
+
+        _pendingFilterElementType = null;
+        _pendingFilterWeaponType = null;
+        _workflowState = SwitchCharacterState.FindAndClickAvatar;
+        return Task.FromResult(StateHandlerResult.Success);
+    }
+
+    /// <summary>
+    /// 查找并点击当前角色头像。
+    /// </summary>
+    /// <param name="page">页面操作对象。</param>
+    /// <returns>头像查找完成后进入清除筛选状态。</returns>
+    [StateHandler(SwitchCharacterState.FindAndClickAvatar, RetryTimeout = 12000, RetryInterval = 300, TransitionTimeout = 3000)]
+    private async Task<StateHandlerResult> HandleFindAndClickAvatar(BvPage page)
+    {
+        if (_currentRole == null)
+        {
+            _result = false;
+            _workflowState = SwitchCharacterState.ReturnMainUi;
+            return StateHandlerResult.Success;
+        }
+
+        _currentAvatarFound = await FindAndClickAvatar(_currentRole, Recognizer, _ct);
+        _workflowState = SwitchCharacterState.ClearFilter;
+        return StateHandlerResult.Success;
+    }
+
+    /// <summary>
+    /// 清除当前筛选条件。
+    /// </summary>
+    /// <param name="page">页面操作对象。</param>
+    /// <returns>根据头像查找结果进入确认、补位或返回主界面状态。</returns>
+    [StateHandler(SwitchCharacterState.ClearFilter, RetryTimeout = 12000, RetryInterval = 300, TransitionTimeout = 3000)]
+    private Task<StateHandlerResult> HandleClearFilter(BvPage page)
+    {
+        using var capture = CaptureToRectArea();
+        if (IsFilterApplied(capture))
+        {
+            ClearFilter(page);
+            _workflowState = SwitchCharacterState.ClearFilter;
+            return Task.FromResult(StateHandlerResult.Wait);
+        }
+
+        if (_currentRole == null)
+        {
+            _result = false;
+            _workflowState = SwitchCharacterState.ReturnMainUi;
+            return Task.FromResult(StateHandlerResult.Success);
+        }
+
+        if (_currentAvatarFound)
+        {
+            _workflowState = SwitchCharacterState.VerifyRoleInSlot;
+            return Task.FromResult(StateHandlerResult.Success);
+        }
+
+        if (_currentRoleIsRefill)
+        {
+            _logger.LogWarning("切换角色：未找到补位角色 {Name}，保留空位", _currentRole.Name);
+            _currentRole = null;
+            _workflowState = SwitchCharacterState.PrepareRefillRole;
+            return Task.FromResult(StateHandlerResult.Success);
+        }
+
+        _logger.LogError("切换角色：未找到目标角色 {Name}", _currentRole.Name);
+        _result = false;
+        _workflowState = SwitchCharacterState.ReturnMainUi;
+        return Task.FromResult(StateHandlerResult.Success);
+    }
+
+    /// <summary>
+    /// 确认当前角色已进入目标槽位。
+    /// </summary>
+    /// <param name="page">页面操作对象。</param>
+    /// <returns>确认成功后进入下一角色；失败时重试或结束。</returns>
+    [StateHandler(SwitchCharacterState.VerifyRoleInSlot, RetryTimeout = 12000, RetryInterval = 300, TransitionTimeout = 3000)]
+    private async Task<StateHandlerResult> HandleVerifyRoleInSlot(BvPage page)
+    {
+        if (_currentRole == null)
+        {
+            _result = false;
+            _workflowState = SwitchCharacterState.ReturnMainUi;
+            return StateHandlerResult.Success;
+        }
+
+        if (await WaitForRoleInSlot(_currentRole, Recognizer, _ct))
+        {
+            _logger.LogInformation("切换角色：{Name} 已进入 {Slot} 号位", _currentRole.Name, _currentRole.Slot);
+            _currentRole = null;
+            _workflowState = _currentRoleIsRefill
+                ? SwitchCharacterState.PrepareRefillRole
+                : SwitchCharacterState.PrepareNextRole;
+            return StateHandlerResult.Success;
+        }
+
+        if (_currentRoleIsRefill)
+        {
+            _logger.LogWarning("切换角色：补位角色 {Name} 未进入槽位 {Slot}，保留空位", _currentRole.Name, _currentRole.Slot);
+            _currentRole = null;
+            _workflowState = SwitchCharacterState.PrepareRefillRole;
+            return StateHandlerResult.Success;
+        }
+
+        if (_currentRoleAttempt < 2)
+        {
+            _workflowState = SwitchCharacterState.ClearMisplacedRole;
+            return StateHandlerResult.Success;
+        }
+
+        _logger.LogError("切换角色：未能将目标角色 {Name} 放入槽位 {Slot}", _currentRole.Name, _currentRole.Slot);
+        _result = false;
+        _workflowState = SwitchCharacterState.ReturnMainUi;
+        return StateHandlerResult.Success;
+    }
+
+    /// <summary>
+    /// 清理误进入其他槽位的目标角色。
+    /// </summary>
+    /// <param name="page">页面操作对象。</param>
+    /// <returns>清理后重新进入筛选流程。</returns>
+    [StateHandler(SwitchCharacterState.ClearMisplacedRole, RetryTimeout = 12000, RetryInterval = 300, TransitionTimeout = 3000)]
+    private async Task<StateHandlerResult> HandleClearMisplacedRole(BvPage page)
+    {
+        if (_currentRole == null)
+        {
+            _result = false;
+            _workflowState = SwitchCharacterState.ReturnMainUi;
+            return StateHandlerResult.Success;
+        }
+
+        await ClearMisplacedRole(_currentRole, Recognizer, _ct);
+        _currentRoleAttempt++;
+        SetCurrentRoleFilter(_currentRole);
+        _workflowState = SwitchCharacterState.OpenFilterPanel;
+        return StateHandlerResult.Success;
+    }
+
+    /// <summary>
+    /// 准备本次被清出的原队角色补位。
+    /// </summary>
+    /// <param name="page">页面操作对象。</param>
+    /// <returns>有补位任务时进入筛选流程；无补位任务时进入保存状态。</returns>
+    [StateHandler(SwitchCharacterState.PrepareRefillRole, RetryTimeout = 12000, RetryInterval = 300, TransitionTimeout = 3000)]
+    private Task<StateHandlerResult> HandlePrepareRefillRole(BvPage page)
+    {
+        if (!_fillSlotsInitialized)
+        {
+            _fillSlots = new Queue<int>(_sourceClearedSlots.OrderBy(slot => slot));
+            _fillSlotsInitialized = true;
+        }
+
+        while (_fillSlots.Count > 0)
+        {
+            if (_refillCandidates.Count == 0)
+            {
+                _logger.LogInformation("切换角色：补位候选已耗尽，剩余空槽保留为空");
+                _workflowState = SwitchCharacterState.SaveConfiguration;
+                return Task.FromResult(StateHandlerResult.Success);
+            }
+
+            var slot = _fillSlots.Dequeue();
+            var candidate = _refillCandidates.Dequeue();
+            _logger.LogInformation("切换角色：使用原队角色 {Name} 补位到槽位 {Slot}", candidate, slot);
+            SetCurrentRole(CreateTargetRole(slot, candidate), isRefill: true);
+            _workflowState = SwitchCharacterState.OpenFilterPanel;
+            return Task.FromResult(StateHandlerResult.Success);
+        }
+
+        _workflowState = SwitchCharacterState.SaveConfiguration;
+        return Task.FromResult(StateHandlerResult.Success);
+    }
+
+    /// <summary>
+    /// 保存当前配置。
+    /// </summary>
+    /// <param name="page">页面操作对象。</param>
+    /// <returns>点击保存配置返回 Success；未找到按钮返回 Retry。</returns>
+    [StateHandler(SwitchCharacterState.SaveConfiguration, RetryTimeout = 12000, RetryInterval = 500, TransitionTimeout = 3000)]
+    private Task<StateHandlerResult> HandleSaveConfiguration(BvPage page)
+    {
+        if (!TryClickText(page, "保存配置", Rect1080(360, 999, 128, 40)))
+        {
+            _logger.LogWarning("切换角色：未找到保存配置按钮");
+            return Task.FromResult(StateHandlerResult.Retry);
+        }
+
+        _result = true;
+        _clearCombatScenesAfterReturn = true;
+        return Task.FromResult(StateHandlerResult.Success);
+    }
+
+    /// <summary>
+    /// 返回主界面并结束工作流。
+    /// </summary>
+    /// <param name="page">页面操作对象。</param>
+    /// <returns>返回主界面后进入完成状态。</returns>
+    [StateHandler(SwitchCharacterState.ReturnMainUi, RetryTimeout = 15000, RetryInterval = 500, TransitionTimeout = 7000)]
+    private async Task<StateHandlerResult> HandleReturnMainUi(BvPage page)
+    {
+        await _returnMainUiTask.Start(_ct);
+        if (_result && _clearCombatScenesAfterReturn)
+        {
+            RunnerContext.Instance.ClearCombatScenes();
+        }
+
+        _workflowState = SwitchCharacterState.Completed;
+        return StateHandlerResult.Success;
+    }
+
+    #endregion
+
+    /// <summary>
+    /// 解析四个槽位参数，跳过空槽位并转换角色名。
+    /// </summary>
+    /// <param name="slots">1-4 号槽位角色名。</param>
+    /// <returns>目标槽位角色列表。</returns>
+    private static List<TargetRole> ParseRoles(IReadOnlyList<string?> slots)
+    {
+        List<TargetRole> roles = [];
+        for (int i = 0; i < slots.Count; i++)
+        {
+            var name = slots[i]?.Trim();
+            if (string.IsNullOrEmpty(name))
+            {
+                continue;
+            }
+
+            roles.Add(CreateTargetRole(i + 1, name));
+        }
+
+        return roles;
+    }
+
+    /// <summary>
+    /// 根据输入名称创建目标角色定义。
+    /// </summary>
+    /// <param name="slot">目标槽位。</param>
+    /// <param name="name">输入角色名或别名。</param>
+    /// <returns>目标角色定义。</returns>
+    private static TargetRole CreateTargetRole(int slot, string name)
+    {
+        var standardName = ToConfiguredAvatarName(name);
+        if (standardName == TravelerAliasName)
+        {
+            return new TargetRole(
+                slot,
+                TravelerAliasName,
+                [PlayerBoyName, PlayerGirlName],
+                [PlayerBoyName, PlayerGirlName],
+                true,
+                SwordWeaponType);
+        }
+
+        if (standardName is PlayerBoyName or PlayerGirlName)
+        {
+            return new TargetRole(
+                slot,
+                standardName,
+                [standardName],
+                [PlayerBoyName, PlayerGirlName],
+                true,
+                SwordWeaponType);
+        }
+
+        var skipElementFilter = standardName.StartsWith("奇偶", StringComparison.Ordinal);
+        return new TargetRole(
+            slot,
+            standardName,
+            [standardName],
+            [standardName],
+            skipElementFilter,
+            null);
+    }
+
+    /// <summary>
+    /// 将输入名称转换为配置中的标准名称。
+    /// </summary>
+    /// <param name="name">角色名或别名。</param>
+    /// <returns>配置中的标准名称。</returns>
+    private static string ToConfiguredAvatarName(string name)
+    {
+        if (DefaultAutoFightConfig.CombatAvatarMap.ContainsKey(name))
+        {
+            return name;
+        }
+
+        return DefaultAutoFightConfig.AvatarAliasToStandardName(name);
+    }
+
+    /// <summary>
+    /// 判断目标槽位中是否存在同一实际角色的冲突。
+    /// </summary>
+    /// <param name="roles">目标槽位角色列表。</param>
+    /// <returns>存在冲突返回 true。</returns>
+    private static bool HasConflictingRoleTargets(IReadOnlyList<TargetRole> roles)
+    {
+        for (int i = 0; i < roles.Count; i++)
+        {
+            for (int j = i + 1; j < roles.Count; j++)
+            {
+                if (roles[i].ConflictNames.Intersect(roles[j].ConflictNames, StringComparer.Ordinal).Any())
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// 获取当前不在目标槽位、需要重新选择的目标角色。
+    /// </summary>
+    /// <param name="roles">目标槽位角色列表。</param>
+    /// <param name="currentSlots">当前已选角色快照。</param>
+    /// <returns>需要重新选择的目标角色列表。</returns>
+    private static List<TargetRole> GetRolesToSelect(IReadOnlyCollection<TargetRole> roles, IReadOnlyCollection<TeamSlotSnapshot> currentSlots)
+    {
+        var currentNameBySlot = currentSlots.ToDictionary(slot => slot.Slot, slot => slot.Name);
+        return roles
+            .Where(role => !currentNameBySlot.TryGetValue(role.Slot, out var currentName) || !role.Matches(currentName))
+            .OrderBy(role => role.Slot)
+            .ToList();
+    }
+
+    /// <summary>
+    /// 计算本次需要取消选择的槽位。
+    /// </summary>
+    /// <param name="rolesToSelect">需要重新选择的目标角色。</param>
+    /// <param name="currentSlots">当前已选角色快照。</param>
+    /// <returns>需要取消选择的槽位集合。</returns>
+    private static HashSet<int> GetSlotsToClear(IReadOnlyCollection<TargetRole> rolesToSelect, IReadOnlyCollection<TeamSlotSnapshot> currentSlots)
+    {
+        HashSet<int> slotsToClear = rolesToSelect.Select(role => role.Slot).ToHashSet();
+
+        foreach (var currentSlot in currentSlots)
+        {
+            if (currentSlot.Name == null)
+            {
+                continue;
+            }
+
+            foreach (var role in rolesToSelect)
+            {
+                if (role.Matches(currentSlot.Name) && role.Slot != currentSlot.Slot)
+                {
+                    slotsToClear.Add(currentSlot.Slot);
+                }
+            }
+        }
+
+        return slotsToClear;
+    }
+
+    /// <summary>
+    /// 获取本次取消选择前被移出的原队角色，作为后续补位候选。
+    /// </summary>
+    /// <param name="initialSlots">取消选择前的已选角色快照。</param>
+    /// <param name="slotsToClear">本次需要取消选择的槽位。</param>
+    /// <param name="roles">目标槽位角色列表。</param>
+    /// <returns>补位候选队列。</returns>
+    private static Queue<string> GetRefillCandidates(
+        IReadOnlyCollection<TeamSlotSnapshot> initialSlots,
+        IReadOnlySet<int> slotsToClear,
+        IReadOnlyCollection<TargetRole> roles)
+    {
+        var excludedNames = roles.SelectMany(role => role.ConflictNames).ToHashSet(StringComparer.Ordinal);
+        Queue<string> candidates = new();
+
+        foreach (var slot in initialSlots.OrderBy(slot => slot.Slot))
+        {
+            if (!slotsToClear.Contains(slot.Slot)
+                || string.IsNullOrEmpty(slot.Name)
+                || excludedNames.Contains(slot.Name))
+            {
+                continue;
+            }
+
+            candidates.Enqueue(slot.Name);
+            excludedNames.Add(slot.Name);
+        }
+
+        return candidates;
+    }
+
+    /// <summary>
+    /// 取消本次需要替换的已选角色。
+    /// </summary>
+    /// <param name="currentSlots">当前已选角色快照。</param>
+    /// <param name="slotsToClear">需要取消选择的槽位。</param>
+    /// <param name="ct">取消令牌。</param>
+    private async Task ClearSelectedRoles(
+        IEnumerable<TeamSlotSnapshot> currentSlots,
+        IReadOnlySet<int> slotsToClear,
+        CancellationToken ct)
+    {
+        foreach (var slot in currentSlots
+                     .Where(slot => slot.IsSelected && slotsToClear.Contains(slot.Slot))
+                     .OrderByDescending(slot => slot.Slot))
+        {
+            ClickTeamSlot(slot);
+            await Delay(300, ct);
+        }
+    }
+
+    /// <summary>
+    /// 点击快速编队列表中的已选角色卡片。
+    /// </summary>
+    /// <param name="slot">已选角色快照。</param>
+    private void ClickTeamSlot(TeamSlotSnapshot slot)
+    {
+        if (!slot.CardRect.HasValue)
+        {
+            _logger.LogWarning("切换角色：槽位 {Slot} 缺少网格卡片区域，无法点击取消", slot.Slot);
+            return;
+        }
+
+        var cardRect = slot.CardRect.Value;
+        GameCaptureRegion.GameRegionClick((_, _) => (
+            cardRect.X + cardRect.Width / 2d,
+            cardRect.Y + cardRect.Height / 2d));
+    }
+
+    /// <summary>
+    /// 识别快速编队列表中 1-4 号已选角色。
+    /// </summary>
+    /// <param name="recognizer">头像模型识别器。</param>
+    /// <param name="ct">取消令牌。</param>
+    /// <returns>当前已选角色快照。</returns>
+    private async Task<List<TeamSlotSnapshot>> RecognizeTeamSlots(AvatarGridIconRecognizer recognizer, CancellationToken ct)
+    {
+        var gridScreen = new GridScreen(GridParams.Templates[GridScreenName.PartySetupCharacters], _logger, ct);
+        List<(int X, string? Name, Rect CardRect)> cards = [];
+
+        await foreach ((ImageRegion pageRegion, Rect itemRect) in gridScreen.WithCancellation(ct))
+        {
+            cards.Add(RecognizeTeamCard(pageRegion, itemRect, recognizer));
+
+            if (cards.Count >= 4)
+            {
+                break;
+            }
+        }
+
+        var slots = cards
+            .OrderBy(card => card.X)
+            .Select((card, index) => new TeamSlotSnapshot(index + 1, card.Name, true, card.CardRect))
+            .ToList();
+
+        for (int slot = slots.Count + 1; slot <= 4; slot++)
+        {
+            slots.Add(new TeamSlotSnapshot(slot, null, false, null));
+        }
+
+        return slots;
+    }
+
+    /// <summary>
+    /// 识别快速编队列表中指定槽位对应的角色。
+    /// </summary>
+    /// <param name="slot">槽位编号，取值 1-4。</param>
+    /// <param name="recognizer">头像模型识别器。</param>
+    /// <param name="ct">取消令牌。</param>
+    /// <returns>指定槽位快照。</returns>
+    private async Task<TeamSlotSnapshot> RecognizeTeamSlot(int slot, AvatarGridIconRecognizer recognizer, CancellationToken ct)
+    {
+        return (await RecognizeTeamSlots(recognizer, ct)).FirstOrDefault(snapshot => snapshot.Slot == slot)
+               ?? new TeamSlotSnapshot(slot, null, false, null);
+    }
+
+    /// <summary>
+    /// 从网格卡片中识别角色头像。
+    /// </summary>
+    /// <param name="pageRegion">当前网格页截图。</param>
+    /// <param name="itemRect">当前网格卡片区域。</param>
+    /// <param name="recognizer">头像模型识别器。</param>
+    /// <returns>角色卡片横坐标、角色名和卡片区域。</returns>
+    private (int X, string? Name, Rect CardRect) RecognizeTeamCard(ImageRegion pageRegion, Rect itemRect, AvatarGridIconRecognizer recognizer)
+    {
+        var cardRect = pageRegion.ConvertPositionToGameCaptureRegion(itemRect.X, itemRect.Y, itemRect.Width, itemRect.Height);
+        using ImageRegion itemRegion = pageRegion.DeriveCrop(itemRect);
+        using Mat icon = itemRegion.SrcMat.GetGridIcon();
+        var candidate = recognizer.Recognize(icon);
+        if (candidate.Score < MatchThreshold)
+        {
+            _logger.LogDebug("切换角色：网格卡片 X={X} 识别分数过低，score={Score:0.000}", itemRect.X, candidate.Score);
+            return (itemRect.X, null, cardRect);
+        }
+
+        _logger.LogDebug("切换角色：网格卡片 X={X} 为 {CharacterName}，score={Score:0.000}",
+            itemRect.X,
+            candidate.CharacterName,
+            candidate.Score);
+        return (itemRect.X, candidate.CharacterName, cardRect);
+    }
+
+    /// <summary>
+    /// 等待指定槽位识别为目标角色。
+    /// </summary>
+    /// <param name="role">目标角色。</param>
+    /// <param name="recognizer">头像模型识别器。</param>
+    /// <param name="ct">取消令牌。</param>
+    /// <returns>目标槽位识别为目标角色返回 true。</returns>
+    private async Task<bool> WaitForRoleInSlot(TargetRole role, AvatarGridIconRecognizer recognizer, CancellationToken ct)
+    {
+        return await NewRetry.WaitForAction(async () =>
+        {
+            var snapshot = await RecognizeTeamSlot(role.Slot, recognizer, ct);
+            return role.Matches(snapshot.Name);
+        }, ct, 6, 300);
+    }
+
+    /// <summary>
+    /// 清掉误进入其他槽位的目标角色。
+    /// </summary>
+    /// <param name="role">目标角色。</param>
+    /// <param name="recognizer">头像模型识别器。</param>
+    /// <param name="ct">取消令牌。</param>
+    private async Task ClearMisplacedRole(TargetRole role, AvatarGridIconRecognizer recognizer, CancellationToken ct)
+    {
+        var misplacedSlots = (await RecognizeTeamSlots(recognizer, ct))
+            .Where(slot => slot.Slot != role.Slot && role.Matches(slot.Name))
+            .OrderByDescending(slot => slot.Slot)
+            .ToList();
+
+        foreach (var slot in misplacedSlots)
+        {
+            _logger.LogWarning("切换角色：{Name} 进入了非目标槽位 {Slot}，取消选中后重试", role.Name, slot.Slot);
+            ClickTeamSlot(slot);
+            await Delay(300, ct);
+        }
+    }
+
+    /// <summary>
+    /// 获取筛选面板底部已选筛选标签区域。
+    /// </summary>
+    /// <returns>底部筛选标签区域。</returns>
+    private Rect GetFilterTagsRoi()
+    {
+        return Rect1080(35, 910, 745, 55);
+    }
+
+    /// <summary>
+    /// 获取筛选面板中的元素选项区域。
+    /// </summary>
+    /// <returns>元素选项区域，不包含底部筛选标签。</returns>
+    private Rect GetElementFilterOptionsRoi()
+    {
+        return Rect1080(35, 150, 745, 360);
+    }
+
+    /// <summary>
+    /// 获取筛选面板中的武器选项区域。
+    /// </summary>
+    /// <returns>武器选项区域，不包含底部筛选标签。</returns>
+    private Rect GetWeaponFilterOptionsRoi()
+    {
+        return Rect1080(35, 560, 745, 280);
+    }
+
+    /// <summary>
+    /// 在当前筛选后的角色网格中查找目标角色头像并点击加入队伍。
+    /// </summary>
+    /// <param name="role">目标角色。</param>
+    /// <param name="recognizer">头像模型识别器。</param>
+    /// <param name="ct">取消令牌。</param>
+    /// <returns>找到并点击目标角色返回 true；遍历结束仍未找到返回 false。</returns>
+    private async Task<bool> FindAndClickAvatar(TargetRole role, AvatarGridIconRecognizer recognizer, CancellationToken ct)
+    {
+        var gridScreen = new GridScreen(GridParams.Templates[GridScreenName.PartySetupCharacters], _logger, ct);
+        await foreach ((ImageRegion pageRegion, Rect itemRect) in gridScreen.WithCancellation(ct))
+        {
+            using ImageRegion itemRegion = pageRegion.DeriveCrop(itemRect);
+            using Mat icon = itemRegion.SrcMat.GetGridIcon();
+            var candidate = recognizer.Recognize(icon);
+            _logger.LogDebug("切换角色：识别头像 {CharacterName}，score={Score:0.000}", candidate.CharacterName, candidate.Score);
+            if (role.Matches(candidate.CharacterName) && candidate.Score >= MatchThreshold)
+            {
+                itemRegion.Click();
+                await Delay(300, ct);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// 尝试清除当前筛选条件，为下一个目标角色恢复完整角色列表。
+    /// </summary>
+    /// <param name="page">页面操作对象。</param>
+    private void ClearFilter(BvPage page)
+    {
+        if (!TryClickText(page, "清除", Rect1080(699, 922, 55, 31)))
+        {
+            _logger.LogDebug("切换角色：未找到清除筛选按钮，继续执行");
+        }
+    }
+
+    /// <summary>
+    /// 在当前截图中 OCR 查找文本并点击一次。
+    /// </summary>
+    /// <param name="page">页面操作对象。</param>
+    /// <param name="text">目标文本。</param>
+    /// <param name="roi">识别区域。</param>
+    /// <returns>找到并点击文本返回 true。</returns>
+    private static bool TryClickText(BvPage page, string text, Rect roi)
+    {
+        var regions = page.GetByText(text, roi).FindAll();
+        try
+        {
+            var region = regions
+                .OrderBy(region => region.Y)
+                .ThenBy(region => region.X)
+                .FirstOrDefault();
+            if (region == null)
+            {
+                return false;
+            }
+
+            region.Click();
+            return true;
+        }
+        finally
+        {
+            foreach (var region in regions)
+            {
+                region.Dispose();
+            }
+        }
+    }
+
+    /// <summary>
+    /// 尝试返回主界面，失败时仅记录日志。
+    /// </summary>
+    /// <param name="ct">取消令牌。</param>
+    private async Task TryReturnMainUi(CancellationToken ct)
+    {
+        try
+        {
+            await _returnMainUiTask.Start(ct);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogDebug(ex, "切换角色：返回主界面失败");
+        }
+    }
+
+    /// <summary>
+    /// 判断截图指定区域内是否包含目标文本。
+    /// </summary>
+    /// <param name="capture">当前截图。</param>
+    /// <param name="text">目标文本。</param>
+    /// <param name="roi">识别区域。</param>
+    /// <returns>包含目标文本返回 true。</returns>
+    private static bool ContainsText(ImageRegion capture, string text, Rect roi)
+    {
+        var regions = capture.FindMulti(RecognitionObject.Ocr(roi));
+        try
+        {
+            return regions.Any(region => region.Text.Contains(text, StringComparison.Ordinal));
+        }
+        finally
+        {
+            foreach (var region in regions)
+            {
+                region.Dispose();
+            }
+        }
+    }
+
+    /// <summary>
+    /// 将 1080P 基准区域按当前资源缩放比例转换为实际识别区域。
+    /// </summary>
+    /// <param name="x">1080P 坐标系下的 X。</param>
+    /// <param name="y">1080P 坐标系下的 Y。</param>
+    /// <param name="width">1080P 坐标系下的宽度。</param>
+    /// <param name="height">1080P 坐标系下的高度。</param>
+    /// <returns>缩放后的识别区域。</returns>
+    private Rect Rect1080(int x, int y, int width, int height)
+    {
+        return new Rect(
+            (int)Math.Round(x * _assetScale),
+            (int)Math.Round(y * _assetScale),
+            (int)Math.Round(width * _assetScale),
+            (int)Math.Round(height * _assetScale));
+    }
+}

--- a/BetterGenshinImpact/GameTask/Model/GameUI/GridParams.cs
+++ b/BetterGenshinImpact/GameTask/Model/GameUI/GridParams.cs
@@ -39,7 +39,8 @@ namespace BetterGenshinImpact.GameTask.Model.GameUI
             { GridScreenName.PreciousItems, weapons },
             { GridScreenName.Furnishings, weapons },
             { GridScreenName.ArtifactSalvage, new GridParams(new Rect(48, 106, 1267, 768), 9, 3, 40, 28, 0.018) },
-            { GridScreenName.Crafting, new GridParams(new Rect(45, 170, 705, 790), 5, 3, 40, 32, 0.024)}
+            { GridScreenName.Crafting, new GridParams(new Rect(45, 170, 705, 790), 5, 3, 40, 32, 0.024)},
+            { GridScreenName.PartySetupCharacters, new GridParams(new Rect(26, 97, 763, 546), 5, 3, 40, 28, 0.018)}
         }.ToFrozenDictionary();
     }
 }

--- a/BetterGenshinImpact/GameTask/Model/GameUI/GridScreen.cs
+++ b/BetterGenshinImpact/GameTask/Model/GameUI/GridScreen.cs
@@ -59,7 +59,7 @@ namespace BetterGenshinImpact.GameTask.Model.GameUI
 
         public IAsyncEnumerator<Tuple<ImageRegion, Rect>> GetAsyncEnumerator(CancellationToken cancellationToken = default)
         {
-            return new GridEnumerator(this, @params.Roi, @params.Columns, input, new GridScroller(@params, logger, input, ct), ct);
+            return new GridEnumerator(this, @params.Roi, @params.Columns, new GridScroller(@params, logger, input, ct), ct);
         }
 
         public class GridEnumerator : IAsyncEnumerator<Tuple<ImageRegion, Rect>>
@@ -67,7 +67,6 @@ namespace BetterGenshinImpact.GameTask.Model.GameUI
             private readonly GridScreen owner;
             private readonly Rect roi;
             private readonly CancellationToken ct;
-            private readonly InputSimulator input = Simulation.SendInput;
             private readonly int columns;
             private readonly GridScroller gridScroller;
 
@@ -75,8 +74,7 @@ namespace BetterGenshinImpact.GameTask.Model.GameUI
             /// 单次滚动得到的页面
             /// </summary>
             /// <param name="ImageRegion">供枚举输出的队列</param>
-            /// <param name="AntiRecycling">为了防止Grid的页面元素自动回收复用技术导致item高亮干扰，每次滚动后记录靠近下方的一个item，在下次滚动前主动点击该item</param>
-            private record Page(ImageRegion PageRegion, Queue<Rect> ItemRects, Rect? AntiRecycling);
+            private record Page(ImageRegion PageRegion, Queue<Rect> ItemRects);
             private Page? currentPage;
             private Tuple<ImageRegion, Rect>? current;
             Tuple<ImageRegion, Rect> IAsyncEnumerator<Tuple<ImageRegion, Rect>>.Current => current ?? throw new NullReferenceException();
@@ -91,14 +89,12 @@ namespace BetterGenshinImpact.GameTask.Model.GameUI
             /// <param name="s2Round">滚过一整页时发出的滚动命令次数</param>
             /// <param name="s3Scale">微调滚动时控制首行距离上边界的参数</param>
             /// <param name="logger"></param>
-            /// <param name="input"></param>
             /// <param name="ct"></param>
-            internal GridEnumerator(GridScreen owner, Rect roi, int columns, InputSimulator input, GridScroller gridScroller, CancellationToken ct)
+            internal GridEnumerator(GridScreen owner, Rect roi, int columns, GridScroller gridScroller, CancellationToken ct)
             {
                 this.owner = owner;
                 this.roi = roi;
                 this.ct = ct;
-                this.input = input;
                 this.columns = columns;
                 this.gridScroller = gridScroller;
             }
@@ -335,6 +331,7 @@ namespace BetterGenshinImpact.GameTask.Model.GameUI
                 }
                 // 根据聚簇结果补漏……
                 List<GridCell> cells = GridCell.ClusterToCells(rectList, threshold).ToList();
+                NormalizeOversizedRecognizedCells(mat, cells, threshold);
                 GridCell.FillMissingGridCells(ref cells);
                 FillExtraBottomRow(mat, ref cells);
 
@@ -359,6 +356,46 @@ namespace BetterGenshinImpact.GameTask.Model.GameUI
                 }
 
                 return result;
+            }
+
+            /// <summary>
+            /// 白色选中框有时会让直接识别到的格子边界偏大，先收缩到当前页的标准尺寸再补幻影格子。
+            /// </summary>
+            private static void NormalizeOversizedRecognizedCells(Mat mat, List<GridCell> cells, int threshold)
+            {
+                if (cells.Count < 3)
+                {
+                    return;
+                }
+
+                int standardWidth = Median(cells.Select(c => c.Rect.Width));
+                int standardHeight = Median(cells.Select(c => c.Rect.Height));
+                int tolerance = Math.Max(2, threshold / 4);
+                foreach (GridCell cell in cells.Where(c => !c.IsPhantom))
+                {
+                    if (cell.Rect.Width <= standardWidth + tolerance && cell.Rect.Height <= standardHeight + tolerance)
+                    {
+                        continue;
+                    }
+
+                    double centerX = cell.Rect.X + cell.Rect.Width / 2d;
+                    double centerY = cell.Rect.Y + cell.Rect.Height / 2d;
+                    int x = (int)Math.Round(centerX - standardWidth / 2d, MidpointRounding.AwayFromZero);
+                    int y = (int)Math.Round(centerY - standardHeight / 2d, MidpointRounding.AwayFromZero);
+                    cell.Rect = new Rect(x, y, standardWidth, standardHeight).ClampTo(mat);
+                }
+            }
+
+            private static int Median(IEnumerable<int> values)
+            {
+                int[] sorted = values.OrderBy(v => v).ToArray();
+                int middle = sorted.Length / 2;
+                if (sorted.Length % 2 == 1)
+                {
+                    return sorted[middle];
+                }
+
+                return (int)Math.Round((sorted[middle - 1] + sorted[middle]) / 2d, MidpointRounding.AwayFromZero);
             }
 
             /// <summary>
@@ -459,17 +496,6 @@ namespace BetterGenshinImpact.GameTask.Model.GameUI
                     {
                         if (this.currentPage != null)   // 当前页遍历完了就向下滚动
                         {
-                            if (this.currentPage.AntiRecycling.HasValue)
-                            {
-                                using DesktopRegion desktop = new DesktopRegion(this.input.Mouse);
-                                var (x, y, w, h) = (this.currentPage.AntiRecycling.Value.X, this.currentPage.AntiRecycling.Value.Y, this.currentPage.AntiRecycling.Value.Width, this.currentPage.AntiRecycling.Value.Height);
-                                var (gcX, gcY) = (TaskContext.Instance().SystemInfo.CaptureAreaRect.X, TaskContext.Instance().SystemInfo.CaptureAreaRect.Y);
-                                desktop.ClickTo(gcX + this.roi.X + x + (w / 2d), gcY + this.roi.Y + y + (h / 2d));
-                                await TaskControl.Delay(500, ct);
-                                desktop.ClickTo(gcX + this.roi.X + x + (w / 2d), gcY + this.roi.Y + y + (h / 2d));
-                                await TaskControl.Delay(500, ct);
-                            }
-
                             using var ra4 = TaskControl.CaptureToRectArea();
                             ra4.MoveTo(this.roi.X + this.roi.Width / 2, this.roi.Y + this.roi.Height / 2);
                             await TaskControl.Delay(300, ct);
@@ -485,30 +511,8 @@ namespace BetterGenshinImpact.GameTask.Model.GameUI
                         }
                         else
                         {
-                            // 第一页采集时，主动操作来避免图标高亮
-                            Rect rect12 = new Rect(0, 0, (int)(this.roi.Width * 1.5 / this.columns), this.roi.Height);
-                            // 双击第三列，采集第一、二列
-                            using DesktopRegion desktop = new DesktopRegion(this.input.Mouse);
-                            var (gcX, gcY) = (TaskContext.Instance().SystemInfo.CaptureAreaRect.X, TaskContext.Instance().SystemInfo.CaptureAreaRect.Y);
-                            desktop.ClickTo(gcX + this.roi.X + this.roi.Width * 2.5 / this.columns, gcY + this.roi.Y + this.roi.Width * 0.5 / this.columns);
-                            await TaskControl.Delay(300, ct);
-                            desktop.ClickTo(gcX + this.roi.X + this.roi.Width * 2.5 / this.columns, gcY + this.roi.Y + this.roi.Width * 0.5 / this.columns);
-                            await TaskControl.Delay(500, ct);
-
-                            using ImageRegion ra12 = TaskControl.CaptureToRectArea();
-                            using ImageRegion imageRegion12 = ra12.DeriveCrop(this.roi);
-                            using Mat columns12 = new Mat(imageRegion12.SrcMat, rect12);
-
-                            // 双击第一列，采集第二列以后的列
-                            desktop.ClickTo(gcX + this.roi.X + this.roi.Width * 0.5 / this.columns, gcY + this.roi.Y + this.roi.Width * 0.5 / this.columns);
-                            await TaskControl.Delay(300, ct);
-                            desktop.ClickTo(gcX + this.roi.X + this.roi.Width * 0.5 / this.columns, gcY + this.roi.Y + this.roi.Width * 0.5 / this.columns);
-                            await TaskControl.Delay(500, ct);
-
-                            using ImageRegion raRest = TaskControl.CaptureToRectArea();
-                            imageRegion = raRest.DeriveCrop(this.roi);
-                            using Mat subMat12 = imageRegion.SrcMat.SubMat(rect12);
-                            columns12.CopyTo(subMat12); // 拼接两次的采集
+                            using ImageRegion ra = TaskControl.CaptureToRectArea();
+                            imageRegion = ra.DeriveCrop(this.roi);
                         }
 
                         var rects = GetGridItems(imageRegion.SrcMat, this.columns);
@@ -521,8 +525,7 @@ namespace BetterGenshinImpact.GameTask.Model.GameUI
                         }
 
                         this.currentPage?.PageRegion?.Dispose();
-                        this.currentPage = new Page(imageRegion, new Queue<Rect>(cells.OrderBy(c => c.RowNum).ThenBy(c => c.ColNum).Select(c => c.Rect)),
-                            cells.GroupBy(c => c.RowNum).OrderByDescending(g => g.Key).Skip(1)?.FirstOrDefault()?.OrderBy(c => c.ColNum)?.FirstOrDefault()?.Rect);
+                        this.currentPage = new Page(imageRegion, new Queue<Rect>(cells.OrderBy(c => c.RowNum).ThenBy(c => c.ColNum).Select(c => c.Rect)));
 
                         owner.OnAfterTurnToNewPage?.Invoke(Tuple.Create(imageRegion, cells.Select(c => Tuple.Create(c.Rect, c.IsPhantom))));
                     }

--- a/BetterGenshinImpact/GameTask/Model/GameUI/GridScreenName.cs
+++ b/BetterGenshinImpact/GameTask/Model/GameUI/GridScreenName.cs
@@ -30,6 +30,11 @@ namespace BetterGenshinImpact.GameTask.Model.GameUI
         [Description("圣遗物套装筛选")]
         ArtifactSetFilter,
         [Description("合成")]
-        Crafting
+        Crafting,
+        /// <summary>
+        /// 队伍配置快速编队界面的左侧角色头像网格。
+        /// </summary>
+        [Description("队伍配置角色")]
+        PartySetupCharacters
     }
 }


### PR DESCRIPTION
需配合https://github.com/babalae/bettergi-libraries/pull/16 食用
调用示例 ，支持替换任意数量角色位，“空”跟“荧”可以精确传入名称，也可以传入“旅行者”自动识别

```js
await genshin.SwitchCharacter("胡桃", "芭芭拉", "珊瑚宫心海", "班尼特")

//1号位
await genshin.SwitchCharacter("胡桃")
//4号位
await genshin.SwitchCharacter("", "", "", "胡桃")

//3、4号位
await genshin.SwitchCharacter("", "", "珊瑚宫心海", "胡桃")
```

特殊情况：比如1号位已经是胡桃，又仅指定了2号位放入胡桃`await genshin.SwitchCharacter("","胡桃")`，这样不会让队伍变成三人，而是会将原本2号位的角色换到1号位。



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 更新说明

* **New Features**
  * 新增队伍配置界面角色网格的头像识别，并支持查询元素/武器信息。
  * 新增快速编队流程：按 1~4 槽位重组队伍，自动筛选与确认目标角色进入指定槽位。
  * 扩展网格屏幕配置，新增队伍配置角色网格入口。

* **Bug Fixes**
  * 优化队伍切换失败处理与日志输出，减少中断与误操作。
  * 改进网格识别后处理与尺寸校正，提高页面识别稳定性。

* **Chores**
  * 更新部分角色别名映射，提升识别/匹配一致性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->