### PR TITLE
添加js脚本读取用户已订阅的脚本路线文件的接口

### DIFF
--- a/BetterGenshinImpact/Core/Script/Dependence/AutoPathingScript.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/AutoPathingScript.cs
@@ -95,6 +95,13 @@ public class AutoPathingScript
     public string[] ReadPathSync(string subPath = "./") => AutoPathingFile.ReadPathSync(subPath);
 
     /// <summary>
+    /// 读取 AutoPathing 目录下指定文件的文本内容
+    /// </summary>
+    /// <param name="subPath">相对于 User\AutoPathing 的文件路径</param>
+    /// <returns>文件文本内容，读取失败时返回空字符串</returns>
+    public string ReadTextSync(string subPath) => AutoPathingFile.ReadTextSync(subPath);
+
+    /// <summary>
     /// LimitedFile 实例，用于操作 AutoPathing 目录
     /// </summary>
     private LimitedFile AutoPathingFile => _autoPathingFile;


### PR DESCRIPTION
为`AutoPathingScript`添加`ReadTextSync`方法，以便js脚本能读取用户已订阅的脚本路线文件

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增了读取自动寻路相关文本文件的能力，支持按指定子路径获取内容。
  * 当文件读取失败时，会返回空字符串，提升了调用时的稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->