### PR TITLE
fix(gpuUsage): show highest gpu usage in HardwareMonitor

### DIFF
--- a/BetterGenshinImpact/Service/OverlayMetricsService.cs
+++ b/BetterGenshinImpact/Service/OverlayMetricsService.cs
@@ -241,7 +241,11 @@ public sealed class OverlayMetricsService : IDisposable
                     }
                     else if (IsGpu(hardware.HardwareType))
                     {
-                        gpuUsage = TryGetLoad(hardware, "GPU Core") ?? TryGetFirstSensorValue(hardware, SensorType.Load) ?? gpuUsage;
+                        var curGpuUsage = TryGetLoad(hardware, "GPU Core") ?? TryGetFirstSensorValue(hardware, SensorType.Load);
+                        if (curGpuUsage.HasValue)
+                        {
+                            gpuUsage = gpuUsage.HasValue ? Math.Max(gpuUsage.Value, curGpuUsage.Value) : curGpuUsage.Value;
+                        }
                     }
                     else if (hardware.HardwareType == HardwareType.Memory)
                     {


### PR DESCRIPTION
## Problem:
When using dual graphics cards (internal graphics + discrete graphics), the data from the discrete graphics card may be overwritten by the data from the internal graphics card due to the order of the loop traversal, resulting in 0% display.
## Solution:
Compare and retain the maximum value of gpu usage in the loop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化了硬件监控中的 GPU 使用率显示逻辑，减少在多硬件读取时出现的波动或覆盖问题。
  * 当某个 GPU 未提供有效数据时，会更稳定地保留已有结果，提升指标展示的一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->