### PR TITLE
fix(Metrics): bind the shortcut of Metrics display to LogBoxDisplayHotkey

### DIFF
--- a/BetterGenshinImpact/ViewModel/Pages/HotKeyPageViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/HotKeyPageViewModel.cs
@@ -387,7 +387,7 @@ public partial class HotKeyPageViewModel : ObservableObject, IViewModel
         systemDirectory.Children.Add(takeScreenshotHotKeySettingModel);
 
         systemDirectory.Children.Add(new HotKeySettingModel(
-            "日志与状态窗口展示开关",
+            "日志，状态窗与指标栏展示开关",
             nameof(Config.HotKeyConfig.LogBoxDisplayHotkey),
             Config.HotKeyConfig.LogBoxDisplayHotkey,
             Config.HotKeyConfig.LogBoxDisplayHotkeyType,
@@ -396,6 +396,8 @@ public partial class HotKeyPageViewModel : ObservableObject, IViewModel
                 TaskContext.Instance().Config.MaskWindowConfig.ShowLogBox = !TaskContext.Instance().Config.MaskWindowConfig.ShowLogBox;
                 // 与状态窗口同步
                 TaskContext.Instance().Config.MaskWindowConfig.ShowStatus = TaskContext.Instance().Config.MaskWindowConfig.ShowLogBox;
+                // 与指标栏同步
+                TaskContext.Instance().Config.MaskWindowConfig.ShowOverlayMetrics = TaskContext.Instance().Config.MaskWindowConfig.ShowLogBox;
             }
         ));
 


### PR DESCRIPTION
LogBoxDisplayHotkey will synchronize the display of the metrics bar.

Close #3253 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 优化了“日志/状态/指标栏”相关快捷键的显示名称，界面文案更清晰。
  * 切换该快捷键时，会同步更新指标栏和日志框的显示状态，操作结果更一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->