### PR TITLE
fix: 一条龙首领讨伐改为读取各自配置

### DIFF
--- a/BetterGenshinImpact/Core/Config/OneDragonFlowConfig.cs
+++ b/BetterGenshinImpact/Core/Config/OneDragonFlowConfig.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using BetterGenshinImpact.GameTask;
+using BetterGenshinImpact.GameTask.AutoBoss;
 using BetterGenshinImpact.GameTask.AutoLeyLineOutcrop;
 using BetterGenshinImpact.Helpers;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -219,6 +220,10 @@ public partial class OneDragonFlowConfig : ObservableObject
     // 完成后操作
     [ObservableProperty]
     private string _completionAction = string.Empty;
+
+    // 自动首领讨伐配置（每条一条龙配置独立保存）
+    [ObservableProperty]
+    private AutoBossConfig _autoBossConfig = new();
     
     // 通过当天（4点起始）是哪一天来返回配置
     public (string partyName, string domainName, string sundaySelectedValue) GetDomainConfig()

--- a/BetterGenshinImpact/GameTask/AutoBoss/AutoBossConfig.cs
+++ b/BetterGenshinImpact/GameTask/AutoBoss/AutoBossConfig.cs
@@ -4,7 +4,7 @@ using System;
 namespace BetterGenshinImpact.GameTask.AutoBoss;
 
 /// <summary>
-/// 自动首领讨伐的持久化配置，由独立任务页和一条龙入口复用。
+/// 自动首领讨伐的持久化配置，由独立任务页和每条一条龙配置分别保存。
 /// </summary>
 [Serializable]
 public partial class AutoBossConfig : ObservableObject

--- a/BetterGenshinImpact/Model/OneDragonTaskItem.cs
+++ b/BetterGenshinImpact/Model/OneDragonTaskItem.cs
@@ -116,26 +116,27 @@ public partial class OneDragonTaskItem : ObservableObject
             case "自动首领讨伐":
                 Action = async () =>
                 {
-                    if (string.IsNullOrEmpty(TaskContext.Instance().Config.AutoBossConfig.StrategyName))
+                    var autoBossConfig = config.AutoBossConfig ??= new AutoBossConfig();
+                    if (string.IsNullOrEmpty(autoBossConfig.StrategyName))
                     {
-                        TaskContext.Instance().Config.AutoBossConfig.StrategyName = "根据队伍自动选择";
+                        autoBossConfig.StrategyName = "根据队伍自动选择";
                     }
 
                     var taskSettingsPageViewModel = App.GetService<TaskSettingsPageViewModel>();
-                    if (taskSettingsPageViewModel!.GetFightStrategy(TaskContext.Instance().Config.AutoBossConfig.StrategyName, out var path))
+                    if (taskSettingsPageViewModel!.GetFightStrategy(autoBossConfig.StrategyName, out var path))
                     {
                         TaskControl.Logger.LogError("自动首领讨伐战斗策略{Msg}，跳过", "未配置");
                         return;
                     }
 
-                    if (string.IsNullOrWhiteSpace(TaskContext.Instance().Config.AutoBossConfig.BossName))
+                    if (string.IsNullOrWhiteSpace(autoBossConfig.BossName))
                     {
                         TaskControl.Logger.LogError("一条龙配置内{Msg}需要讨伐的首领，跳过", "未选择");
                         return;
                     }
 
                     AutoBossParam param = new AutoBossParam(path);
-                    param.SetAutoBossConfig(TaskContext.Instance().Config.AutoBossConfig);
+                    param.SetAutoBossConfig(autoBossConfig);
                     await new AutoBossTask(param).Start(CancellationContext.Instance.Cts.Token);
                 };
                 break;

--- a/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml
+++ b/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml
@@ -1168,7 +1168,7 @@
                                           Width="200"
                                           Margin="0,0,36,0"
                                           ItemsSource="{Binding AutoFightViewModel.CombatStrategyList}"
-                                          SelectedItem="{Binding Config.AutoBossConfig.StrategyName, Mode=TwoWay}">
+                                          SelectedItem="{Binding SelectedConfig.AutoBossConfig.StrategyName, Mode=TwoWay}">
                                     <b:Interaction.Triggers>
                                         <b:EventTrigger EventName="DropDownOpened">
                                             <b:InvokeCommandAction Command="{Binding StrategyDropDownOpenedCommand}"
@@ -1204,7 +1204,7 @@
                                                        Margin="0,0,36,0"
                                                        behavior:DomainCascadingComboBoxBehavior.UseFullLabelsWhenOpen="True"
                                                        ItemsSource="{x:Static helpers:AutoBossCascadingItems.Items}"
-                                                       SelectedCascadingItem="{Binding Config.AutoBossConfig.BossName, Mode=TwoWay, Converter={StaticResource AutoBossNameConverter}}" />
+                                                       SelectedCascadingItem="{Binding SelectedConfig.AutoBossConfig.BossName, Mode=TwoWay, Converter={StaticResource AutoBossNameConverter}}" />
                             </Grid>
 
                             <Grid Margin="16">
@@ -1231,7 +1231,7 @@
                                             Grid.Column="1"
                                             Width="200"
                                             Margin="0,0,36,0"
-                                            Text="{Binding Config.AutoBossConfig.TeamName, Mode=TwoWay}"
+                                            Text="{Binding SelectedConfig.AutoBossConfig.TeamName, Mode=TwoWay}"
                                             PlaceholderText="例如：首领队" />
                             </Grid>
 
@@ -1258,7 +1258,7 @@
                                                  Grid.RowSpan="2"
                                                  Grid.Column="1"
                                                  Margin="0,0,36,0"
-                                                 IsChecked="{Binding Config.AutoBossConfig.SpecifyRunCount, Mode=TwoWay}" />
+                                                 IsChecked="{Binding SelectedConfig.AutoBossConfig.SpecifyRunCount, Mode=TwoWay}" />
                             </Grid>
 
                             <Border Margin="16,8,16,16"
@@ -1266,14 +1266,14 @@
                                     BorderBrush="{ui:ThemeResource CardStrokeColorDefaultBrush}"
                                     Background="{ui:ThemeResource ControlFillColorSecondaryBrush}"
                                     CornerRadius="8"
-                                    Visibility="{Binding Config.AutoBossConfig.SpecifyRunCount, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}">
+                                    Visibility="{Binding SelectedConfig.AutoBossConfig.SpecifyRunCount, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}">
                                 <StackPanel Margin="12">
                                     <StackPanel Orientation="Horizontal"
                                                 Margin="0,8,0,12">
                                         <ui:TextBlock Text="讨伐次数："
                                                       VerticalAlignment="Center"
                                                       Margin="0,0,8,0" />
-                                        <ui:NumberBox Value="{Binding Config.AutoBossConfig.RunCount, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                        <ui:NumberBox Value="{Binding SelectedConfig.AutoBossConfig.RunCount, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                                       Minimum="1"
                                                       MaxDecimalPlaces="0"
                                                       SmallChange="1"
@@ -1288,14 +1288,14 @@
                                         <ui:TextBlock Text="原粹不足时使用须臾树脂补充："
                                                       VerticalAlignment="Center"
                                                       Margin="0,0,8,0" />
-                                        <ui:ToggleSwitch IsChecked="{Binding Config.AutoBossConfig.UseTransientResin, Mode=TwoWay}" />
+                                        <ui:ToggleSwitch IsChecked="{Binding SelectedConfig.AutoBossConfig.UseTransientResin, Mode=TwoWay}" />
                                     </StackPanel>
 
                                     <StackPanel Orientation="Horizontal">
                                         <ui:TextBlock Text="原粹不足时使用脆弱树脂补充："
                                                       VerticalAlignment="Center"
                                                       Margin="0,0,8,0" />
-                                        <ui:ToggleSwitch IsChecked="{Binding Config.AutoBossConfig.UseFragileResin, Mode=TwoWay}" />
+                                        <ui:ToggleSwitch IsChecked="{Binding SelectedConfig.AutoBossConfig.UseFragileResin, Mode=TwoWay}" />
                                     </StackPanel>
                                 </StackPanel>
                             </Border>
@@ -1323,7 +1323,7 @@
                                                  Grid.RowSpan="2"
                                                  Grid.Column="1"
                                                  Margin="0,0,36,0"
-                                                 IsChecked="{Binding Config.AutoBossConfig.ReturnToStatueAfterEachRound, Mode=TwoWay}" />
+                                                 IsChecked="{Binding SelectedConfig.AutoBossConfig.ReturnToStatueAfterEachRound, Mode=TwoWay}" />
                             </Grid>
 
                             <Grid Margin="16">
@@ -1349,7 +1349,7 @@
                                                  Grid.RowSpan="2"
                                                  Grid.Column="1"
                                                  Margin="0,0,36,0"
-                                                 IsChecked="{Binding Config.AutoBossConfig.RewardRecognitionEnabled, Mode=TwoWay}" />
+                                                 IsChecked="{Binding SelectedConfig.AutoBossConfig.RewardRecognitionEnabled, Mode=TwoWay}" />
                             </Grid>
 
                             <Grid Margin="16">
@@ -1382,7 +1382,7 @@
                                               LargeChange="3"
                                               SpinButtonPlacementMode="Hidden"
                                               AcceptsExpression="False"
-                                              Value="{Binding Config.AutoBossConfig.ReviveRetryCount, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                              Value="{Binding SelectedConfig.AutoBossConfig.ReviveRetryCount, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                             </Grid>
                         </StackPanel>
                     </ui:CardExpander>

--- a/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
@@ -312,6 +312,13 @@ public partial class OneDragonFlowViewModel : ViewModel
             var config = JsonConvert.DeserializeObject<OneDragonFlowConfig>(json);
             if (config != null)
             {
+                if (config.AutoBossConfig == null)
+                {
+                    config.AutoBossConfig = JsonConvert.DeserializeObject<GameTask.AutoBoss.AutoBossConfig>(
+                        JsonConvert.SerializeObject(TaskContext.Instance().Config.AutoBossConfig))
+                        ?? new GameTask.AutoBoss.AutoBossConfig();
+                }
+
                 configs.Add(config);
                 if (config.Name == TaskContext.Instance().Config.SelectedOneDragonFlowConfigName)
                 {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * “自动首领讨伐”相关设置现在可按每条一条龙配置单独保存，切换不同配置时会保留各自的首领讨伐参数。
  * 配置界面中的相关选项已改为跟随当前选中的配置生效。

* **Bug 修复**
  * 修复了部分情况下自动首领讨伐配置为空导致的设置丢失问题。
  * 优化了指定次数、原粹补充、返回神像、奖励识别和复活重试等选项的显示与加载一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->