### PR TITLE
fix:补充自动首领的一条龙配置

### DIFF
--- a/BetterGenshinImpact/Core/Config/OneDragonFlowConfig.cs
+++ b/BetterGenshinImpact/Core/Config/OneDragonFlowConfig.cs
@@ -37,6 +37,67 @@ public partial class OneDragonFlowConfig : ObservableObject
 
     [ObservableProperty]
     private bool _weeklyDomainEnabled = false;
+
+    #region 自动首领讨伐配置
+
+    [ObservableProperty]
+    private string _autoBossName = string.Empty;
+
+    [ObservableProperty]
+    private string _autoBossStrategyName = "根据队伍自动选择";
+
+    [ObservableProperty]
+    private string _autoBossTeamName = string.Empty;
+
+    [ObservableProperty]
+    private bool _autoBossSpecifyRunCount = false;
+
+    [ObservableProperty]
+    private int _autoBossRunCount = 1;
+
+    [ObservableProperty]
+    private bool _autoBossUseTransientResin = false;
+
+    [ObservableProperty]
+    private bool _autoBossUseFragileResin = false;
+
+    [ObservableProperty]
+    private int _autoBossReviveRetryCount = 3;
+
+    [ObservableProperty]
+    private bool _autoBossReturnToStatueAfterEachRound = false;
+
+    [ObservableProperty]
+    private bool _autoBossRewardRecognitionEnabled = false;
+
+    partial void OnAutoBossSpecifyRunCountChanged(bool value)
+    {
+        if (value)
+        {
+            return;
+        }
+
+        AutoBossUseTransientResin = false;
+        AutoBossUseFragileResin = false;
+    }
+
+    partial void OnAutoBossRunCountChanged(int value)
+    {
+        if (value < 1)
+        {
+            AutoBossRunCount = 1;
+        }
+    }
+
+    partial void OnAutoBossReviveRetryCountChanged(int value)
+    {
+        if (value < 0)
+        {
+            AutoBossReviveRetryCount = 0;
+        }
+    }
+
+    #endregion
     
     // 领取每日奖励的好感队伍名称
     [ObservableProperty]

--- a/BetterGenshinImpact/GameTask/AutoBoss/AutoBossConfig.cs
+++ b/BetterGenshinImpact/GameTask/AutoBoss/AutoBossConfig.cs
@@ -4,7 +4,7 @@ using System;
 namespace BetterGenshinImpact.GameTask.AutoBoss;
 
 /// <summary>
-/// 自动首领讨伐的持久化配置，由独立任务页和一条龙入口复用。
+/// 自动首领讨伐的持久化配置，由独立任务页使用。
 /// </summary>
 [Serializable]
 public partial class AutoBossConfig : ObservableObject

--- a/BetterGenshinImpact/GameTask/AutoBoss/AutoBossParam.cs
+++ b/BetterGenshinImpact/GameTask/AutoBoss/AutoBossParam.cs
@@ -90,19 +90,33 @@ public class AutoBossParam : BaseTaskParam<AutoBossTask>
     /// <summary>
     /// 使用当前全局 AutoBoss 配置创建参数，主要用于 JS 无参构造和一条龙默认启动。
     /// </summary>
-    public AutoBossParam() : base(null, null)
+    public AutoBossParam() : this(true)
     {
-        SetDefault();
     }
 
     /// <summary>
     /// 使用当前全局 AutoBoss 配置创建参数，并用传入路径覆盖实际战斗策略路径。
     /// </summary>
     /// <param name="combatStrategyPath">自动战斗策略文件或策略目录路径。</param>
-    public AutoBossParam(string combatStrategyPath) : base(null, null)
+    public AutoBossParam(string combatStrategyPath) : this(true)
     {
-        SetDefault();
         CombatStrategyPath = combatStrategyPath;
+    }
+
+    private AutoBossParam(bool loadDefaultConfig) : base(null, null)
+    {
+        if (loadDefaultConfig)
+        {
+            SetDefault();
+        }
+    }
+
+    internal static AutoBossParam CreateWithoutDefaultConfig(string combatStrategyPath)
+    {
+        return new AutoBossParam(false)
+        {
+            CombatStrategyPath = combatStrategyPath
+        };
     }
 
     /// <summary>

--- a/BetterGenshinImpact/Model/OneDragonTaskItem.cs
+++ b/BetterGenshinImpact/Model/OneDragonTaskItem.cs
@@ -116,26 +116,35 @@ public partial class OneDragonTaskItem : ObservableObject
             case "自动首领讨伐":
                 Action = async () =>
                 {
-                    if (string.IsNullOrEmpty(TaskContext.Instance().Config.AutoBossConfig.StrategyName))
+                    if (string.IsNullOrEmpty(config.AutoBossStrategyName))
                     {
-                        TaskContext.Instance().Config.AutoBossConfig.StrategyName = "根据队伍自动选择";
+                        config.AutoBossStrategyName = "根据队伍自动选择";
                     }
 
                     var taskSettingsPageViewModel = App.GetService<TaskSettingsPageViewModel>();
-                    if (taskSettingsPageViewModel!.GetFightStrategy(TaskContext.Instance().Config.AutoBossConfig.StrategyName, out var path))
+                    if (taskSettingsPageViewModel!.GetFightStrategy(config.AutoBossStrategyName, out var path))
                     {
                         TaskControl.Logger.LogError("自动首领讨伐战斗策略{Msg}，跳过", "未配置");
                         return;
                     }
 
-                    if (string.IsNullOrWhiteSpace(TaskContext.Instance().Config.AutoBossConfig.BossName))
+                    if (string.IsNullOrWhiteSpace(config.AutoBossName))
                     {
                         TaskControl.Logger.LogError("一条龙配置内{Msg}需要讨伐的首领，跳过", "未选择");
                         return;
                     }
 
-                    AutoBossParam param = new AutoBossParam(path);
-                    param.SetAutoBossConfig(TaskContext.Instance().Config.AutoBossConfig);
+                    AutoBossParam param = AutoBossParam.CreateWithoutDefaultConfig(path);
+                    param.BossName = config.AutoBossName;
+                    param.StrategyName = config.AutoBossStrategyName;
+                    param.TeamName = config.AutoBossTeamName;
+                    param.SpecifyRunCount = config.AutoBossSpecifyRunCount;
+                    param.RunCount = config.AutoBossRunCount;
+                    param.UseTransientResin = config.AutoBossUseTransientResin;
+                    param.UseFragileResin = config.AutoBossUseFragileResin;
+                    param.ReviveRetryCount = config.AutoBossReviveRetryCount;
+                    param.ReturnToStatueAfterEachRound = config.AutoBossReturnToStatueAfterEachRound;
+                    param.RewardRecognitionEnabled = config.AutoBossRewardRecognitionEnabled;
                     await new AutoBossTask(param).Start(CancellationContext.Instance.Cts.Token);
                 };
                 break;

--- a/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml
+++ b/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml
@@ -1168,7 +1168,7 @@
                                           Width="200"
                                           Margin="0,0,36,0"
                                           ItemsSource="{Binding AutoFightViewModel.CombatStrategyList}"
-                                          SelectedItem="{Binding Config.AutoBossConfig.StrategyName, Mode=TwoWay}">
+                                          SelectedItem="{Binding SelectedConfig.AutoBossStrategyName, Mode=TwoWay}">
                                     <b:Interaction.Triggers>
                                         <b:EventTrigger EventName="DropDownOpened">
                                             <b:InvokeCommandAction Command="{Binding StrategyDropDownOpenedCommand}"
@@ -1204,7 +1204,7 @@
                                                        Margin="0,0,36,0"
                                                        behavior:DomainCascadingComboBoxBehavior.UseFullLabelsWhenOpen="True"
                                                        ItemsSource="{x:Static helpers:AutoBossCascadingItems.Items}"
-                                                       SelectedCascadingItem="{Binding Config.AutoBossConfig.BossName, Mode=TwoWay, Converter={StaticResource AutoBossNameConverter}}" />
+                                                       SelectedCascadingItem="{Binding SelectedConfig.AutoBossName, Mode=TwoWay, Converter={StaticResource AutoBossNameConverter}}" />
                             </Grid>
 
                             <Grid Margin="16">
@@ -1231,7 +1231,7 @@
                                             Grid.Column="1"
                                             Width="200"
                                             Margin="0,0,36,0"
-                                            Text="{Binding Config.AutoBossConfig.TeamName, Mode=TwoWay}"
+                                            Text="{Binding SelectedConfig.AutoBossTeamName, Mode=TwoWay}"
                                             PlaceholderText="例如：首领队" />
                             </Grid>
 
@@ -1258,7 +1258,7 @@
                                                  Grid.RowSpan="2"
                                                  Grid.Column="1"
                                                  Margin="0,0,36,0"
-                                                 IsChecked="{Binding Config.AutoBossConfig.SpecifyRunCount, Mode=TwoWay}" />
+                                                 IsChecked="{Binding SelectedConfig.AutoBossSpecifyRunCount, Mode=TwoWay}" />
                             </Grid>
 
                             <Border Margin="16,8,16,16"
@@ -1266,14 +1266,14 @@
                                     BorderBrush="{ui:ThemeResource CardStrokeColorDefaultBrush}"
                                     Background="{ui:ThemeResource ControlFillColorSecondaryBrush}"
                                     CornerRadius="8"
-                                    Visibility="{Binding Config.AutoBossConfig.SpecifyRunCount, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}">
+                                    Visibility="{Binding SelectedConfig.AutoBossSpecifyRunCount, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}">
                                 <StackPanel Margin="12">
                                     <StackPanel Orientation="Horizontal"
                                                 Margin="0,8,0,12">
                                         <ui:TextBlock Text="讨伐次数："
                                                       VerticalAlignment="Center"
                                                       Margin="0,0,8,0" />
-                                        <ui:NumberBox Value="{Binding Config.AutoBossConfig.RunCount, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                        <ui:NumberBox Value="{Binding SelectedConfig.AutoBossRunCount, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                                                       Minimum="1"
                                                       MaxDecimalPlaces="0"
                                                       SmallChange="1"
@@ -1288,14 +1288,14 @@
                                         <ui:TextBlock Text="原粹不足时使用须臾树脂补充："
                                                       VerticalAlignment="Center"
                                                       Margin="0,0,8,0" />
-                                        <ui:ToggleSwitch IsChecked="{Binding Config.AutoBossConfig.UseTransientResin, Mode=TwoWay}" />
+                                        <ui:ToggleSwitch IsChecked="{Binding SelectedConfig.AutoBossUseTransientResin, Mode=TwoWay}" />
                                     </StackPanel>
 
                                     <StackPanel Orientation="Horizontal">
                                         <ui:TextBlock Text="原粹不足时使用脆弱树脂补充："
                                                       VerticalAlignment="Center"
                                                       Margin="0,0,8,0" />
-                                        <ui:ToggleSwitch IsChecked="{Binding Config.AutoBossConfig.UseFragileResin, Mode=TwoWay}" />
+                                        <ui:ToggleSwitch IsChecked="{Binding SelectedConfig.AutoBossUseFragileResin, Mode=TwoWay}" />
                                     </StackPanel>
                                 </StackPanel>
                             </Border>
@@ -1323,7 +1323,7 @@
                                                  Grid.RowSpan="2"
                                                  Grid.Column="1"
                                                  Margin="0,0,36,0"
-                                                 IsChecked="{Binding Config.AutoBossConfig.ReturnToStatueAfterEachRound, Mode=TwoWay}" />
+                                                 IsChecked="{Binding SelectedConfig.AutoBossReturnToStatueAfterEachRound, Mode=TwoWay}" />
                             </Grid>
 
                             <Grid Margin="16">
@@ -1349,7 +1349,7 @@
                                                  Grid.RowSpan="2"
                                                  Grid.Column="1"
                                                  Margin="0,0,36,0"
-                                                 IsChecked="{Binding Config.AutoBossConfig.RewardRecognitionEnabled, Mode=TwoWay}" />
+                                                 IsChecked="{Binding SelectedConfig.AutoBossRewardRecognitionEnabled, Mode=TwoWay}" />
                             </Grid>
 
                             <Grid Margin="16">
@@ -1382,7 +1382,7 @@
                                               LargeChange="3"
                                               SpinButtonPlacementMode="Hidden"
                                               AcceptsExpression="False"
-                                              Value="{Binding Config.AutoBossConfig.ReviveRetryCount, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                              Value="{Binding SelectedConfig.AutoBossReviveRetryCount, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                             </Grid>
                         </StackPanel>
                     </ui:CardExpander>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增“自动首领讨伐”相关配置项，可在一条龙流程中直接设置首领、策略、队伍、讨伐次数、复活重试、返回神像、奖励识别等选项。
  * 新增原粹不足时的树脂补充选择，可分别启用涤净树脂或脆弱树脂。
* **优化**
  * 自动首领讨伐的页面绑定已统一到新的配置入口，设置项同步更直接。
  * 当取消“指定运行次数”时，会自动关闭树脂补充选项；讨伐次数和重试次数也会自动修正为有效值。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->