### PR TITLE
feat: 一条龙支持重复任务和从此执行书签

### DIFF
--- a/BetterGenshinImpact/Core/Config/OneDragonFlowConfig.cs
+++ b/BetterGenshinImpact/Core/Config/OneDragonFlowConfig.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using BetterGenshinImpact.GameTask;
 using BetterGenshinImpact.GameTask.AutoLeyLineOutcrop;
@@ -14,10 +14,19 @@ public partial class OneDragonFlowConfig : ObservableObject
     [ObservableProperty]
     private string _name = string.Empty;
 
+    // 下次执行的任务 Id（为空表示从头开始）
+    [ObservableProperty]
+    private string _nextTaskId = string.Empty;
+
     /// <summary>
-    /// 所有任务的开关状态
+    /// 所有任务的开关状态（键为任务 Id）
     /// </summary>
     public Dictionary<string, bool> TaskEnabledList { get; set; } = new();
+
+    /// <summary>
+    /// 任务定义（Id → 任务名），用于支持同名任务重复添加
+    /// </summary>
+    public Dictionary<string, string> TaskDefinitions { get; set; } = new();
    
     // 合成树脂的国家
     [ObservableProperty]

--- a/BetterGenshinImpact/Core/Config/OneDragonFlowConfig.cs
+++ b/BetterGenshinImpact/Core/Config/OneDragonFlowConfig.cs
@@ -24,6 +24,11 @@ public partial class OneDragonFlowConfig : ObservableObject
     public Dictionary<string, bool> TaskEnabledList { get; set; } = new();
 
     /// <summary>
+    /// 任务执行顺序（任务 Id 列表），用于显式恢复 TaskList 顺序
+    /// </summary>
+    public List<string> TaskOrder { get; set; } = new();
+
+    /// <summary>
     /// 任务定义（Id → 任务名），用于支持同名任务重复添加
     /// </summary>
     public Dictionary<string, string> TaskDefinitions { get; set; } = new();

--- a/BetterGenshinImpact/Model/OneDragonTaskItem.cs
+++ b/BetterGenshinImpact/Model/OneDragonTaskItem.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using BetterGenshinImpact.ViewModel.Pages.OneDragon;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -21,9 +21,13 @@ public partial class OneDragonTaskItem : ObservableObject
 {
     [ObservableProperty] private string _name;
 
+    [ObservableProperty] private string _id = Guid.NewGuid().ToString();
+
     [ObservableProperty] private Brush _statusColor = Brushes.Gray;
 
     [ObservableProperty] private bool _isEnabled = true;
+
+    [ObservableProperty] private bool _isNextTask = false;
 
     [ObservableProperty] private OneDragonBaseViewModel? _viewModel;
 
@@ -32,6 +36,11 @@ public partial class OneDragonTaskItem : ObservableObject
     public OneDragonTaskItem(string name)
     {
         Name = name;
+    }
+
+    public OneDragonTaskItem(string name, string id) : this(name)
+    {
+        _id = id;
     }
 
     // public OneDragonTaskItem(Type viewModelType, Func<Task> action)
@@ -47,13 +56,14 @@ public partial class OneDragonTaskItem : ObservableObject
 
     public void InitAction(OneDragonFlowConfig config)
     {
-        if (config.TaskEnabledList.TryGetValue(Name, out _))
+        if (config.TaskEnabledList.ContainsKey(Id))
         {
-            config.TaskEnabledList[Name] = IsEnabled;
+            config.TaskEnabledList[Id] = IsEnabled;
         }
         else
         {
-            config.TaskEnabledList.Add(Name, IsEnabled);
+            config.TaskEnabledList.Add(Id, IsEnabled);
+            config.TaskDefinitions[Id] = Name;
         }
 
         switch (Name)

--- a/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml
+++ b/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml
@@ -43,8 +43,13 @@
                    <MenuItem Command="{Binding DeleteTaskGroupCommand}"
                              CommandParameter="{Binding SelectedItem, RelativeSource={RelativeSource AncestorType=ui:ListView}}"
                              Header="删除配置" />
-           </ContextMenu>
-       </DockPanel.ContextMenu>
+                   <Separator />
+                   <MenuItem Command="{Binding NextTaskGroupCommand}"
+                             Header="从此执行" />
+                   <MenuItem Command="{Binding ClearNextTaskGroupCommand}"
+                             Header="清除标记" />
+               </ContextMenu>
+           </DockPanel.ContextMenu>
        <Grid DockPanel.Dock="Top"
         Margin="0,0,0,10">
         <Grid.ColumnDefinitions>
@@ -165,7 +170,18 @@
                                             <TextBlock Grid.Column="2"
                                                        VerticalAlignment="Center"
                                                        IsHitTestVisible="False"
-                                                       Text="{Binding Name}" Width="100"/>
+                                                       Text="{Binding Name}" Width="100">
+                                                <TextBlock.Style>
+                                                    <Style TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
+                                                        <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}" />
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding IsNextTask}" Value="True">
+                                                                <Setter Property="Foreground" Value="DodgerBlue" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </TextBlock.Style>
+                                            </TextBlock>
                                             
                                             
                                             <ui:ToggleSwitch Grid.Column="3" IsChecked="{Binding IsEnabled, Mode=TwoWay}" />

--- a/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml
+++ b/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml
@@ -151,6 +151,13 @@
                             <ui:ListView.ItemTemplate>
                                 <DataTemplate>
                                     <ui:Card Margin="0,2,14,2">
+                                        <ui:Card.ContextMenu>
+                                            <ContextMenu>
+                                                <MenuItem Header="复制"
+                                                          Command="{Binding RelativeSource={RelativeSource AncestorType=ui:ListView}, Path=DataContext.CopyTaskCommand}"
+                                                          CommandParameter="{Binding}" />
+                                            </ContextMenu>
+                                        </ui:Card.ContextMenu>
                                         <Grid>
                                             <Grid.ColumnDefinitions>
                                                 <ColumnDefinition Width="Auto" />

--- a/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml
+++ b/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml
@@ -36,15 +36,17 @@
         </Grid.ColumnDefinitions>
 
         <!--  左侧任务列表  -->
-       <DockPanel Grid.Column="0">
+       <DockPanel Grid.Column="0"
+                  ContextMenuOpening="DockPanel_ContextMenuOpening">
            <DockPanel.ContextMenu>
                <ContextMenu>
                    <MenuItem Command="{Binding AddTaskGroupCommand}" Header="新增配置" />
                    <MenuItem Command="{Binding DeleteTaskGroupCommand}"
                              CommandParameter="{Binding SelectedItem, RelativeSource={RelativeSource AncestorType=ui:ListView}}"
-                             Header="删除配置" />
+                             Header="删除" />
                    <Separator />
                    <MenuItem Command="{Binding NextTaskGroupCommand}"
+                             CommandParameter="{Binding SelectedItem, RelativeSource={RelativeSource AncestorType=ui:ListView}}"
                              Header="从此执行" />
                    <MenuItem Command="{Binding ClearNextTaskGroupCommand}"
                              Header="清除标记" />
@@ -151,21 +153,6 @@
                             <ui:ListView.ItemTemplate>
                                 <DataTemplate>
                                     <ui:Card Margin="0,2,14,2">
-                                        <ui:Card.ContextMenu>
-                                            <ContextMenu>
-                                                <MenuItem Command="{Binding RelativeSource={RelativeSource AncestorType=ui:ListView}, Path=DataContext.AddTaskGroupCommand}"
-                                                          Header="新增配置" />
-                                                <MenuItem Header="删除"
-                                                          Command="{Binding RelativeSource={RelativeSource AncestorType=ui:ListView}, Path=DataContext.DeleteTaskCommand}"
-                                                          CommandParameter="{Binding}" />
-                                                <Separator />
-                                                <MenuItem Header="从此执行"
-                                                          Command="{Binding RelativeSource={RelativeSource AncestorType=ui:ListView}, Path=DataContext.SetTaskAsNextCommand}"
-                                                          CommandParameter="{Binding}" />
-                                                <MenuItem Header="清除标记"
-                                                          Command="{Binding RelativeSource={RelativeSource AncestorType=ui:ListView}, Path=DataContext.ClearNextTaskGroupCommand}" />
-                                            </ContextMenu>
-                                        </ui:Card.ContextMenu>
                                         <Grid>
                                             <Grid.ColumnDefinitions>
                                                 <ColumnDefinition Width="Auto" />

--- a/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml
+++ b/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml
@@ -153,9 +153,17 @@
                                     <ui:Card Margin="0,2,14,2">
                                         <ui:Card.ContextMenu>
                                             <ContextMenu>
-                                                <MenuItem Header="复制"
-                                                          Command="{Binding RelativeSource={RelativeSource AncestorType=ui:ListView}, Path=DataContext.CopyTaskCommand}"
+                                                <MenuItem Command="{Binding RelativeSource={RelativeSource AncestorType=ui:ListView}, Path=DataContext.AddTaskGroupCommand}"
+                                                          Header="新增配置" />
+                                                <MenuItem Header="删除"
+                                                          Command="{Binding RelativeSource={RelativeSource AncestorType=ui:ListView}, Path=DataContext.DeleteTaskCommand}"
                                                           CommandParameter="{Binding}" />
+                                                <Separator />
+                                                <MenuItem Header="从此执行"
+                                                          Command="{Binding RelativeSource={RelativeSource AncestorType=ui:ListView}, Path=DataContext.SetTaskAsNextCommand}"
+                                                          CommandParameter="{Binding}" />
+                                                <MenuItem Header="清除标记"
+                                                          Command="{Binding RelativeSource={RelativeSource AncestorType=ui:ListView}, Path=DataContext.ClearNextTaskGroupCommand}" />
                                             </ContextMenu>
                                         </ui:Card.ContextMenu>
                                         <Grid>

--- a/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml.cs
+++ b/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿using BetterGenshinImpact.ViewModel.Pages;
+using BetterGenshinImpact.ViewModel.Pages;
 using BetterGenshinImpact.ViewModel.Pages;
 using System.Windows;
 using System.Windows.Controls;
@@ -66,19 +66,8 @@ public partial class OneDragonFlowPage
                 return;
             }
             
-            // 过滤已存在的配置组
-            var availableGroups = ViewModel.ScriptGroups
-                .Where(sg => ViewModel.TaskList == null || !ViewModel.TaskList.Any(task => task.Name == sg.Name))
-                .ToList();
-                
-            if (!availableGroups.Any())
-            {
-                Toast.Warning("没有可添加的配置组");
-                return;
-            }
-            
-            // 设置ItemsControl的数据源
-            ScriptGroupItemsControl.ItemsSource = availableGroups;
+            // 设置ItemsControl的数据源（不过滤已存在的，允许重复添加）
+            ScriptGroupItemsControl.ItemsSource = ViewModel.ScriptGroups;
             
             // 获取主窗口
             var mainWindow = Application.Current.MainWindow;

--- a/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml.cs
+++ b/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml.cs
@@ -154,6 +154,30 @@ public partial class OneDragonFlowPage
         return null;
     }
     
+    private void DockPanel_ContextMenuOpening(object sender, ContextMenuEventArgs e)
+    {
+        var dockPanel = sender as DockPanel;
+        if (dockPanel == null) return;
+        
+        var hitTest = System.Windows.Media.VisualTreeHelper.HitTest(dockPanel, System.Windows.Input.Mouse.GetPosition(dockPanel));
+        if (hitTest != null)
+        {
+            var listViewItem = FindVisualParent<ListViewItem>(hitTest.VisualHit);
+            if (listViewItem != null)
+            {
+                listViewItem.IsSelected = true;
+            }
+        }
+    }
+    
+    private static T FindVisualParent<T>(DependencyObject child) where T : DependencyObject
+    {
+        var parent = System.Windows.Media.VisualTreeHelper.GetParent(child);
+        if (parent == null) return null;
+        if (parent is T result) return result;
+        return FindVisualParent<T>(parent);
+    }
+    
     private async void SereniteaPotTpType_Clicked(object sender, RoutedEventArgs e)
     {
         if (ViewModel.SelectedConfig == null)

--- a/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
@@ -367,18 +367,17 @@ public partial class OneDragonFlowViewModel : ViewModel
             OneDragonTaskItem taskItem;
             if (isOldFormat)
             {
-                // 旧格式：键=任务名 → 创建新 Id
                 taskItem = new OneDragonTaskItem(key) { IsEnabled = enabled };
             }
             else
             {
-                // 新格式：键=Id，从 TaskDefinitions 取任务名
                 if (!SelectedConfig.TaskDefinitions.TryGetValue(key, out var name))
                 {
                     continue;
                 }
                 taskItem = new OneDragonTaskItem(name, key) { IsEnabled = enabled };
             }
+            taskItem.IsNextTask = key == SelectedConfig.NextTaskId;
             TaskList.Add(taskItem);
         }
     }

--- a/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
@@ -690,6 +690,27 @@ public partial class OneDragonFlowViewModel : ViewModel
     }
 
     [RelayCommand]
+    private void CopyTask(OneDragonTaskItem? taskItem)
+    {
+        if (taskItem == null) return;
+
+        var copy = new OneDragonTaskItem(taskItem.Name) { IsEnabled = taskItem.IsEnabled };
+
+        var index = TaskList.IndexOf(taskItem);
+        if (index >= 0)
+        {
+            TaskList.Insert(index + 1, copy);
+        }
+        else
+        {
+            TaskList.Add(copy);
+        }
+
+        SaveConfig();
+        Toast.Success($"已复制任务: {taskItem.Name}");
+    }
+
+    [RelayCommand]
     private void DeleteTaskGroup()
     {
         DeleteConfigDisplayTaskListFromConfig();

--- a/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
@@ -163,54 +163,44 @@ public partial class OneDragonFlowViewModel : ViewModel
                 IsEnabled = true
             };
             
-            if (TaskList.All(task => task.Name != taskItem.Name))
+            var names = selectedGroupName.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(name => name.Trim())
+                .ToList();
+            bool containsAnyDefaultGroup =
+                names.Any(name => ScriptGroupsdefault.Any(defaultSg => defaultSg.Name == name));
+                
+            if (containsAnyDefaultGroup)
             {
-                var names = selectedGroupName.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
-                    .Select(name => name.Trim())
-                    .ToList();
-                bool containsAnyDefaultGroup =
-                    names.Any(name => ScriptGroupsdefault.Any(defaultSg => defaultSg.Name == name));
-                    
-                if (containsAnyDefaultGroup)
+                int lastDefaultGroupIndex = -1;
+                for (int i = TaskList.Count - 1; i >= 0; i--)
                 {
-                    int lastDefaultGroupIndex = -1;
-                    for (int i = TaskList.Count - 1; i >= 0; i--)
+                    if (ScriptGroupsdefault.Any(defaultSg => defaultSg.Name == TaskList[i].Name))
                     {
-                        if (ScriptGroupsdefault.Any(defaultSg => defaultSg.Name == TaskList[i].Name))
-                        {
-                            lastDefaultGroupIndex = i;
-                            break;
-                        }
+                        lastDefaultGroupIndex = i;
+                        break;
                     }
-                    if (lastDefaultGroupIndex >= 0)
-                    {
-                        TaskList.Insert(lastDefaultGroupIndex + 1, taskItem);
-                    }
-                    else
-                    {
-                        TaskList.Insert(0, taskItem);
-                    }
-                    if (pickTaskCount == 1)
-                    {
-                        Toast.Success("一条龙任务添加成功");
-                    }
+                }
+                if (lastDefaultGroupIndex >= 0)
+                {
+                    TaskList.Insert(lastDefaultGroupIndex + 1, taskItem);
                 }
                 else
                 {
-                    TaskList.Add(taskItem);
-                    if (pickTaskCount == 1)
-                    {
-                        Toast.Success("配置组添加成功");
-                    }
+                    TaskList.Insert(0, taskItem);
+                }
+                if (pickTaskCount == 1)
+                {
+                    Toast.Success("一条龙任务添加成功");
                 }
             }
             else
             {
+                TaskList.Add(taskItem);
                 if (pickTaskCount == 1)
                 {
-                    Toast.Warning("任务或配置组已存在");
+                    Toast.Success("配置组添加成功");
                 }
-            } 
+            }
         }
         if (pickTaskCount > 1)
         {
@@ -357,14 +347,28 @@ public partial class OneDragonFlowViewModel : ViewModel
         }
 
         TaskList.Clear();
+
+        // 旧格式兼容：TaskDefinitions 为空时，TaskEnabledList 键为任务名
+        bool isOldFormat = SelectedConfig.TaskDefinitions == null || SelectedConfig.TaskDefinitions.Count == 0;
+
         foreach (var kvp in SelectedConfig.TaskEnabledList)
         {
-            var taskItem = new OneDragonTaskItem(kvp.Key)
+            OneDragonTaskItem taskItem;
+            if (isOldFormat)
             {
-                IsEnabled = kvp.Value
-            };
+                // 旧格式：键=任务名 → 创建新 Id
+                taskItem = new OneDragonTaskItem(kvp.Key) { IsEnabled = kvp.Value };
+            }
+            else
+            {
+                // 新格式：键=Id，从 TaskDefinitions 取任务名
+                if (!SelectedConfig.TaskDefinitions.TryGetValue(kvp.Key, out var name))
+                {
+                    continue;
+                }
+                taskItem = new OneDragonTaskItem(name, kvp.Key) { IsEnabled = kvp.Value };
+            }
             TaskList.Add(taskItem);
-            // _logger.LogInformation($"加载配置: {kvp.Key} {kvp.Value}");
         }
     }
 
@@ -408,10 +412,12 @@ public partial class OneDragonFlowViewModel : ViewModel
             return;
         }
 
+        SelectedConfig.TaskDefinitions.Clear();
         SelectedConfig.TaskEnabledList.Clear();
         foreach (var task in TaskList)
         {
-            SelectedConfig.TaskEnabledList[task.Name] = task.IsEnabled;
+            SelectedConfig.TaskDefinitions[task.Id] = task.Name;
+            SelectedConfig.TaskEnabledList[task.Id] = task.IsEnabled;
         }
 
         WriteConfig(SelectedConfig);
@@ -540,6 +546,24 @@ public partial class OneDragonFlowViewModel : ViewModel
         CancellationContext.Instance.Set();
 
         var taskListCopy = new List<OneDragonTaskItem>(TaskList);//避免执行过程中修改TaskList
+
+        // 如果设置了 NextTaskId，从指定任务开始执行
+        if (!string.IsNullOrEmpty(SelectedConfig.NextTaskId))
+        {
+            var taskIndex = taskListCopy.FindIndex(t => t.Id == SelectedConfig.NextTaskId);
+            if (taskIndex >= 0)
+            {
+                _logger.LogInformation("一条龙：任务将从 {Name} 开始执行", taskListCopy[taskIndex].Name);
+                taskListCopy = taskListCopy.Skip(taskIndex).ToList();
+            }
+            else
+            {
+                _logger.LogWarning("一条龙：未找到标记的任务，将从头开始执行");
+            }
+            SelectedConfig.NextTaskId = string.Empty;
+            LoadDisplayTaskListFromConfig();
+        }
+
         foreach (var task in taskListCopy)
         {
             task.InitAction(SelectedConfig);
@@ -685,6 +709,57 @@ public partial class OneDragonFlowViewModel : ViewModel
         DeleteConfigDisplayTaskListFromConfig();
         SaveConfig();
         InputScriptGroupName = null;
+    }
+
+    [RelayCommand]
+    private void NextTaskGroup()
+    {
+        if (SelectedConfig == null)
+        {
+            Toast.Warning("请先选择一条龙配置单");
+            return;
+        }
+
+        var enabledTasks = TaskList.Where(t => t.IsEnabled).ToList();
+        if (enabledTasks.Count == 0)
+        {
+            Toast.Warning("请先启用一条龙任务");
+            return;
+        }
+
+        var currentTask = enabledTasks.FirstOrDefault(t => t.Name == InputScriptGroupName);
+        if (currentTask == null)
+        {
+            var taskName = TaskList.FirstOrDefault(t => t.Name == InputScriptGroupName)?.Name ?? "未知任务";
+            Toast.Warning($"当前任务 <{taskName}> 已禁用，请先启用后再从此开始执行");
+            return;
+        }
+
+        SelectedConfig.NextTaskId = currentTask.Id;
+        foreach (var task in TaskList)
+        {
+            task.IsNextTask = task.Id == currentTask.Id;
+        }
+        Toast.Success($"设置从 <{currentTask.Name}> 开始执行任务列表");
+        SaveConfig();
+    }
+
+    [RelayCommand]
+    private void ClearNextTaskGroup()
+    {
+        if (SelectedConfig == null)
+        {
+            Toast.Warning("请先选择一条龙配置单");
+            return;
+        }
+
+        SelectedConfig.NextTaskId = string.Empty;
+        foreach (var task in TaskList)
+        {
+            task.IsNextTask = false;
+        }
+        Toast.Success("清除从此执行标记完成");
+        SaveConfig();
     }
 
     [RelayCommand]

--- a/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
@@ -375,31 +375,18 @@ public partial class OneDragonFlowViewModel : ViewModel
     [RelayCommand]
     private void DeleteConfigDisplayTaskListFromConfig()
     {
-        if (SelectedConfig == null || SelectedTask == null ||
-            SelectedConfig.TaskEnabledList == null) //|| SelectedConfig.TaskEnabledList == null 
+        if (SelectedConfig == null || SelectedTask == null)
         {
             Toast.Warning("请先选择配置组和任务");
             return;
         }
 
-        var deleteId = SelectedTask?.Id;
-        TaskList.Clear();
-        foreach (var kvp in SelectedConfig.TaskEnabledList)
+        var itemToDelete = TaskList.FirstOrDefault(t => t.Id == SelectedTask.Id);
+        if (itemToDelete != null)
         {
-            if (deleteId != null && kvp.Key == deleteId)
-            {
-                continue;
-            }
-            if (!SelectedConfig.TaskDefinitions.TryGetValue(kvp.Key, out var name))
-            {
-                continue;
-            }
-            TaskList.Add(new OneDragonTaskItem(name, kvp.Key)
-            {
-                IsEnabled = kvp.Value
-            });
+            TaskList.Remove(itemToDelete);
+            Toast.Information("已经删除");
         }
-        Toast.Information("已经删除");
     }
 
     [RelayCommand]

--- a/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
@@ -162,6 +162,7 @@ public partial class OneDragonFlowViewModel : ViewModel
             {
                 IsEnabled = true
             };
+            taskItem.Id = GenerateUniqueTaskId();
             
             var names = selectedGroupName.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
                 .Select(name => name.Trim())
@@ -689,12 +690,27 @@ public partial class OneDragonFlowViewModel : ViewModel
         });
     }
 
+    /// <summary>
+    /// 生成与 TaskList 中现有 ID 不重复的唯一 ID。
+    /// </summary>
+    private string GenerateUniqueTaskId()
+    {
+        var existingIds = new HashSet<string>(TaskList.Select(t => t.Id));
+        string newId;
+        do
+        {
+            newId = Guid.NewGuid().ToString();
+        } while (existingIds.Contains(newId));
+        return newId;
+    }
+
     [RelayCommand]
     private void CopyTask(OneDragonTaskItem? taskItem)
     {
         if (taskItem == null) return;
 
         var copy = new OneDragonTaskItem(taskItem.Name) { IsEnabled = taskItem.IsEnabled };
+        copy.Id = GenerateUniqueTaskId();
 
         var index = TaskList.IndexOf(taskItem);
         if (index >= 0)

--- a/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
@@ -382,20 +382,24 @@ public partial class OneDragonFlowViewModel : ViewModel
             return;
         }
 
+        var deleteId = SelectedTask?.Id;
         TaskList.Clear();
         foreach (var kvp in SelectedConfig.TaskEnabledList)
         {
-            var taskItem = new OneDragonTaskItem(kvp.Key)
+            if (deleteId != null && kvp.Key == deleteId)
+            {
+                continue;
+            }
+            if (!SelectedConfig.TaskDefinitions.TryGetValue(kvp.Key, out var name))
+            {
+                continue;
+            }
+            TaskList.Add(new OneDragonTaskItem(name, kvp.Key)
             {
                 IsEnabled = kvp.Value
-            };
-            if (taskItem.Name != InputScriptGroupName)
-            {
-                TaskList.Add(taskItem);
-                taskItem = null;
-                Toast.Information("已经删除");
-            }
+            });
         }
+        Toast.Information("已经删除");
     }
 
     [RelayCommand]
@@ -454,7 +458,7 @@ public partial class OneDragonFlowViewModel : ViewModel
             TaskContext.Instance().Config.SelectedOneDragonFlowConfigName = SelectedConfig.Name;
             foreach (var task in TaskList)
             {
-                if (SelectedConfig.TaskEnabledList.TryGetValue(task.Name, out var value))
+                if (SelectedConfig.TaskEnabledList.TryGetValue(task.Id, out var value))
                 {
                     task.IsEnabled = value;
                 }
@@ -580,11 +584,6 @@ public partial class OneDragonFlowViewModel : ViewModel
             ScriptGroups.Remove(task);
         }
 
-        foreach (var scriptGroup in ScriptGroups)
-        {
-            SelectedConfig.TaskEnabledList.Remove(scriptGroup.Name);
-        }
-
         if (SelectedConfig == null || taskListCopy.Count(t => t.IsEnabled) == 0)
         {
             Toast.Warning("请先选择任务");
@@ -603,8 +602,8 @@ public partial class OneDragonFlowViewModel : ViewModel
         }
 
         SaveConfig();
-        int enabledTaskCount = SelectedConfig.TaskEnabledList.Count(t =>
-            t.Value && ScriptGroupsdefault.All(defaultTask => defaultTask.Name != t.Key));
+        int enabledTaskCount = TaskList.Count(t =>
+            t.IsEnabled && !ScriptGroupsdefault.Any(d => d.Name == t.Name));
         _logger.LogInformation($"启用配置组任务的数量: {enabledTaskCount}");
 
         if (enabledoneTaskCount <= 0)
@@ -638,7 +637,7 @@ public partial class OneDragonFlowViewModel : ViewModel
 
                         Notify.Event(NotificationEvent.DragonStart).Success("配置组任务启动");
 
-                        if (SelectedConfig.TaskEnabledList[task.Name])
+                        if (SelectedConfig.TaskEnabledList[task.Id])
                         {
                             _logger.LogInformation($"配置组任务执行: {finishTaskcount++}/{enabledTaskCount}");
                             await Task.Delay(500);
@@ -720,18 +719,15 @@ public partial class OneDragonFlowViewModel : ViewModel
             return;
         }
 
-        var enabledTasks = TaskList.Where(t => t.IsEnabled).ToList();
-        if (enabledTasks.Count == 0)
-        {
-            Toast.Warning("请先启用一条龙任务");
-            return;
-        }
-
-        var currentTask = enabledTasks.FirstOrDefault(t => t.Name == InputScriptGroupName);
+        var currentTask = SelectedTask;
         if (currentTask == null)
         {
-            var taskName = TaskList.FirstOrDefault(t => t.Name == InputScriptGroupName)?.Name ?? "未知任务";
-            Toast.Warning($"当前任务 <{taskName}> 已禁用，请先启用后再从此开始执行");
+            Toast.Warning("请先选择要从此开始执行的任务");
+            return;
+        }
+        if (!currentTask.IsEnabled)
+        {
+            Toast.Warning($"当前任务 <{currentTask.Name}> 已禁用，请先启用后再从此开始执行");
             return;
         }
 

--- a/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
@@ -352,22 +352,32 @@ public partial class OneDragonFlowViewModel : ViewModel
         // 旧格式兼容：TaskDefinitions 为空时，TaskEnabledList 键为任务名
         bool isOldFormat = SelectedConfig.TaskDefinitions == null || SelectedConfig.TaskDefinitions.Count == 0;
 
-        foreach (var kvp in SelectedConfig.TaskEnabledList)
+        // 使用 TaskOrder 恢复顺序；若无则回退到 TaskEnabledList 的键顺序
+        var orderedKeys = SelectedConfig.TaskOrder?.Count > 0
+            ? SelectedConfig.TaskOrder
+            : SelectedConfig.TaskEnabledList.Keys.ToList();
+
+        foreach (var key in orderedKeys)
         {
+            if (!SelectedConfig.TaskEnabledList.TryGetValue(key, out var enabled))
+            {
+                continue;
+            }
+
             OneDragonTaskItem taskItem;
             if (isOldFormat)
             {
                 // 旧格式：键=任务名 → 创建新 Id
-                taskItem = new OneDragonTaskItem(kvp.Key) { IsEnabled = kvp.Value };
+                taskItem = new OneDragonTaskItem(key) { IsEnabled = enabled };
             }
             else
             {
                 // 新格式：键=Id，从 TaskDefinitions 取任务名
-                if (!SelectedConfig.TaskDefinitions.TryGetValue(kvp.Key, out var name))
+                if (!SelectedConfig.TaskDefinitions.TryGetValue(key, out var name))
                 {
                     continue;
                 }
-                taskItem = new OneDragonTaskItem(name, kvp.Key) { IsEnabled = kvp.Value };
+                taskItem = new OneDragonTaskItem(name, key) { IsEnabled = enabled };
             }
             TaskList.Add(taskItem);
         }
@@ -406,10 +416,12 @@ public partial class OneDragonFlowViewModel : ViewModel
 
         SelectedConfig.TaskDefinitions.Clear();
         SelectedConfig.TaskEnabledList.Clear();
+        SelectedConfig.TaskOrder.Clear();
         foreach (var task in TaskList)
         {
             SelectedConfig.TaskDefinitions[task.Id] = task.Name;
             SelectedConfig.TaskEnabledList[task.Id] = task.IsEnabled;
+            SelectedConfig.TaskOrder.Add(task.Id);
         }
 
         WriteConfig(SelectedConfig);
@@ -563,7 +575,7 @@ public partial class OneDragonFlowViewModel : ViewModel
 
         int finishOneTaskcount = 1;
         int finishTaskcount = 1;
-        int enabledTaskCountall = SelectedConfig.TaskEnabledList.Count(t => t.Value);
+        int enabledTaskCountall = taskListCopy.Count(t => t.IsEnabled);
         _logger.LogInformation($"启用任务总数量: {enabledTaskCountall}");
         
         ReadScriptGroup();
@@ -579,7 +591,7 @@ public partial class OneDragonFlowViewModel : ViewModel
             return;
         }
 
-        int enabledoneTaskCount = SelectedConfig.TaskEnabledList.Count(t => t.Value);
+        int enabledoneTaskCount = taskListCopy.Count(t => t.IsEnabled);
         _logger.LogInformation($"启用一条龙任务的数量: {enabledoneTaskCount}");
 
         await ScriptService.StartGameTask();
@@ -590,7 +602,7 @@ public partial class OneDragonFlowViewModel : ViewModel
         }
 
         SaveConfig();
-        int enabledTaskCount = TaskList.Count(t =>
+        int enabledTaskCount = taskListCopy.Count(t =>
             t.IsEnabled && !ScriptGroupsdefault.Any(d => d.Name == t.Name));
         _logger.LogInformation($"启用配置组任务的数量: {enabledTaskCount}");
 

--- a/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
@@ -727,6 +727,40 @@ public partial class OneDragonFlowViewModel : ViewModel
     }
 
     [RelayCommand]
+    private void DeleteTask(OneDragonTaskItem? taskItem)
+    {
+        if (taskItem == null) return;
+
+        TaskList.Remove(taskItem);
+        SaveConfig();
+        Toast.Success($"已删除任务: {taskItem.Name}");
+    }
+
+    [RelayCommand]
+    private void SetTaskAsNext(OneDragonTaskItem? taskItem)
+    {
+        if (taskItem == null) return;
+        if (SelectedConfig == null)
+        {
+            Toast.Warning("请先选择一条龙配置单");
+            return;
+        }
+        if (!taskItem.IsEnabled)
+        {
+            Toast.Warning($"当前任务 <{taskItem.Name}> 已禁用，请先启用后再从此开始执行");
+            return;
+        }
+
+        SelectedConfig.NextTaskId = taskItem.Id;
+        foreach (var task in TaskList)
+        {
+            task.IsNextTask = task.Id == taskItem.Id;
+        }
+        Toast.Success($"设置从 <{taskItem.Name}> 开始执行任务列表");
+        SaveConfig();
+    }
+
+    [RelayCommand]
     private void DeleteTaskGroup()
     {
         DeleteConfigDisplayTaskListFromConfig();


### PR DESCRIPTION
部分内容来自 @kaedelcb 的版本，经过适应性改造

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 支持以任务唯一标识进行配置关联，允许同名任务并存且互不覆盖。
  - 新增“从此执行/清除标记”：可为“一条龙”设置断点并取消后续执行位置。
  - 任务条目右键新增“复制”：可将任务复用到其后并自动分配新标识。
- **改进**
  - 待执行任务以蓝色高亮显示，并与断点标记联动。
  - 配置加载/保存兼容旧版与新版格式；任务启用与执行判定改按唯一标识处理。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->