### PR TITLE
feat(Http): JS HTTP 请求支持自定义请求头

### DIFF
--- a/BetterGenshinImpact/Core/Script/Dependence/Http.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/Http.cs
@@ -1,11 +1,14 @@
 using BetterGenshinImpact.Core.Script.Utils;
+using Microsoft.ClearScript;
 using System;
+using System.Collections;
 using System.IO;
 using System.Threading.Tasks;
 using OpenCvSharp;
 using System.Linq;
 using System.Text.Json;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Net.Http;
 using System.Text;
 using BetterGenshinImpact.GameTask;
@@ -15,7 +18,30 @@ namespace BetterGenshinImpact.Core.Script.Dependence;
 
 public class Http
 {
-    private readonly ILogger<Http> _logger = App.GetLogger<Http>();
+    private static readonly HashSet<string> ContentHeaderNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "Content-Type",
+        "Content-Length",
+        "Content-Encoding",
+        "Content-Language",
+        "Content-Disposition",
+        "Content-Location",
+        "Content-Range"
+    };
+
+    private readonly ILogger<Http> _logger;
+    private readonly HttpClient? _httpClient;
+
+    public Http()
+    {
+        _logger = App.GetLogger<Http>();
+    }
+
+    public Http(HttpClient httpClient, ILogger<Http>? logger = null)
+    {
+        _httpClient = httpClient;
+        _logger = logger ?? App.GetLogger<Http>();
+    }
 
     private void CheckHttpPermission(string url)
     {
@@ -61,50 +87,55 @@ public class Http
     /// <returns></returns>
     public async Task<HttpReponse> Request(string method, string url, string? body = null, string? headersJson = null)
     {
-        _logger.LogDebug($"[HTTP] 发送HTTP请求: {method} {url} Body: {(body != null ? body : "null")} Headers: {(headersJson != null ? headersJson : "null")}");
+        return await RequestCore(method, url, body, headersJson);
+    }
+
+    /// <summary>
+    /// 执行HTTP请求，支持从JS传入普通对象作为请求头。
+    /// </summary>
+    /// <param name="method">HTTP方法</param>
+    /// <param name="url">请求URL</param>
+    /// <param name="body">请求体</param>
+    /// <param name="headers">请求头，支持JS对象、字典、键值对集合或JSON字符串</param>
+    /// <returns></returns>
+    public async Task<HttpReponse> Request(string method, string url, string? body, object? headers)
+    {
+        return await RequestCore(method, url, body, headers);
+    }
+
+    private async Task<HttpReponse> RequestCore(string method, string url, string? body, object? headers)
+    {
+        _logger.LogDebug("[HTTP] 发送HTTP请求: {Method} {Url} BodyLength: {BodyLength}", method, url, body?.Length ?? 0);
         CheckHttpPermission(url);
 
-        var dictHeaders = new Dictionary<string, string>();
-        if (!string.IsNullOrWhiteSpace(headersJson))
+        var dictHeaders = ConvertToHeaderDictionary(headers);
+        if (dictHeaders.Count > 0)
         {
-            try
+            _logger.LogDebug("[HTTP] 请求头名称: {HeaderNames}", string.Join(", ", dictHeaders.Keys));
+        }
+
+        var request = new HttpRequestMessage(new HttpMethod(method), url);
+        if (body != null)
+        {
+            request.Content = new StringContent(body, Encoding.UTF8);
+            request.Content.Headers.Clear();
+            if (!dictHeaders.ContainsKey("Content-Type"))
             {
-                var headers = JsonSerializer.Deserialize<Dictionary<string, string>>(headersJson);
-                if (headers != null)
-                {
-                    dictHeaders = headers;
-                }
-            }
-            catch (JsonException)
-            {
-                throw new ArgumentException("Headers JSON格式错误");
+                request.Content.Headers.TryAddWithoutValidation("Content-Type", "application/json");
             }
         }
 
-        // header全部小写
-        dictHeaders = dictHeaders.ToDictionary(kvp => kvp.Key.ToLowerInvariant(), kvp => kvp.Value);
+        ApplyHeaders(request, dictHeaders);
 
-        // 提前取出来Content-Type，防止被覆盖
-        string contentType = "application/json";
-        if (dictHeaders.TryGetValue("content-type", out var ct))
-        {
-            contentType = ct;
-            dictHeaders.Remove("content-type");
-        }
-
-        // 使用HttpClient发送请求
-        using var httpClient = new HttpClient();
-        httpClient.DefaultRequestHeaders.Clear();
-        foreach (var header in dictHeaders)
-        {
-            httpClient.DefaultRequestHeaders.Add(header.Key, header.Value);
-        }
-
-        var content = body == null ? null : new StringContent(body, Encoding.UTF8, contentType);
-        var response = await httpClient.SendAsync(new HttpRequestMessage(new HttpMethod(method), url) { Content = content });
+        using var localHttpClient = _httpClient == null ? new HttpClient() : null;
+        var httpClient = _httpClient ?? localHttpClient!;
+        var response = await httpClient.SendAsync(request);
 
         var responseCode = (int)response.StatusCode;
-        var responseHeaders = response.Headers.ToDictionary(h => h.Key, h => h.Value.First()); // 只取第一个值
+        var responseHeaders = response.Headers
+            .Concat(response.Content.Headers)
+            .GroupBy(h => h.Key, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(h => h.Key, h => h.First().Value.FirstOrDefault() ?? "", StringComparer.OrdinalIgnoreCase);
         var responseBody = await response.Content.ReadAsStringAsync();
         return new HttpReponse
         {
@@ -112,5 +143,251 @@ public class Http
             headers = responseHeaders,
             body = responseBody,
         };
+    }
+
+    private void ApplyHeaders(HttpRequestMessage request, Dictionary<string, string> headers)
+    {
+        foreach (var header in headers)
+        {
+            if (ContentHeaderNames.Contains(header.Key))
+            {
+                if (request.Content == null)
+                {
+                    _logger.LogDebug("[HTTP] 请求无Body，忽略内容请求头: {HeaderName}", header.Key);
+                    continue;
+                }
+
+                if (header.Key.Equals("Content-Length", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (!long.TryParse(header.Value, NumberStyles.None, CultureInfo.InvariantCulture, out var contentLength))
+                    {
+                        throw new ArgumentException("Content-Length请求头必须是有效的非负整数");
+                    }
+
+                    request.Content.Headers.ContentLength = contentLength;
+                    continue;
+                }
+
+                if (!request.Content.Headers.TryAddWithoutValidation(header.Key, header.Value))
+                {
+                    throw new ArgumentException($"无法添加内容请求头: {header.Key}");
+                }
+
+                continue;
+            }
+
+            if (!request.Headers.TryAddWithoutValidation(header.Key, header.Value))
+            {
+                throw new ArgumentException($"无法添加请求头: {header.Key}");
+            }
+        }
+    }
+
+    private static Dictionary<string, string> ConvertToHeaderDictionary(object? headers)
+    {
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        if (headers == null || headers is Undefined)
+        {
+            return result;
+        }
+
+        if (headers is string headersJson)
+        {
+            AddJsonHeaders(result, headersJson);
+            return result;
+        }
+
+        if (headers is ScriptObject scriptObject)
+        {
+            AddScriptObjectHeaders(result, scriptObject);
+            return result;
+        }
+
+        if (headers is IDictionary dictionary)
+        {
+            AddDictionaryHeaders(result, dictionary);
+            return result;
+        }
+
+        if (TryAddReflectedScriptObjectHeaders(result, headers))
+        {
+            return result;
+        }
+
+        if (headers is IEnumerable enumerable)
+        {
+            AddEnumerableHeaders(result, enumerable);
+            return result;
+        }
+
+        throw new ArgumentException($"无法将请求头转换为Header字典，实际类型: {headers.GetType().FullName}");
+    }
+
+    private static void AddJsonHeaders(Dictionary<string, string> result, string headersJson)
+    {
+        if (string.IsNullOrWhiteSpace(headersJson))
+        {
+            return;
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(headersJson);
+            if (document.RootElement.ValueKind != JsonValueKind.Object)
+            {
+                throw new ArgumentException("Headers JSON必须是对象");
+            }
+
+            foreach (var property in document.RootElement.EnumerateObject())
+            {
+                AddHeader(result, property.Name, JsonElementToHeaderValue(property.Value));
+            }
+        }
+        catch (JsonException ex)
+        {
+            throw new ArgumentException("Headers JSON格式错误", ex);
+        }
+    }
+
+    private static string JsonElementToHeaderValue(JsonElement value)
+    {
+        return value.ValueKind switch
+        {
+            JsonValueKind.String => value.GetString() ?? "",
+            JsonValueKind.Null => "",
+            JsonValueKind.Undefined => "",
+            _ => value.GetRawText()
+        };
+    }
+
+    private static void AddScriptObjectHeaders(Dictionary<string, string> result, ScriptObject scriptObject)
+    {
+        foreach (var propertyName in scriptObject.PropertyNames)
+        {
+            var value = scriptObject.GetProperty(propertyName);
+            if (value is Undefined)
+            {
+                continue;
+            }
+
+            AddHeader(result, propertyName, ConvertHeaderValueToString(propertyName, value));
+        }
+    }
+
+    private static bool TryAddReflectedScriptObjectHeaders(Dictionary<string, string> result, object headers)
+    {
+        var type = headers.GetType();
+        var propertyNamesProperty = type.GetProperty("PropertyNames");
+        if (propertyNamesProperty?.GetValue(headers) is not IEnumerable propertyNames)
+        {
+            return false;
+        }
+
+        var getPropertyMethod = type.GetMethod("GetProperty", [typeof(string)]);
+        var indexerProperty = type.GetProperty("Item", [typeof(string)]);
+        foreach (var propertyNameObject in propertyNames)
+        {
+            var propertyName = ConvertHeaderNameToString(propertyNameObject);
+            object? value;
+            if (getPropertyMethod != null)
+            {
+                value = getPropertyMethod.Invoke(headers, [propertyName]);
+            }
+            else if (indexerProperty != null)
+            {
+                value = indexerProperty.GetValue(headers, [propertyName]);
+            }
+            else
+            {
+                return false;
+            }
+
+            if (value is Undefined)
+            {
+                continue;
+            }
+
+            AddHeader(result, propertyName, ConvertHeaderValueToString(propertyName, value));
+        }
+
+        return true;
+    }
+
+    private static void AddDictionaryHeaders(Dictionary<string, string> result, IDictionary dictionary)
+    {
+        foreach (DictionaryEntry entry in dictionary)
+        {
+            AddHeader(result, ConvertHeaderNameToString(entry.Key), ConvertHeaderValueToString(entry.Key, entry.Value));
+        }
+    }
+
+    private static void AddEnumerableHeaders(Dictionary<string, string> result, IEnumerable enumerable)
+    {
+        foreach (var item in enumerable)
+        {
+            if (item == null)
+            {
+                continue;
+            }
+
+            if (item is DictionaryEntry dictionaryEntry)
+            {
+                AddHeader(result, ConvertHeaderNameToString(dictionaryEntry.Key), ConvertHeaderValueToString(dictionaryEntry.Key, dictionaryEntry.Value));
+                continue;
+            }
+
+            var itemType = item.GetType();
+            var keyProperty = itemType.GetProperty("Key");
+            var valueProperty = itemType.GetProperty("Value");
+            if (keyProperty == null || valueProperty == null)
+            {
+                throw new ArgumentException($"无法将请求头集合项转换为键值对，集合项类型: {itemType.FullName}");
+            }
+
+            var key = keyProperty.GetValue(item);
+            var value = valueProperty.GetValue(item);
+            AddHeader(result, ConvertHeaderNameToString(key), ConvertHeaderValueToString(key, value));
+        }
+    }
+
+    private static void AddHeader(Dictionary<string, string> result, string name, string value)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new ArgumentException("Header名称不能为空");
+        }
+
+        result[name] = value;
+    }
+
+    private static string ConvertHeaderNameToString(object? name)
+    {
+        var headerName = ConvertHeaderValueToString(null, name);
+        if (string.IsNullOrWhiteSpace(headerName))
+        {
+            throw new ArgumentException("Header名称不能为空");
+        }
+
+        return headerName;
+    }
+
+    private static string ConvertHeaderValueToString(object? name, object? value)
+    {
+        if (value == null || value is Undefined)
+        {
+            return "";
+        }
+
+        if (value is string stringValue)
+        {
+            return stringValue;
+        }
+
+        if (value is IFormattable formattable)
+        {
+            return formattable.ToString(null, CultureInfo.InvariantCulture);
+        }
+
+        return value.ToString() ?? "";
     }
 }


### PR DESCRIPTION
## 改动简介

之前 JS 脚本里调用 `http.request` 传请求头不太顺手：只能传 JSON 字符串，而且 Header 会被强制转小写，导致一些需要区分大小写的接口（比如米游社相关常用的 `DS`、`x-rpc-*` 等）无法正确发送。

这次给 `Http.cs` 新增了一个重载，支持直接传入普通 JS 对象、Dictionary 或者 JSON 字符串作为请求头。请求头会按原样发送，`Content-Type`、`Content-Length` 这类内容头也会正确挂到请求体上，不会再被错误地丢到默认请求头里。

## 调用方式

```js
// GET 带请求头，第三个参数 body 传 null
const getResult = await http.request("GET", url, null, {
    "Accept": "application/json",
    "User-Agent": "Mozilla/5.0"
});

// POST 带请求头
const postResult = await http.request(
    "POST",
    url,
    JSON.stringify(data),
    {
        "Content-Type": "application/json",
        "Accept": "application/json"
    }
);
```

旧的调用方式仍然兼容：

```js
await http.request("GET", url);
await http.request("POST", url, body);
await http.request("POST", url, body, JSON.stringify(headers));
```

## 返回结果

返回对象保持不变：

```js
result.status_code; // 状态码
result.headers;     // 响应头
result.body;        // 响应体字符串
```

## 注意事项

- 脚本仍需在 `manifest.json` 中配置 `http_allowed_urls`，并在调度器中开启 JS HTTP 权限；本次改动没有放宽 URL 白名单约束。
- 日志里只会记录 Header 名称，不会输出 Header 值，避免泄露 `Cookie`、`Authorization`、`DS` 等敏感信息。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 支持在请求中传入更灵活的请求头配置。
  * 支持自动识别并应用请求头与内容请求头。
  * 带请求体且未指定类型时，默认使用 `application/json`。
  * 响应结果现在会包含更完整的响应头信息。

* **改进**
  * 优化请求头校验，忽略无请求体时不适用的内容请求头，并校验 `Content-Length` 格式。
  * 保留基于清单配置的 URL 访问权限控制。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->