### PR TITLE
feat: 增加地图遮罩中单独标点的隐藏与显示功能

### DIFF
--- a/BetterGenshinImpact/GameTask/MapMask/MapMaskConfig.cs
+++ b/BetterGenshinImpact/GameTask/MapMask/MapMaskConfig.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using CommunityToolkit.Mvvm.ComponentModel;
 using System.Text.Json.Serialization;
 
@@ -33,18 +32,6 @@ public partial class MapMaskConfig : ObservableObject
     [ObservableProperty]
     private bool _pathAutoRecordEnabled = false;
 
-    /// <summary>
-    /// 已选择的地图遮罩标点分类。
-    /// </summary>
-    [ObservableProperty]
-    private List<MapMaskSelectedLabelConfig> _selectedLabelItems = [];
-
-    /// <summary>
-    /// 已隐藏的地图遮罩标点 key。
-    /// </summary>
-    [ObservableProperty]
-    private List<string> _hiddenMapPointKeys = [];
-
     private MapPointApiProvider _mapPointApiProvider = MapPointApiProvider.MihoyoMap;
 
     private string _hoYoLabLanguage = HoYoLabLanguageEnUs;
@@ -61,20 +48,4 @@ public partial class MapMaskConfig : ObservableObject
         get => _hoYoLabLanguage;
         set => SetProperty(ref _hoYoLabLanguage, value);
     }
-}
-
-[Serializable]
-public sealed class MapMaskSelectedLabelConfig
-{
-    public string Id { get; set; } = string.Empty;
-
-    public List<string> LabelIds { get; set; } = [];
-
-    public string ParentId { get; set; } = string.Empty;
-
-    public string Name { get; set; } = string.Empty;
-
-    public string IconUrl { get; set; } = string.Empty;
-
-    public int PointCount { get; set; }
 }

--- a/BetterGenshinImpact/GameTask/MapMask/MapMaskConfig.cs
+++ b/BetterGenshinImpact/GameTask/MapMask/MapMaskConfig.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using CommunityToolkit.Mvvm.ComponentModel;
 using System.Text.Json.Serialization;
 
@@ -32,6 +33,18 @@ public partial class MapMaskConfig : ObservableObject
     [ObservableProperty]
     private bool _pathAutoRecordEnabled = false;
 
+    /// <summary>
+    /// 已选择的地图遮罩标点分类。
+    /// </summary>
+    [ObservableProperty]
+    private List<MapMaskSelectedLabelConfig> _selectedLabelItems = [];
+
+    /// <summary>
+    /// 已隐藏的地图遮罩标点 key。
+    /// </summary>
+    [ObservableProperty]
+    private List<string> _hiddenMapPointKeys = [];
+
     private MapPointApiProvider _mapPointApiProvider = MapPointApiProvider.MihoyoMap;
 
     private string _hoYoLabLanguage = HoYoLabLanguageEnUs;
@@ -48,4 +61,20 @@ public partial class MapMaskConfig : ObservableObject
         get => _hoYoLabLanguage;
         set => SetProperty(ref _hoYoLabLanguage, value);
     }
+}
+
+[Serializable]
+public sealed class MapMaskSelectedLabelConfig
+{
+    public string Id { get; set; } = string.Empty;
+
+    public List<string> LabelIds { get; set; } = [];
+
+    public string ParentId { get; set; } = string.Empty;
+
+    public string Name { get; set; } = string.Empty;
+
+    public string IconUrl { get; set; } = string.Empty;
+
+    public int PointCount { get; set; }
 }

--- a/BetterGenshinImpact/GameTask/MapMask/MapMaskStateStorage.cs
+++ b/BetterGenshinImpact/GameTask/MapMask/MapMaskStateStorage.cs
@@ -1,0 +1,123 @@
+using BetterGenshinImpact.Core.Config;
+using BetterGenshinImpact.Service;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+
+namespace BetterGenshinImpact.GameTask.MapMask;
+
+[Serializable]
+public sealed class MapMaskState
+{
+    public List<MapMaskSelectedLabelState> SelectedLabelItems { get; set; } = [];
+
+    public List<string> HiddenMapPointKeys { get; set; } = [];
+}
+
+[Serializable]
+public sealed class MapMaskSelectedLabelState
+{
+    public string Id { get; set; } = string.Empty;
+
+    public List<string> LabelIds { get; set; } = [];
+
+    public string ParentId { get; set; } = string.Empty;
+
+    public string Name { get; set; } = string.Empty;
+
+    public string IconUrl { get; set; } = string.Empty;
+
+    public int PointCount { get; set; }
+}
+
+public static class MapMaskStateStorage
+{
+    private const string StateRelativePath = @"User/mapmask.json";
+    private static readonly object Locker = new();
+    private static MapMaskState? _state;
+
+    public static MapMaskState Read()
+    {
+        lock (Locker)
+        {
+            _state ??= ReadFromFile();
+            return _state;
+        }
+    }
+
+    public static void Save(MapMaskState state)
+    {
+        lock (Locker)
+        {
+            _state = Normalize(state);
+            WriteToFile(_state);
+        }
+    }
+
+    public static void Clear()
+    {
+        Save(new MapMaskState());
+    }
+
+    private static MapMaskState ReadFromFile()
+    {
+        try
+        {
+            var filePath = Global.Absolute(StateRelativePath);
+            if (!File.Exists(filePath))
+            {
+                return new MapMaskState();
+            }
+
+            var json = File.ReadAllText(filePath);
+            return Normalize(JsonSerializer.Deserialize<MapMaskState>(json, ConfigService.JsonOptions));
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine(e.Message);
+            Console.WriteLine(e.StackTrace);
+            return new MapMaskState();
+        }
+    }
+
+    private static MapMaskState Normalize(MapMaskState? state)
+    {
+        state ??= new MapMaskState();
+        state.SelectedLabelItems ??= [];
+        state.HiddenMapPointKeys ??= [];
+        state.SelectedLabelItems = state.SelectedLabelItems.Where(x => x != null).ToList();
+
+        foreach (var item in state.SelectedLabelItems)
+        {
+            item.Id ??= string.Empty;
+            item.LabelIds ??= [];
+            item.ParentId ??= string.Empty;
+            item.Name ??= string.Empty;
+            item.IconUrl ??= string.Empty;
+        }
+
+        return state;
+    }
+
+    private static void WriteToFile(MapMaskState state)
+    {
+        try
+        {
+            var filePath = Global.Absolute(StateRelativePath);
+            var directoryPath = Path.GetDirectoryName(filePath);
+            if (!string.IsNullOrWhiteSpace(directoryPath) && !Directory.Exists(directoryPath))
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+
+            File.WriteAllText(filePath, JsonSerializer.Serialize(state, ConfigService.JsonOptions));
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine(e.Message);
+            Console.WriteLine(e.StackTrace);
+        }
+    }
+}

--- a/BetterGenshinImpact/Model/MaskMap/MaskMapPoint.cs
+++ b/BetterGenshinImpact/Model/MaskMap/MaskMapPoint.cs
@@ -32,6 +32,8 @@ public class MaskMapPoint
 
     public List<MaskMapLink> VideoUrls { get; set; } = new();
 
+    public bool IsHidden { get; set; }
+
     public bool Contains(double px, double py)
     {
         return px >= X - MaskMapPointStatic.Width / 2 && px <= X + MaskMapPointStatic.Width / 2 &&

--- a/BetterGenshinImpact/View/Controls/MiniMapPointsCanvas.cs
+++ b/BetterGenshinImpact/View/Controls/MiniMapPointsCanvas.cs
@@ -202,6 +202,11 @@ public sealed class MiniMapPointsCanvas : FrameworkElement
 
     private void DrawPoint(DrawingContext dc, MaskMapPoint point, double centerX, double centerY, double width, double height)
     {
+        if (point.IsHidden)
+        {
+            dc.PushOpacity(0.35);
+        }
+
         var radius = width / 2.0;
         const double strokeThickness = 2.0;
 
@@ -252,6 +257,11 @@ public sealed class MiniMapPointsCanvas : FrameworkElement
             var brush = new SolidColorBrush(GenerateRandomColor(point.Id));
             brush.Freeze();
             dc.DrawEllipse(brush, null, new Point(centerX, centerY), width / 2.0, height / 2.0);
+        }
+
+        if (point.IsHidden)
+        {
+            dc.Pop();
         }
     }
 

--- a/BetterGenshinImpact/View/Controls/PointsCanvas.cs
+++ b/BetterGenshinImpact/View/Controls/PointsCanvas.cs
@@ -272,6 +272,11 @@ public class PointsCanvas : FrameworkElement
     /// </summary>
     private void DrawPoint(DrawingContext dc, MaskMapPoint point, double centerX, double centerY, double width, double height)
     {
+        if (point.IsHidden)
+        {
+            dc.PushOpacity(0.35);
+        }
+
         double radius = width / 2.0;
         double strokeThickness = 2.0;
 
@@ -334,6 +339,11 @@ public class PointsCanvas : FrameworkElement
             brush.Freeze();
 
             dc.DrawEllipse(brush, null, new Point(centerX, centerY), width / 2.0, height / 2.0);
+        }
+
+        if (point.IsHidden)
+        {
+            dc.Pop();
         }
     }
 

--- a/BetterGenshinImpact/View/MaskWindow.xaml
+++ b/BetterGenshinImpact/View/MaskWindow.xaml
@@ -88,7 +88,7 @@
                     ClipToBounds="True">
                 <controls:MiniMapPointsCanvas x:Name="MiniMapPointsCanvasControl"
                                               Visibility="{Binding Config.MapMaskConfig.MiniMapMaskEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"
-                                              PointsSource="{Binding VisibleMapPoints}"
+                                              PointsSource="{Binding MapPoints}"
                                               LabelsSource="{Binding MapPointLabels}"
                                               IsHitTestVisible="False">
                     <Canvas.Left>
@@ -548,7 +548,7 @@
                                    x:Name="PointsCanvasControl"
                                    Visibility="{Binding IsInBigMapUi, Converter={StaticResource BooleanToVisibilityConverter}}"
                                    HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
-                                   PointsSource="{Binding VisibleMapPoints}"
+                                   PointsSource="{Binding MapPoints}"
                                    LabelsSource="{Binding MapPointLabels}"
                                    PointClickCommand="{Binding PointClickCommand}"
                                    PointRightClickCommand="{Binding PointRightClickCommand}"
@@ -621,8 +621,22 @@
                                        BorderBrush="#26FFFFFF"
                                        Cursor="Hand"
                                        Icon="{ui:SymbolIcon EyeOff24}"
-                                       Content="{Binding HiddenToggleText}"
-                                       ToolTip="{Binding HiddenToggleText}"
+                                       Content="隐藏"
+                                       ToolTip="隐藏"
+                                       Visibility="{Binding IsCurrentPointHidden, Converter={StaticResource BooleanToVisibilityRevertConverter}}"
+                                       Command="{Binding ToggleHiddenCommand}" />
+                            <ui:Button Grid.Column="1"
+                                       MinWidth="58"
+                                       Height="28"
+                                       Padding="8,0"
+                                       Margin="8,-2,0,0"
+                                       Background="#2FFFFFFF"
+                                       BorderBrush="#26FFFFFF"
+                                       Cursor="Hand"
+                                       Icon="{ui:SymbolIcon Eye24}"
+                                       Content="显示"
+                                       ToolTip="显示"
+                                       Visibility="{Binding IsCurrentPointHidden, Converter={StaticResource BooleanToVisibilityConverter}}"
                                        Command="{Binding ToggleHiddenCommand}" />
                             <ui:Button Grid.Column="2"
                                        Width="28"

--- a/BetterGenshinImpact/View/MaskWindow.xaml
+++ b/BetterGenshinImpact/View/MaskWindow.xaml
@@ -88,7 +88,7 @@
                     ClipToBounds="True">
                 <controls:MiniMapPointsCanvas x:Name="MiniMapPointsCanvasControl"
                                               Visibility="{Binding Config.MapMaskConfig.MiniMapMaskEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"
-                                              PointsSource="{Binding MapPoints}"
+                                              PointsSource="{Binding VisibleMapPoints}"
                                               LabelsSource="{Binding MapPointLabels}"
                                               IsHitTestVisible="False">
                     <Canvas.Left>
@@ -548,7 +548,7 @@
                                    x:Name="PointsCanvasControl"
                                    Visibility="{Binding IsInBigMapUi, Converter={StaticResource BooleanToVisibilityConverter}}"
                                    HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
-                                   PointsSource="{Binding MapPoints}"
+                                   PointsSource="{Binding VisibleMapPoints}"
                                    LabelsSource="{Binding MapPointLabels}"
                                    PointClickCommand="{Binding PointClickCommand}"
                                    PointRightClickCommand="{Binding PointRightClickCommand}"
@@ -604,6 +604,7 @@
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*" />
                                 <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="Auto" />
                             </Grid.ColumnDefinitions>
                             <TextBlock Grid.Column="0"
                                        FontSize="14"
@@ -612,6 +613,18 @@
                                        Text="{Binding Title}"
                                        TextTrimming="CharacterEllipsis" />
                             <ui:Button Grid.Column="1"
+                                       MinWidth="58"
+                                       Height="28"
+                                       Padding="8,0"
+                                       Margin="8,-2,0,0"
+                                       Background="#2FFFFFFF"
+                                       BorderBrush="#26FFFFFF"
+                                       Cursor="Hand"
+                                       Icon="{ui:SymbolIcon EyeOff24}"
+                                       Content="{Binding HiddenToggleText}"
+                                       ToolTip="{Binding HiddenToggleText}"
+                                       Command="{Binding ToggleHiddenCommand}" />
+                            <ui:Button Grid.Column="2"
                                        Width="28"
                                        Height="28"
                                        Padding="0"
@@ -903,6 +916,31 @@
                                                         PreviewMouseLeftButtonDown="MapLabelSearchTextBox_OnPreviewMouseLeftButtonDown" />
 
                                             <StackPanel Grid.Column="3" Orientation="Horizontal" Margin="8,0,0,0">
+                                                <TextBlock VerticalAlignment="Center"
+                                                           Margin="0,0,8,0"
+                                                           Foreground="{ui:ThemeResource TextFillColorSecondaryBrush}"
+                                                           ToolTip="当前显示/全部标点"
+                                                           Text="{Binding MapPointVisibilitySummary}" />
+                                                <ui:Button Width="32"
+                                                           Height="32"
+                                                           Margin="0,0,6,0"
+                                                           Background="#FF2B2F37"
+                                                           Foreground="White"
+                                                           Cursor="Hand"
+                                                           Icon="{ui:SymbolIcon EyeOff24}"
+                                                           ToolTip="全部隐藏"
+                                                           IsEnabled="{Binding HasMapPoints}"
+                                                           Command="{Binding HideAllMapPointsCommand}" />
+                                                <ui:Button Width="32"
+                                                           Height="32"
+                                                           Margin="0,0,6,0"
+                                                           Background="#FF2B2F37"
+                                                           Foreground="White"
+                                                           Cursor="Hand"
+                                                           Icon="{ui:SymbolIcon Eye24}"
+                                                           ToolTip="全部显示"
+                                                           IsEnabled="{Binding HasHiddenMapPoints}"
+                                                           Command="{Binding ShowAllMapPointsCommand}" />
                                                 <ui:Button
                                                            Width="32"
                                                            Height="32"

--- a/BetterGenshinImpact/ViewModel/MaskMapPointInfoPopupViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/MaskMapPointInfoPopupViewModel.cs
@@ -23,12 +23,17 @@ public partial class MaskMapPointInfoPopupViewModel : ObservableObject
     private static readonly HttpClient _http = new();
     private MemoryStream? _imageStream;
 
+    public event EventHandler<MaskMapPoint?>? ToggleHiddenRequested;
+
     [ObservableProperty] private bool _isOpen;
     [ObservableProperty] private bool _isLoading;
     [ObservableProperty] private bool _isTextLoading;
     [ObservableProperty] private string _textError = string.Empty;
     [ObservableProperty] private Rect _placementRect = Rect.Empty;
     [ObservableProperty] private string _title = string.Empty;
+    [ObservableProperty] private MaskMapPoint? _currentPoint;
+    [ObservableProperty] private bool _isCurrentPointHidden;
+    [ObservableProperty] private string _hiddenToggleText = "隐藏";
     [ObservableProperty] private string _text = string.Empty;
     [ObservableProperty] private IReadOnlyList<MaskMapLink> _urlList = Array.Empty<MaskMapLink>();
     [ObservableProperty] private bool _hasUrlList;
@@ -45,7 +50,7 @@ public partial class MaskMapPointInfoPopupViewModel : ObservableObject
         HasUrlList = value is { Count: > 0 };
     }
 
-    public async Task ShowAsync(MaskMapPoint point, Point anchorPosition, string title, CancellationToken externalCt = default)
+    public async Task ShowAsync(MaskMapPoint point, Point anchorPosition, string title, bool isHidden, CancellationToken externalCt = default)
     {
         _cts?.Cancel();
         _cts?.Dispose();
@@ -59,6 +64,8 @@ public partial class MaskMapPointInfoPopupViewModel : ObservableObject
             MaskMapPointStatic.Height);
 
         Title = title ?? string.Empty;
+        CurrentPoint = point;
+        SetHiddenState(isHidden);
         Text = string.Empty;
         UrlList = point.VideoUrls;
         TextError = string.Empty;
@@ -151,6 +158,12 @@ public partial class MaskMapPointInfoPopupViewModel : ObservableObject
             IsImageLoading = false;
             IsLoading = false;
         }
+    }
+
+    public void SetHiddenState(bool isHidden)
+    {
+        IsCurrentPointHidden = isHidden;
+        HiddenToggleText = isHidden ? "显示" : "隐藏";
     }
 
     private void DisposeImageStream()
@@ -262,6 +275,12 @@ public partial class MaskMapPointInfoPopupViewModel : ObservableObject
     }
 
     [RelayCommand]
+    private void ToggleHidden()
+    {
+        ToggleHiddenRequested?.Invoke(this, CurrentPoint);
+    }
+
+    [RelayCommand]
     public void Close()
     {
         _cts?.Cancel();
@@ -269,6 +288,8 @@ public partial class MaskMapPointInfoPopupViewModel : ObservableObject
         _cts = null;
         IsOpen = false;
         IsLoading = false;
+        CurrentPoint = null;
+        SetHiddenState(false);
         IsTextLoading = false;
         TextError = string.Empty;
         Text = string.Empty;

--- a/BetterGenshinImpact/ViewModel/MaskMapPointInfoPopupViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/MaskMapPointInfoPopupViewModel.cs
@@ -33,7 +33,6 @@ public partial class MaskMapPointInfoPopupViewModel : ObservableObject
     [ObservableProperty] private string _title = string.Empty;
     [ObservableProperty] private MaskMapPoint? _currentPoint;
     [ObservableProperty] private bool _isCurrentPointHidden;
-    [ObservableProperty] private string _hiddenToggleText = "隐藏";
     [ObservableProperty] private string _text = string.Empty;
     [ObservableProperty] private IReadOnlyList<MaskMapLink> _urlList = Array.Empty<MaskMapLink>();
     [ObservableProperty] private bool _hasUrlList;
@@ -163,7 +162,6 @@ public partial class MaskMapPointInfoPopupViewModel : ObservableObject
     public void SetHiddenState(bool isHidden)
     {
         IsCurrentPointHidden = isHidden;
-        HiddenToggleText = isHidden ? "显示" : "隐藏";
     }
 
     private void DisposeImageStream()

--- a/BetterGenshinImpact/ViewModel/MaskWindowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/MaskWindowViewModel.cs
@@ -137,6 +137,7 @@ namespace BetterGenshinImpact.ViewModel
         private readonly HashSet<string> _hiddenMapPointIds = new(StringComparer.Ordinal);
         private readonly SemaphoreSlim _iconLoadSemaphore = new(10, 10);
         private readonly OverlayMetricsService? _overlayMetricsService = App.GetService<OverlayMetricsService>();
+        private bool _isRestoringMapMaskConfig;
         private bool _metricsSubscribed;
         private bool _fpsStarted;
 
@@ -215,6 +216,7 @@ namespace BetterGenshinImpact.ViewModel
                 await EnsureIconLoadedAsync(item, CancellationToken.None);
             }
 
+            SaveSelectedMapLabelItemsToConfig();
             StartRefreshSelectedMapPoints();
         }
 
@@ -227,6 +229,8 @@ namespace BetterGenshinImpact.ViewModel
             }
 
             SelectedMapLabelItems.Clear();
+            SaveSelectedMapLabelItemsToConfig();
+            ClearHiddenMapPointConfig();
             StartRefreshSelectedMapPoints();
         }
 
@@ -243,6 +247,7 @@ namespace BetterGenshinImpact.ViewModel
 
             SyncSelectedMapPointApiProviderFromConfig();
             SyncSelectedHoYoLabLanguageFromConfig();
+            LoadHiddenMapPointKeysFromConfig();
             InitMetrics();
         }
 
@@ -353,6 +358,7 @@ namespace BetterGenshinImpact.ViewModel
             _mapLabelItemsCts?.Cancel();
             _mapPointListCts?.Cancel();
             PointInfoPopup.Close();
+            ClearSavedMapMaskPointConfig();
 
             Interlocked.Increment(ref _mapLabelTreeLoadVersion);
             _isMapLabelTreeLoaded = false;
@@ -511,6 +517,12 @@ namespace BetterGenshinImpact.ViewModel
             {
                 IsMapPointPickerOpen = false;
                 PointInfoPopup.Close();
+                return;
+            }
+
+            if (!_isMapLabelTreeLoaded && HasSavedMapLabelSelection())
+            {
+                _ = EnsureLabelTreeLoadedAsync();
             }
         }
 
@@ -555,6 +567,7 @@ namespace BetterGenshinImpact.ViewModel
                 var vms = categories.Select(x => new MapLabelCategoryVm(x)).ToList();
                 MapLabelCategories = new ObservableCollection<MapLabelCategoryVm>(vms);
                 await SelectMapLabelCategory(MapLabelCategories.FirstOrDefault());
+                await RestoreSelectedMapLabelItemsFromConfigAsync();
                 _isMapLabelTreeLoaded = true;
             }
             catch (Exception ex)
@@ -569,6 +582,96 @@ namespace BetterGenshinImpact.ViewModel
                 //     _ = EnsureLabelTreeLoadedAsync();
                 // }
             }
+        }
+
+        private bool HasSavedMapLabelSelection()
+        {
+            return TaskContext.Instance().Config.MapMaskConfig.SelectedLabelItems?.Count > 0;
+        }
+
+        private async Task RestoreSelectedMapLabelItemsFromConfigAsync()
+        {
+            var savedItems = TaskContext.Instance().Config.MapMaskConfig.SelectedLabelItems ?? [];
+            if (savedItems.Count == 0)
+            {
+                return;
+            }
+
+            _isRestoringMapMaskConfig = true;
+            try
+            {
+                SelectedMapLabelItems.Clear();
+                foreach (var savedItem in savedItems)
+                {
+                    var item = FindMapLabelItem(savedItem.Id)
+                               ?? new MapLabelItemVm(new MaskMapPointLabel
+                               {
+                                   LabelId = savedItem.Id,
+                                   LabelIds = savedItem.LabelIds ?? [],
+                                   ParentId = savedItem.ParentId,
+                                   Name = savedItem.Name,
+                                   IconUrl = savedItem.IconUrl,
+                                   PointCount = savedItem.PointCount
+                               });
+
+                    if (SelectedMapLabelItems.Any(x => x.Id == item.Id))
+                    {
+                        continue;
+                    }
+
+                    SelectedMapLabelItems.Add(item);
+                    await EnsureIconLoadedAsync(item, CancellationToken.None);
+                }
+            }
+            finally
+            {
+                _isRestoringMapMaskConfig = false;
+            }
+
+            if (SelectedMapLabelItems.Count > 0)
+            {
+                StartRefreshSelectedMapPoints();
+            }
+        }
+
+        private MapLabelItemVm? FindMapLabelItem(string id)
+        {
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                return null;
+            }
+
+            return MapLabelCategories
+                .SelectMany(x => x.Items)
+                .FirstOrDefault(x => x.Id == id);
+        }
+
+        private void SaveSelectedMapLabelItemsToConfig()
+        {
+            if (_isRestoringMapMaskConfig)
+            {
+                return;
+            }
+
+            TaskContext.Instance().Config.MapMaskConfig.SelectedLabelItems = SelectedMapLabelItems
+                .Select(x => new MapMaskSelectedLabelConfig
+                {
+                    Id = x.Id,
+                    LabelIds = x.LabelIds.ToList(),
+                    ParentId = x.ParentId,
+                    Name = x.Name,
+                    IconUrl = x.IconUrl,
+                    PointCount = x.PointCount
+                })
+                .ToList();
+        }
+
+        private void ClearSavedMapMaskPointConfig()
+        {
+            var mapMaskConfig = TaskContext.Instance().Config.MapMaskConfig;
+            mapMaskConfig.SelectedLabelItems = [];
+            mapMaskConfig.HiddenMapPointKeys = [];
+            _hiddenMapPointIds.Clear();
         }
 
         private void StartRefreshSelectedMapPoints()
@@ -829,6 +932,7 @@ namespace BetterGenshinImpact.ViewModel
             }
 
             ApplyMapPointHiddenStates();
+            SaveHiddenMapPointKeysToConfig();
             SyncPointInfoPopupHiddenState();
         }
 
@@ -847,6 +951,7 @@ namespace BetterGenshinImpact.ViewModel
             }
 
             ApplyMapPointHiddenStates();
+            SaveHiddenMapPointKeysToConfig();
             SyncPointInfoPopupHiddenState();
         }
 
@@ -860,16 +965,17 @@ namespace BetterGenshinImpact.ViewModel
 
             _hiddenMapPointIds.Clear();
             ApplyMapPointHiddenStates();
+            SaveHiddenMapPointKeysToConfig();
             SyncPointInfoPopupHiddenState();
         }
 
         private void ReplaceMapPoints(IEnumerable<MaskMapPoint> points)
         {
-            _hiddenMapPointIds.Clear();
+            LoadHiddenMapPointKeysFromConfig();
             var pointList = points.ToList();
             foreach (var point in pointList)
             {
-                point.IsHidden = false;
+                point.IsHidden = IsMapPointHidden(point);
             }
 
             MapPoints = new ObservableCollection<MaskMapPoint>(pointList);
@@ -896,7 +1002,47 @@ namespace BetterGenshinImpact.ViewModel
 
         private static string GetMapPointKey(MaskMapPoint point)
         {
-            return point.Id;
+            var mapMaskConfig = TaskContext.Instance().Config.MapMaskConfig;
+            var provider = mapMaskConfig.MapPointApiProvider.ToString();
+            if (mapMaskConfig.MapPointApiProvider != MapPointApiProvider.HoYoLab)
+            {
+                return $"{provider}:{point.Id}";
+            }
+
+            var language = HoYoLabMapApiService.NormalizeLanguage(mapMaskConfig.HoYoLabLanguage);
+            return $"{provider}:{language}:{point.Id}";
+        }
+
+        private void LoadHiddenMapPointKeysFromConfig()
+        {
+            _hiddenMapPointIds.Clear();
+
+            var keys = TaskContext.Instance().Config.MapMaskConfig.HiddenMapPointKeys ?? [];
+            foreach (var key in keys)
+            {
+                if (!string.IsNullOrWhiteSpace(key))
+                {
+                    _hiddenMapPointIds.Add(key);
+                }
+            }
+        }
+
+        private void SaveHiddenMapPointKeysToConfig()
+        {
+            if (_isRestoringMapMaskConfig)
+            {
+                return;
+            }
+
+            TaskContext.Instance().Config.MapMaskConfig.HiddenMapPointKeys = _hiddenMapPointIds
+                .OrderBy(x => x, StringComparer.Ordinal)
+                .ToList();
+        }
+
+        private void ClearHiddenMapPointConfig()
+        {
+            _hiddenMapPointIds.Clear();
+            SaveHiddenMapPointKeysToConfig();
         }
 
         private void SyncPointInfoPopupHiddenState()

--- a/BetterGenshinImpact/ViewModel/MaskWindowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/MaskWindowViewModel.cs
@@ -76,11 +76,27 @@ namespace BetterGenshinImpact.ViewModel
 
         [ObservableProperty] private ObservableCollection<MaskMapPoint> _mapPoints = [];
 
+        [ObservableProperty] private ObservableCollection<MaskMapPoint> _visibleMapPoints = [];
+
         [ObservableProperty] private ObservableCollection<MaskMapPointLabel> _mapPointLabels = [];
 
         [ObservableProperty] private bool _isMapPointsLoading;
 
         [ObservableProperty] private string _mapPointsLoadingText = "正在加载点位...";
+
+        public int MapPointTotalCount => MapPoints.Count;
+
+        public int VisibleMapPointCount => VisibleMapPoints.Count;
+
+        public int HiddenMapPointCount => MapPoints.Count(IsMapPointHidden);
+
+        public bool HasMapPoints => MapPointTotalCount > 0;
+
+        public bool HasHiddenMapPoints => HiddenMapPointCount > 0;
+
+        public string MapPointVisibilitySummary => HasMapPoints
+            ? $"{VisibleMapPointCount}/{MapPointTotalCount}"
+            : "0/0";
 
         public double MiniMapOverlayLeftRatio => MapAssets.MimiMapRect1080P.X / 1920d;
 
@@ -120,6 +136,7 @@ namespace BetterGenshinImpact.ViewModel
         private CancellationTokenSource? _mapPointListCts;
         private int _mapLabelItemsLoadVersion;
         private int _mapPointsLoadVersion;
+        private readonly HashSet<string> _hiddenMapPointIds = new(StringComparer.Ordinal);
         private readonly SemaphoreSlim _iconLoadSemaphore = new(10, 10);
         private readonly OverlayMetricsService? _overlayMetricsService = App.GetService<OverlayMetricsService>();
         private bool _metricsSubscribed;
@@ -127,6 +144,8 @@ namespace BetterGenshinImpact.ViewModel
 
         public MaskWindowViewModel()
         {
+            PointInfoPopup.ToggleHiddenRequested += (_, point) => ToggleMapPointHidden(point);
+
             WeakReferenceMessenger.Default.Register<PropertyChangedMessage<object>>(this, (sender, msg) =>
             {
                 if (msg.PropertyName == "RefreshSettings")
@@ -348,7 +367,7 @@ namespace BetterGenshinImpact.ViewModel
                 MapLabelCategories = [];
                 MapLabelItems = [];
                 MapPointLabels = [];
-                MapPoints = [];
+                ReplaceMapPoints(Array.Empty<MaskMapPoint>());
             }, DispatcherPriority.Background);
 
             if (IsMapPointPickerOpen)
@@ -581,7 +600,7 @@ namespace BetterGenshinImpact.ViewModel
                     await Application.Current.Dispatcher.InvokeAsync(() =>
                     {
                         MapPointLabels = [];
-                        MapPoints = [];
+                        ReplaceMapPoints(Array.Empty<MaskMapPoint>());
                     }, DispatcherPriority.Background);
                     return;
                 }
@@ -599,7 +618,7 @@ namespace BetterGenshinImpact.ViewModel
                 await Application.Current.Dispatcher.InvokeAsync(() =>
                 {
                     MapPointLabels = new ObservableCollection<MaskMapPointLabel>(result.Labels);
-                    MapPoints = new ObservableCollection<MaskMapPoint>(result.Points);
+                    ReplaceMapPoints(result.Points);
                 }, DispatcherPriority.Background);
             }
             catch (OperationCanceledException)
@@ -764,7 +783,8 @@ namespace BetterGenshinImpact.ViewModel
             {
                 return;
             }
-            await PointInfoPopup.ShowAsync(point, args!.AnchorPosition, ResolvePointTitle(point));
+
+            await PointInfoPopup.ShowAsync(point, args!.AnchorPosition, ResolvePointTitle(point), IsMapPointHidden(point));
         }
 
         private string ResolvePointTitle(MaskMapPoint point)
@@ -781,11 +801,7 @@ namespace BetterGenshinImpact.ViewModel
         [RelayCommand]
         private Task OnPointRightClick(MaskMapPoint? point)
         {
-            if (point != null)
-            {
-                // 自定义右键逻辑
-            }
-
+            ToggleMapPointHidden(point);
             return Task.CompletedTask;
         }
 
@@ -798,6 +814,108 @@ namespace BetterGenshinImpact.ViewModel
             }
 
             return Task.CompletedTask;
+        }
+
+        [RelayCommand]
+        private void ToggleMapPointHidden(MaskMapPoint? point)
+        {
+            if (point == null)
+            {
+                return;
+            }
+
+            var key = GetMapPointKey(point);
+            if (!_hiddenMapPointIds.Add(key))
+            {
+                _hiddenMapPointIds.Remove(key);
+            }
+
+            RebuildVisibleMapPoints();
+            SyncPointInfoPopupHiddenState();
+        }
+
+        [RelayCommand]
+        private void HideAllMapPoints()
+        {
+            if (MapPoints.Count == 0)
+            {
+                return;
+            }
+
+            _hiddenMapPointIds.Clear();
+            foreach (var point in MapPoints)
+            {
+                _hiddenMapPointIds.Add(GetMapPointKey(point));
+            }
+
+            RebuildVisibleMapPoints();
+            SyncPointInfoPopupHiddenState();
+        }
+
+        [RelayCommand]
+        private void ShowAllMapPoints()
+        {
+            if (_hiddenMapPointIds.Count == 0)
+            {
+                return;
+            }
+
+            _hiddenMapPointIds.Clear();
+            RebuildVisibleMapPoints();
+            SyncPointInfoPopupHiddenState();
+        }
+
+        private void ReplaceMapPoints(IEnumerable<MaskMapPoint> points)
+        {
+            _hiddenMapPointIds.Clear();
+            MapPoints = new ObservableCollection<MaskMapPoint>(points);
+            RebuildVisibleMapPoints();
+            SyncPointInfoPopupHiddenState();
+        }
+
+        private void RebuildVisibleMapPoints()
+        {
+            VisibleMapPoints = new ObservableCollection<MaskMapPoint>(MapPoints.Where(x => !IsMapPointHidden(x)));
+            NotifyMapPointVisibilityPropertiesChanged();
+        }
+
+        private bool IsMapPointHidden(MaskMapPoint point)
+        {
+            return _hiddenMapPointIds.Contains(GetMapPointKey(point));
+        }
+
+        private static string GetMapPointKey(MaskMapPoint point)
+        {
+            return point.Id;
+        }
+
+        private void SyncPointInfoPopupHiddenState()
+        {
+            var currentPoint = PointInfoPopup.CurrentPoint;
+            if (currentPoint != null)
+            {
+                PointInfoPopup.SetHiddenState(IsMapPointHidden(currentPoint));
+            }
+        }
+
+        partial void OnMapPointsChanged(ObservableCollection<MaskMapPoint> value)
+        {
+            NotifyMapPointVisibilityPropertiesChanged();
+        }
+
+        partial void OnVisibleMapPointsChanged(ObservableCollection<MaskMapPoint> value)
+        {
+            NotifyMapPointVisibilityPropertiesChanged();
+        }
+
+        private void NotifyMapPointVisibilityPropertiesChanged()
+        {
+            OnPropertyChanged(nameof(MapPointTotalCount));
+            OnPropertyChanged(nameof(VisibleMapPointCount));
+            OnPropertyChanged(nameof(HiddenMapPointCount));
+            OnPropertyChanged(nameof(HasMapPoints));
+            OnPropertyChanged(nameof(HasHiddenMapPoints));
+            OnPropertyChanged(nameof(MapPointVisibilitySummary));
         }
     }
 

--- a/BetterGenshinImpact/ViewModel/MaskWindowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/MaskWindowViewModel.cs
@@ -76,8 +76,6 @@ namespace BetterGenshinImpact.ViewModel
 
         [ObservableProperty] private ObservableCollection<MaskMapPoint> _mapPoints = [];
 
-        [ObservableProperty] private ObservableCollection<MaskMapPoint> _visibleMapPoints = [];
-
         [ObservableProperty] private ObservableCollection<MaskMapPointLabel> _mapPointLabels = [];
 
         [ObservableProperty] private bool _isMapPointsLoading;
@@ -86,7 +84,7 @@ namespace BetterGenshinImpact.ViewModel
 
         public int MapPointTotalCount => MapPoints.Count;
 
-        public int VisibleMapPointCount => VisibleMapPoints.Count;
+        public int VisibleMapPointCount => MapPoints.Count(x => !x.IsHidden);
 
         public int HiddenMapPointCount => MapPoints.Count(IsMapPointHidden);
 
@@ -830,7 +828,7 @@ namespace BetterGenshinImpact.ViewModel
                 _hiddenMapPointIds.Remove(key);
             }
 
-            RebuildVisibleMapPoints();
+            ApplyMapPointHiddenStates();
             SyncPointInfoPopupHiddenState();
         }
 
@@ -848,7 +846,7 @@ namespace BetterGenshinImpact.ViewModel
                 _hiddenMapPointIds.Add(GetMapPointKey(point));
             }
 
-            RebuildVisibleMapPoints();
+            ApplyMapPointHiddenStates();
             SyncPointInfoPopupHiddenState();
         }
 
@@ -861,21 +859,33 @@ namespace BetterGenshinImpact.ViewModel
             }
 
             _hiddenMapPointIds.Clear();
-            RebuildVisibleMapPoints();
+            ApplyMapPointHiddenStates();
             SyncPointInfoPopupHiddenState();
         }
 
         private void ReplaceMapPoints(IEnumerable<MaskMapPoint> points)
         {
             _hiddenMapPointIds.Clear();
-            MapPoints = new ObservableCollection<MaskMapPoint>(points);
-            RebuildVisibleMapPoints();
+            var pointList = points.ToList();
+            foreach (var point in pointList)
+            {
+                point.IsHidden = false;
+            }
+
+            MapPoints = new ObservableCollection<MaskMapPoint>(pointList);
+            NotifyMapPointVisibilityPropertiesChanged();
             SyncPointInfoPopupHiddenState();
         }
 
-        private void RebuildVisibleMapPoints()
+        private void ApplyMapPointHiddenStates()
         {
-            VisibleMapPoints = new ObservableCollection<MaskMapPoint>(MapPoints.Where(x => !IsMapPointHidden(x)));
+            var pointList = MapPoints.ToList();
+            foreach (var point in pointList)
+            {
+                point.IsHidden = IsMapPointHidden(point);
+            }
+
+            MapPoints = new ObservableCollection<MaskMapPoint>(pointList);
             NotifyMapPointVisibilityPropertiesChanged();
         }
 
@@ -899,11 +909,6 @@ namespace BetterGenshinImpact.ViewModel
         }
 
         partial void OnMapPointsChanged(ObservableCollection<MaskMapPoint> value)
-        {
-            NotifyMapPointVisibilityPropertiesChanged();
-        }
-
-        partial void OnVisibleMapPointsChanged(ObservableCollection<MaskMapPoint> value)
         {
             NotifyMapPointVisibilityPropertiesChanged();
         }

--- a/BetterGenshinImpact/ViewModel/MaskWindowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/MaskWindowViewModel.cs
@@ -137,7 +137,7 @@ namespace BetterGenshinImpact.ViewModel
         private readonly HashSet<string> _hiddenMapPointIds = new(StringComparer.Ordinal);
         private readonly SemaphoreSlim _iconLoadSemaphore = new(10, 10);
         private readonly OverlayMetricsService? _overlayMetricsService = App.GetService<OverlayMetricsService>();
-        private bool _isRestoringMapMaskConfig;
+        private bool _isRestoringMapMaskState;
         private bool _metricsSubscribed;
         private bool _fpsStarted;
 
@@ -216,7 +216,7 @@ namespace BetterGenshinImpact.ViewModel
                 await EnsureIconLoadedAsync(item, CancellationToken.None);
             }
 
-            SaveSelectedMapLabelItemsToConfig();
+            SaveSelectedMapLabelItemsToStorage();
             StartRefreshSelectedMapPoints();
         }
 
@@ -229,8 +229,8 @@ namespace BetterGenshinImpact.ViewModel
             }
 
             SelectedMapLabelItems.Clear();
-            SaveSelectedMapLabelItemsToConfig();
-            ClearHiddenMapPointConfig();
+            SaveSelectedMapLabelItemsToStorage();
+            ClearHiddenMapPointState();
             StartRefreshSelectedMapPoints();
         }
 
@@ -247,7 +247,7 @@ namespace BetterGenshinImpact.ViewModel
 
             SyncSelectedMapPointApiProviderFromConfig();
             SyncSelectedHoYoLabLanguageFromConfig();
-            LoadHiddenMapPointKeysFromConfig();
+            LoadHiddenMapPointKeysFromStorage();
             InitMetrics();
         }
 
@@ -358,7 +358,7 @@ namespace BetterGenshinImpact.ViewModel
             _mapLabelItemsCts?.Cancel();
             _mapPointListCts?.Cancel();
             PointInfoPopup.Close();
-            ClearSavedMapMaskPointConfig();
+            ClearSavedMapMaskPointState();
 
             Interlocked.Increment(ref _mapLabelTreeLoadVersion);
             _isMapLabelTreeLoaded = false;
@@ -567,7 +567,7 @@ namespace BetterGenshinImpact.ViewModel
                 var vms = categories.Select(x => new MapLabelCategoryVm(x)).ToList();
                 MapLabelCategories = new ObservableCollection<MapLabelCategoryVm>(vms);
                 await SelectMapLabelCategory(MapLabelCategories.FirstOrDefault());
-                await RestoreSelectedMapLabelItemsFromConfigAsync();
+                await RestoreSelectedMapLabelItemsFromStorageAsync();
                 _isMapLabelTreeLoaded = true;
             }
             catch (Exception ex)
@@ -586,18 +586,18 @@ namespace BetterGenshinImpact.ViewModel
 
         private bool HasSavedMapLabelSelection()
         {
-            return TaskContext.Instance().Config.MapMaskConfig.SelectedLabelItems?.Count > 0;
+            return MapMaskStateStorage.Read().SelectedLabelItems.Count > 0;
         }
 
-        private async Task RestoreSelectedMapLabelItemsFromConfigAsync()
+        private async Task RestoreSelectedMapLabelItemsFromStorageAsync()
         {
-            var savedItems = TaskContext.Instance().Config.MapMaskConfig.SelectedLabelItems ?? [];
+            var savedItems = MapMaskStateStorage.Read().SelectedLabelItems;
             if (savedItems.Count == 0)
             {
                 return;
             }
 
-            _isRestoringMapMaskConfig = true;
+            _isRestoringMapMaskState = true;
             try
             {
                 SelectedMapLabelItems.Clear();
@@ -625,7 +625,7 @@ namespace BetterGenshinImpact.ViewModel
             }
             finally
             {
-                _isRestoringMapMaskConfig = false;
+                _isRestoringMapMaskState = false;
             }
 
             if (SelectedMapLabelItems.Count > 0)
@@ -646,15 +646,16 @@ namespace BetterGenshinImpact.ViewModel
                 .FirstOrDefault(x => x.Id == id);
         }
 
-        private void SaveSelectedMapLabelItemsToConfig()
+        private void SaveSelectedMapLabelItemsToStorage()
         {
-            if (_isRestoringMapMaskConfig)
+            if (_isRestoringMapMaskState)
             {
                 return;
             }
 
-            TaskContext.Instance().Config.MapMaskConfig.SelectedLabelItems = SelectedMapLabelItems
-                .Select(x => new MapMaskSelectedLabelConfig
+            var state = MapMaskStateStorage.Read();
+            state.SelectedLabelItems = SelectedMapLabelItems
+                .Select(x => new MapMaskSelectedLabelState
                 {
                     Id = x.Id,
                     LabelIds = x.LabelIds.ToList(),
@@ -664,13 +665,12 @@ namespace BetterGenshinImpact.ViewModel
                     PointCount = x.PointCount
                 })
                 .ToList();
+            MapMaskStateStorage.Save(state);
         }
 
-        private void ClearSavedMapMaskPointConfig()
+        private void ClearSavedMapMaskPointState()
         {
-            var mapMaskConfig = TaskContext.Instance().Config.MapMaskConfig;
-            mapMaskConfig.SelectedLabelItems = [];
-            mapMaskConfig.HiddenMapPointKeys = [];
+            MapMaskStateStorage.Clear();
             _hiddenMapPointIds.Clear();
         }
 
@@ -932,7 +932,7 @@ namespace BetterGenshinImpact.ViewModel
             }
 
             ApplyMapPointHiddenStates();
-            SaveHiddenMapPointKeysToConfig();
+            SaveHiddenMapPointKeysToStorage();
             SyncPointInfoPopupHiddenState();
         }
 
@@ -951,7 +951,7 @@ namespace BetterGenshinImpact.ViewModel
             }
 
             ApplyMapPointHiddenStates();
-            SaveHiddenMapPointKeysToConfig();
+            SaveHiddenMapPointKeysToStorage();
             SyncPointInfoPopupHiddenState();
         }
 
@@ -965,13 +965,13 @@ namespace BetterGenshinImpact.ViewModel
 
             _hiddenMapPointIds.Clear();
             ApplyMapPointHiddenStates();
-            SaveHiddenMapPointKeysToConfig();
+            SaveHiddenMapPointKeysToStorage();
             SyncPointInfoPopupHiddenState();
         }
 
         private void ReplaceMapPoints(IEnumerable<MaskMapPoint> points)
         {
-            LoadHiddenMapPointKeysFromConfig();
+            LoadHiddenMapPointKeysFromStorage();
             var pointList = points.ToList();
             foreach (var point in pointList)
             {
@@ -1013,11 +1013,11 @@ namespace BetterGenshinImpact.ViewModel
             return $"{provider}:{language}:{point.Id}";
         }
 
-        private void LoadHiddenMapPointKeysFromConfig()
+        private void LoadHiddenMapPointKeysFromStorage()
         {
             _hiddenMapPointIds.Clear();
 
-            var keys = TaskContext.Instance().Config.MapMaskConfig.HiddenMapPointKeys ?? [];
+            var keys = MapMaskStateStorage.Read().HiddenMapPointKeys;
             foreach (var key in keys)
             {
                 if (!string.IsNullOrWhiteSpace(key))
@@ -1027,22 +1027,24 @@ namespace BetterGenshinImpact.ViewModel
             }
         }
 
-        private void SaveHiddenMapPointKeysToConfig()
+        private void SaveHiddenMapPointKeysToStorage()
         {
-            if (_isRestoringMapMaskConfig)
+            if (_isRestoringMapMaskState)
             {
                 return;
             }
 
-            TaskContext.Instance().Config.MapMaskConfig.HiddenMapPointKeys = _hiddenMapPointIds
+            var state = MapMaskStateStorage.Read();
+            state.HiddenMapPointKeys = _hiddenMapPointIds
                 .OrderBy(x => x, StringComparer.Ordinal)
                 .ToList();
+            MapMaskStateStorage.Save(state);
         }
 
-        private void ClearHiddenMapPointConfig()
+        private void ClearHiddenMapPointState()
         {
             _hiddenMapPointIds.Clear();
-            SaveHiddenMapPointKeysToConfig();
+            SaveHiddenMapPointKeysToStorage();
         }
 
         private void SyncPointInfoPopupHiddenState()


### PR DESCRIPTION
如题所示，该 PR 主要包含以下更新
- 右键点位切换隐藏/显示，并支持全部隐藏/全部显示。
- 大地图/小地图改为显示可见点位集合，详情页和点位选择浮层加了对应按钮
- 大地图和小地图画布绘制时用 0.35 透明度显示，所以隐藏后仍然可以点击、右键、打开详情再恢复。
- 选择分类、重置选择、隐藏/显示单点、全部隐藏/全部显示时都会同步写入配置
- 进入大地图时，如果配置里有保存过的标点分类，会自动加载分类树、恢复选中项、拉取点位。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 支持隐藏或显示单个地图点位，并以半透明效果标识已隐藏点位。
  - 新增“全部隐藏”“全部显示”操作及点位可见性统计。
  - 点位隐藏状态和标签选择状态会自动保存并在下次使用时恢复。
  - 优化点位弹窗与右键操作，方便快速切换显示状态。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->