### PR TITLE
feat: 低血量回复时机改为可选项（任何路径点/只在传送点/不回复）

### DIFF
--- a/BetterGenshinImpact/Core/Config/PathingConditionConfig.cs
+++ b/BetterGenshinImpact/Core/Config/PathingConditionConfig.cs
@@ -33,16 +33,16 @@ public partial class PathingConditionConfig : ObservableObject
     // 低血量回复时机
     private RecoverTiming? _recoverTiming;
 
-    public RecoverTiming? RecoverTiming
+    public RecoverTiming RecoverTiming
     {
         get
         {
             if (_recoverTiming is null)
             {
                 // 首次读取时从旧字段自动迁移
-                _recoverTiming = _onlyInTeleportRecover ? Core.Config.RecoverTiming.OnlyTeleport : Core.Config.RecoverTiming.AnyWaypoint;
+                _recoverTiming = RecoverTimingMigration.Migrate(_onlyInTeleportRecover);
             }
-            return _recoverTiming;
+            return _recoverTiming.Value;
         }
         set => SetProperty(ref _recoverTiming, value);
     }

--- a/BetterGenshinImpact/Core/Config/PathingConditionConfig.cs
+++ b/BetterGenshinImpact/Core/Config/PathingConditionConfig.cs
@@ -1,4 +1,4 @@
-﻿using BetterGenshinImpact.GameTask.AutoFight.Model;
+using BetterGenshinImpact.GameTask.AutoFight.Model;
 using BetterGenshinImpact.Model;
 using CommunityToolkit.Mvvm.ComponentModel;
 using System;
@@ -29,7 +29,24 @@ public partial class PathingConditionConfig : ObservableObject
     // 只在传送传送点时复活
     [ObservableProperty]
     private bool _onlyInTeleportRecover = false;
-    
+
+    // 低血量回复时机
+    private RecoverTiming? _recoverTiming;
+
+    public RecoverTiming? RecoverTiming
+    {
+        get
+        {
+            if (_recoverTiming is null)
+            {
+                // 首次读取时从旧字段自动迁移
+                _recoverTiming = _onlyInTeleportRecover ? Core.Config.RecoverTiming.OnlyTeleport : Core.Config.RecoverTiming.AnyWaypoint;
+            }
+            return _recoverTiming;
+        }
+        set => SetProperty(ref _recoverTiming, value);
+    }
+
     // 使用小道具的间隔时间(ms)
     [ObservableProperty]
     private int _useGadgetIntervalMs = 0;

--- a/BetterGenshinImpact/Core/Config/PathingPartyConfig.cs
+++ b/BetterGenshinImpact/Core/Config/PathingPartyConfig.cs
@@ -15,6 +15,15 @@ public enum RecoverTiming
     Never
 }
 
+/// <summary>
+/// 从旧字段 OnlyInTeleportRecover 迁移到 RecoverTiming 枚举的共享方法
+/// </summary>
+internal static class RecoverTimingMigration
+{
+    public static RecoverTiming Migrate(bool onlyInTeleportRecover)
+        => onlyInTeleportRecover ? RecoverTiming.OnlyTeleport : RecoverTiming.AnyWaypoint;
+}
+
 [Serializable]
 public partial class PathingPartyConfig : ObservableObject
 {
@@ -82,16 +91,16 @@ public partial class PathingPartyConfig : ObservableObject
     // 低血量回复时机
     private RecoverTiming? _recoverTiming;
 
-    public RecoverTiming? RecoverTiming
+    public RecoverTiming RecoverTiming
     {
         get
         {
             if (_recoverTiming is null)
             {
                 // 首次读取时从旧字段自动迁移
-                _recoverTiming = _onlyInTeleportRecover ? Core.Config.RecoverTiming.OnlyTeleport : Core.Config.RecoverTiming.AnyWaypoint;
+                _recoverTiming = RecoverTimingMigration.Migrate(_onlyInTeleportRecover);
             }
-            return _recoverTiming;
+            return _recoverTiming.Value;
         }
         set => SetProperty(ref _recoverTiming, value);
     }

--- a/BetterGenshinImpact/Core/Config/PathingPartyConfig.cs
+++ b/BetterGenshinImpact/Core/Config/PathingPartyConfig.cs
@@ -8,6 +8,13 @@ using System.Text.Json.Serialization;
 
 namespace BetterGenshinImpact.Core.Config;
 
+public enum RecoverTiming
+{
+    AnyWaypoint,
+    OnlyTeleport,
+    Never
+}
+
 [Serializable]
 public partial class PathingPartyConfig : ObservableObject
 {
@@ -71,7 +78,24 @@ public partial class PathingPartyConfig : ObservableObject
     // 只在传送传送点时复活
     [ObservableProperty]
     private bool _onlyInTeleportRecover = false;
-    
+
+    // 低血量回复时机
+    private RecoverTiming? _recoverTiming;
+
+    public RecoverTiming? RecoverTiming
+    {
+        get
+        {
+            if (_recoverTiming is null)
+            {
+                // 首次读取时从旧字段自动迁移
+                _recoverTiming = _onlyInTeleportRecover ? Core.Config.RecoverTiming.OnlyTeleport : Core.Config.RecoverTiming.AnyWaypoint;
+            }
+            return _recoverTiming;
+        }
+        set => SetProperty(ref _recoverTiming, value);
+    }
+
     //允许在jsScript脚本中使用此地图追踪配置
     [ObservableProperty]
     private bool _jsScriptUseEnabled = true;
@@ -135,6 +159,7 @@ public partial class PathingPartyConfig : ObservableObject
         return new PathingPartyConfig
         {
             OnlyInTeleportRecover = pathingConditionConfig.OnlyInTeleportRecover,
+            RecoverTiming = pathingConditionConfig.RecoverTiming,
             UseGadgetIntervalMs = pathingConditionConfig.UseGadgetIntervalMs,
             AutoEatEnabled = pathingConditionConfig.AutoEatEnabled
         };

--- a/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
@@ -619,7 +619,7 @@ public class PathExecutor
 
     private async Task RecoverWhenLowHp(WaypointForTrack waypoint)
     {
-        var timing = PartyConfig.RecoverTiming ?? (PartyConfig.OnlyInTeleportRecover ? RecoverTiming.OnlyTeleport : RecoverTiming.AnyWaypoint);
+        var timing = PartyConfig.RecoverTiming;
         if (timing == RecoverTiming.Never)
         {
             return;

--- a/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
@@ -1,4 +1,4 @@
-﻿using BetterGenshinImpact.Core.Config;
+using BetterGenshinImpact.Core.Config;
 using BetterGenshinImpact.Core.Simulator;
 using BetterGenshinImpact.GameTask.AutoFight.Assets;
 using BetterGenshinImpact.GameTask.AutoFight.Model;
@@ -619,7 +619,13 @@ public class PathExecutor
 
     private async Task RecoverWhenLowHp(WaypointForTrack waypoint)
     {
-        if (PartyConfig.OnlyInTeleportRecover && waypoint.Type != WaypointType.Teleport.Code)
+        var timing = PartyConfig.RecoverTiming ?? (PartyConfig.OnlyInTeleportRecover ? RecoverTiming.OnlyTeleport : RecoverTiming.AnyWaypoint);
+        if (timing == RecoverTiming.Never)
+        {
+            return;
+        }
+
+        if (timing == RecoverTiming.OnlyTeleport && waypoint.Type != WaypointType.Teleport.Code)
         {
             return;
         }

--- a/BetterGenshinImpact/View/Pages/View/PathingConfigView.xaml
+++ b/BetterGenshinImpact/View/Pages/View/PathingConfigView.xaml
@@ -265,7 +265,7 @@
                 </ui:CardControl>
                 
                 
-                <ui:CardControl Margin="0,0,0,12" >
+                <ui:CardControl Margin="0,0,0,6">
                     <ui:CardControl.Icon>
                         <ui:FontIcon Glyph="&#xe3b2;" Style="{StaticResource FaFontIconStyle}" />
                     </ui:CardControl.Icon>
@@ -278,19 +278,23 @@
                             <ui:TextBlock Grid.Row="0"
                                           Grid.Column="0"
                                           FontTypography="Body"
-                                          Text="只在传送点时恢复"
+                                          Text="低血量回复时机"
                                           TextWrapping="Wrap" />
                             <ui:TextBlock Grid.Row="1"
                                           Grid.Column="0"
                                           Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
-                                          Text="只有路径在传送点时，才会去七天神像恢复"
+                                          Text="选择低血量时的回复策略：任何路径点/只在传送点/不回复"
                                           TextWrapping="Wrap" />
                         </Grid>
                     </ui:CardControl.Header>
 
-                    <ui:ToggleSwitch
+                    <ComboBox
+                        MinWidth="100"
                         Margin="0,0,36,0"
-                        IsChecked="{Binding Config.PathingConditionConfig.OnlyInTeleportRecover, Mode=TwoWay}" />
+                        SelectedValuePath="Key"
+                        DisplayMemberPath="Value"
+                        ItemsSource="{Binding RecoverTimingSource}"
+                        SelectedValue="{Binding Config.PathingConditionConfig.RecoverTiming}" />
                 </ui:CardControl>
             </StackPanel>
         </ScrollViewer>

--- a/BetterGenshinImpact/View/Pages/View/PathingConfigView.xaml
+++ b/BetterGenshinImpact/View/Pages/View/PathingConfigView.xaml
@@ -291,8 +291,8 @@
                     <ComboBox
                         MinWidth="100"
                         Margin="0,0,36,0"
-                        SelectedValuePath="Key"
-                        DisplayMemberPath="Value"
+                        SelectedValuePath="Value"
+                        DisplayMemberPath="Key"
                         ItemsSource="{Binding RecoverTimingSource}"
                         SelectedValue="{Binding Config.PathingConditionConfig.RecoverTiming}" />
                 </ui:CardControl>

--- a/BetterGenshinImpact/View/Pages/View/PathingConfigView.xaml
+++ b/BetterGenshinImpact/View/Pages/View/PathingConfigView.xaml
@@ -291,8 +291,8 @@
                     <ComboBox
                         MinWidth="100"
                         Margin="0,0,36,0"
-                        SelectedValuePath="Value"
-                        DisplayMemberPath="Key"
+                        SelectedValuePath="Key"
+                        DisplayMemberPath="Value"
                         ItemsSource="{Binding RecoverTimingSource}"
                         SelectedValue="{Binding Config.PathingConditionConfig.RecoverTiming}" />
                 </ui:CardControl>

--- a/BetterGenshinImpact/View/Pages/View/ScriptGroupConfigView.xaml
+++ b/BetterGenshinImpact/View/Pages/View/ScriptGroupConfigView.xaml
@@ -314,8 +314,8 @@
                                   Grid.RowSpan="2"
                                   Grid.Column="1"
                                   MinWidth="100"
-                                  SelectedValuePath="Key"
-                                  DisplayMemberPath="Value"
+                                  SelectedValuePath="Value"
+                                  DisplayMemberPath="Key"
                                   ItemsSource="{Binding RecoverTimingSource}"
                                   SelectedValue="{Binding PathingConfig.RecoverTiming}" />
 

--- a/BetterGenshinImpact/View/Pages/View/ScriptGroupConfigView.xaml
+++ b/BetterGenshinImpact/View/Pages/View/ScriptGroupConfigView.xaml
@@ -314,8 +314,8 @@
                                   Grid.RowSpan="2"
                                   Grid.Column="1"
                                   MinWidth="100"
-                                  SelectedValuePath="Value"
-                                  DisplayMemberPath="Key"
+                                  SelectedValuePath="Key"
+                                  DisplayMemberPath="Value"
                                   ItemsSource="{Binding RecoverTimingSource}"
                                   SelectedValue="{Binding PathingConfig.RecoverTiming}" />
 

--- a/BetterGenshinImpact/View/Pages/View/ScriptGroupConfigView.xaml
+++ b/BetterGenshinImpact/View/Pages/View/ScriptGroupConfigView.xaml
@@ -303,17 +303,21 @@
                         <ui:TextBlock Grid.Row="0"
                                       Grid.Column="0"
                                       FontTypography="Body"
-                                      Text="只在传送点时恢复"
+                                      Text="低血量回复时机"
                                       TextWrapping="Wrap" />
                         <ui:TextBlock Grid.Row="1"
                                       Grid.Column="0"
                                       Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
-                                      Text="只有路径在传送点时，才会去七天神像恢复"
+                                      Text="选择低血量时的回复策略：任何路径点/只在传送点/不回复"
                                       TextWrapping="Wrap" />
-                        <ui:ToggleSwitch Grid.Row="0"
-                                         Grid.RowSpan="2"
-                                         Grid.Column="1"
-                                         IsChecked="{Binding PathingConfig.OnlyInTeleportRecover, Mode=TwoWay}" />
+                        <ComboBox Grid.Row="0"
+                                  Grid.RowSpan="2"
+                                  Grid.Column="1"
+                                  MinWidth="100"
+                                  SelectedValuePath="Key"
+                                  DisplayMemberPath="Value"
+                                  ItemsSource="{Binding RecoverTimingSource}"
+                                  SelectedValue="{Binding PathingConfig.RecoverTiming}" />
 
                     </Grid>
                     <Grid Margin="16">

--- a/BetterGenshinImpact/ViewModel/Pages/View/PathingConfigViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/View/PathingConfigViewModel.cs
@@ -1,8 +1,10 @@
-﻿using BetterGenshinImpact.Core.Config;
+using BetterGenshinImpact.Core.Config;
 using BetterGenshinImpact.GameTask;
 using BetterGenshinImpact.Model;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
 
 namespace BetterGenshinImpact.ViewModel.Pages.View;
@@ -10,6 +12,14 @@ namespace BetterGenshinImpact.ViewModel.Pages.View;
 public partial class PathingConfigViewModel : ObservableObject, IViewModel
 {
     public AllConfig Config { get; } = TaskContext.Instance().Config;
+
+    [ObservableProperty]
+    private ObservableCollection<KeyValuePair<string, RecoverTiming>> _recoverTimingSource = new()
+    {
+        new KeyValuePair<string, RecoverTiming>("任何路径点", RecoverTiming.AnyWaypoint),
+        new KeyValuePair<string, RecoverTiming>("只在传送点", RecoverTiming.OnlyTeleport),
+        new KeyValuePair<string, RecoverTiming>("不回复", RecoverTiming.Never),
+    };
 
     [RelayCommand]
     public void OnAddPartyConditionConfig()

--- a/BetterGenshinImpact/ViewModel/Pages/View/PathingConfigViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/View/PathingConfigViewModel.cs
@@ -14,11 +14,11 @@ public partial class PathingConfigViewModel : ObservableObject, IViewModel
     public AllConfig Config { get; } = TaskContext.Instance().Config;
 
     [ObservableProperty]
-    private ObservableCollection<KeyValuePair<string, RecoverTiming>> _recoverTimingSource = new()
+    private ObservableCollection<KeyValuePair<RecoverTiming, string>> _recoverTimingSource = new()
     {
-        new KeyValuePair<string, RecoverTiming>("任何路径点", RecoverTiming.AnyWaypoint),
-        new KeyValuePair<string, RecoverTiming>("只在传送点", RecoverTiming.OnlyTeleport),
-        new KeyValuePair<string, RecoverTiming>("不回复", RecoverTiming.Never),
+        new KeyValuePair<RecoverTiming, string>(RecoverTiming.AnyWaypoint, "任何路径点"),
+        new KeyValuePair<RecoverTiming, string>(RecoverTiming.OnlyTeleport, "只在传送点"),
+        new KeyValuePair<RecoverTiming, string>(RecoverTiming.Never, "不回复"),
     };
 
     [RelayCommand]

--- a/BetterGenshinImpact/ViewModel/Pages/View/ScriptGroupConfigViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/View/ScriptGroupConfigViewModel.cs
@@ -54,11 +54,11 @@ public partial class ScriptGroupConfigViewModel : ObservableObject, IViewModel
     };
 
     [ObservableProperty]
-    private ObservableCollection<KeyValuePair<string, RecoverTiming>> _recoverTimingSource = new()
+    private ObservableCollection<KeyValuePair<RecoverTiming, string>> _recoverTimingSource = new()
     {
-        new KeyValuePair<string, RecoverTiming>("任何路径点", RecoverTiming.AnyWaypoint),
-        new KeyValuePair<string, RecoverTiming>("只在传送点", RecoverTiming.OnlyTeleport),
-        new KeyValuePair<string, RecoverTiming>("不回复", RecoverTiming.Never),
+        new KeyValuePair<RecoverTiming, string>(RecoverTiming.AnyWaypoint, "任何路径点"),
+        new KeyValuePair<RecoverTiming, string>(RecoverTiming.OnlyTeleport, "只在传送点"),
+        new KeyValuePair<RecoverTiming, string>(RecoverTiming.Never, "不回复"),
     };
     public ScriptGroupConfigViewModel(AllConfig config, ScriptGroupConfig scriptGroupConfig)
     {

--- a/BetterGenshinImpact/ViewModel/Pages/View/ScriptGroupConfigViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/View/ScriptGroupConfigViewModel.cs
@@ -51,7 +51,15 @@ public partial class ScriptGroupConfigViewModel : ObservableObject, IViewModel
     {
         new KeyValuePair<string, string>("StartTime", "开始时间"),
         new KeyValuePair<string, string>("EndTime", "结束时间")
-    };  
+    };
+
+    [ObservableProperty]
+    private ObservableCollection<KeyValuePair<string, RecoverTiming>> _recoverTimingSource = new()
+    {
+        new KeyValuePair<string, RecoverTiming>("任何路径点", RecoverTiming.AnyWaypoint),
+        new KeyValuePair<string, RecoverTiming>("只在传送点", RecoverTiming.OnlyTeleport),
+        new KeyValuePair<string, RecoverTiming>("不回复", RecoverTiming.Never),
+    };
     public ScriptGroupConfigViewModel(AllConfig config, ScriptGroupConfig scriptGroupConfig)
     {
         ScriptGroupConfig = scriptGroupConfig;


### PR DESCRIPTION
添加 RecoverTiming 枚举，替换原有 bool OnlyInTeleportRecover
- 新增 RecoverTiming 枚举: AnyWaypoint / OnlyTeleport / Never
- 新字段 RecoverTiming 为可空类型，旧配置自动迁移
- UI 从 ToggleSwitch 改为 ComboBox 三种选项
- 兼容旧 OnlyInTeleportRecover 字段，首次读取时自动填充新字段

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增“低血量回复时机”设置：任何路径点 / 仅在传送点 / 不回复三种策略。
  - 自动寻路在低血量时将按所选策略执行回复。

- **界面优化**
  - 将原先“仅在传送点回复”开关升级为下拉选择。
  - 路径配置页与脚本组配置页均已同步支持该选项。

- **兼容性**
  - 自动继承并转换旧的仅在传送点回复设置，无需重新配置。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->