### PR TITLE
feat:页面触控板、鼠标滚动交互优化

### DIFF
--- a/BetterGenshinImpact/View/MainWindow.xaml.cs
+++ b/BetterGenshinImpact/View/MainWindow.xaml.cs
@@ -3,7 +3,10 @@ using BetterGenshinImpact.ViewModel;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Threading;
 using BetterGenshinImpact.GameTask;
 using BetterGenshinImpact.Helpers.Ui;
 using Wpf.Ui;
@@ -16,6 +19,14 @@ namespace BetterGenshinImpact.View;
 public partial class MainWindow : FluentWindow, INavigationWindow
 {
     private readonly ILogger<MainWindow> _logger = App.GetLogger<MainWindow>();
+    private ScrollViewer? _currentScrollViewer;
+    private double _targetOffset;
+    private double _velocity;
+    private double _lastInputTime;
+    private readonly double _lerpFactor = 0.35;
+    private readonly double _scrollSensitivity = 0.27;
+    private readonly double _inertiaDecay = 0.94;
+    private readonly double _minVelocity = 0.3;
 
     public MainWindowViewModel ViewModel { get; }
 
@@ -32,7 +43,109 @@ public partial class MainWindow : FluentWindow, INavigationWindow
 
         Application.Current.MainWindow = this;
 
-        Loaded += (s, e) => Activate();
+        AddHandler(PreviewMouseWheelEvent, new MouseWheelEventHandler(OnGlobalPreviewMouseWheel), true);
+
+        Loaded += (s, e) =>
+        {
+            Activate();
+            CompositionTarget.Rendering += OnCompositionTargetRendering;
+        };
+    }
+
+    private void OnGlobalPreviewMouseWheel(object sender, MouseWheelEventArgs e)
+    {
+        e.Handled = true;
+
+        var scrollViewer = FindScrollViewerUnderMouse(e);
+        if (scrollViewer == null)
+            return;
+
+        if (_currentScrollViewer != scrollViewer)
+        {
+            scrollViewer.CanContentScroll = false;
+            _currentScrollViewer = scrollViewer;
+            _targetOffset = scrollViewer.VerticalOffset;
+        }
+
+        double delta = e.Delta;
+        double scrollAmount = delta * _scrollSensitivity;
+
+        _targetOffset -= scrollAmount;
+        _targetOffset = Math.Max(0, Math.Min(_targetOffset, scrollViewer.ScrollableHeight));
+
+        _lastInputTime = Environment.TickCount;
+    }
+
+    private ScrollViewer? FindScrollViewerUnderMouse(MouseWheelEventArgs e)
+    {
+        Point mousePos = e.GetPosition(this);
+        HitTestResult result = VisualTreeHelper.HitTest(this, mousePos);
+
+        if (result != null && result.VisualHit != null)
+        {
+            DependencyObject current = result.VisualHit;
+            while (current != null)
+            {
+                if (current is ScrollViewer scrollViewer && scrollViewer.ScrollableHeight > 0)
+                {
+                    return scrollViewer;
+                }
+                current = VisualTreeHelper.GetParent(current);
+            }
+        }
+
+        return FindVisualChild<ScrollViewer>(RootNavigation);
+    }
+
+    private void OnCompositionTargetRendering(object? sender, EventArgs e)
+    {
+        if (_currentScrollViewer == null)
+            return;
+
+        double current = _currentScrollViewer.VerticalOffset;
+        double diff = _targetOffset - current;
+
+        if (Math.Abs(diff) < 0.1 && Math.Abs(_velocity) < _minVelocity)
+            return;
+
+        double now = Environment.TickCount;
+        double timeSinceLastInput = now - _lastInputTime;
+
+        if (timeSinceLastInput > 80 && Math.Abs(diff) < 1.0)
+        {
+            if (Math.Abs(_velocity) > _minVelocity)
+            {
+                _velocity *= _inertiaDecay;
+                _targetOffset += _velocity;
+                _targetOffset = Math.Max(0, Math.Min(_targetOffset, _currentScrollViewer.ScrollableHeight));
+            }
+        }
+
+        diff = _targetOffset - current;
+        if (Math.Abs(diff) > 0.1)
+        {
+            double newPosition = current + diff * _lerpFactor;
+            _velocity = newPosition - current;
+            _currentScrollViewer.ScrollToVerticalOffset(newPosition);
+        }
+    }
+
+    private T? FindVisualChild<T>(DependencyObject parent) where T : DependencyObject
+    {
+        for (int i = 0; i < VisualTreeHelper.GetChildrenCount(parent); i++)
+        {
+            var child = VisualTreeHelper.GetChild(parent, i);
+            if (child is T typedChild)
+            {
+                return typedChild;
+            }
+            var foundChild = FindVisualChild<T>(child);
+            if (foundChild != null)
+            {
+                return foundChild;
+            }
+        }
+        return null;
     }
 
     protected override void OnSourceInitialized(EventArgs e)
@@ -44,6 +157,8 @@ public partial class MainWindow : FluentWindow, INavigationWindow
     protected override void OnClosed(EventArgs e)
     {
         _logger.LogDebug("主窗体退出");
+        CompositionTarget.Rendering -= OnCompositionTargetRendering;
+        RemoveHandler(PreviewMouseWheelEvent, new MouseWheelEventHandler(OnGlobalPreviewMouseWheel));
         base.OnClosed(e);
         App.GetService<NotifyIconViewModel>()?.Exit();
     }


### PR DESCRIPTION
## 为主窗口`MainWindow`实现了基于`CompositionTarget.Rendering`的像素级平滑滚动，替代 WPF `ScrollViewer`默认的行级离散滚动。新增 Lerp 插值跟手和惯性减速，最高可跟随显示器刷新率。
参数
## `_lerpFactor`，目前：0.35，跟手系数，越大越跟手，小于1
## `_scrollSensitivity`，目前：0.27，滚动灵敏度，控制每次滚轮的位移量
## `_inertiaDecay`，目前：0.94，惯性衰减系数，越接近1惯性滑行越远
## `_minVelocity`，目前：0.3，最小惯性速度，低于此值停止惯性滚动
## 后面计划做一个可以个性化自定义这个参数的设置功能。
## 后面是AI写的介绍：




# feat: 为主窗口添加平滑滚动与惯性效果

## 📌 变更类型

- [x] 新功能（feature）
- [ ] Bug 修复
- [ ] 重构
- [x] 样式/UI

## 📝 变更概述

为主窗口 `MainWindow` 实现了基于 `CompositionTarget.Rendering` 的像素级平滑滚动，替代 WPF `ScrollViewer` 默认的行级离散滚动。新增 Lerp 插值跟手 + 惯性减速系统，滚动体验显著提升，最高可跟随显示器刷新率。

## 🔧 技术实现

### 核心思路

WPF 原生 `ScrollViewer` 默认按行滚动（`CanContentScroll=true`），体感生硬且有跳跃感。本次改动在事件隧道阶段（`PreviewMouseWheel`）拦截滚轮事件，阻止默认行为，转而由自定义渲染回调驱动滚动位置，实现像素级平滑过渡。

### 实现步骤

| 步骤 | 说明 |
|------|------|
| **全局事件拦截** | 在 `PreviewMouseWheel` 隧道阶段拦截所有鼠标滚轮事件，`e.Handled = true` 阻止 `ScrollViewer` 默认滚动 |
| **动态定位** | 通过 `VisualTreeHelper.HitTest` 找到鼠标下方的 `ScrollViewer`；若命中测试未命中，回退到 `RootNavigation` 的子级 `ScrollViewer` |
| **像素级滚动** | 设置 `CanContentScroll = false` 启用像素级滚动模式 |
| **Lerp 插值** | 每帧用 `current + diff * _lerpFactor` 线性插值逼近目标位置，实现跟手效果 |
| **惯性系统** | 持续记录滚动速度（`_velocity`），停止输入后按 `_inertiaDecay` 系数自然衰减，低于 `_minVelocity` 时停止 |
| **同步渲染** | 使用 `CompositionTarget.Rendering` 与显示器刷新同步，帧率上限即显示器刷新率 |

### 可调参数

| 参数 | 值 | 作用 |
|------|----|------|
| `_lerpFactor` | 0.35 | 跟手系数，越大越跟手（0~1） |
| `_scrollSensitivity` | 0.27 | 滚动灵敏度，控制每次滚轮的位移量 |
| `_inertiaDecay` | 0.94 | 惯性衰减系数，越接近 1 惯性滑行越远 |
| `_minVelocity` | 0.3 | 最小惯性速度，低于此值停止惯性滚动 |

### 修改的文件

- `View/MainWindow.xaml.cs`

### 新增方法

| 方法 | 说明 |
|------|------|
| `OnGlobalPreviewMouseWheel` | 拦截滚轮事件，计算目标滚动位置 |
| `FindScrollViewerUnderMouse` | 命中测试查找鼠标下方的 ScrollViewer |
| `OnCompositionTargetRendering` | 渲染回调，驱动平滑滚动与惯性动画 |
| `FindVisualChild<T>` | 可视树中查找指定类型的子元素（通用辅助方法） |

### 修改的方法

- `OnClosed`：新增事件反注册，防止内存泄漏

## ⚠️ 注意事项

1. `CompositionTarget.Rendering` 和 `PreviewMouseWheel` 事件已在 `OnClosed` 中正确反注册
2. `CanContentScroll = false` 会改变 ScrollViewer 的虚拟化行为，如果存在大数据量列表需关注性能
3. 当前参数为默认值，后续可根据用户反馈微调

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化鼠标滚轮滚动体验，支持更平滑的滚动和惯性效果。
  * 改进滚动区域识别，确保鼠标悬停位置对应的内容能够正确滚动。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->