### PR TITLE
fix: 修复CombatCommand当前角色NPE并提取共享执行器CombatScriptExecutor

### DIFF
--- a/BetterGenshinImpact/Core/Script/Dependence/Dispatcher.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/Dispatcher.cs
@@ -22,8 +22,10 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using BetterGenshinImpact.GameTask.AutoFight;
+using BetterGenshinImpact.GameTask.AutoFight.Script;
 using BetterGenshinImpact.GameTask.AutoLeyLineOutcrop;
 using BetterGenshinImpact.GameTask.AutoStygianOnslaught;
+using BetterGenshinImpact.GameTask.Common;
 
 namespace BetterGenshinImpact.Core.Script.Dependence;
 
@@ -372,6 +374,31 @@ public class Dispatcher
         var factory = GameTask.AutoFight.Factory.CombatTaskFactoryProvider.GetFactory(param.CombatStrategyPath);
         var fightTask = factory.CreateTask(param);
         await fightTask.Start(cancellationToken);  
+    }
+    
+    /// <summary>
+    /// 运行简易战斗策略脚本。
+    /// 使用策略语言直接控制角色执行动作（如 e、q、attack 等），适合快速操作。
+    /// </summary>
+    /// <param name="script">策略字符串，支持逗号/换行/分号分隔指令，可选角色名前缀</param>
+    /// <param name="avatarName">指定操作的角色名（可选，不指定则操作当前角色）</param>
+    /// <param name="customCt">自定义取消令牌</param>
+    public async Task RunCombatScript(string script, string? avatarName = null, CancellationToken? customCt = null)
+    {
+        if (string.IsNullOrWhiteSpace(script))
+        {
+            throw new ArgumentException("策略字符串不能为空", nameof(script));
+        }
+
+        CancellationToken cancellationToken = customCt ?? CancellationContext.Instance.Cts.Token;
+
+        // 1. 解析策略字符串（ParseContext 已处理全角符号、注释、分号/逗号分隔）
+        var combatScript = CombatScriptParser.ParseContext(script, validate: false);
+        if (combatScript.CombatCommands.Count == 0) return;
+
+        _logger.LogInformation("执行 {Text}", "简易策略脚本");
+
+        await CombatScriptExecutor.ExecuteAsync(combatScript, cancellationToken, _logger);
     }
     
     /// <summary>  

--- a/BetterGenshinImpact/Core/Script/Dependence/Dispatcher.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/Dispatcher.cs
@@ -393,7 +393,7 @@ public class Dispatcher
         CancellationToken cancellationToken = customCt ?? CancellationContext.Instance.Cts.Token;
 
         // 1. 解析策略字符串（ParseContext 已处理全角符号、注释、分号/逗号分隔）
-        var combatScript = CombatScriptParser.ParseContext(script, validate: false);
+        var combatScript = CombatScriptParser.ParseContext(script, validate: false, defaultAvatarName: avatarName);
         if (combatScript.CombatCommands.Count == 0) return;
 
         _logger.LogInformation("执行 {Text}", "简易策略脚本");

--- a/BetterGenshinImpact/GameTask/AutoFight/AutoFightJsonTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/AutoFightJsonTask.cs
@@ -655,31 +655,21 @@ public class AutoFightJsonTask : ISoloTask
         {
             if (_ct.IsCancellationRequested) break;
 
-            try
+            var firstSpaceIndex = preAction.IndexOf(' ');
+            var character = CombatScriptParser.CurrentAvatarName;
+            var commands = preAction;
+            if (firstSpaceIndex > 0)
             {
-                var firstSpaceIndex = preAction.IndexOf(' ');
-                var character = CombatScriptParser.CurrentAvatarName;
-                var commands = preAction;
-                if (firstSpaceIndex > 0)
-                {
-                    character = preAction[..firstSpaceIndex];
-                    commands = preAction[(firstSpaceIndex + 1)..];
-                }
-
-                var cmdList = CombatScriptParser.ParseLineCommands(commands, character);
-                foreach (var cmd in cmdList)
-                {
-                    if (_ct.IsCancellationRequested) break;
-                    cmd.Execute(combatScenes);
-                    await Delay(300, _ct);
-                }
-
-                Logger.LogInformation("战斗前动作：{Action}", preAction);
+                character = preAction[..firstSpaceIndex];
+                commands = preAction[(firstSpaceIndex + 1)..];
             }
-            catch (Exception e)
-            {
-                Logger.LogWarning("战斗前动作执行失败：{Action}，{Msg}", preAction, e.Message);
-            }
+
+            var cmdList = CombatScriptParser.ParseLineCommands(commands, character);
+            var combatScript = new CombatScript([character], cmdList);
+
+            await CombatScriptExecutor.ExecuteAsync(combatScript, _ct, Logger, combatScenes);
+            Logger.LogInformation("战斗前动作：{Action}", preAction);
+            await Delay(300, _ct);
         }
     }
 

--- a/BetterGenshinImpact/GameTask/AutoFight/AutoFightJsonTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/AutoFightJsonTask.cs
@@ -4,6 +4,7 @@ using BetterGenshinImpact.Core.Simulator.Extensions;
 using BetterGenshinImpact.GameTask.AutoFight.Assets;
 using BetterGenshinImpact.GameTask.AutoFight.Model;
 using BetterGenshinImpact.GameTask.AutoFight.Script;
+using BetterGenshinImpact.GameTask.AutoGeniusInvokation.Exception;
 using BetterGenshinImpact.GameTask.Model.Area;
 using BetterGenshinImpact.Helpers;
 using Microsoft.Extensions.DependencyInjection;
@@ -667,7 +668,14 @@ public class AutoFightJsonTask : ISoloTask
             var cmdList = CombatScriptParser.ParseLineCommands(commands, character);
             var combatScript = new CombatScript([character], cmdList);
 
-            await CombatScriptExecutor.ExecuteAsync(combatScript, _ct, Logger, combatScenes);
+            try
+            {
+                await CombatScriptExecutor.ExecuteAsync(combatScript, _ct, Logger, combatScenes);
+            }
+            catch (RetryException e)
+            {
+                Logger.LogWarning("战斗前动作重试异常，跳过此动作继续：{Msg}", e.Message);
+            }
             Logger.LogInformation("战斗前动作：{Action}", preAction);
             await Delay(300, _ct);
         }

--- a/BetterGenshinImpact/GameTask/AutoFight/Model/CombatScenes.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Model/CombatScenes.cs
@@ -478,9 +478,10 @@ public class CombatScenes : IDisposable
         if (index > 0)
         {
             LastActiveAvatarIndex = index;
+            return Avatars[LastActiveAvatarIndex - 1].Name;
         }
 
-        return Avatars[LastActiveAvatarIndex - 1].Name;
+        return null;
     }
 
     /// <summary>

--- a/BetterGenshinImpact/GameTask/AutoFight/Script/CombatCommand.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Script/CombatCommand.cs
@@ -84,7 +84,9 @@ public class CombatCommand
         Avatar? avatar;
         if (Name == CombatScriptParser.CurrentAvatarName)
         {
-            avatar = combatScenes.SelectAvatar(Name);
+            var currentName = combatScenes.CurrentAvatar();
+            avatar = currentName != null ? combatScenes.SelectAvatar(currentName) : null;
+            avatar ??= combatScenes.SelectAvatar(1);
         }
         else
         {

--- a/BetterGenshinImpact/GameTask/AutoFight/Script/CombatCommand.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Script/CombatCommand.cs
@@ -84,7 +84,7 @@ public class CombatCommand
         Avatar? avatar;
         if (Name == CombatScriptParser.CurrentAvatarName)
         {
-            var currentName = combatScenes.CurrentAvatar();
+            var currentName = combatScenes.CurrentAvatar(true);
             avatar = currentName != null ? combatScenes.SelectAvatar(currentName) : null;
             avatar ??= combatScenes.SelectAvatar(1);
         }

--- a/BetterGenshinImpact/GameTask/AutoFight/Script/CombatScriptExecutor.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Script/CombatScriptExecutor.cs
@@ -1,0 +1,88 @@
+using BetterGenshinImpact.GameTask.AutoFight.Model;
+using BetterGenshinImpact.GameTask.AutoGeniusInvokation.Exception;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using static BetterGenshinImpact.GameTask.Common.TaskControl;
+
+namespace BetterGenshinImpact.GameTask.AutoFight.Script;
+
+public static class CombatScriptExecutor
+{
+    /// <summary>
+    /// 执行简易战斗策略脚本。
+    /// </summary>
+    /// <param name="combatScript">已解析的策略</param>
+    /// <param name="ct">取消令牌</param>
+    /// <param name="logger">日志</param>
+    /// <param name="combatScenes">
+    /// 可选。传了则使用现成的 CombatScenes（由调用方管理生命周期）；
+    /// 不传则在内部通过截图自动创建并管理生命周期。
+    /// </param>
+    public static async Task ExecuteAsync(
+        CombatScript combatScript,
+        CancellationToken ct,
+        ILogger logger,
+        CombatScenes? combatScenes = null)
+    {
+        var ownsScenes = false;
+        if (combatScenes == null)
+        {
+            using var capture = CaptureToRectArea();
+            combatScenes = new CombatScenes();
+            combatScenes.InitializeTeam(capture);
+            ownsScenes = true;
+            if (!combatScenes.CheckTeamInitialized())
+            {
+                logger.LogError("队伍识别未初始化成功！");
+                return;
+            }
+        }
+
+        try
+        {
+            combatScenes.BeforeTask(ct);
+
+            // 提前校验是否存在策略要求的角色
+            if (!combatScript.AvatarNames.Contains(CombatScriptParser.CurrentAvatarName))
+            {
+                bool hasAvatar = combatScenes.GetAvatars().Any(avatar => combatScript.AvatarNames.Contains(avatar.Name));
+                if (!hasAvatar)
+                {
+                    logger.LogError("简易策略脚本要求的角色不存在！队伍中需要存在下面角色中的一个或多个：{AvatarNames}", string.Join(", ", combatScript.AvatarNames));
+                    return;
+                }
+            }
+
+            try
+            {
+                // 通用化战斗策略
+                for (var i = 0; i < combatScript.CombatCommands.Count; i++)
+                {
+                    var command = combatScript.CombatCommands[i];
+                    var lastCommand = i == 0 ? command : combatScript.CombatCommands[i - 1];
+                    ct.ThrowIfCancellationRequested();
+                    command.Execute(combatScenes, lastCommand);
+                }
+            }
+            catch (RetryException e)
+            {
+                logger.LogWarning("简易策略脚本执行时出现重试异常，原因：{Msg}，重试中...", e.Message);
+                throw;
+            }
+            catch (Exception e)
+            {
+                logger.LogError(e, "执行简易策略脚本时发生错误！");
+            }
+        }
+        finally
+        {
+            if (ownsScenes)
+            {
+                combatScenes.Dispose();
+            }
+        }
+    }
+}

--- a/BetterGenshinImpact/GameTask/AutoFight/Script/CombatScriptExecutor.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Script/CombatScriptExecutor.cs
@@ -33,12 +33,13 @@ public static class CombatScriptExecutor
             using var capture = CaptureToRectArea();
             combatScenes = new CombatScenes();
             combatScenes.InitializeTeam(capture);
-            ownsScenes = true;
             if (!combatScenes.CheckTeamInitialized())
             {
                 logger.LogError("队伍识别未初始化成功！");
+                combatScenes.Dispose();
                 return;
             }
+            ownsScenes = true;
         }
 
         try

--- a/BetterGenshinImpact/GameTask/AutoFight/Script/CombatScriptParser.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Script/CombatScriptParser.cs
@@ -65,7 +65,7 @@ public class CombatScriptParser
         return combatScript;
     }
 
-    public static CombatScript ParseContext(string context, bool validate = true)
+    public static CombatScript ParseContext(string context, bool validate = true, string? defaultAvatarName = null)
     {
         var lines = context.Split(["\r\n", "\r", "\n"], StringSplitOptions.RemoveEmptyEntries);
         var result = new List<string>();
@@ -90,16 +90,16 @@ public class CombatScriptParser
             }
         }
 
-        return ParseLines(result, validate);
+        return ParseLines(result, validate, defaultAvatarName);
     }
 
-    private static CombatScript ParseLines(List<string> lines, bool validate = true)
+    private static CombatScript ParseLines(List<string> lines, bool validate = true, string? defaultAvatarName = null)
     {
         List<CombatCommand> combatCommands = [];
         HashSet<string> combatAvatarNames = [];
         foreach (var line in lines)
         {
-            var oneLineCombatCommands = ParseLine(line, combatAvatarNames, validate);
+            var oneLineCombatCommands = ParseLine(line, combatAvatarNames, validate, defaultAvatarName);
             combatCommands.AddRange(oneLineCombatCommands);
         }
 
@@ -109,14 +109,14 @@ public class CombatScriptParser
         return new CombatScript(combatAvatarNames, combatCommands);
     }
 
-    private static List<CombatCommand> ParseLine(string line, HashSet<string> combatAvatarNames, bool validate = true)
+    private static List<CombatCommand> ParseLine(string line, HashSet<string> combatAvatarNames, bool validate = true, string? defaultAvatarName = null)
     {
         line = line.Trim();
         var oneLineCombatCommands = new List<CombatCommand>();
         // 以空格分隔角色和指令 截取第一个空格前的内容为角色名称，后面的为指令
         // 20241116更新 不输入角色名称时，直接以当前角色为准
         var firstSpaceIndex = line.IndexOf(' ');
-        var character = CurrentAvatarName;
+        var character = defaultAvatarName ?? CurrentAvatarName;
         var commands = line;
         if (firstSpaceIndex > 0)
         {

--- a/BetterGenshinImpact/GameTask/AutoFight/Script/CombatScriptParser.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Script/CombatScriptParser.cs
@@ -140,7 +140,12 @@ public class CombatScriptParser
         }
         else
         {
-            if (validate && separatorIndex == -1)
+            // 无显式前缀时，若提供了 defaultAvatarName 则对其标准化；否则走验证失败
+            if (defaultAvatarName != null)
+            {
+                character = DefaultAutoFightConfig.AvatarAliasToStandardName(defaultAvatarName);
+            }
+            else if (validate)
             {
                 Logger.LogError("战斗脚本格式错误，必须以空格分隔角色和指令");
                 throw new Exception("战斗脚本格式错误，必须以空格分隔角色和指令");

--- a/BetterGenshinImpact/GameTask/AutoFight/Script/CombatScriptParser.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Script/CombatScriptParser.cs
@@ -115,18 +115,32 @@ public class CombatScriptParser
         var oneLineCombatCommands = new List<CombatCommand>();
         // 以空格分隔角色和指令 截取第一个空格前的内容为角色名称，后面的为指令
         // 20241116更新 不输入角色名称时，直接以当前角色为准
-        var firstSpaceIndex = line.IndexOf(' ');
+        // 用括号嵌套深度查找角色分隔符：深度为 0 时的空格才是角色名和指令的分隔
+        // 无角色前缀时（如 walk(s, 0.2)），所有空格都在括号内，separatorIndex 保持 -1
+        var depth = 0;
+        var separatorIndex = -1;
+        for (var i = 0; i < line.Length; i++)
+        {
+            if (line[i] == '(') depth++;
+            else if (line[i] == ')') depth--;
+            else if (line[i] == ' ' && depth == 0)
+            {
+                separatorIndex = i;
+                break;
+            }
+        }
+
         var character = defaultAvatarName ?? CurrentAvatarName;
         var commands = line;
-        if (firstSpaceIndex > 0)
+        if (separatorIndex > 0)
         {
-            character = line[..firstSpaceIndex];
+            character = line[..separatorIndex];
             character = DefaultAutoFightConfig.AvatarAliasToStandardName(character);
-            commands = line[(firstSpaceIndex + 1)..];
+            commands = line[(separatorIndex + 1)..];
         }
         else
         {
-            if (validate)
+            if (validate && separatorIndex == -1)
             {
                 Logger.LogError("战斗脚本格式错误，必须以空格分隔角色和指令");
                 throw new Exception("战斗脚本格式错误，必须以空格分隔角色和指令");

--- a/BetterGenshinImpact/GameTask/AutoPathing/Handler/CombatScriptHandler.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/Handler/CombatScriptHandler.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using System.Linq;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using BetterGenshinImpact.GameTask.AutoFight.Script;
-using BetterGenshinImpact.GameTask.AutoGeniusInvokation.Exception;
 using BetterGenshinImpact.GameTask.AutoPathing.Model;
 using Microsoft.Extensions.Logging;
 using static BetterGenshinImpact.GameTask.Common.TaskControl;
@@ -25,41 +23,7 @@ public class CombatScriptHandler : IActionHandler
                 return;
             }
 
-            // 设置取消令牌到 CombatScenes 和 Avatar 对象
-            combatScenes.BeforeTask(ct);
-
-
-            // 提前校验是否存在策略要求的角色
-            if (!combatScript.AvatarNames.Contains(CombatScriptParser.CurrentAvatarName))
-            {
-                bool hasAvatar = combatScenes.GetAvatars().Any(avatar => combatScript.AvatarNames.Contains(avatar.Name));
-                if (!hasAvatar)
-                {
-                    Logger.LogError("简易策略脚本要求的角色不存在！队伍中需要存在下面角色中的一个或多个：{AvatarNames}", string.Join(", ", combatScript.AvatarNames));
-                    return;
-                }
-            }
-
-            try
-            {
-                // 通用化战斗策略
-                for (var i = 0; i < combatScript.CombatCommands.Count; i++)
-                {
-                    var command = combatScript.CombatCommands[i];
-                    var lastCommand = i == 0 ? command : combatScript.CombatCommands[i - 1];
-                    ct.ThrowIfCancellationRequested();
-                    command.Execute(combatScenes, lastCommand);
-                }
-            }
-            catch (RetryException e)
-            {
-                Logger.LogWarning("简易策略脚本执行时出现重试异常，原因：{Msg}，重试中...", e.Message);
-                throw;
-            }
-            catch (Exception e)
-            {
-                Logger.LogError(e, "执行简易策略脚本时发生错误！");
-            }
+            await CombatScriptExecutor.ExecuteAsync(combatScript, ct, Logger, combatScenes);
         }
         else
         {

--- a/Test/BetterGenshinImpact.UnitTest/GameTaskTests/AutoFightTests/CombatScriptParserTests.cs
+++ b/Test/BetterGenshinImpact.UnitTest/GameTaskTests/AutoFightTests/CombatScriptParserTests.cs
@@ -45,4 +45,20 @@ public class CombatScriptParserTests
         Assert.Equal("s", script.CombatCommands[0].Args[0]);
         Assert.Equal("0.2", script.CombatCommands[0].Args[1]);
     }
+
+    /// <summary>
+    /// 无角色前缀时传入 defaultAvatarName，应使用该名称作为角色名并正常解析指令
+    /// </summary>
+    [Fact]
+    public void ParseLine_NoPrefixWithDefaultAvatarName_UsesProvidedName()
+    {
+        var script = CombatScriptParser.ParseContext("walk(s, 0.2)", validate: true, defaultAvatarName: "娜维娅");
+        Assert.Single(script.CombatCommands);
+        Assert.Equal("娜维娅", script.CombatCommands[0].Name);
+        Assert.Contains("walk", script.CombatCommands[0].Method.Alias);
+        Assert.NotNull(script.CombatCommands[0].Args);
+        Assert.Equal(2, script.CombatCommands[0].Args.Count);
+        Assert.Equal("s", script.CombatCommands[0].Args[0]);
+        Assert.Equal("0.2", script.CombatCommands[0].Args[1]);
+    }
 }

--- a/Test/BetterGenshinImpact.UnitTest/GameTaskTests/AutoFightTests/CombatScriptParserTests.cs
+++ b/Test/BetterGenshinImpact.UnitTest/GameTaskTests/AutoFightTests/CombatScriptParserTests.cs
@@ -1,0 +1,48 @@
+using BetterGenshinImpact.GameTask.AutoFight.Script;
+
+namespace BetterGenshinImpact.UnitTest.GameTaskTests.AutoFightTests;
+
+public class CombatScriptParserTests
+{
+    /// <summary>
+    /// 无角色前缀的指令中含有空格参数（如 walk(s, 0.2)），不应将空格误识别为角色分隔符
+    /// </summary>
+    [Fact]
+    public void ParseLine_NoPrefixWithSpacedArg_PreservesWholeLineAsCommands()
+    {
+        // 无 validate 模式，执行 ParseContext
+        var script = CombatScriptParser.ParseContext("walk(s, 0.2)", validate: false);
+        Assert.Single(script.CombatCommands);
+        Assert.Contains("walk", script.CombatCommands[0].Method.Alias);
+        Assert.NotNull(script.CombatCommands[0].Args);
+        Assert.Equal(2, script.CombatCommands[0].Args.Count);
+        Assert.Equal("s", script.CombatCommands[0].Args[0]);
+        Assert.Equal("0.2", script.CombatCommands[0].Args[1]);
+    }
+
+    /// <summary>
+    /// 有角色前缀的指令正常解析
+    /// </summary>
+    [Fact]
+    public void ParseLine_WithCharPrefix_SplitsCorrectly()
+    {
+        var script = CombatScriptParser.ParseContext("娜维娅 e", validate: false);
+        Assert.Single(script.CombatCommands);
+        Assert.Contains("e", script.CombatCommands[0].Method.Alias);
+    }
+
+    /// <summary>
+    /// 有角色前缀且指令含有空格参数（如 娜维娅 walk(s, 0.2)），应正确拆分
+    /// </summary>
+    [Fact]
+    public void ParseLine_CharPrefixWithSpacedArg_SplitsCorrectly()
+    {
+        var script = CombatScriptParser.ParseContext("娜维娅 walk(s, 0.2)", validate: false);
+        Assert.Single(script.CombatCommands);
+        Assert.Contains("walk", script.CombatCommands[0].Method.Alias);
+        Assert.NotNull(script.CombatCommands[0].Args);
+        Assert.Equal(2, script.CombatCommands[0].Args.Count);
+        Assert.Equal("s", script.CombatCommands[0].Args[0]);
+        Assert.Equal("0.2", script.CombatCommands[0].Args[1]);
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增“简易战斗策略脚本”统一执行：支持指定默认角色名，并可传入自定义取消令牌以中止执行。
- **改进**
  - 自动战斗前动作与策略脚本执行改为统一的异步流程，减少逐条执行差异。
  - 命令解析更稳健：支持括号嵌套与含空格参数的场景，避免误拆分。
  - 角色选择/当前出战识别更准确：识别失败时不再错误回退。
- **测试**
  - 补充策略脚本解析用例，覆盖无前缀与带角色前缀的空格参数场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->