### PR TITLE
fix: SingleSelectText 方法在 isOrange = true 時 skipTimes 參數無法按預期生效

### DIFF
--- a/BetterGenshinImpact/GameTask/Common/Job/ChooseTalkOptionTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/ChooseTalkOptionTask.cs
@@ -37,7 +37,7 @@ public partial class ChooseTalkOptionTask
     /// </summary>
     /// <param name="option"></param>
     /// <param name="ct"></param>
-    /// <param name="skipTimes">200ms一次，点击几次空格</param>
+    /// <param name="skipTimes">內部文字識別失敗後的最大重試次數，不填時默認爲 10</param>
     /// <param name="isOrange"></param>
     /// <returns></returns>
     public async Task<TalkOptionRes> SingleSelectText(string option, CancellationToken ct, int skipTimes = 10, bool isOrange = false)
@@ -48,49 +48,51 @@ public partial class ChooseTalkOptionTask
             return TalkOptionRes.NotFound;
         }
 
-        await Task.Delay(500, ct);
-
         bool firstOcrOption = true;
+        bool textFound = false;
         for (var i = 0; i < skipTimes; i++) // 重试N次
         {
+            await Task.Delay(500, ct);
+
             var region = CaptureToRectArea();
             var optionRegions = RecognizeOption(region, ct);
             if (optionRegions == null)
             {
                 TaskContext.Instance().PostMessageSimulator.KeyPressBackground(User32.VK.VK_SPACE);
-                await Delay(500, ct);
-                continue; // retry
             }
-            else
+            // 首次识别到文字，延迟 1s 保证文字已经完全展示
+            if (firstOcrOption)
             {
-                // 首次识别到文字，延迟1s重新识别一次，保证文字已经完全展示
-                if (firstOcrOption)
-                {
-                    await Delay(1000, ct);
-                    firstOcrOption = false;
-                }
+                await Delay(1000, ct);
+                firstOcrOption = false;
             }
 
-            foreach (var optionRa in optionRegions)
+            if (optionRegions != null)
             {
-                if (optionRa.Text.Contains(option))
+                foreach (var optionRa in optionRegions)
                 {
-                    if (isOrange)
+                    if (optionRa.Text.Contains(option))
                     {
+                        textFound = true;
+                        // 在未識別到橙色字樣時重試，而非直接返回
                         // region.DeriveCrop(optionRa.ToRect()).SrcMat.SaveImage(Global.Absolute($"log\\t{optionRa.Text}.png"));
-                        if (!IsOrangeOption(region.DeriveCrop(optionRa.ToRect()).SrcMat))
+                        if (isOrange && !IsOrangeOption(region.DeriveCrop(optionRa.ToRect()).SrcMat))
                         {
-                            return TalkOptionRes.FoundButNotOrange;
+                            break;
                         }
-                    }
 
-                    ClickOcrRegion(optionRa);
-                    await Task.Delay(300, ct);
-                    return TalkOptionRes.FoundAndClick;
+                        ClickOcrRegion(optionRa);
+                        await Task.Delay(300, ct);
+                        return TalkOptionRes.FoundAndClick;
+                    }
                 }
             }
         }
 
+        if (isOrange && textFound)
+        {
+            return TalkOptionRes.FoundButNotOrange;
+        }
         return TalkOptionRes.NotFound;
     }
 


### PR DESCRIPTION
fix: Delay 500ms when the recognition failed inside the method SingleSelectText, fix when having argument isOrange = true, the skipTimes become invalidated.

在修改前，代碼有可能在例如“領取每日獎勵”時因正確匹配字段但未能正確匹配顏色失敗。這可能是由執行函數 ```CaptureToRectArea``` 的時機所導致。
在“領取每日獎勵”中，我們有 ```_chooseTalkOptionTask.SingleSelectText(this.dailyLocalizedString, ct, 10, true);``` ，我們期望獲得橙色字樣的按鈕的同時給予 10 次重試次數。而在原先的代碼中， ```if (!IsOrangeOption(region.DeriveCrop(optionRa.ToRect()).SrcMat))``` 後便直接 ```return TalkOptionRes.FoundButNotOrange;``` ，這並不符合語義上的預期。
這次修改主要改動了 ```SingleSelectText``` 方法在內部 OCR 識別失敗時的處理邏輯。使得在 OCR 識別失敗，未識別到目標字段與目標字段顏色錯誤時皆延遲 500ms 重試。

Before the fix, the code might get a failure result in "Claim daily reward" due to having a correct result but a incorrect colour of target string. That might caused by the chance of function ```CaptureToRectArea```.
When "Claim daily reward", we have ```_chooseTalkOptionTask.SingleSelectText(this.dailyLocalizedString, ct, 10, true);``` and we want the orange colour option while having 10 retry counts available. However, in the former codes, we ```return TalkOptionRes.FoundButNotOrange;``` right after ```if (!IsOrangeOption(region.DeriveCrop(optionRa.ToRect()).SrcMat))```, It’s not what we expected.
In this modification, the logic of handling internal OCR failure has been changed for method ```SingleSelectText```. Resulting in retry after a 500ms delay for OCR failure, mismatched target string and mismatched string colour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化对话选项识别与重试逻辑，识别到目标文本但颜色不匹配时会继续重试。
  * 改进识别结果判断，减少因颜色识别失败导致的误判，并在重试结束后返回更准确的结果。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->