### PR TITLE
fix: 临时修复 ConfirmParty 点击白色确认按钮失效

### DIFF
--- a/BetterGenshinImpact/GameTask/Common/Job/SwitchPartyTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/SwitchPartyTask.cs
@@ -234,7 +234,7 @@ public class SwitchPartyTask
 
     private async Task ConfirmParty(ImageRegion page, CancellationToken ct, bool isInPartyViewUi = false)
     {
-        var r1 = Bv.ClickWhiteConfirmButton(page.DeriveCrop(0, page.Height / 4, page.Width / 4, page.Height - page.Height / 4));
+        var r1 = Bv.ClickWhiteConfirmButton(page);
         var partyChooseUiClosed = await NewRetry.WaitForAction(() =>
         {
             using var ra2 = CaptureToRectArea();
@@ -246,7 +246,7 @@ public class SwitchPartyTask
         }
         await Delay(200, ct);
         using var ra = CaptureToRectArea();
-        var r2 = Bv.ClickWhiteConfirmButton(ra.DeriveCrop(page.Width - page.Width / 4, page.Height / 4, page.Width / 4, page.Height - page.Height / 4));
+        var r2 = Bv.ClickWhiteConfirmButton(ra);
         await Delay(500, ct);
         if (isInPartyViewUi) await _returnMainUiTask.Start(ct);
     }


### PR DESCRIPTION
PR #3250 引入的 RecognitionAssets.LoadTemplateImage 中，模板缩放使用 captureWidth / 1920d 计算。而 ConfirmParty 调用 DeriveCrop 将截图裁剪到左下角子区域后再传入 ClickWhiteConfirmButton ，裁剪区域的宽度被当作截图宽度，导致模板被缩放到 25%，匹配失败。

当前修复直接跳过裁剪，传入完整截图进行模板匹配。这会扩大搜索范围，但能恢复换队功能的可用性。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 优化队伍切换时确认按钮的识别与点击范围。
  * 提升切换前后确认操作的稳定性与成功率。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->