### PR TITLE
feat:为桑多涅重击添加特化逻辑

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
@@ -979,78 +979,84 @@ public class Avatar
             var lastSeenBlood = DateTime.UtcNow;
 
             // 主循环：持续到取消或重击时间耗尽
-            while (!Ct.IsCancellationRequested && ms >= 0)
+            // 使用 try/finally 确保异常时也会清理绘制并松开按键
+            try
             {
-                // 检测屏幕中的血条（红色连通域），结果坐标在 1500×900 裁剪空间内
-                var bars = FindBloodBars();
-                // 过滤掉 x <= 200 的非敌人血条（如 UI 元素、角色自身元素等误检）
-                var valid = bars.Where(b => b.x > 200).ToList();
-
-                // 每帧重新截图，用于绘制覆盖层
-                using (var drawRegion = CaptureToRectArea())
+                while (!Ct.IsCancellationRequested && ms >= 0)
                 {
-                    // 构建绘制列表，初始包含预瞄准星（红色方框，中心(960, 540)）
-                    var drawList = new System.Collections.Generic.List<View.Drawable.RectDrawable>
+                    // 每帧截图一次，复用给 FindBloodBars 和绘制覆盖层
+                    using (var capture = CaptureToRectArea())
                     {
-                        drawRegion.ToRectDrawable(new OpenCvSharp.Rect(preAimX - 25, 540 - 25, 50, 50), "preAim", new System.Drawing.Pen(System.Drawing.Color.Red, 2))
-                    };
+                        // 检测屏幕中的血条（红色连通域），结果坐标在 1500×900 裁剪空间内
+                        var bars = FindBloodBars(capture);
+                        // 过滤掉 x <= 200 的非敌人血条（如 UI 元素、角色自身元素等误检）
+                        var valid = bars.Where(b => b.x > 200).ToList();
 
-                    if (valid.Count > 0)
-                    {
-                        // 有可瞄准的血条：更新最后见到血条的时间
-                        lastSeenBlood = DateTime.UtcNow;
-
-                        // 选择距离预瞄点(960, 480)最近的血条作为目标
-                        var nearest = valid.OrderBy(b => Math.Abs((b.x + b.width / 2) - preAimX) + Math.Abs((b.y + b.height / 2) - preAimY)).First();
-                        // 计算准星到目标中心的偏移量（像素）
-                        var offsetX = (nearest.x + nearest.width / 2) - preAimX;
-                        var offsetY = (nearest.y + nearest.height / 2) - preAimY;
-                        // 以 0.25 系数移动鼠标（平滑跟踪，避免剧烈抖动）
-                        Simulation.SendInput.Mouse.MoveMouseBy((int)(offsetX * 0.25 * dpi), (int)(offsetY * 0.25 * dpi));
-
-                        // 血条框绘制：追踪目标用绿色框，其他血条用红色框
-                        foreach (var b in valid)
+                        // 构建绘制列表，初始包含预瞄准星（红色方框，中心(960, 540)）
+                        var drawList = new System.Collections.Generic.List<View.Drawable.RectDrawable>
                         {
-                            var rect = new OpenCvSharp.Rect(b.x, b.y, b.width, b.height);
-                            if (b.x == nearest.x && b.y == nearest.y && b.width == nearest.width && b.height == nearest.height)
-                                drawList.Add(drawRegion.ToRectDrawable(rect, "target", new System.Drawing.Pen(System.Drawing.Color.LimeGreen, 2)));
-                            else
-                                drawList.Add(drawRegion.ToRectDrawable(rect, "blood"));
-                        }
-                    }
-                    else
-                    {
-                        // 无可瞄准血条时：向右旋转搜索敌人
-                        // 但若存在传奇血条（y 50~96，即屏幕顶部附近的特殊血条），无法定位，不转动
-                        if (!bars.Any(b => b.y > 50 && b.y < 96))
+                            capture.ToRectDrawable(new OpenCvSharp.Rect(preAimX - 25, 540 - 25, 50, 50), "preAim", new System.Drawing.Pen(System.Drawing.Color.Red, 2))
+                        };
+
+                        if (valid.Count > 0)
                         {
-                            // 连续超过1秒未找到任何血条，提前退出
-                            if ((DateTime.UtcNow - lastSeenBlood).TotalSeconds >= 1)
+                            // 有可瞄准的血条：更新最后见到血条的时间
+                            lastSeenBlood = DateTime.UtcNow;
+
+                            // 选择距离预瞄点(960, 480)最近的血条作为目标
+                            var nearest = valid.OrderBy(b => Math.Abs((b.x + b.width / 2) - preAimX) + Math.Abs((b.y + b.height / 2) - preAimY)).First();
+                            // 计算准星到目标中心的偏移量（像素）
+                            var offsetX = (nearest.x + nearest.width / 2) - preAimX;
+                            var offsetY = (nearest.y + nearest.height / 2) - preAimY;
+                            // 以 0.25 系数移动鼠标（平滑跟踪，避免剧烈抖动）
+                            Simulation.SendInput.Mouse.MoveMouseBy((int)(offsetX * 0.25 * dpi), (int)(offsetY * 0.25 * dpi));
+
+                            // 血条框绘制：追踪目标用绿色框，其他血条用红色框
+                            foreach (var b in valid)
                             {
-                                Logger.LogInformation("桑多涅重击特化：超过1秒未找到血条，提前退出");
-                                View.Drawable.VisionContext.Instance().DrawContent.PutOrRemoveRectList("SandroneBloodBars", drawList);
-                                break;
+                                var rect = new OpenCvSharp.Rect(b.x, b.y, b.width, b.height);
+                                if (b.x == nearest.x && b.y == nearest.y && b.width == nearest.width && b.height == nearest.height)
+                                    drawList.Add(capture.ToRectDrawable(rect, "target", new System.Drawing.Pen(System.Drawing.Color.LimeGreen, 2)));
+                                else
+                                    drawList.Add(capture.ToRectDrawable(rect, "blood"));
                             }
-
-                            Simulation.SendInput.Mouse.MoveMouseBy((int)(500 * dpi), 0);
-                            // 大旋转后额外等待一帧，避免连续快速旋转导致视角失控
-                            Sleep(frameIntervalMs);
-                            ms -= frameIntervalMs;
                         }
+                        else
+                        {
+                            // 无可瞄准血条时：向右旋转搜索敌人
+                            // 但若存在传奇血条（y 50~96，即屏幕顶部附近的特殊血条），无法定位，不转动
+                            if (!bars.Any(b => b.y > 50 && b.y < 96))
+                            {
+                                // 连续超过1秒未找到任何血条，提前退出
+                                if ((DateTime.UtcNow - lastSeenBlood).TotalSeconds >= 1)
+                                {
+                                    Logger.LogInformation("桑多涅重击特化：超过1秒未找到血条，提前退出");
+                                    View.Drawable.VisionContext.Instance().DrawContent.PutOrRemoveRectList("SandroneBloodBars", drawList);
+                                    break;
+                                }
+
+                                Simulation.SendInput.Mouse.MoveMouseBy((int)(500 * dpi), 0);
+                                // 大旋转后额外等待一帧，避免连续快速旋转导致视角失控
+                                Sleep(frameIntervalMs);
+                                ms -= frameIntervalMs;
+                            }
+                        }
+
+                        // 将本帧绘制列表提交到遮罩窗口显示
+                        View.Drawable.VisionContext.Instance().DrawContent.PutOrRemoveRectList("SandroneBloodBars", drawList);
                     }
 
-                    // 将本帧绘制列表提交到遮罩窗口显示
-                    View.Drawable.VisionContext.Instance().DrawContent.PutOrRemoveRectList("SandroneBloodBars", drawList);
+                    // 等待一帧间隔后继续
+                    Sleep(frameIntervalMs);
+                    ms -= frameIntervalMs;
                 }
-
-                // 等待一帧间隔后继续
-                Sleep(frameIntervalMs);
-                ms -= frameIntervalMs;
             }
-
-            // 循环结束：清除绘制、松开重击键
-            View.Drawable.VisionContext.Instance().DrawContent.RemoveRect("SandroneBloodBars");
-            Simulation.SendInput.SimulateAction(GIActions.NormalAttack, KeyType.KeyUp);
+            finally
+            {
+                // 确保清理绘制并松开重击键
+                View.Drawable.VisionContext.Instance().DrawContent.RemoveRect("SandroneBloodBars");
+                Simulation.SendInput.SimulateAction(GIActions.NormalAttack, KeyType.KeyUp);
+            }
         }
         else
         {
@@ -1254,15 +1260,16 @@ public class Avatar
         return null;
     }
 
-    public static List<(int x, int y, int width, int height)> FindBloodBars()
+    public static List<(int x, int y, int width, int height)> FindBloodBars(ImageRegion? existingCapture = null)
     {
         var results = new List<(int x, int y, int width, int height)>();
 
-        using var image = CaptureToRectArea();
+        using var image = existingCapture ?? CaptureToRectArea();
         var bloodLower = new OpenCvSharp.Scalar(255, 90, 90); // BGR 红色
 
+        using var cropped = image.DeriveCrop(0, 0, 1500, 900);
         using Mat mask = Core.Recognition.OpenCv.OpenCvCommonHelper.Threshold(
-            image.DeriveCrop(0, 0, 1500, 900).SrcMat, bloodLower);
+            cropped.SrcMat, bloodLower);
 
         using Mat labels = new Mat();
         using Mat stats = new Mat();

--- a/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
@@ -1042,8 +1042,8 @@ public class Avatar
                                 Simulation.SendInput.Mouse.MoveMouseBy((int)(offsetX * 0.35 * dpi), (int)(offsetY * 0.25 * dpi));
                             }
 
-                            // OCR 无结果时：若不存在传奇血条，向右旋转搜索敌人
-                            if (!damageResult.HasValue && !hasLegendaryBar)
+                            // OCR 无结果时：向右旋转搜索敌人
+                            if (!damageResult.HasValue)
                             {
                                 // 连续超过1秒未找到任何血条，提前退出
                                 if ((DateTime.UtcNow - lastSeenTargetTime).TotalSeconds >= 1)

--- a/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
@@ -961,19 +961,35 @@ public class Avatar
         }
         else if (Name == "桑多涅")
         {
+            // 桑多涅重击特化逻辑（简化版）
+            // 按下重击后，以固定帧间隔循环执行以下操作：
+            // 1. 截取屏幕检测血条（红色连通域）
+            // 2. 若有血条存在，取离预瞄点(960, 480)最近的血条，移动鼠标对准
+            // 3. 若无血条，且不存在传奇血条（y 50~96）时，向右旋转搜索敌人
+            // 4. 绘制预瞄准星和血条框用于调试
             var dpi = TaskContext.Instance().DpiScale;
-            const int preAimX = 960;
-            const int preAimY = 480;
-            const int frameIntervalMs = 50;
+            const int preAimX = 960;   // 预瞄准星 X 坐标（屏幕中心）
+            const int preAimY = 480;   // 预瞄准星 Y 坐标（屏幕垂直中心偏上）
+            const int frameIntervalMs = 50;  // 每帧间隔（与主循环帧率对齐）
 
+            // 按下重击键，进入蓄力状态
             Simulation.SendInput.SimulateAction(GIActions.NormalAttack, KeyType.KeyDown);
+
+            // 连续未找到血条的计时，超过1秒时提前退出
+            var lastSeenBlood = DateTime.UtcNow;
+
+            // 主循环：持续到取消或重击时间耗尽
             while (!Ct.IsCancellationRequested && ms >= 0)
             {
+                // 检测屏幕中的血条（红色连通域），结果坐标在 1500×900 裁剪空间内
                 var bars = FindBloodBars();
+                // 过滤掉 x <= 200 的非敌人血条（如 UI 元素、角色自身元素等误检）
                 var valid = bars.Where(b => b.x > 200).ToList();
 
+                // 每帧重新截图，用于绘制覆盖层
                 using (var drawRegion = CaptureToRectArea())
                 {
+                    // 构建绘制列表，初始包含预瞄准星（红色方框，中心(960, 540)）
                     var drawList = new System.Collections.Generic.List<View.Drawable.RectDrawable>
                     {
                         drawRegion.ToRectDrawable(new OpenCvSharp.Rect(preAimX - 25, 540 - 25, 50, 50), "preAim", new System.Drawing.Pen(System.Drawing.Color.Red, 2))
@@ -981,11 +997,18 @@ public class Avatar
 
                     if (valid.Count > 0)
                     {
+                        // 有可瞄准的血条：更新最后见到血条的时间
+                        lastSeenBlood = DateTime.UtcNow;
+
+                        // 选择距离预瞄点(960, 480)最近的血条作为目标
                         var nearest = valid.OrderBy(b => Math.Abs((b.x + b.width / 2) - preAimX) + Math.Abs((b.y + b.height / 2) - preAimY)).First();
+                        // 计算准星到目标中心的偏移量（像素）
                         var offsetX = (nearest.x + nearest.width / 2) - preAimX;
                         var offsetY = (nearest.y + nearest.height / 2) - preAimY;
-                        Simulation.SendInput.Mouse.MoveMouseBy((int)(offsetX * 0.5 * dpi), (int)(offsetY * 0.5 * dpi));
+                        // 以 0.25 系数移动鼠标（平滑跟踪，避免剧烈抖动）
+                        Simulation.SendInput.Mouse.MoveMouseBy((int)(offsetX * 0.25 * dpi), (int)(offsetY * 0.25 * dpi));
 
+                        // 血条框绘制：追踪目标用绿色框，其他血条用红色框
                         foreach (var b in valid)
                         {
                             var rect = new OpenCvSharp.Rect(b.x, b.y, b.width, b.height);
@@ -997,16 +1020,35 @@ public class Avatar
                     }
                     else
                     {
-                        Simulation.SendInput.Mouse.MoveMouseBy((int)(500 * dpi), 0);
+                        // 无可瞄准血条时：向右旋转搜索敌人
+                        // 但若存在传奇血条（y 50~96，即屏幕顶部附近的特殊血条），无法定位，不转动
+                        if (!bars.Any(b => b.y > 50 && b.y < 96))
+                        {
+                            // 连续超过1秒未找到任何血条，提前退出
+                            if ((DateTime.UtcNow - lastSeenBlood).TotalSeconds >= 1)
+                            {
+                                Logger.LogInformation("桑多涅重击特化：超过1秒未找到血条，提前退出");
+                                View.Drawable.VisionContext.Instance().DrawContent.PutOrRemoveRectList("SandroneBloodBars", drawList);
+                                break;
+                            }
+
+                            Simulation.SendInput.Mouse.MoveMouseBy((int)(500 * dpi), 0);
+                            // 大旋转后额外等待一帧，避免连续快速旋转导致视角失控
+                            Sleep(frameIntervalMs);
+                            ms -= frameIntervalMs;
+                        }
                     }
 
+                    // 将本帧绘制列表提交到遮罩窗口显示
                     View.Drawable.VisionContext.Instance().DrawContent.PutOrRemoveRectList("SandroneBloodBars", drawList);
                 }
 
+                // 等待一帧间隔后继续
                 Sleep(frameIntervalMs);
                 ms -= frameIntervalMs;
             }
 
+            // 循环结束：清除绘制、松开重击键
             View.Drawable.VisionContext.Instance().DrawContent.RemoveRect("SandroneBloodBars");
             Simulation.SendInput.SimulateAction(GIActions.NormalAttack, KeyType.KeyUp);
         }

--- a/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
@@ -1046,9 +1046,9 @@ public class Avatar
                             if (!damageResult.HasValue)
                             {
                                 // 不存在传奇血条时：连续超过1秒未找到目标，提前退出
-                                if (!hasLegendaryBar && (DateTime.UtcNow - lastSeenTargetTime).TotalSeconds >= 1)
+                                if (!hasLegendaryBar && (DateTime.UtcNow - lastSeenTargetTime).TotalSeconds >= 1.5)
                                 {
-                                    Logger.LogInformation("桑多涅重击特化：超过1秒未找到目标，提前退出");
+                                    Logger.LogInformation("桑多涅重击特化：超过1.5秒未找到目标，提前退出");
                                     View.Drawable.VisionContext.Instance().DrawContent.PutOrRemoveRectList("SandroneBloodBars", drawList);
                                     break;
                                 }

--- a/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
@@ -1045,8 +1045,8 @@ public class Avatar
                             // OCR 无结果时：向右旋转搜索敌人
                             if (!damageResult.HasValue)
                             {
-                                // 连续超过1秒未找到任何血条，提前退出
-                                if ((DateTime.UtcNow - lastSeenTargetTime).TotalSeconds >= 1)
+                                // 不存在传奇血条时：连续超过1秒未找到目标，提前退出
+                                if (!hasLegendaryBar && (DateTime.UtcNow - lastSeenTargetTime).TotalSeconds >= 1)
                                 {
                                     Logger.LogInformation("桑多涅重击特化：超过1秒未找到目标，提前退出");
                                     View.Drawable.VisionContext.Instance().DrawContent.PutOrRemoveRectList("SandroneBloodBars", drawList);

--- a/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
@@ -1053,9 +1053,7 @@ public class Avatar
                                     break;
                                 }
 
-                                Simulation.SendInput.Mouse.MoveMouseBy((int)(500 * dpi), 0);
-                                // 大旋转后额外等待一帧，避免连续快速旋转导致视角失控
-                                Sleep(frameIntervalMs);
+                                Simulation.SendInput.Mouse.MoveMouseBy((int)(1000 * dpi), 0);
                             }
                         }
 

--- a/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
@@ -1032,7 +1032,7 @@ public class Avatar
                             if (damageResult.HasValue)
                             {
                                 var (dcx, dcy, dtext) = damageResult.Value;
-                                Logger.LogDebug("伤害数字追踪: 坐标({X},{Y}) 文本:{Text}", dcx, dcy, dtext);
+                                Logger.LogInformation("伤害数字追踪: 坐标({X},{Y}) 文本:{Text}", dcx, dcy, dtext);
                                 lastSeenTargetTime = DateTime.UtcNow;
                                 var offsetX = dcx - preAimX;
                                 var offsetY = dcy - preAimY;

--- a/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
@@ -1003,26 +1003,46 @@ public class Avatar
 
                         if (valid.Count > 0)
                         {
-                            // 有可瞄准的血条：更新最后见到目标的时间
-                            lastSeenTargetTime = DateTime.UtcNow;
+                            // 检测是否存在传奇血条（y 50~96 范围，位于屏幕顶部的特殊血条）
+                            bool hasLegendaryBar = bars.Any(b => b.y > 50 && b.y < 96);
 
-                            // 选择距离预瞄点(960, 480)最近的血条作为目标
-                            var nearest = valid.OrderBy(b => Math.Abs((b.x + b.width / 2) - preAimX) + Math.Abs((b.y + b.height / 2) - preAimY)).First();
-                            Logger.LogInformation("追踪血条: 裁剪坐标({X},{Y}) 大小({W}×{H})", nearest.x, nearest.y, nearest.width, nearest.height);
-                            // 计算准星到目标中心的偏移量（像素）
-                            var offsetX = (nearest.x + nearest.width / 2) - preAimX;
-                            var offsetY = (nearest.y + nearest.height / 2) - preAimY;
-                            // 以 0.35 系数移动鼠标（平滑跟踪，避免剧烈抖动）
-                            Simulation.SendInput.Mouse.MoveMouseBy((int)(offsetX * 0.35 * dpi), (int)(offsetY * 0.25 * dpi));
-
-                            // 血条框绘制：追踪目标用绿色框，其他血条用红色框
-                            foreach (var b in valid)
+                            if (hasLegendaryBar)
                             {
-                                var rect = new OpenCvSharp.Rect(b.x, b.y, b.width, b.height);
-                                if (b.x == nearest.x && b.y == nearest.y && b.width == nearest.width && b.height == nearest.height)
-                                    drawList.Add(capture.ToRectDrawable(rect, "target", new System.Drawing.Pen(System.Drawing.Color.LimeGreen, 2)));
-                                else
-                                    drawList.Add(capture.ToRectDrawable(rect, "blood"));
+                                // 传奇血条存在时，使用 OCR 追踪伤害数字，避免直接追踪顶部血条导致视角上抬
+                                var damageResult = FindDamageNumber(capture);
+                                if (damageResult.HasValue)
+                                {
+                                    var (dcx, dcy, dtext) = damageResult.Value;
+                                    Logger.LogInformation("伤害数字追踪: 坐标({X},{Y}) 文本:{Text}", dcx, dcy, dtext);
+                                    lastSeenTargetTime = DateTime.UtcNow;
+                                    var offsetX = dcx - preAimX;
+                                    var offsetY = dcy - preAimY;
+                                    Simulation.SendInput.Mouse.MoveMouseBy((int)(offsetX * 0.35 * dpi), (int)(offsetY * 0.25 * dpi));
+                                }
+                            }
+                            else
+                            {
+                                // 有可瞄准的普通血条：更新最后见到目标的时间
+                                lastSeenTargetTime = DateTime.UtcNow;
+
+                                // 选择距离预瞄点(960, 480)最近的血条作为目标
+                                var nearest = valid.OrderBy(b => Math.Abs((b.x + b.width / 2) - preAimX) + Math.Abs((b.y + b.height / 2) - preAimY)).First();
+                                Logger.LogInformation("追踪血条: 裁剪坐标({X},{Y}) 大小({W}×{H})", nearest.x, nearest.y, nearest.width, nearest.height);
+                                // 计算准星到目标中心的偏移量（像素）
+                                var offsetX = (nearest.x + nearest.width / 2) - preAimX;
+                                var offsetY = (nearest.y + nearest.height / 2) - preAimY;
+                                // 以 0.35 系数移动鼠标（平滑跟踪，避免剧烈抖动）
+                                Simulation.SendInput.Mouse.MoveMouseBy((int)(offsetX * 0.35 * dpi), (int)(offsetY * 0.25 * dpi));
+
+                                // 普通血条框绘制：追踪目标用绿色框，其他血条用红色框
+                                foreach (var b in valid)
+                                {
+                                    var rect = new OpenCvSharp.Rect(b.x, b.y, b.width, b.height);
+                                    if (b.x == nearest.x && b.y == nearest.y && b.width == nearest.width && b.height == nearest.height)
+                                        drawList.Add(capture.ToRectDrawable(rect, "target", new System.Drawing.Pen(System.Drawing.Color.LimeGreen, 2)));
+                                    else
+                                        drawList.Add(capture.ToRectDrawable(rect, "blood"));
+                                }
                             }
                         }
                         else

--- a/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
@@ -977,12 +977,14 @@ public class Avatar
 
             // 连续未找到血条的计时，超过1秒时提前退出
             var lastSeenBlood = DateTime.UtcNow;
+            var startTime = DateTime.UtcNow;
+            var maxDurationMs = ms;
 
             // 主循环：持续到取消或重击时间耗尽
             // 使用 try/finally 确保异常时也会清理绘制并松开按键
             try
             {
-                while (!Ct.IsCancellationRequested && ms >= 0)
+                while (!Ct.IsCancellationRequested && (DateTime.UtcNow - startTime).TotalMilliseconds < maxDurationMs)
                 {
                     // 每帧截图一次，复用给 FindBloodBars 和绘制覆盖层
                     using (var capture = CaptureToRectArea())
@@ -1038,7 +1040,6 @@ public class Avatar
                                 Simulation.SendInput.Mouse.MoveMouseBy((int)(500 * dpi), 0);
                                 // 大旋转后额外等待一帧，避免连续快速旋转导致视角失控
                                 Sleep(frameIntervalMs);
-                                ms -= frameIntervalMs;
                             }
                         }
 
@@ -1048,7 +1049,6 @@ public class Avatar
 
                     // 等待一帧间隔后继续
                     Sleep(frameIntervalMs);
-                    ms -= frameIntervalMs;
                 }
             }
             finally

--- a/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
@@ -1035,7 +1035,7 @@ public class Avatar
                             if (damageResult.HasValue)
                             {
                                 var (dcx, dcy, dtext) = damageResult.Value;
-                                Logger.LogInformation("伤害数字追踪: 坐标({X},{Y}) 文本:{Text}", dcx, dcy, dtext);
+                                // Logger.LogInformation("伤害数字追踪: 坐标({X},{Y}) 文本:{Text}", dcx, dcy, dtext);
                                 lastSeenTargetTime = DateTime.UtcNow;
                                 var offsetX = dcx - preAimX;
                                 var offsetY = dcy - preAimY;

--- a/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
@@ -1001,53 +1001,36 @@ public class Avatar
                             capture.ToRectDrawable(new OpenCvSharp.Rect(preAimX - 25, 540 - 25, 50, 50), "preAim", new System.Drawing.Pen(System.Drawing.Color.Red, 2))
                         };
 
-                        if (valid.Count > 0)
+                        // 检测是否存在传奇血条（y 50~96 范围，位于屏幕顶部的特殊血条）
+                        bool hasLegendaryBar = bars.Any(b => b.y > 50 && b.y < 96);
+
+                        if (valid.Count > 0 && !hasLegendaryBar)
                         {
-                            // 检测是否存在传奇血条（y 50~96 范围，位于屏幕顶部的特殊血条）
-                            bool hasLegendaryBar = bars.Any(b => b.y > 50 && b.y < 96);
+                            // 有可瞄准的普通血条：更新最后见到目标的时间
+                            lastSeenTargetTime = DateTime.UtcNow;
 
-                            if (hasLegendaryBar)
+                            // 选择距离预瞄点(960, 480)最近的血条作为目标
+                            var nearest = valid.OrderBy(b => Math.Abs((b.x + b.width / 2) - preAimX) + Math.Abs((b.y + b.height / 2) - preAimY)).First();
+                            Logger.LogInformation("追踪血条: 裁剪坐标({X},{Y}) 大小({W}×{H})", nearest.x, nearest.y, nearest.width, nearest.height);
+                            // 计算准星到目标中心的偏移量（像素）
+                            var offsetX = (nearest.x + nearest.width / 2) - preAimX;
+                            var offsetY = (nearest.y + nearest.height / 2) - preAimY;
+                            // 以 0.35 系数移动鼠标（平滑跟踪，避免剧烈抖动）
+                            Simulation.SendInput.Mouse.MoveMouseBy((int)(offsetX * 0.35 * dpi), (int)(offsetY * 0.25 * dpi));
+
+                            // 普通血条框绘制：追踪目标用绿色框，其他血条用红色框
+                            foreach (var b in valid)
                             {
-                                // 传奇血条存在时，使用 OCR 追踪伤害数字，避免直接追踪顶部血条导致视角上抬
-                                var damageResult = FindDamageNumber(capture);
-                                if (damageResult.HasValue)
-                                {
-                                    var (dcx, dcy, dtext) = damageResult.Value;
-                                    Logger.LogInformation("伤害数字追踪: 坐标({X},{Y}) 文本:{Text}", dcx, dcy, dtext);
-                                    lastSeenTargetTime = DateTime.UtcNow;
-                                    var offsetX = dcx - preAimX;
-                                    var offsetY = dcy - preAimY;
-                                    Simulation.SendInput.Mouse.MoveMouseBy((int)(offsetX * 0.35 * dpi), (int)(offsetY * 0.25 * dpi));
-                                }
-                            }
-                            else
-                            {
-                                // 有可瞄准的普通血条：更新最后见到目标的时间
-                                lastSeenTargetTime = DateTime.UtcNow;
-
-                                // 选择距离预瞄点(960, 480)最近的血条作为目标
-                                var nearest = valid.OrderBy(b => Math.Abs((b.x + b.width / 2) - preAimX) + Math.Abs((b.y + b.height / 2) - preAimY)).First();
-                                Logger.LogInformation("追踪血条: 裁剪坐标({X},{Y}) 大小({W}×{H})", nearest.x, nearest.y, nearest.width, nearest.height);
-                                // 计算准星到目标中心的偏移量（像素）
-                                var offsetX = (nearest.x + nearest.width / 2) - preAimX;
-                                var offsetY = (nearest.y + nearest.height / 2) - preAimY;
-                                // 以 0.35 系数移动鼠标（平滑跟踪，避免剧烈抖动）
-                                Simulation.SendInput.Mouse.MoveMouseBy((int)(offsetX * 0.35 * dpi), (int)(offsetY * 0.25 * dpi));
-
-                                // 普通血条框绘制：追踪目标用绿色框，其他血条用红色框
-                                foreach (var b in valid)
-                                {
-                                    var rect = new OpenCvSharp.Rect(b.x, b.y, b.width, b.height);
-                                    if (b.x == nearest.x && b.y == nearest.y && b.width == nearest.width && b.height == nearest.height)
-                                        drawList.Add(capture.ToRectDrawable(rect, "target", new System.Drawing.Pen(System.Drawing.Color.LimeGreen, 2)));
-                                    else
-                                        drawList.Add(capture.ToRectDrawable(rect, "blood"));
-                                }
+                                var rect = new OpenCvSharp.Rect(b.x, b.y, b.width, b.height);
+                                if (b.x == nearest.x && b.y == nearest.y && b.width == nearest.width && b.height == nearest.height)
+                                    drawList.Add(capture.ToRectDrawable(rect, "target", new System.Drawing.Pen(System.Drawing.Color.LimeGreen, 2)));
+                                else
+                                    drawList.Add(capture.ToRectDrawable(rect, "blood"));
                             }
                         }
                         else
                         {
-                            // 无可瞄准血条时：先用 OCR 找伤害数字作为备用
+                            // 无血条或存在传奇血条：用 OCR 找伤害数字作为追踪目标
                             var damageResult = FindDamageNumber(capture);
                             if (damageResult.HasValue)
                             {
@@ -1058,9 +1041,9 @@ public class Avatar
                                 var offsetY = dcy - preAimY;
                                 Simulation.SendInput.Mouse.MoveMouseBy((int)(offsetX * 0.35 * dpi), (int)(offsetY * 0.25 * dpi));
                             }
-                            // OCR 无结果时：向右旋转搜索敌人
-                            // 但若存在传奇血条（y 50~96，即屏幕顶部附近的特殊血条），无法定位，不转动
-                            else if (!bars.Any(b => b.y > 50 && b.y < 96))
+
+                            // OCR 无结果时：若不存在传奇血条，向右旋转搜索敌人
+                            if (!damageResult.HasValue && !hasLegendaryBar)
                             {
                                 // 连续超过1秒未找到任何血条，提前退出
                                 if ((DateTime.UtcNow - lastSeenTargetTime).TotalSeconds >= 1)

--- a/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
@@ -1008,7 +1008,7 @@ public class Avatar
 
                             // 选择距离预瞄点(960, 480)最近的血条作为目标
                             var nearest = valid.OrderBy(b => Math.Abs((b.x + b.width / 2) - preAimX) + Math.Abs((b.y + b.height / 2) - preAimY)).First();
-                            Logger.LogDebug("追踪血条: 裁剪坐标({X},{Y}) 大小({W}×{H})", nearest.x, nearest.y, nearest.width, nearest.height);
+                            Logger.LogInformation("追踪血条: 裁剪坐标({X},{Y}) 大小({W}×{H})", nearest.x, nearest.y, nearest.width, nearest.height);
                             // 计算准星到目标中心的偏移量（像素）
                             var offsetX = (nearest.x + nearest.width / 2) - preAimX;
                             var offsetY = (nearest.y + nearest.height / 2) - preAimY;

--- a/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
@@ -1,3 +1,4 @@
+using BetterGenshinImpact.Core.Recognition;
 using BetterGenshinImpact.Core.Recognition.OCR;
 using BetterGenshinImpact.Core.Recognition.OpenCv;
 using BetterGenshinImpact.Core.Script.Dependence;
@@ -976,7 +977,7 @@ public class Avatar
             Simulation.SendInput.SimulateAction(GIActions.NormalAttack, KeyType.KeyDown);
 
             // 连续未找到血条的计时，超过1秒时提前退出
-            var lastSeenBlood = DateTime.UtcNow;
+            var lastSeenTargetTime = DateTime.UtcNow;
             var startTime = DateTime.UtcNow;
             var maxDurationMs = ms;
 
@@ -1002,16 +1003,17 @@ public class Avatar
 
                         if (valid.Count > 0)
                         {
-                            // 有可瞄准的血条：更新最后见到血条的时间
-                            lastSeenBlood = DateTime.UtcNow;
+                            // 有可瞄准的血条：更新最后见到目标的时间
+                            lastSeenTargetTime = DateTime.UtcNow;
 
                             // 选择距离预瞄点(960, 480)最近的血条作为目标
                             var nearest = valid.OrderBy(b => Math.Abs((b.x + b.width / 2) - preAimX) + Math.Abs((b.y + b.height / 2) - preAimY)).First();
+                            Logger.LogDebug("追踪血条: 裁剪坐标({X},{Y}) 大小({W}×{H})", nearest.x, nearest.y, nearest.width, nearest.height);
                             // 计算准星到目标中心的偏移量（像素）
                             var offsetX = (nearest.x + nearest.width / 2) - preAimX;
                             var offsetY = (nearest.y + nearest.height / 2) - preAimY;
-                            // 以 0.25 系数移动鼠标（平滑跟踪，避免剧烈抖动）
-                            Simulation.SendInput.Mouse.MoveMouseBy((int)(offsetX * 0.25 * dpi), (int)(offsetY * 0.25 * dpi));
+                            // 以 0.35 系数移动鼠标（平滑跟踪，避免剧烈抖动）
+                            Simulation.SendInput.Mouse.MoveMouseBy((int)(offsetX * 0.35 * dpi), (int)(offsetY * 0.25 * dpi));
 
                             // 血条框绘制：追踪目标用绿色框，其他血条用红色框
                             foreach (var b in valid)
@@ -1025,14 +1027,25 @@ public class Avatar
                         }
                         else
                         {
-                            // 无可瞄准血条时：向右旋转搜索敌人
+                            // 无可瞄准血条时：先用 OCR 找伤害数字作为备用
+                            var damageResult = FindDamageNumber(capture);
+                            if (damageResult.HasValue)
+                            {
+                                var (dcx, dcy, dtext) = damageResult.Value;
+                                Logger.LogDebug("伤害数字追踪: 坐标({X},{Y}) 文本:{Text}", dcx, dcy, dtext);
+                                lastSeenTargetTime = DateTime.UtcNow;
+                                var offsetX = dcx - preAimX;
+                                var offsetY = dcy - preAimY;
+                                Simulation.SendInput.Mouse.MoveMouseBy((int)(offsetX * 0.35 * dpi), (int)(offsetY * 0.25 * dpi));
+                            }
+                            // OCR 无结果时：向右旋转搜索敌人
                             // 但若存在传奇血条（y 50~96，即屏幕顶部附近的特殊血条），无法定位，不转动
-                            if (!bars.Any(b => b.y > 50 && b.y < 96))
+                            else if (!bars.Any(b => b.y > 50 && b.y < 96))
                             {
                                 // 连续超过1秒未找到任何血条，提前退出
-                                if ((DateTime.UtcNow - lastSeenBlood).TotalSeconds >= 1)
+                                if ((DateTime.UtcNow - lastSeenTargetTime).TotalSeconds >= 1)
                                 {
-                                    Logger.LogInformation("桑多涅重击特化：超过1秒未找到血条，提前退出");
+                                    Logger.LogInformation("桑多涅重击特化：超过1秒未找到目标，提前退出");
                                     View.Drawable.VisionContext.Instance().DrawContent.PutOrRemoveRectList("SandroneBloodBars", drawList);
                                     break;
                                 }
@@ -1292,5 +1305,55 @@ public class Avatar
         }
 
         return results;
+    }
+
+    /// <summary>
+    /// OCR 寻找伤害数字/反应文字作为追踪目标（备用寻敌）。
+    /// 在 450,240-1600,900 区域 OCR，过滤条件：
+    ///   - 有效项1：排除首位 '+'，去除非数字后纯数字 ≥4 位
+    ///   - 有效项2：文本包含反应关键词（免疫/蒸发/感电/结晶/扩散/绽放/冻结/超载/融化/燃烧/超导/激化），跳过数字过滤
+    /// 按面积加权得到中心坐标，返回离加权中心最近的有效项。
+    /// </summary>
+    public static (int centerX, int centerY, string text)? FindDamageNumber(ImageRegion? existingCapture = null)
+    {
+        using var ra = existingCapture ?? CaptureToRectArea();
+        var ocrResults = ra.FindMulti(RecognitionObject.Ocr(450, 240, 1150, 660));
+
+        string[] reactionKeywords = ["免疫", "蒸发", "感电", "结晶", "扩散", "绽放", "冻结", "超载", "融化", "燃烧", "超导", "激化"];
+        var validItems = new List<(int cx, int cy, int area, string text)>();
+
+        foreach (var r in ocrResults)
+        {
+            var text = r.Text?.Trim();
+            if (string.IsNullOrEmpty(text)) continue;
+
+            // 有效项2：反应关键词（跳过所有过滤）
+            if (reactionKeywords.Any(k => text.Contains(k)))
+            {
+                validItems.Add((r.X + r.Width / 2, r.Y + r.Height / 2, r.Width * r.Height, text));
+                continue;
+            }
+
+            // 有效项1：排除 '+' 开头
+            if (text[0] == '+') continue;
+
+            // 去除非数字，纯数字 ≥4 位
+            var digits = new string(text.Where(char.IsDigit).ToArray());
+            if (digits.Length >= 4)
+            {
+                validItems.Add((r.X + r.Width / 2, r.Y + r.Height / 2, r.Width * r.Height, text));
+            }
+        }
+
+        if (validItems.Count == 0) return null;
+
+        int totalArea = validItems.Sum(i => i.area);
+        if (totalArea == 0) return null;
+
+        double avgX = (double)validItems.Sum(i => i.cx * i.area) / totalArea;
+        double avgY = (double)validItems.Sum(i => i.cy * i.area) / totalArea;
+
+        var closest = validItems.OrderBy(i => Math.Abs(i.cx - avgX) + Math.Abs(i.cy - avgY)).First();
+        return (closest.cx, closest.cy, closest.text);
     }
 }

--- a/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
@@ -10,6 +10,7 @@ using BetterGenshinImpact.Helpers;
 using Microsoft.Extensions.Logging;
 using OpenCvSharp;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -958,6 +959,57 @@ public class Avatar
 
             Simulation.SendInput.SimulateAction(GIActions.NormalAttack, KeyType.KeyUp);
         }
+        else if (Name == "桑多涅")
+        {
+            var dpi = TaskContext.Instance().DpiScale;
+            const int preAimX = 960;
+            const int preAimY = 480;
+            const int frameIntervalMs = 50;
+
+            Simulation.SendInput.SimulateAction(GIActions.NormalAttack, KeyType.KeyDown);
+            while (!Ct.IsCancellationRequested && ms >= 0)
+            {
+                var bars = FindBloodBars();
+                var valid = bars.Where(b => b.x > 200).ToList();
+
+                using (var drawRegion = CaptureToRectArea())
+                {
+                    var drawList = new System.Collections.Generic.List<View.Drawable.RectDrawable>
+                    {
+                        drawRegion.ToRectDrawable(new OpenCvSharp.Rect(preAimX - 25, 540 - 25, 50, 50), "preAim", new System.Drawing.Pen(System.Drawing.Color.Red, 2))
+                    };
+
+                    if (valid.Count > 0)
+                    {
+                        var nearest = valid.OrderBy(b => Math.Abs((b.x + b.width / 2) - preAimX) + Math.Abs((b.y + b.height / 2) - preAimY)).First();
+                        var offsetX = (nearest.x + nearest.width / 2) - preAimX;
+                        var offsetY = (nearest.y + nearest.height / 2) - preAimY;
+                        Simulation.SendInput.Mouse.MoveMouseBy((int)(offsetX * 0.5 * dpi), (int)(offsetY * 0.5 * dpi));
+
+                        foreach (var b in valid)
+                        {
+                            var rect = new OpenCvSharp.Rect(b.x, b.y, b.width, b.height);
+                            if (b.x == nearest.x && b.y == nearest.y && b.width == nearest.width && b.height == nearest.height)
+                                drawList.Add(drawRegion.ToRectDrawable(rect, "target", new System.Drawing.Pen(System.Drawing.Color.LimeGreen, 2)));
+                            else
+                                drawList.Add(drawRegion.ToRectDrawable(rect, "blood"));
+                        }
+                    }
+                    else
+                    {
+                        Simulation.SendInput.Mouse.MoveMouseBy((int)(500 * dpi), 0);
+                    }
+
+                    View.Drawable.VisionContext.Instance().DrawContent.PutOrRemoveRectList("SandroneBloodBars", drawList);
+                }
+
+                Sleep(frameIntervalMs);
+                ms -= frameIntervalMs;
+            }
+
+            View.Drawable.VisionContext.Instance().DrawContent.RemoveRect("SandroneBloodBars");
+            Simulation.SendInput.SimulateAction(GIActions.NormalAttack, KeyType.KeyUp);
+        }
         else
         {
             Simulation.SendInput.SimulateAction(GIActions.NormalAttack, KeyType.KeyDown);
@@ -1158,5 +1210,38 @@ public class Avatar
         }
 
         return null;
+    }
+
+    public static List<(int x, int y, int width, int height)> FindBloodBars()
+    {
+        var results = new List<(int x, int y, int width, int height)>();
+
+        using var image = CaptureToRectArea();
+        var bloodLower = new OpenCvSharp.Scalar(255, 90, 90); // BGR 红色
+
+        using Mat mask = Core.Recognition.OpenCv.OpenCvCommonHelper.Threshold(
+            image.DeriveCrop(0, 0, 1500, 900).SrcMat, bloodLower);
+
+        using Mat labels = new Mat();
+        using Mat stats = new Mat();
+        using Mat centroids = new Mat();
+
+        int numLabels = Cv2.ConnectedComponentsWithStats(
+            mask, labels, stats, centroids,
+            connectivity: PixelConnectivity.Connectivity4, ltype: MatType.CV_32S);
+
+        for (int i = 1; i < numLabels; i++)
+        {
+            using Mat row = stats.Row(i);
+            if (row.GetArray(out int[] arr))
+            {
+                int x = arr[0], y = arr[1], width = arr[2], height = arr[3];
+                if (y < 50)
+                    continue;
+                results.Add((x, y, width, height));
+            }
+        }
+
+        return results;
     }
 }

--- a/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
@@ -1315,7 +1315,7 @@ public class Avatar
     /// 在 450,240-1600,900 区域 OCR，过滤条件：
     ///   - 有效项1：排除首位 '+'，去除非数字后纯数字 ≥4 位
     ///   - 有效项2：文本包含反应关键词（免疫/蒸发/感电/结晶/扩散/绽放/冻结/超载/融化/燃烧/超导/激化），跳过数字过滤
-    /// 按面积加权得到中心坐标，返回离加权中心最近的有效项。
+    /// 按 h²×文本字数 加权得到中心坐标，返回离加权中心最近的有效项。
     /// </summary>
     public static (int centerX, int centerY, string text)? FindDamageNumber(ImageRegion? existingCapture = null)
     {
@@ -1333,7 +1333,7 @@ public class Avatar
             // 有效项2：反应关键词（跳过所有过滤）
             if (reactionKeywords.Any(k => text.Contains(k)))
             {
-                validItems.Add((r.X + r.Width / 2, r.Y + r.Height / 2, r.Width * r.Height, text));
+                validItems.Add((r.X + r.Width / 2, r.Y + r.Height / 2, r.Height * r.Height * text.Length, text));
                 continue;
             }
 
@@ -1344,7 +1344,7 @@ public class Avatar
             var digits = new string(text.Where(char.IsDigit).ToArray());
             if (digits.Length >= 4)
             {
-                validItems.Add((r.X + r.Width / 2, r.Y + r.Height / 2, r.Width * r.Height, text));
+                validItems.Add((r.X + r.Width / 2, r.Y + r.Height / 2, r.Height * r.Height * text.Length, text));
             }
         }
 


### PR DESCRIPTION
基于血条位置识别进行锁头（bushi）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 优化角色“桑多涅”的重击战斗流程：可自动识别敌方血条位置进行平滑瞄准与持续跟踪；并对特定血条类型进行区分以提升命中稳定性。
  - 当未能锁定有效血条时，会改为识别画面中的伤害/反应文字（OCR）作为追踪目标并继续调整。
  - 支持随时取消中断；退出后自动松开重击按键。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->