### PR TITLE
fix: JSON 战斗策略 morePriorities 执行时 count 条件恒为 true

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoFight/AutoFightJsonTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/AutoFightJsonTask.cs
@@ -415,7 +415,7 @@ public class AutoFightJsonTask : ISoloTask
                                 }
                             }
 
-                            evaluator.UpdateLastExecTime(prioritizedAction.Priority);
+                            evaluator.UpdateLastExecTime(action.Index);
                             lastExecutedAction = action;
                             anyExecuted = true;
                             lastFightName = action.Character ?? "";


### PR DESCRIPTION
UpdateLastExecTime 误传了 prioritizedAction.Priority（排序优先级） 而非 action.Index（动作索引），导致 morePriorities 条目触发时
_execHistory 记录的是 Priority 而非 Index，count(index, ...) 条件 始终查到 0，条件恒为 true。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修正自动战斗动作执行时间的记录方式，确保冷却与频率限制条件基于正确的动作进行判断。
  * 改善后续动作可执行时间的判定，避免因动作标识对应错误导致条件判断异常。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->