### PR TITLE
fix: 查找和关闭游戏进程时按SessionId过滤，避免多用户串扰

### DIFF
--- a/BetterGenshinImpact/GameTask/SystemControl.cs
+++ b/BetterGenshinImpact/GameTask/SystemControl.cs
@@ -1,5 +1,6 @@
 using BetterGenshinImpact.View.Windows;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -105,12 +106,21 @@ public class SystemControl
         var currentSessionId = Process.GetCurrentProcess().SessionId;
         foreach (var name in names)
         {
-            var pros = Process.GetProcessesByName(name)
-                .Where(p => p.SessionId == currentSessionId)
-                .ToArray();
-            if (pros.Length is not 0)
+            foreach (var p in Process.GetProcessesByName(name))
             {
-                return pros[0].MainWindowHandle;
+                try
+                {
+                    if (p.SessionId == currentSessionId)
+                        return p.MainWindowHandle;
+                }
+                catch (InvalidOperationException)
+                {
+                    // 进程已退出，跳过
+                }
+                finally
+                {
+                    p.Dispose();
+                }
             }
         }
 
@@ -329,15 +339,29 @@ public class SystemControl
         {
             var currentSessionId = Process.GetCurrentProcess().SessionId;
             var processNames = TaskContext.Instance().GetGenshinGameProcessNameList();
-            var processes = processNames
-                .SelectMany(n => Process.GetProcessesByName(n).Where(p => p.SessionId == currentSessionId))
-                .GroupBy(p => p.Id)
-                .Select(g => g.First())
-                .ToArray();
-
-            if (processes.Length > 0)
+            var processes = new List<Process>();
+            foreach (var name in processNames)
             {
-                foreach (var process in processes)
+                foreach (var p in Process.GetProcessesByName(name))
+                {
+                    try
+                    {
+                        if (p.SessionId == currentSessionId)
+                            processes.Add(p);
+                        else
+                            p.Dispose();
+                    }
+                    catch (InvalidOperationException)
+                    {
+                        p.Dispose();
+                    }
+                }
+            }
+            var targets = processes.GroupBy(p => p.Id).Select(g => g.First()).ToArray();
+
+            if (targets.Length > 0)
+            {
+                foreach (var process in targets)
                 {
                     try
                     {

--- a/BetterGenshinImpact/GameTask/SystemControl.cs
+++ b/BetterGenshinImpact/GameTask/SystemControl.cs
@@ -102,9 +102,12 @@ public class SystemControl
 
     public static nint FindHandleByProcessName(params string[] names)
     {
+        var currentSessionId = Process.GetCurrentProcess().SessionId;
         foreach (var name in names)
         {
-            var pros = Process.GetProcessesByName(name);
+            var pros = Process.GetProcessesByName(name)
+                .Where(p => p.SessionId == currentSessionId)
+                .ToArray();
             if (pros.Length is not 0)
             {
                 return pros[0].MainWindowHandle;
@@ -324,9 +327,10 @@ public class SystemControl
     {
         try
         {
+            var currentSessionId = Process.GetCurrentProcess().SessionId;
             var processNames = TaskContext.Instance().GetGenshinGameProcessNameList();
             var processes = processNames
-                .SelectMany(Process.GetProcessesByName)
+                .SelectMany(n => Process.GetProcessesByName(n).Where(p => p.SessionId == currentSessionId))
                 .GroupBy(p => p.Id)
                 .Select(g => g.First())
                 .ToArray();


### PR DESCRIPTION
多用户场景下需要按当前用户过滤

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 优化游戏进程识别与关闭流程：仅匹配当前会话中的同名进程，避免误识别或误关闭其他会话的实例。
  * 对已退出或不可访问的进程进行跳过处理，降低异常中断风险。
  * 关闭过程中加强资源释放与收尾，提升整体稳定性与可靠性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->