### PR TITLE
feat: 排版修复、边距统一与滚动交互优化

### DIFF
--- a/BetterGenshinImpact/App.xaml
+++ b/BetterGenshinImpact/App.xaml
@@ -1,4 +1,4 @@
-﻿<Application x:Class="BetterGenshinImpact.App"
+<Application x:Class="BetterGenshinImpact.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:behavior="clr-namespace:BetterGenshinImpact.View.Behavior"
@@ -15,8 +15,15 @@
                 <ResourceDictionary Source="/View/Controls/Drawer/DrawerStyles.xaml" />
             </ResourceDictionary.MergedDictionaries>
 
+            <!-- ===== 字体 ===== -->
             <FontFamily x:Key="TextThemeFontFamily">/Resources/Fonts/MiSans-Regular.ttf#MiSans</FontFamily>
             <FontFamily x:Key="DigitalThemeFontFamily">/Resources/Fonts/deluge-led.ttf#Deluge LED</FontFamily>
+
+            <!-- ===== 设计令牌 ===== -->
+            <CornerRadius x:Key="ControlCornerRadius">6</CornerRadius>
+            <Thickness x:Key="PagePadding">48,20,48,28</Thickness>
+
+            <!-- ===== 全局 Converter ===== -->
             <bgivc:DomainNameToCascadingItemConverter x:Key="DomainNameConverter" />
             <bgivc:AutoBossNameToCascadingItemConverter x:Key="AutoBossNameConverter" />
             <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
@@ -29,6 +36,8 @@
             <bgivc:StringToColorConverter x:Key="StringToColorConverter" />
             <bgivc:TrConverter x:Key="TrConverter" />
             <bgivc:AdaptiveUniformGridColumnsConverter x:Key="AdaptiveUniformGridColumnsConverter" />
+
+            <!-- ===== 全局 TextBox 安全剪贴板 ===== -->
             <Style BasedOn="{StaticResource DefaultTextBoxStyle}" TargetType="{x:Type TextBox}">
                 <Setter Property="behavior:ClipboardInterceptor.EnableSafeClipboard" Value="True" />
             </Style>

--- a/BetterGenshinImpact/View/MainWindow.xaml.cs
+++ b/BetterGenshinImpact/View/MainWindow.xaml.cs
@@ -3,7 +3,10 @@ using BetterGenshinImpact.ViewModel;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Threading;
 using BetterGenshinImpact.GameTask;
 using BetterGenshinImpact.Helpers.Ui;
 using Wpf.Ui;
@@ -16,6 +19,20 @@ namespace BetterGenshinImpact.View;
 public partial class MainWindow : FluentWindow, INavigationWindow
 {
     private readonly ILogger<MainWindow> _logger = App.GetLogger<MainWindow>();
+    private ScrollViewer? _currentScrollViewer;
+    private double _targetOffset;
+    private double _inputVelocity;
+    private double _lastInputTime;
+    private bool _isContinuousInput;
+    private bool _isInertiaActive;
+    private bool _isRenderingSubscribed;
+    private DateTime _lastFrameTime = DateTime.Now;
+    private readonly double _continuousLerpFactor = 0.35;
+    private readonly double _discreteLerpFactor = 0.85;
+    private readonly double _scrollSensitivity = 0.27;
+    private readonly double _inertiaDecay = 0.94;
+    private readonly double _minVelocity = 0.3;
+    private const double TargetFps = 60.0;
 
     public MainWindowViewModel ViewModel { get; }
 
@@ -32,7 +49,155 @@ public partial class MainWindow : FluentWindow, INavigationWindow
 
         Application.Current.MainWindow = this;
 
+        AddHandler(PreviewMouseWheelEvent, new MouseWheelEventHandler(OnGlobalPreviewMouseWheel), true);
+
         Loaded += (s, e) => Activate();
+    }
+
+    private void OnGlobalPreviewMouseWheel(object sender, MouseWheelEventArgs e)
+    {
+        var scrollViewer = FindScrollViewerUnderMouse(e);
+        if (scrollViewer == null)
+            return;
+
+        e.Handled = true;
+
+        if (_currentScrollViewer != scrollViewer)
+        {
+            _currentScrollViewer = scrollViewer;
+            scrollViewer.CanContentScroll = false;
+            _targetOffset = scrollViewer.VerticalOffset;
+        }
+
+        double now = Environment.TickCount;
+
+        double delta = e.Delta;
+        double scrollAmount = delta * _scrollSensitivity;
+
+        _targetOffset -= scrollAmount;
+        _targetOffset = Math.Max(0, Math.Min(_targetOffset, scrollViewer.ScrollableHeight));
+
+        // 鼠标滚轮 delta 固定为 ±120，触控板 delta 小且变化（通常 < 50）
+        bool isMouseWheel = Math.Abs(delta) >= 100;
+
+        if (!isMouseWheel)
+        {
+            // 触控板：累积速度用于后续惯性
+            _isContinuousInput = true;
+            _inputVelocity = -scrollAmount * 0.35;
+        }
+        else
+        {
+            // 鼠标滚轮：目标位移已在 _targetOffset 中，无需惯性
+            _isContinuousInput = false;
+            _inputVelocity = 0;
+        }
+        _isInertiaActive = false;
+        _lastInputTime = now;
+
+        // 按需订阅：有滚动活动才监听渲染帧
+        if (!_isRenderingSubscribed)
+        {
+            _isRenderingSubscribed = true;
+            CompositionTarget.Rendering += OnCompositionTargetRendering;
+        }
+    }
+
+    private ScrollViewer? FindScrollViewerUnderMouse(MouseWheelEventArgs e)
+    {
+        Point mousePos = e.GetPosition(this);
+        HitTestResult result = VisualTreeHelper.HitTest(this, mousePos);
+
+        if (result != null && result.VisualHit != null)
+        {
+            DependencyObject current = result.VisualHit;
+            while (current != null)
+            {
+                if (current is ScrollViewer scrollViewer && scrollViewer.ScrollableHeight > 0)
+                {
+                    return scrollViewer;
+                }
+                current = VisualTreeHelper.GetParent(current);
+            }
+        }
+
+        return FindVisualChild<ScrollViewer>(RootNavigation);
+    }
+
+    private void OnCompositionTargetRendering(object? sender, EventArgs e)
+    {
+        if (_currentScrollViewer == null)
+            return;
+
+        double current = _currentScrollViewer.VerticalOffset;
+        double diff = _targetOffset - current;
+
+        if (Math.Abs(diff) < 0.1 && Math.Abs(_inputVelocity) < _minVelocity)
+        {
+            // 滚动结束，取消渲染订阅
+            if (_isRenderingSubscribed)
+            {
+                _isRenderingSubscribed = false;
+                CompositionTarget.Rendering -= OnCompositionTargetRendering;
+            }
+            return;
+        }
+
+        double deltaTime = (DateTime.Now - _lastFrameTime).TotalSeconds;
+        _lastFrameTime = DateTime.Now;
+        deltaTime = Math.Min(deltaTime, 0.1);
+
+        double dtScale = deltaTime * TargetFps;
+        double effectiveLerp = _isContinuousInput ? _continuousLerpFactor : _discreteLerpFactor;
+        double normalizedLerp = 1.0 - Math.Pow(1.0 - effectiveLerp, dtScale);
+        double normalizedDecay = Math.Pow(_inertiaDecay, dtScale);
+
+        double now = Environment.TickCount;
+        double timeSinceLastInput = now - _lastInputTime;
+
+        if (timeSinceLastInput > 80 && Math.Abs(diff) < 1.0)
+        {
+            _isInertiaActive = true;
+        }
+
+        if (_isInertiaActive)
+        {
+            if (Math.Abs(_inputVelocity) > _minVelocity)
+            {
+                _inputVelocity *= normalizedDecay;
+                _targetOffset += _inputVelocity;
+                _targetOffset = Math.Max(0, Math.Min(_targetOffset, _currentScrollViewer.ScrollableHeight));
+            }
+            else
+            {
+                _isInertiaActive = false;
+            }
+        }
+
+        diff = _targetOffset - current;
+        if (Math.Abs(diff) > 0.1)
+        {
+            double newPosition = current + diff * normalizedLerp;
+            _currentScrollViewer.ScrollToVerticalOffset(newPosition);
+        }
+    }
+
+    private T? FindVisualChild<T>(DependencyObject parent) where T : DependencyObject
+    {
+        for (int i = 0; i < VisualTreeHelper.GetChildrenCount(parent); i++)
+        {
+            var child = VisualTreeHelper.GetChild(parent, i);
+            if (child is T typedChild)
+            {
+                return typedChild;
+            }
+            var foundChild = FindVisualChild<T>(child);
+            if (foundChild != null)
+            {
+                return foundChild;
+            }
+        }
+        return null;
     }
 
     protected override void OnSourceInitialized(EventArgs e)
@@ -44,6 +209,8 @@ public partial class MainWindow : FluentWindow, INavigationWindow
     protected override void OnClosed(EventArgs e)
     {
         _logger.LogDebug("主窗体退出");
+        CompositionTarget.Rendering -= OnCompositionTargetRendering;
+        RemoveHandler(PreviewMouseWheelEvent, new MouseWheelEventHandler(OnGlobalPreviewMouseWheel));
         base.OnClosed(e);
         App.GetService<NotifyIconViewModel>()?.Exit();
     }

--- a/BetterGenshinImpact/View/MainWindow.xaml.cs
+++ b/BetterGenshinImpact/View/MainWindow.xaml.cs
@@ -98,6 +98,7 @@ public partial class MainWindow : FluentWindow, INavigationWindow
         // 按需订阅：有滚动活动才监听渲染帧
         if (!_isRenderingSubscribed)
         {
+            _lastFrameTime = DateTime.Now;
             _isRenderingSubscribed = true;
             CompositionTarget.Rendering += OnCompositionTargetRendering;
         }
@@ -165,7 +166,7 @@ public partial class MainWindow : FluentWindow, INavigationWindow
             if (Math.Abs(_inputVelocity) > _minVelocity)
             {
                 _inputVelocity *= normalizedDecay;
-                _targetOffset += _inputVelocity;
+                _targetOffset += _inputVelocity * dtScale;
                 _targetOffset = Math.Max(0, Math.Min(_targetOffset, _currentScrollViewer.ScrollableHeight));
             }
             else

--- a/BetterGenshinImpact/View/Pages/CommonSettingsPage.xaml
+++ b/BetterGenshinImpact/View/Pages/CommonSettingsPage.xaml
@@ -17,10 +17,11 @@
       Foreground="{DynamicResource TextFillColorPrimaryBrush}"
       mc:Ignorable="d">
 
-    <StackPanel Margin="42,16,42,12">
-        <ui:TextBlock Margin="0,0,0,8"
-                      FontTypography="BodyStrong"
-                      Text="软件设置" />
+    <StackPanel Margin="{StaticResource PagePadding}">
+        <TextBlock Margin="0,0,0,12"
+                   FontSize="18"
+                   FontWeight="SemiBold"
+                   Text="软件设置" />
         
                 <ui:CardControl Margin="0,0,0,12" Icon="{ui:SymbolIcon Globe24}">
             <ui:CardControl.Header>

--- a/BetterGenshinImpact/View/Pages/HotkeyPage.xaml
+++ b/BetterGenshinImpact/View/Pages/HotkeyPage.xaml
@@ -18,7 +18,7 @@
              Foreground="{DynamicResource TextFillColorPrimaryBrush}"
              mc:Ignorable="d">
 
-    <Grid Margin="42,16,42,12">
+    <Grid Margin="{StaticResource PagePadding}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
@@ -33,34 +33,6 @@
                       Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
                       Text="全局热键：只支持组合键和功能键，软件启动直接生效。键鼠监听：支持任意键盘单键、鼠标侧键，功能启动后才生效（推荐）。点击类型按钮可以切换快捷键类型。其中存在长按需求的功能不能使用全局热键。"
                       TextWrapping="Wrap" />
-
-        <!--<ItemsControl Grid.Row="2" ItemsSource="{Binding HotKeySettingModels}">
-            <ItemsControl.ItemTemplate>
-                <DataTemplate DataType="{x:Type model:HotKeySettingModel}">
-                    <Grid Margin="0,8">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="100" />
-                            <ColumnDefinition Width="180" />
-                        </Grid.ColumnDefinitions>
-                        <ui:TextBlock Grid.Column="0"
-                                      VerticalAlignment="Center"
-                                      Text="{Binding FunctionName}" />
-                        <ui:Button Grid.Column="1"
-                                   Margin="0,0,8,0"
-                                   HorizontalAlignment="Right"
-                                   Command="{Binding SwitchHotKeyTypeCommand}"
-                                   Content="{Binding HotKeyTypeName, Mode=OneWay}"
-                                   IsEnabled="{Binding SwitchHotkeyTypeEnabled, Mode=OneWay}" />
-                        <hotKey:HotKeyTextBox Grid.Column="2"
-                                              HotKeyTypeName="{Binding HotKeyTypeName, Mode=OneWay}"
-                                              Hotkey="{Binding HotKey}"
-                                              Style="{StaticResource DefaultTextBoxStyle}"
-                                              TextAlignment="Center" />
-                    </Grid>
-                </DataTemplate>
-            </ItemsControl.ItemTemplate>
-        </ItemsControl>-->
 
         <ui:Border Grid.Row="2"
                    Background="{DynamicResource CardBackground}"

--- a/BetterGenshinImpact/View/Pages/JsListPage.xaml
+++ b/BetterGenshinImpact/View/Pages/JsListPage.xaml
@@ -26,7 +26,7 @@
     </UserControl.Resources>
 
     <Grid>
-        <Grid Margin="42,16,42,12">
+        <Grid Margin="{StaticResource PagePadding}">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />

--- a/BetterGenshinImpact/View/Pages/KeyBindingsSettingsPage.xaml
+++ b/BetterGenshinImpact/View/Pages/KeyBindingsSettingsPage.xaml
@@ -18,7 +18,7 @@
              Foreground="{DynamicResource TextFillColorPrimaryBrush}"
              mc:Ignorable="d">
 
-    <Grid Margin="42,16,42,12">
+    <Grid Margin="{StaticResource PagePadding}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />

--- a/BetterGenshinImpact/View/Pages/KeyMouseRecordPage.xaml
+++ b/BetterGenshinImpact/View/Pages/KeyMouseRecordPage.xaml
@@ -22,7 +22,7 @@
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </UserControl.Resources>
-    <Grid Margin="42,16,42,12">
+    <Grid Margin="{StaticResource PagePadding}">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />

--- a/BetterGenshinImpact/View/Pages/MacroSettingsPage.xaml
+++ b/BetterGenshinImpact/View/Pages/MacroSettingsPage.xaml
@@ -15,7 +15,7 @@
       FontFamily="{StaticResource TextThemeFontFamily}"
       Foreground="{DynamicResource TextFillColorPrimaryBrush}"
       mc:Ignorable="d">
-    <StackPanel Margin="42,16,42,12">
+    <StackPanel Margin="{StaticResource PagePadding}">
         <ui:TextBlock Margin="0,0,0,8"
                       FontTypography="BodyStrong"
                       Text="辅助操控设置" />

--- a/BetterGenshinImpact/View/Pages/MapPathingPage.xaml
+++ b/BetterGenshinImpact/View/Pages/MapPathingPage.xaml
@@ -27,7 +27,7 @@
         </ResourceDictionary>
     </UserControl.Resources>
     <Grid>
-        <Grid Margin="42,16,42,12">
+        <Grid Margin="{StaticResource PagePadding}">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />

--- a/BetterGenshinImpact/View/Pages/NotificationSettingsPage.xaml
+++ b/BetterGenshinImpact/View/Pages/NotificationSettingsPage.xaml
@@ -15,7 +15,7 @@
       Foreground="{DynamicResource TextFillColorPrimaryBrush}"
       mc:Ignorable="d">
 
-    <StackPanel Margin="42,16,42,12">
+    <StackPanel Margin="{StaticResource PagePadding}">
         <ui:TextBlock Margin="0,0,0,8"
                       FontTypography="BodyStrong"
                       Text="通知设置" />

--- a/BetterGenshinImpact/View/Pages/TaskSettingsPage.xaml
+++ b/BetterGenshinImpact/View/Pages/TaskSettingsPage.xaml
@@ -1090,7 +1090,7 @@
                                 Orientation="Horizontal"
                                 VerticalAlignment="Center"
                                 Margin="0,0,38,0">
-                        <ui:ToggleSwitch IsEnabled="{Binding Config.AutoFightConfig.KazuhaPickupEnabled, Mode=TwoWay}"
+                        <ui:ToggleSwitch IsEnabled="{Binding Config.AutoFightConfig.KazuhaPickupEnabled}"
                                          IsChecked="{Binding Config.AutoFightConfig.QinDoublePickUp, Mode=TwoWay}" />
                         <ui:TextBlock Margin="4,0,0,0"
                                       VerticalAlignment="Center"
@@ -2867,7 +2867,7 @@
                                 Orientation="Horizontal"
                                 VerticalAlignment="Center"
                                 Margin="0,0,38,0">
-                        <ui:ToggleSwitch IsEnabled="{Binding Config.AutoLeyLineOutcropConfig.FightConfig.KazuhaPickupEnabled, Mode=TwoWay}"
+                        <ui:ToggleSwitch IsEnabled="{Binding Config.AutoLeyLineOutcropConfig.FightConfig.KazuhaPickupEnabled}"
                                          IsChecked="{Binding Config.AutoLeyLineOutcropConfig.FightConfig.QinDoublePickUp, Mode=TwoWay}" />
                         <ui:TextBlock Margin="4,0,0,0"
                                       VerticalAlignment="Center"

--- a/BetterGenshinImpact/View/Pages/TaskSettingsPage.xaml
+++ b/BetterGenshinImpact/View/Pages/TaskSettingsPage.xaml
@@ -23,10 +23,11 @@
       Foreground="{DynamicResource TextFillColorPrimaryBrush}"
       mc:Ignorable="d">
 
-    <StackPanel Margin="42,16,42,12">
-        <ui:TextBlock Margin="0,0,0,8"
-                      FontTypography="BodyStrong"
-                      Text="独立任务设置" />
+    <StackPanel Margin="{StaticResource PagePadding}">
+        <TextBlock Margin="0,0,0,12"
+                   FontSize="18"
+                   FontWeight="SemiBold"
+                   Text="独立任务设置" />
         <!--  ~1~  停止任务  @1@  -->
         <!-- <ui:CardControl Margin="0,0,0,12" Icon="{ui:SymbolIcon DismissCircle24}"> -->
         <!--     <ui:CardControl.Header> -->
@@ -1057,20 +1058,20 @@
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
-                    <ui:TextBlock Grid.Row="0"
-                                  Grid.Column="0"
-                                  FontTypography="Body"
-                                  Text="聚集材料动作"
-                                  TextWrapping="Wrap" />
-                    <ui:TextBlock Grid.Row="0"
-                                  Grid.Column="0"
-                                  Margin="90,0,5,0"
-                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
-                                  FontSize="10"
-                                  FontTypography="Body"
-                                  VerticalAlignment="Bottom"
-                                  Text="(二次拾取：琴首次拾取空,再次拾取。万叶即使刚使用过技能，也会强制再次拾取。)"
-                                  TextWrapping="Wrap" />
+                    <StackPanel Grid.Row="0"
+                                Grid.Column="0"
+                                Orientation="Horizontal">
+                        <ui:TextBlock FontTypography="Body"
+                                      VerticalAlignment="Center"
+                                      Text="聚集材料动作"
+                                      TextWrapping="Wrap" />
+                        <ui:TextBlock Margin="6,0,5,0"
+                                      Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                      FontSize="10"
+                                      VerticalAlignment="Center"
+                                      Text="(二次拾取：琴首次拾取空,再次拾取。万叶即使刚使用过技能，也会强制再次拾取。)"
+                                      TextWrapping="Wrap" />
+                    </StackPanel>
                     
                     <ui:TextBlock Grid.Row="1"
                                   Grid.Column="0"
@@ -1083,23 +1084,22 @@
                                      Margin="0,0,10,0"
                                      IsChecked="{Binding Config.AutoFightConfig.KazuhaPickupEnabled, Mode=TwoWay}" />
                     
-                    <ui:ToggleSwitch Grid.Row="0"
-                                     Grid.RowSpan="2"
-                                     Grid.Column="2"
-                                     Margin="0,0,38,0"
-                                     IsEnabled="{Binding Config.AutoFightConfig.KazuhaPickupEnabled, Mode=TwoWay}"
-                                     IsChecked="{Binding Config.AutoFightConfig.QinDoublePickUp, Mode=TwoWay}" />
-                    <ui:TextBlock Grid.Row="0"
-                                  Grid.RowSpan="2"
-                                  Grid.Column="2"
-                                  HorizontalAlignment="Center"
-                                  VerticalAlignment="Center"
-                                  FontSize="8"
-                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
-                                  Margin="0,0,38,26"
-                                  FontTypography="Body"
-                                  Text="二次拾取"
-                                  TextWrapping="Wrap" />
+                    <StackPanel Grid.Row="0"
+                                Grid.RowSpan="2"
+                                Grid.Column="2"
+                                Orientation="Horizontal"
+                                VerticalAlignment="Center"
+                                Margin="0,0,38,0">
+                        <ui:ToggleSwitch IsEnabled="{Binding Config.AutoFightConfig.KazuhaPickupEnabled, Mode=TwoWay}"
+                                         IsChecked="{Binding Config.AutoFightConfig.QinDoublePickUp, Mode=TwoWay}" />
+                        <ui:TextBlock Margin="4,0,0,0"
+                                      VerticalAlignment="Center"
+                                      FontSize="8"
+                                      Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                      FontTypography="Body"
+                                      Text="二次拾取"
+                                      TextWrapping="Wrap" />
+                    </StackPanel>
                 </Grid>
                 <Separator Margin="-18,0"
                            BorderThickness="0,1,0,0" />
@@ -2835,20 +2835,20 @@
                         <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
-                    <ui:TextBlock Grid.Row="0"
-                                  Grid.Column="0"
-                                  FontTypography="Body"
-                                  Text="聚集材料动作"
-                                  TextWrapping="Wrap" />
-                    <ui:TextBlock Grid.Row="0"
-                                  Grid.Column="0"
-                                  Margin="90,0,5,0"
-                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
-                                  FontSize="10"
-                                  FontTypography="Body"
-                                  VerticalAlignment="Bottom"
-                                  Text="(二次拾取：琴首次拾取空,再次拾取。万叶即使刚使用过技能，也会强制再次拾取。)"
-                                  TextWrapping="Wrap" />
+                    <StackPanel Grid.Row="0"
+                                Grid.Column="0"
+                                Orientation="Horizontal">
+                        <ui:TextBlock FontTypography="Body"
+                                      VerticalAlignment="Center"
+                                      Text="聚集材料动作"
+                                      TextWrapping="Wrap" />
+                        <ui:TextBlock Margin="6,0,5,0"
+                                      Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                      FontSize="10"
+                                      VerticalAlignment="Center"
+                                      Text="(二次拾取：琴首次拾取空,再次拾取。万叶即使刚使用过技能，也会强制再次拾取。)"
+                                      TextWrapping="Wrap" />
+                    </StackPanel>
 
                     <ui:TextBlock Grid.Row="1"
                                   Grid.Column="0"
@@ -2861,23 +2861,22 @@
                                      Margin="0,0,10,0"
                                      IsChecked="{Binding Config.AutoLeyLineOutcropConfig.FightConfig.KazuhaPickupEnabled, Mode=TwoWay}" />
 
-                    <ui:ToggleSwitch Grid.Row="0"
-                                     Grid.RowSpan="2"
-                                     Grid.Column="2"
-                                     Margin="0,0,38,0"
-                                     IsEnabled="{Binding Config.AutoLeyLineOutcropConfig.FightConfig.KazuhaPickupEnabled, Mode=TwoWay}"
-                                     IsChecked="{Binding Config.AutoLeyLineOutcropConfig.FightConfig.QinDoublePickUp, Mode=TwoWay}" />
-                    <ui:TextBlock Grid.Row="0"
-                                  Grid.RowSpan="2"
-                                  Grid.Column="2"
-                                  HorizontalAlignment="Center"
-                                  VerticalAlignment="Center"
-                                  FontSize="8"
-                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
-                                  Margin="0,0,38,26"
-                                  FontTypography="Body"
-                                  Text="二次拾取"
-                                  TextWrapping="Wrap" />
+                    <StackPanel Grid.Row="0"
+                                Grid.RowSpan="2"
+                                Grid.Column="2"
+                                Orientation="Horizontal"
+                                VerticalAlignment="Center"
+                                Margin="0,0,38,0">
+                        <ui:ToggleSwitch IsEnabled="{Binding Config.AutoLeyLineOutcropConfig.FightConfig.KazuhaPickupEnabled, Mode=TwoWay}"
+                                         IsChecked="{Binding Config.AutoLeyLineOutcropConfig.FightConfig.QinDoublePickUp, Mode=TwoWay}" />
+                        <ui:TextBlock Margin="4,0,0,0"
+                                      VerticalAlignment="Center"
+                                      FontSize="8"
+                                      Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                      FontTypography="Body"
+                                      Text="二次拾取"
+                                      TextWrapping="Wrap" />
+                    </StackPanel>
                 </Grid>
                 <Grid Margin="16">
                     <Grid.RowDefinitions>

--- a/BetterGenshinImpact/View/Pages/TriggerSettingsPage.xaml
+++ b/BetterGenshinImpact/View/Pages/TriggerSettingsPage.xaml
@@ -16,11 +16,12 @@
       Foreground="{DynamicResource TextFillColorPrimaryBrush}"
       mc:Ignorable="d">
 
-    <StackPanel Margin="42,16,42,12">
+    <StackPanel Margin="{StaticResource PagePadding}">
 
-        <ui:TextBlock Margin="0,0,0,8"
-                      FontTypography="BodyStrong"
-                      Text="实时触发的自动化任务设置" />
+        <TextBlock Margin="0,0,0,12"
+                   FontSize="18"
+                   FontWeight="SemiBold"
+                   Text="实时触发的自动化任务设置" />
         <ui:CardExpander Margin="0,0,0,12"
                          ContentPadding="0"
                          Icon="{ui:SymbolIcon HandWave24}">

--- a/BetterGenshinImpact/View/Pages/View/HardwareAccelerationView.xaml
+++ b/BetterGenshinImpact/View/Pages/View/HardwareAccelerationView.xaml
@@ -27,7 +27,7 @@
         <ScrollViewer Grid.Row="1"
                       HorizontalScrollBarVisibility="Auto"
                       VerticalScrollBarVisibility="Auto">
-        <StackPanel Width="700" Margin="42,16,42,12">
+        <StackPanel MaxWidth="700" Margin="{StaticResource PagePadding}">
             <!--  推理设备配置  -->
             <ui:CardExpander Margin="0,0,0,12"
                              ContentPadding="0"

--- a/BetterGenshinImpact/View/Pages/View/ScriptGroupConfigView.xaml
+++ b/BetterGenshinImpact/View/Pages/View/ScriptGroupConfigView.xaml
@@ -29,7 +29,7 @@
                     d:DesignHeight="1600"
                     HorizontalScrollBarVisibility="Auto"
                     VerticalScrollBarVisibility="Auto">
-        <StackPanel Height="Auto" Width="700" Margin="42,16,42,12">
+        <StackPanel Height="Auto" MaxWidth="700" Margin="{StaticResource PagePadding}">
 
             <ui:CardExpander Margin="0,0,0,12"
                              ContentPadding="0"


### PR DESCRIPTION
# 原#3287
# 减去了排版的更改
# 主要进行了滚动交互优化以及页边距修复


## 改动概述

### 设计令牌（App.xaml）
- 新增 `PagePadding`（页面统一内边距）和 `ControlCornerRadius`（控件圆角）两个令牌

### 边距统一（11 个页面）
- 统一用 `{StaticResource PagePadding}` 替代硬编码 `Margin="42,16,42,12"`
- 涉及：CommonSettingsPage、JsListPage、KeyBindingsSettingsPage、KeyMouseRecordPage、
  MacroSettingsPage、MapPathingPage、NotificationSettingsPage、TriggerSettingsPage、
  TaskSettingsPage、HardwareAccelerationView、ScriptGroupConfigView

### 排版修复（TaskSettingsPage）
- 「自动战斗 → 聚集材料动作」区域：标题和注释从覆盖式 Grid 改为 StackPanel 水平排列
- 「地脉之花 → 聚集材料动作」区域：同上
- 「二次拾取」开关行：ToggleSwitch 和标签从覆盖式定位改为 StackPanel 自然间距

### 触控板/鼠标滚动优化（MainWindow.xaml.cs）
- 通过 `|delta|` 值区分鼠标滚轮和触控板输入
- 鼠标滚轮：高响应 Lerp（0.85），无惯性，避免"一滚到底"
- 触控板：速度累积 + 惯性衰减 + 帧率归一化（144Hz/60Hz 手感一致）
- Rendering 按需订阅，空闲时无 CPU 占用

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增更平滑的滚动惯性：鼠标滚轮与触控板/连续滚动分别处理，提升滚动体验。
* **界面改进**
  * 引入统一的页面内边距（PagePadding）与控件圆角规范（ControlCornerRadius），多处设置页已同步适配。
  * 统一并优化多个页面的标题样式、间距与布局对齐；任务设置中开关与说明文字的排版更清晰、更易阅读。
  * 页面内容宽度与外边距改为更自适应的显示效果。
* **稳定性**
  * 关闭窗口后停止相关滚动更新，减少残留回调带来的潜在问题。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->