### PR TITLE
fix: handle URL activation in running instance

### DIFF
--- a/BetterGenshinImpact/App.xaml.cs
+++ b/BetterGenshinImpact/App.xaml.cs
@@ -50,7 +50,8 @@ public partial class App : Application
     private static readonly IHost _host = Host.CreateDefaultBuilder()
         .CheckIntegration()
         .UseElevated()
-        .UseSingleInstance("BetterGI")
+        .UseSingleInstance("BetterGI", activationCallback: args =>
+            GetService<HomePageViewModel>()?.HandleActivation(CommandLineOptions.Parse(args)))
         .ConfigureLogging(builder => { builder.ClearProviders(); })
         .ConfigureServices((context, services) =>
             {

--- a/BetterGenshinImpact/Helpers/RuntimeHelper.cs
+++ b/BetterGenshinImpact/Helpers/RuntimeHelper.cs
@@ -3,10 +3,12 @@ using BetterGenshinImpact.GameTask;
 using BetterGenshinImpact.Service;
 using BetterGenshinImpact.View.Windows;
 using Microsoft.Extensions.Hosting;
+using Newtonsoft.Json;
 using System;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
+using System.IO.Pipes;
 using System.Linq;
 using System.Security.Principal;
 using System.Text;
@@ -19,6 +21,9 @@ namespace BetterGenshinImpact.Helpers;
 
 internal static class RuntimeHelper
 {
+    // Keep the named handle alive for the lifetime of the primary process.
+    private static EventWaitHandle? _singleInstanceHandle;
+
     public static bool IsElevated { get; } = GetElevated();
     public static bool IsDebuggerAttached => Debugger.IsAttached;
     public static bool IsDesignMode { get; } = GetDesignMode();
@@ -116,33 +121,57 @@ internal static class RuntimeHelper
         Environment.Exit(exitCode ?? 'r' + 'u' + 'n' + 'a' + 's');
     }
 
-    public static void CheckSingleInstance(string instanceName, Action<bool> callback = null!)
+    public static void CheckSingleInstance(string instanceName, Action<bool> callback = null!, Action<string[]> activationCallback = null!)
     {
-        EventWaitHandle? handle;
+        var pipeName = $"{instanceName}.Activation";
 
         try
         {
-            handle = EventWaitHandle.OpenExisting(instanceName);
-            handle.Set();
+            using EventWaitHandle handle = EventWaitHandle.OpenExisting(instanceName);
+            try
+            {
+                using NamedPipeClientStream pipe = new(".", pipeName, PipeDirection.Out);
+                pipe.Connect(3000);
+                using BinaryWriter writer = new(pipe);
+                writer.Write(JsonConvert.SerializeObject(Environment.GetCommandLineArgs()));
+                writer.Flush();
+            }
+            catch (Exception ex) when (ex is IOException or TimeoutException)
+            {
+                Debug.WriteLine(ex);
+            }
             callback?.Invoke(false);
             Environment.Exit(0xFFFF);
         }
         catch (WaitHandleCannotBeOpenedException)
         {
             callback?.Invoke(true);
-            handle = new EventWaitHandle(false, EventResetMode.AutoReset, instanceName);
+            _singleInstanceHandle = new EventWaitHandle(false, EventResetMode.AutoReset, instanceName);
         }
 
         _ = Task.Factory.StartNew(() =>
         {
-            while (handle.WaitOne())
+            while (true)
             {
-                Application.Current.Dispatcher?.BeginInvoke(() =>
+                try
                 {
-                    Application.Current.MainWindow?.Show();
-                    Application.Current.MainWindow?.Activate();
-                    SystemControl.RestoreWindow(new WindowInteropHelper(Application.Current.MainWindow).Handle);
-                });
+                    using NamedPipeServerStream pipe = new(pipeName, PipeDirection.In);
+                    pipe.WaitForConnection();
+                    using BinaryReader reader = new(pipe);
+                    var args = JsonConvert.DeserializeObject<string[]>(reader.ReadString()) ?? [];
+
+                    Application.Current.Dispatcher?.BeginInvoke(() =>
+                    {
+                        Application.Current.MainWindow?.Show();
+                        Application.Current.MainWindow?.Activate();
+                        SystemControl.RestoreWindow(new WindowInteropHelper(Application.Current.MainWindow).Handle);
+                        activationCallback?.Invoke(args);
+                    });
+                }
+                catch (Exception ex) when (ex is IOException or JsonException)
+                {
+                    // Ignore an interrupted activation and continue listening.
+                }
             }
         }, TaskCreationOptions.LongRunning).ConfigureAwait(false);
     }
@@ -170,11 +199,11 @@ internal static class RuntimeExtension
         return app;
     }
 
-    public static IHostBuilder UseSingleInstance(this IHostBuilder self, string instanceName, Action<bool> callback = null!)
+    public static IHostBuilder UseSingleInstance(this IHostBuilder self, string instanceName, Action<bool> callback = null!, Action<string[]> activationCallback = null!)
     {
         if (!Environment.GetCommandLineArgs().Contains("--no-single"))
         {
-            RuntimeHelper.CheckSingleInstance(instanceName, callback);
+            RuntimeHelper.CheckSingleInstance(instanceName, callback, activationCallback);
         }
         return self;
     }

--- a/BetterGenshinImpact/ViewModel/Pages/HomePageViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/HomePageViewModel.cs
@@ -133,9 +133,14 @@ public partial class HomePageViewModel : ViewModel
 
         _autoRun = false;
 
+        HandleActivation(CommandLineOptions.Instance);
+    }
+
+    public void HandleActivation(CommandLineOptions commandLineOptions)
+    {
         // 只对纯 "start" 参数自动启动截图器
         // startOneDragon、--startGroups 等由各自流程中的 StartGameTask 处理
-        if (CommandLineOptions.Instance.Action == CommandLineAction.Start)
+        if (commandLineOptions.Action == CommandLineAction.Start)
         {
             _ = OnStartTriggerAsync();
         }


### PR DESCRIPTION
## 总结

Fixes #2755

Fixes #300 

当 BetterGI 尚未运行时，使用 `bettergi://start` 可以正常启动程序和截图器。

但当 BetterGI 已经运行时，再次调用 `bettergi://start` 只会唤醒已有窗口，无法启动截图器。

## 已验证

1. 启动 BetterGI，但不启动截图器。
2. 调用 `bettergi://start`。
3. 已运行的 BetterGI 能够收到启动参数。
4. 未运行游戏时，会先启动游戏，再正常启动截图器。

## 注释

和 #3140 的区别在于，当前 PR 只修改了 `bettergi://start`；一条龙，调度组等未进行修改，还是之前的逻辑。这样可以确保修改的最小化以及向后的兼容性

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 优化单实例运行体验：重复启动应用时，将激活请求和命令行参数传递给已运行的实例。
  * 已运行实例可根据收到的启动参数执行相应操作，例如自动开始任务。

* **问题修复**
  * 修复重复启动或通过外部请求激活应用时，启动参数未能正确处理的问题。
  * 改善应用在单实例模式下的激活与响应行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->