### PR TITLE
fix: 转圈异常时先松W再转向，否则按住W转向仍然可能触发转圈

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
@@ -897,8 +897,10 @@ public partial class PathExecutor
 
                 if (consecutiveRotationCountBeyondAngle > 10)
                 {
-                    // 直接站定好转向
+                    // 松W键，站定好转向，转完重新按下W继续走
+                    Simulation.SendInput.SimulateAction(GIActions.MoveForward, KeyType.KeyUp);
                     await WaitUntilRotatedTo(targetOrientation, 2);
+                    Simulation.SendInput.SimulateAction(GIActions.MoveForward, KeyType.KeyDown);
                 }
             }
 


### PR DESCRIPTION
对于相对偶发的场景，暂时松开w以避免转圈应该是可以接受的代价

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 优化自动寻路中的转向处理：角色大幅连续转向时，会暂时停止前进，完成转向后再继续移动。
  * 减少转向过程中移动输入状态异常导致的路径偏移问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->