### PR TITLE
fix(auto-domain): dispose tree detection captures deterministically

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoDomain/AutoDomainTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoDomain/AutoDomainTask.cs
@@ -909,7 +909,18 @@ public class AutoDomainTask : ISoloTask<Dictionary<string, int>>
             var backwardsAndForwardsCount = 0;
             while (!_ct.IsCancellationRequested)
             {
-                var treeRect = DetectTree(CaptureToRectArea());
+                Rect treeRect;
+                // 直接以 ImageRegion 静态类型 Dispose：Region.Dispose() 目前为空实现，using 无法释放截图资源
+                var capture = CaptureToRectArea();
+                try
+                {
+                    treeRect = DetectTree(capture);
+                }
+                finally
+                {
+                    capture.Dispose();
+                }
+
                 if (treeRect != default)
                 {
                     var treeMiddleX = treeRect.X + treeRect.Width / 2;


### PR DESCRIPTION
找树循环中 `DetectTree(CaptureToRectArea())` 的临时 ImageRegion 没有任何引用持有， 每轮约 6.2MB 的 SrcMat 和 DetectTree 内部访问 CacheImage 产生的约 6.2MB Image<Rgb24> 克隆都要等待 GC/终结器回收，导致约 150ms 一轮、每轮约 10MB 的内存增长， BitBlt 后端的 HGlobal 缓冲池也无法复用。

改为紧作用域并在 YOLO 检测完成后立即释放。由于 Region.Dispose() 目前是空实现且 ImageRegion 用 `new` 隐藏而非覆盖，`using var` 会通过接口派发到基类空方法， 因此这里必须以 ImageRegion 静态类型在 finally 中直接调用 Dispose()。

DetectTree 保持借用参数语义，不在方法内部释放；ToRectDrawable 只保留坐标， 不持有 Mat 引用，因此检测返回后立即释放是安全的。

## 背景：这是一个项目级的资源生命周期缺陷

本 PR 是 9 个 PR 修复计划中的第 1 个，只做紧急止血。为了让评审理解为什么这里要用看起来「过时」的 `try/finally` 而不是 `using`，先说明完整问题。

### 大问题

`ImageRegion` 是项目里所有截图和识别的核心载体，它拥有三份重量级资源：原始`SrcMat`、`CacheGreyMat` 灰度 Mat、以及 `CacheImage` 的 ImageSharp `Image<Rgb24>` 克隆。1920×1080×3 输入下，一个完整初始化的 `ImageRegion` 约占 12.4 MB 原生/进程内存。

问题的根子在 Dispose 派发写错了：

- `Region` 实现 `IDisposable`，但 `Region.Dispose()` 是**空方法**；
- `ImageRegion` 用 `public new void Dispose()` **隐藏**基类方法，而不是覆盖虚方法；
- C# 的 `using` 通过 `IDisposable` 接口派发，命中的是空的 `Region.Dispose()`。

结果是：

| 调用形式 | 实际行为 |
|---|---|
| `imageRegion.Dispose()`（静态类型 `ImageRegion`） | 释放 |
| `using var imageRegion = ...` | **不释放** |
| `((IDisposable)imageRegion).Dispose()` | **不释放** |

仓库里约 335 处 `CaptureToRectArea()` 调用分布在约 81 个文件，其中约 215 处写了`using`、约 69 处 `using ... DeriveCrop(...)`——这些看起来完全正确的代码目前**全部没有在释放图像资源**。

后果不只是「慢一点回收」。默认的 BitBlt 截图后端用 `Marshal.AllocHGlobal` 分配缓冲并靠缓冲池复用，`BitBltMat.DisposeUnmanaged()` 执行时才归还缓冲。截图 Mat 不及时 Dispose，下一帧就只能继续新申请约 6MB HGlobal——这直接解释了原生内存的快速增长。

除此之外还有三条独立的泄漏/风险链，都需要后续 PR 处理：

1. **识别内部临时 Mat**：`ImageRegion.Find()` / `FindMulti()` 的二值图、ROI header、颜色范围 OCR 的 Clone 均有未释放路径，部分分支还会用同一个变量覆盖掉前一个 Mat 的唯一引用。这条链不依赖调用方是否正确释放根截图。
2. **所有权逃逸**：`CaptureGameMat()` 返回临时区域的 `SrcMat`、通知服务把`region.CacheImage` 直接赋给 `Screenshot`，都让资源失去可确定的所有者。
3. **借用 ROI 的悬空风险**：`DeriveCrop()` 产生的 ROI 共享父区域像素。对 BitBlt 的外部HGlobal 数据，OpenCV 引用计数为 null，ROI header **不会**阻止父区域把缓冲还池——父先子后释放会让 ROI 读到已被后续帧覆盖的内存，属于比泄漏更严重的数据污染。

因此不能一上来就把 `new Dispose()` 改成 `override`：约 215 个 `using` 会同时开始真正释放，而代码里大量「可能借用、可能自己创建」的混合点（如`using var imageRegion = region ?? CaptureToRectArea();`）会立刻从内存泄漏变成`ObjectDisposedException`。修复必须分阶段：先整理所有权语义（PR2），再启用真实的多态Dispose（PR3），最后逐模块清理。

## 本 PR 的作用：找树循环紧急止血

自动秘境「找树」是当前最容易复现、劣化最快的一条路径：

```csharp
var treeRect = DetectTree(CaptureToRectArea());
```

`CaptureToRectArea()` 每轮创建一个拥有底层 `Mat` 的 `ImageRegion`，`DetectTree()` 又访问 `region.CacheImage` 生成一份完整的 `Image<Rgb24>` 克隆。这个临时 `ImageRegion` 在表达式结束后就没有任何引用持有，没有任何确定性释放。

单轮约 6.2 MB `Mat` + 约 6.2 MB RGB 克隆 ≈ 12.4 MB，尚不含 YOLO 预处理和推理临时内存。循环含 60ms Sleep，叠加 YOLO 耗时约 150ms 一轮——与实测「约每 150ms 增长 10MB」完全吻合。劣化表现为：私有内存和工作集线性增长、BitBlt 缓冲池无法复用、GC 与终结器线程压力升高、YOLO 检测周期越来越长，最终 A/D 移动反馈滞后、过冲、反复横跳。

本 PR 把这一处改为紧作用域，YOLO 检测完成后立即释放，不持有到移动判断和 Sleep 结束。

**为什么是 `try/finally` 而不是 `using`：** 如上所述，在 PR3 修好接口派发之前，`using var capture = CaptureToRectArea();` 命中的是空的 `Region.Dispose()`，等于没改。必须以 `ImageRegion` 静态类型在 `finally` 中直接调用 `Dispose()` 才能真正命中被隐藏的`ImageRegion.Dispose()`。PR3 合并后，这里可以机械地简化回 `using`。

## 修改范围

仅 `BetterGenshinImpact/GameTask/AutoDomain/AutoDomainTask.cs` 一处，12 行新增 / 1 行删除。

- `DetectTree(ImageRegion)` 保持借用参数语义，不在方法内部 Dispose；
- 已确认 `Region.ToRectDrawable()` 只做坐标转换、不持有 `Mat` 引用，因此把检测框交给`VisionContext.DrawContent` 之后立即释放源区域不影响遮罩窗口绘制；
- **不**修改 `Region.Dispose()` / `ImageRegion.Dispose()` 的继承关系（PR3 的职责）；
- **不**改动 `AutoDomainTask.cs` 中其他约 25 处 `CaptureToRectArea()` 调用点；
- **不**重构 YOLO 模型或绘制逻辑。

本 PR 不依赖其他 PR，可独立合并和发布。它不解决大问题，只切断当前最痛的那条增长曲线。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化石化古树检测过程中的截图资源释放，提升长时间运行时的稳定性。
  * 未改变角色移动及按键控制逻辑。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->