### PR TITLE
feat: 新增移动轨迹记录与每日里程统计

### DIFF
--- a/BetterGenshinImpact/Core/Config/AllConfig.cs
+++ b/BetterGenshinImpact/Core/Config/AllConfig.cs
@@ -26,6 +26,7 @@ using BetterGenshinImpact.GameTask.AutoLeyLineOutcrop;
 using BetterGenshinImpact.GameTask.AutoCook;
 using BetterGenshinImpact.GameTask.MapMask;
 using BetterGenshinImpact.GameTask.SkillCd;
+using BetterGenshinImpact.GameTask.TravelLog;
 using BetterGenshinImpact.GameTask.UseRedeemCode;
 
 namespace BetterGenshinImpact.Core.Config;
@@ -194,6 +195,11 @@ public partial class AllConfig : ObservableObject
     public SkillCdConfig SkillCdConfig { get; set; } = new();
 
     /// <summary>
+    /// 移动轨迹记录
+    /// </summary>
+    public TravelLogConfig TravelLogConfig { get; set; } = new();
+
+    /// <summary>
     /// 自动使用
     /// </summary>
     public AutoRedeemCodeConfig AutoRedeemCodeConfig { get; set; } = new();
@@ -292,6 +298,7 @@ public partial class AllConfig : ObservableObject
         DevConfig.PropertyChanged += OnAnyPropertyChanged;
         HardwareAccelerationConfig.PropertyChanged += OnAnyPropertyChanged;
         SkillCdConfig.PropertyChanged += OnAnyPropertyChanged;
+        TravelLogConfig.PropertyChanged += OnAnyPropertyChanged;
     }
 
     public void OnAnyPropertyChanged(object? sender, EventArgs args)

--- a/BetterGenshinImpact/GameTask/GameTaskManager.cs
+++ b/BetterGenshinImpact/GameTask/GameTaskManager.cs
@@ -45,6 +45,7 @@ internal class GameTaskManager
         TriggerDictionary.TryAdd("AutoEat", new AutoEat.AutoEatTrigger());
         TriggerDictionary.TryAdd("MapMask", new MapMaskTrigger());
         TriggerDictionary.TryAdd("SkillCd", new SkillCdTrigger());
+        TriggerDictionary.TryAdd("TravelLog", new TravelLog.TravelLogTrigger());
 
         return ConvertToTriggerList();
     }
@@ -120,6 +121,7 @@ internal class GameTaskManager
             TriggerDictionary.GetValueOrDefault("AutoEat")?.Init();
             TriggerDictionary.GetValueOrDefault("MapMask")?.Init();
             TriggerDictionary.GetValueOrDefault("SkillCd")?.Init();
+            TriggerDictionary.GetValueOrDefault("TravelLog")?.Init();
             // 清理画布
             VisionContext.Instance().DrawContent.ClearAll();
         }

--- a/BetterGenshinImpact/GameTask/TravelLog/Model/TravelLogData.cs
+++ b/BetterGenshinImpact/GameTask/TravelLog/Model/TravelLogData.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+
+namespace BetterGenshinImpact.GameTask.TravelLog.Model;
+
+/// <summary>
+/// 单个轨迹点（原神游戏坐标系，1024 级别，1 单位 ≈ 1 米）
+/// </summary>
+[Serializable]
+public class TravelLogPoint
+{
+    /// <summary>
+    /// Unix 时间戳（秒）
+    /// </summary>
+    public long T { get; set; }
+
+    /// <summary>
+    /// 游戏坐标 X
+    /// </summary>
+    public float X { get; set; }
+
+    /// <summary>
+    /// 游戏坐标 Y
+    /// </summary>
+    public float Y { get; set; }
+}
+
+/// <summary>
+/// 一天的移动轨迹数据
+/// </summary>
+[Serializable]
+public class TravelLogData
+{
+    /// <summary>
+    /// 日期，格式 yyyy-MM-dd
+    /// </summary>
+    public string Date { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 当日累计移动里程（米，不含传送跳变）
+    /// </summary>
+    public double TotalDistance { get; set; }
+
+    /// <summary>
+    /// 轨迹点列表（按时间顺序）
+    /// </summary>
+    public List<TravelLogPoint> Points { get; set; } = [];
+
+    /// <summary>
+    /// 轨迹分段。每段是 Points 中的起始索引：
+    /// 第 i 段 = Points[Segments[i] .. Segments[i+1]-1]（最后一段到 Points 末尾）。
+    /// 传送/长时间无定位会导致开新段，绘制时段间不连线。
+    /// </summary>
+    public List<int> Segments { get; set; } = [];
+}

--- a/BetterGenshinImpact/GameTask/TravelLog/TravelLogConfig.cs
+++ b/BetterGenshinImpact/GameTask/TravelLog/TravelLogConfig.cs
@@ -1,0 +1,17 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using System;
+
+namespace BetterGenshinImpact.GameTask.TravelLog;
+
+/// <summary>
+/// 移动轨迹记录配置
+/// </summary>
+[Serializable]
+public partial class TravelLogConfig : ObservableObject
+{
+    /// <summary>
+    /// 是否启用移动轨迹记录
+    /// </summary>
+    [ObservableProperty]
+    private bool _enabled = false;
+}

--- a/BetterGenshinImpact/GameTask/TravelLog/TravelLogService.cs
+++ b/BetterGenshinImpact/GameTask/TravelLog/TravelLogService.cs
@@ -1,0 +1,312 @@
+using BetterGenshinImpact.Core.Config;
+using BetterGenshinImpact.GameTask.Common;
+using BetterGenshinImpact.GameTask.TravelLog.Model;
+using BetterGenshinImpact.Model;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using OpenCvSharp;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace BetterGenshinImpact.GameTask.TravelLog;
+
+/// <summary>
+/// 移动轨迹记录服务（单例）
+/// 负责轨迹点管理、里程统计、按天持久化
+/// </summary>
+public class TravelLogService : Singleton<TravelLogService>
+{
+    /// <summary>
+    /// 位移小于该值（米）视为噪声，不记录
+    /// </summary>
+    private const double NoiseDistance = 1.5;
+
+    /// <summary>
+    /// 与上一点距离大于该值（米）视为传送，断开轨迹段且不计入里程
+    /// </summary>
+    private const double TeleportDistance = 80;
+
+    /// <summary>
+    /// 持久化节流间隔
+    /// </summary>
+    private static readonly TimeSpan SaveInterval = TimeSpan.FromSeconds(15);
+
+    private readonly object _lock = new();
+
+    private TravelLogData? _today;
+
+    /// <summary>
+    /// 今日数据版本号，每新增一个点 +1，供 UI 轮询判断是否需要重绘
+    /// </summary>
+    private int _todayVersion;
+
+    private bool _dirty;
+    private DateTime _lastSaveTime = DateTime.MinValue;
+
+    private static string TodayString => DateTime.Now.ToString("yyyy-MM-dd");
+
+    private static string StorageDir => Global.Absolute(@"User\TravelLog");
+
+    private static string GetFilePath(string date) => Path.Combine(StorageDir, $"{date}.json");
+
+    /// <summary>
+    /// 今日数据版本号（每次新增轨迹点递增）
+    /// </summary>
+    public int TodayVersion
+    {
+        get { lock (_lock) { return _todayVersion; } }
+    }
+
+    /// <summary>
+    /// 记录一个轨迹点（原神游戏坐标系）
+    /// </summary>
+    public void AddPoint(Point2f gameCoordinates)
+    {
+        // (0,0) 是定位失败的默认值，直接丢弃
+        if (gameCoordinates.X == 0 && gameCoordinates.Y == 0)
+        {
+            return;
+        }
+
+        lock (_lock)
+        {
+            EnsureTodayData();
+
+            var data = _today!;
+            var now = DateTimeOffset.Now.ToUnixTimeSeconds();
+
+            if (data.Points.Count > 0)
+            {
+                var last = data.Points[^1];
+                var distance = Math.Sqrt(Math.Pow(gameCoordinates.X - last.X, 2) + Math.Pow(gameCoordinates.Y - last.Y, 2));
+
+                if (distance < NoiseDistance)
+                {
+                    return;
+                }
+
+                if (distance > TeleportDistance)
+                {
+                    // 传送：开新段，不计里程
+                    data.Segments.Add(data.Points.Count);
+                }
+                else
+                {
+                    data.TotalDistance += distance;
+                }
+            }
+            else if (data.Segments.Count == 0)
+            {
+                data.Segments.Add(0);
+            }
+
+            data.Points.Add(new TravelLogPoint { T = now, X = gameCoordinates.X, Y = gameCoordinates.Y });
+            _todayVersion++;
+            _dirty = true;
+
+            SaveIfNeeded();
+        }
+    }
+
+    /// <summary>
+    /// 获取今日轨迹数据的快照（用于 UI 展示）
+    /// </summary>
+    public TravelLogData GetTodaySnapshot()
+    {
+        lock (_lock)
+        {
+            EnsureTodayData();
+            return Snapshot(_today!);
+        }
+    }
+
+    /// <summary>
+    /// 读取指定日期的轨迹数据（不存在时返回空数据）
+    /// </summary>
+    public TravelLogData LoadByDate(string date)
+    {
+        lock (_lock)
+        {
+            if (date == _today?.Date)
+            {
+                return Snapshot(_today);
+            }
+
+            return LoadFromFile(date) ?? new TravelLogData { Date = date };
+        }
+    }
+
+    /// <summary>
+    /// 列出已有轨迹记录的日期（倒序，最新在前）
+    /// </summary>
+    public List<string> ListAvailableDates()
+    {
+        try
+        {
+            if (!Directory.Exists(StorageDir))
+            {
+                return [TodayString];
+            }
+
+            var dates = Directory.GetFiles(StorageDir, "????-??-??.json")
+                .Select(Path.GetFileNameWithoutExtension)
+                .Where(n => !string.IsNullOrEmpty(n))
+                .Select(n => n!)
+                .ToList();
+
+            if (!dates.Contains(TodayString))
+            {
+                dates.Add(TodayString);
+            }
+
+            return [.. dates.OrderByDescending(d => d)];
+        }
+        catch (Exception e)
+        {
+            TaskControl.Logger.LogWarning(e, "[TravelLog] 枚举轨迹文件失败");
+            return [TodayString];
+        }
+    }
+
+    /// <summary>
+    /// 获取今日最近一段轨迹的快照（用于小地图遮罩等局部展示）
+    /// </summary>
+    /// <param name="maxPoints">最多返回的轨迹点数（从末尾往前取）</param>
+    /// <returns>轨迹点列表 + 分段起始索引（相对于返回列表）</returns>
+    public (List<TravelLogPoint> Points, List<int> SegmentStarts) GetRecentTrajectory(int maxPoints)
+    {
+        lock (_lock)
+        {
+            EnsureTodayData();
+            var data = _today!;
+
+            var startIndex = Math.Max(0, data.Points.Count - maxPoints);
+            var points = data.Points
+                .Skip(startIndex)
+                .Select(p => new TravelLogPoint { T = p.T, X = p.X, Y = p.Y })
+                .ToList();
+
+            var segmentStarts = data.Segments
+                .Where(s => s > startIndex)
+                .Select(s => s - startIndex)
+                .ToList();
+            segmentStarts.Insert(0, 0);
+
+            return (points, segmentStarts);
+        }
+    }
+
+    /// <summary>
+    /// 立即落盘（有未保存数据时），供退出时调用
+    /// </summary>
+    public void Flush()
+    {
+        lock (_lock)
+        {
+            if (_dirty && _today != null)
+            {
+                SaveToFile(_today);
+                _dirty = false;
+            }
+        }
+    }
+
+    /// <summary>
+    /// 确保持有的是今日数据，跨天时先落盘旧数据再切换
+    /// 调用前必须已持有 _lock
+    /// </summary>
+    private void EnsureTodayData()
+    {
+        var today = TodayString;
+        if (_today != null && _today.Date == today)
+        {
+            return;
+        }
+
+        if (_today != null && _dirty)
+        {
+            SaveToFile(_today);
+        }
+
+        _today = LoadFromFile(today) ?? new TravelLogData { Date = today };
+        _dirty = false;
+        _lastSaveTime = DateTime.MinValue;
+        TaskControl.Logger.LogInformation("[TravelLog] 已加载 {Date} 的轨迹数据，历史里程 {Distance} 米，共 {Count} 个轨迹点",
+            today, Math.Round(_today.TotalDistance, 1), _today.Points.Count);
+    }
+
+    /// <summary>
+    /// 节流落盘，调用前必须已持有 _lock
+    /// </summary>
+    private void SaveIfNeeded()
+    {
+        if (!_dirty || DateTime.Now - _lastSaveTime < SaveInterval)
+        {
+            return;
+        }
+
+        SaveToFile(_today!);
+        _dirty = false;
+        _lastSaveTime = DateTime.Now;
+    }
+
+    private static void SaveToFile(TravelLogData data)
+    {
+        try
+        {
+            Directory.CreateDirectory(StorageDir);
+            File.WriteAllText(GetFilePath(data.Date), JsonConvert.SerializeObject(data, Formatting.Indented));
+        }
+        catch (Exception e)
+        {
+            TaskControl.Logger.LogWarning(e, "[TravelLog] 轨迹数据保存失败");
+        }
+    }
+
+    private static TravelLogData? LoadFromFile(string date)
+    {
+        try
+        {
+            var path = GetFilePath(date);
+            if (!File.Exists(path))
+            {
+                return null;
+            }
+
+            var data = JsonConvert.DeserializeObject<TravelLogData>(File.ReadAllText(path));
+            if (data == null || data.Points.Count == 0)
+            {
+                return data;
+            }
+
+            // 兼容旧数据：没有分段信息时视为一整段
+            if (data.Segments.Count == 0)
+            {
+                data.Segments.Add(0);
+            }
+
+            return data;
+        }
+        catch (Exception e)
+        {
+            TaskControl.Logger.LogWarning(e, "[TravelLog] 读取轨迹文件失败：{Date}", date);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// 深拷贝一份数据，避免 UI 读取时与写入线程竞争
+    /// </summary>
+    private static TravelLogData Snapshot(TravelLogData data)
+    {
+        return new TravelLogData
+        {
+            Date = data.Date,
+            TotalDistance = data.TotalDistance,
+            Points = [.. data.Points.Select(p => new TravelLogPoint { T = p.T, X = p.X, Y = p.Y })],
+            Segments = [.. data.Segments]
+        };
+    }
+}

--- a/BetterGenshinImpact/GameTask/TravelLog/TravelLogTrigger.cs
+++ b/BetterGenshinImpact/GameTask/TravelLog/TravelLogTrigger.cs
@@ -1,0 +1,319 @@
+using BetterGenshinImpact.GameTask.Common.BgiVision;
+using BetterGenshinImpact.GameTask.Common.Element.Assets;
+using BetterGenshinImpact.GameTask.Common.Map.Maps;
+using BetterGenshinImpact.GameTask.Common.Map.Maps.Base;
+using BetterGenshinImpact.GameTask.Model.Area;
+using BetterGenshinImpact.Helpers;
+using BetterGenshinImpact.View;
+using Microsoft.Extensions.Logging;
+using OpenCvSharp;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using BetterGenshinImpact.GameTask.Common;
+
+namespace BetterGenshinImpact.GameTask.TravelLog;
+
+/// <summary>
+/// 移动轨迹记录触发器
+/// 在主界面下周期性识别小地图位置，记录移动轨迹并统计里程，
+/// 同时把轨迹推送到遮罩窗口的小地图画布上展示
+/// </summary>
+public class TravelLogTrigger : ITaskTrigger
+{
+    public string Name => "TravelLog";
+
+    public bool IsEnabled
+    {
+        get => TaskContext.Instance().Config.TravelLogConfig.Enabled;
+        set => TaskContext.Instance().Config.TravelLogConfig.Enabled = value;
+    }
+
+    public int Priority => 5;
+
+    public bool IsExclusive => false;
+
+    /// <summary>
+    /// 主界面在触发器体系中归类为 Unknown
+    /// </summary>
+    public GameUiCategory SupportedGameUiCategory => GameUiCategory.Unknown;
+
+    /// <summary>
+    /// 位置识别间隔
+    /// </summary>
+    private static readonly TimeSpan MatchInterval = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// 推送到遮罩画布的轨迹点上限（约 100 分钟路程，大地图概览使用）
+    /// </summary>
+    private const int MaskTrajectoryMaxPoints = 6000;
+
+    private readonly ILogger _logger = TaskControl.Logger;
+
+    private DateTime _lastMatchTime = DateTime.MinValue;
+
+    /// <summary>
+    /// 后台匹配任务忙标志（0 空闲 / 1 忙）
+    /// </summary>
+    private int _matching;
+
+    // 上一次匹配到的位置（2048 级图像坐标），用于局部加速匹配
+    private float _prevX = -1;
+    private float _prevY = -1;
+
+    /// <summary>
+    /// 最近一次推送到遮罩的轨迹版本号
+    /// </summary>
+    private int _lastPushedVersion = -1;
+
+    /// <summary>
+    /// 遮罩画布上的轨迹当前是否由本触发器驱动显示
+    /// </summary>
+    private bool _maskTrajectoryActive;
+
+    public void Init()
+    {
+        _lastMatchTime = DateTime.MinValue;
+        _prevX = -1;
+        _prevY = -1;
+        ClearMaskTrajectory();
+    }
+
+    public void OnCapture(CaptureContent content)
+    {
+        if (!IsEnabled)
+        {
+            ClearMaskTrajectory();
+            return;
+        }
+
+        if (!Bv.IsInMainUi(content.CaptureRectArea))
+        {
+            SuspendMinimapOverlay();
+            return;
+        }
+
+        var now = DateTime.Now;
+        if (now - _lastMatchTime < MatchInterval)
+        {
+            return;
+        }
+
+        // 上一次匹配还没结束则跳过
+        if (Interlocked.CompareExchange(ref _matching, 1, 0) != 0)
+        {
+            return;
+        }
+
+        _lastMatchTime = now;
+
+        // 截图内容在 OnCapture 返回后会被释放，克隆一份给后台任务用
+        var region = new ImageRegion(
+            content.CaptureRectArea.SrcMat.Clone(),
+            content.CaptureRectArea.X,
+            content.CaptureRectArea.Y);
+
+        Task.Run(() =>
+        {
+            try
+            {
+                MatchPosition(region);
+            }
+            catch (Exception e)
+            {
+                _logger.LogDebug(e, "[TravelLog] 位置识别失败");
+            }
+            finally
+            {
+                region.Dispose();
+                Interlocked.Exchange(ref _matching, 0);
+            }
+        });
+    }
+
+    /// <summary>
+    /// 识别当前位置并记录轨迹点
+    /// </summary>
+    private void MatchPosition(ImageRegion region)
+    {
+        var matchingMethod = TaskContext.Instance().Config.PathingConditionConfig.MapMatchingMethod;
+        var sceneMap = MapManager.GetMap(MapTypes.Teyvat, matchingMethod);
+
+        using var miniMapMat = new Mat(region.SrcMat, MapAssets.Get(region).MimiMapRect);
+
+        // 先基于上一位置局部匹配，失败或跳变过大时重置并全图匹配
+        var p = sceneMap.GetMiniMapPosition(miniMapMat, _prevX, _prevY);
+        if (p == default || (_prevX > 0 && _prevY > 0 && p.DistanceTo(new Point2f(_prevX, _prevY)) > 150))
+        {
+            _prevX = -1;
+            _prevY = -1;
+            p = sceneMap.GetMiniMapPosition(miniMapMat, _prevX, _prevY);
+        }
+
+        if (p == default)
+        {
+            return;
+        }
+
+        _prevX = p.X;
+        _prevY = p.Y;
+
+        // 图像坐标（2048 级）→ 游戏坐标（1024 级，1 单位 ≈ 1 米）
+        var gamePoint = sceneMap.ConvertImageCoordinatesToGenshinMapCoordinates(p);
+        if (gamePoint is Point2f gp)
+        {
+            TravelLogService.Instance.AddPoint(gp);
+        }
+
+        PushTrajectoryToMask(sceneMap, p);
+    }
+
+    /// <summary>
+    /// 把今日轨迹（转为 2048 级图像坐标）推送到遮罩的小地图与大地图画布
+    /// </summary>
+    private void PushTrajectoryToMask(ISceneMap sceneMap, Point2f imagePos)
+    {
+        if (MaskWindow.InstanceNullable() == null)
+        {
+            return;
+        }
+
+        var version = TravelLogService.Instance.TodayVersion;
+
+        List<List<System.Windows.Point>>? segments = null;
+        if (version != _lastPushedVersion)
+        {
+            var (points, segmentStarts) = TravelLogService.Instance.GetRecentTrajectory(MaskTrajectoryMaxPoints);
+
+            segments = [];
+            for (var i = 0; i < segmentStarts.Count; i++)
+            {
+                var start = segmentStarts[i];
+                var end = i + 1 < segmentStarts.Count ? segmentStarts[i + 1] : points.Count;
+                if (end - start < 1)
+                {
+                    continue;
+                }
+
+                var segment = new List<System.Windows.Point>(end - start);
+                for (var j = start; j < end; j++)
+                {
+                    var imgPoint = sceneMap.ConvertGenshinMapCoordinatesToImageCoordinates(new Point2f(points[j].X, points[j].Y));
+                    segment.Add(new System.Windows.Point(imgPoint.X, imgPoint.Y));
+                }
+                segments.Add(segment);
+            }
+
+            _lastPushedVersion = version;
+        }
+
+        // 地图遮罩的小地图功能开启时，小地图视口由 MapMaskTrigger 驱动，这里不重复设置；
+        // 大地图视口始终由 MapMaskTrigger 驱动（需要开启地图遮罩才能显示大地图轨迹）
+        var miniMapMaskEnabled = TaskContext.Instance().Config.MapMaskConfig.MiniMapMaskEnabled;
+        System.Windows.Rect? viewport = null;
+        if (!miniMapMaskEnabled)
+        {
+            double viewportSize = MapAssets.MimiMapRect1080P.Width / 3.0 * 10;
+            viewport = new System.Windows.Rect(
+                imagePos.X - viewportSize / 2.0,
+                imagePos.Y - viewportSize / 2.0,
+                viewportSize,
+                viewportSize);
+        }
+
+        if (segments == null && viewport == null)
+        {
+            return;
+        }
+
+        _maskTrajectoryActive = true;
+        UIDispatcherHelper.BeginInvoke(() =>
+        {
+            var window = MaskWindow.InstanceNullable();
+            if (window == null)
+            {
+                return;
+            }
+
+            if (segments != null)
+            {
+                window.MiniMapPointsCanvasControl.UpdateTrajectory(segments);
+                window.PointsCanvasControl.UpdateTrajectory(segments);
+            }
+
+            if (viewport is { } v)
+            {
+                window.MiniMapPointsCanvasControl.UpdateViewport(v.X, v.Y, v.Width, v.Height);
+            }
+        });
+    }
+
+    /// <summary>
+    /// 离开主界面（打开大地图/菜单等）时，仅隐藏小地图圆形覆盖层。
+    /// 大地图画布上的轨迹保留，供大地图遮罩继续展示。
+    /// </summary>
+    private void SuspendMinimapOverlay()
+    {
+        if (!_maskTrajectoryActive || MaskWindow.InstanceNullable() == null)
+        {
+            return;
+        }
+
+        _maskTrajectoryActive = false;
+
+        var miniMapMaskEnabled = TaskContext.Instance().Config.MapMaskConfig.MiniMapMaskEnabled;
+        if (miniMapMaskEnabled)
+        {
+            // 小地图视口由 MapMaskTrigger 管理，它会自行隐藏，无需干预
+            return;
+        }
+
+        UIDispatcherHelper.BeginInvoke(() =>
+        {
+            var window = MaskWindow.InstanceNullable();
+            if (window == null)
+            {
+                return;
+            }
+
+            window.MiniMapPointsCanvasControl.UpdateViewport(0, 0, 0, 0);
+        });
+    }
+
+    /// <summary>
+    /// 功能关闭时，清空两个遮罩画布上的轨迹与本触发器驱动的小地图视口
+    /// </summary>
+    private void ClearMaskTrajectory()
+    {
+        if (_lastPushedVersion < 0 && !_maskTrajectoryActive)
+        {
+            return; // 从未推送过，无需清理
+        }
+
+        _maskTrajectoryActive = false;
+        _lastPushedVersion = -1;
+
+        if (MaskWindow.InstanceNullable() == null)
+        {
+            return;
+        }
+
+        var miniMapMaskEnabled = TaskContext.Instance().Config.MapMaskConfig.MiniMapMaskEnabled;
+        UIDispatcherHelper.BeginInvoke(() =>
+        {
+            var window = MaskWindow.InstanceNullable();
+            if (window == null)
+            {
+                return;
+            }
+
+            window.MiniMapPointsCanvasControl.UpdateTrajectory(null);
+            window.PointsCanvasControl.UpdateTrajectory(null);
+            if (!miniMapMaskEnabled)
+            {
+                window.MiniMapPointsCanvasControl.UpdateViewport(0, 0, 0, 0);
+            }
+        });
+    }
+}

--- a/BetterGenshinImpact/Service/ApplicationHostService.cs
+++ b/BetterGenshinImpact/Service/ApplicationHostService.cs
@@ -36,6 +36,8 @@ public class ApplicationHostService(IServiceProvider serviceProvider) : IHostedS
     /// <param name="cancellationToken">Indicates that the shutdown process should no longer be graceful.</param>
     public async Task StopAsync(CancellationToken cancellationToken)
     {
+        // 退出前把未保存的移动轨迹数据落盘
+        GameTask.TravelLog.TravelLogService.Instance.Flush();
         await Task.CompletedTask;
     }
 

--- a/BetterGenshinImpact/View/Controls/MiniMapPointsCanvas.cs
+++ b/BetterGenshinImpact/View/Controls/MiniMapPointsCanvas.cs
@@ -38,6 +38,11 @@ public sealed class MiniMapPointsCanvas : FrameworkElement
     private Dictionary<string, MaskMapPointLabel> _labelMap = new();
     private Rect _viewportRect = Rect.Empty;
 
+    /// <summary>
+    /// 移动轨迹分段（2048 级图像坐标），段间不连线
+    /// </summary>
+    private IReadOnlyList<IReadOnlyList<Point>>? _trajectorySegments;
+
     public ObservableCollection<MaskMapPoint>? PointsSource
     {
         get => (ObservableCollection<MaskMapPoint>?)GetValue(PointsSourceProperty);
@@ -155,7 +160,7 @@ public sealed class MiniMapPointsCanvas : FrameworkElement
     private void RenderPoints()
     {
         using var dc = _drawingVisual.RenderOpen();
-        if (_allPoints.Count == 0 || _viewportRect.IsEmpty || _viewportRect.Width == 0)
+        if (_viewportRect.IsEmpty || _viewportRect.Width == 0)
         {
             return;
         }
@@ -177,11 +182,19 @@ public sealed class MiniMapPointsCanvas : FrameworkElement
         var clip = new EllipseGeometry(clipRect);
         dc.PushClip(clip);
 
-        var expandedViewport = _viewportRect;
-        expandedViewport.Inflate(MaskMapPointStatic.Width, MaskMapPointStatic.Height);
-
         var scaleX = side / _viewportRect.Width;
         var scaleY = side / _viewportRect.Height;
+
+        DrawTrajectory(dc, clipRect, scaleX, scaleY);
+
+        if (_allPoints.Count == 0)
+        {
+            dc.Pop();
+            return;
+        }
+
+        var expandedViewport = _viewportRect;
+        expandedViewport.Inflate(MaskMapPointStatic.Width, MaskMapPointStatic.Height);
 
         var pointSide = Math.Max(8, Math.Min(16, side / 12.0));
 
@@ -198,6 +211,60 @@ public sealed class MiniMapPointsCanvas : FrameworkElement
         }
 
         dc.Pop();
+    }
+
+    /// <summary>
+    /// 更新移动轨迹并触发重绘
+    /// </summary>
+    /// <param name="segments">轨迹分段（2048 级图像坐标），null 表示清除</param>
+    public void UpdateTrajectory(IReadOnlyList<IReadOnlyList<Point>>? segments)
+    {
+        _trajectorySegments = segments;
+        Refresh();
+    }
+
+    /// <summary>
+    /// 在点位下层绘制移动轨迹折线
+    /// </summary>
+    private void DrawTrajectory(DrawingContext dc, Rect clipRect, double scaleX, double scaleY)
+    {
+        if (_trajectorySegments == null || _trajectorySegments.Count == 0)
+        {
+            return;
+        }
+
+        var brush = new SolidColorBrush(Color.FromArgb(220, 0, 229, 255));
+        brush.Freeze();
+        var pen = new Pen(brush, 2.0);
+        pen.Freeze();
+
+        foreach (var segment in _trajectorySegments)
+        {
+            if (segment.Count < 2)
+            {
+                continue;
+            }
+
+            var geometry = new StreamGeometry();
+            using (var ctx = geometry.Open())
+            {
+                var first = ToLocalPoint(segment[0], clipRect, scaleX, scaleY);
+                ctx.BeginFigure(first, false, false);
+                for (var i = 1; i < segment.Count; i++)
+                {
+                    ctx.LineTo(ToLocalPoint(segment[i], clipRect, scaleX, scaleY), true, false);
+                }
+            }
+            geometry.Freeze();
+            dc.DrawGeometry(null, pen, geometry);
+        }
+    }
+
+    private Point ToLocalPoint(Point imagePoint, Rect clipRect, double scaleX, double scaleY)
+    {
+        return new Point(
+            clipRect.X + (imagePoint.X - _viewportRect.X) * scaleX,
+            clipRect.Y + (imagePoint.Y - _viewportRect.Y) * scaleY);
     }
 
     private void DrawPoint(DrawingContext dc, MaskMapPoint point, double centerX, double centerY, double width, double height)

--- a/BetterGenshinImpact/View/Controls/PointsCanvas.cs
+++ b/BetterGenshinImpact/View/Controls/PointsCanvas.cs
@@ -33,6 +33,11 @@ public class PointsCanvas : FrameworkElement
     private Dictionary<string, MaskMapPointLabel> _labelMap = new();
     private Rect _viewportRect = Rect.Empty;
 
+    /// <summary>
+    /// 移动轨迹分段（2048 级图像坐标），段间不连线
+    /// </summary>
+    private IReadOnlyList<IReadOnlyList<Point>>? _trajectorySegments;
+
     public event EventHandler? ViewportChanged;
 
     #region 依赖属性
@@ -234,37 +239,94 @@ public class PointsCanvas : FrameworkElement
     private void RenderPoints()
     {
         using var dc = _drawingVisual.RenderOpen();
+        if (_viewportRect.IsEmpty || _viewportRect.Width <= 0 || _viewportRect.Height <= 0)
+        {
+            return;
+        }
+
+        var aw = ActualWidth;
+        var ah = ActualHeight;
+        if (aw <= 0 || ah <= 0)
+        {
+            return;
+        }
+
+        var scaleX = aw / _viewportRect.Width;
+        var scaleY = ah / _viewportRect.Height;
+
+        DrawTrajectory(dc, scaleX, scaleY);
+
         if (_allPoints.Count == 0)
         {
             return;
         }
 
-        if (!_viewportRect.IsEmpty)
+        // 扩展可视区域，避免边缘闪烁
+        var expandedViewport = _viewportRect;
+        expandedViewport.Inflate(MaskMapPointStatic.Width, MaskMapPointStatic.Height);
+
+        foreach (var point in _allPoints)
         {
-            // 扩展可视区域，避免边缘闪烁
-            var expandedViewport = _viewportRect;
-            expandedViewport.Inflate(MaskMapPointStatic.Width, MaskMapPointStatic.Height);
-
-            var aw = ActualWidth;
-            var ah = ActualHeight;
-            if (aw <= 0 || ah <= 0)
+            if (expandedViewport.Contains(point.ImageX, point.ImageY))
             {
-                return;
-            }
-
-            var scaleX = aw / _viewportRect.Width;
-            var scaleY = ah / _viewportRect.Height;
-
-            foreach (var point in _allPoints)
-            {
-                if (expandedViewport.Contains(point.ImageX, point.ImageY))
-                {
-                    var localX = (point.ImageX - _viewportRect.X) * scaleX;
-                    var localY = (point.ImageY - _viewportRect.Y) * scaleY;
-                    DrawPoint(dc, point, localX, localY, MaskMapPointStatic.Width, MaskMapPointStatic.Height);
-                }
+                var localX = (point.ImageX - _viewportRect.X) * scaleX;
+                var localY = (point.ImageY - _viewportRect.Y) * scaleY;
+                DrawPoint(dc, point, localX, localY, MaskMapPointStatic.Width, MaskMapPointStatic.Height);
             }
         }
+    }
+
+    /// <summary>
+    /// 更新移动轨迹并触发重绘
+    /// </summary>
+    /// <param name="segments">轨迹分段（2048 级图像坐标），null 表示清除</param>
+    public void UpdateTrajectory(IReadOnlyList<IReadOnlyList<Point>>? segments)
+    {
+        _trajectorySegments = segments;
+        Refresh();
+    }
+
+    /// <summary>
+    /// 在点位下层绘制移动轨迹折线
+    /// </summary>
+    private void DrawTrajectory(DrawingContext dc, double scaleX, double scaleY)
+    {
+        if (_trajectorySegments == null || _trajectorySegments.Count == 0)
+        {
+            return;
+        }
+
+        var brush = new SolidColorBrush(Color.FromArgb(220, 0, 229, 255));
+        brush.Freeze();
+        var pen = new Pen(brush, 2.0);
+        pen.Freeze();
+
+        foreach (var segment in _trajectorySegments)
+        {
+            if (segment.Count < 2)
+            {
+                continue;
+            }
+
+            var geometry = new StreamGeometry();
+            using (var ctx = geometry.Open())
+            {
+                ctx.BeginFigure(ToLocalPoint(segment[0], scaleX, scaleY), false, false);
+                for (var i = 1; i < segment.Count; i++)
+                {
+                    ctx.LineTo(ToLocalPoint(segment[i], scaleX, scaleY), true, false);
+                }
+            }
+            geometry.Freeze();
+            dc.DrawGeometry(null, pen, geometry);
+        }
+    }
+
+    private Point ToLocalPoint(Point imagePoint, double scaleX, double scaleY)
+    {
+        return new Point(
+            (imagePoint.X - _viewportRect.X) * scaleX,
+            (imagePoint.Y - _viewportRect.Y) * scaleY);
     }
 
     /// <summary>

--- a/BetterGenshinImpact/View/MaskWindow.xaml
+++ b/BetterGenshinImpact/View/MaskWindow.xaml
@@ -87,7 +87,7 @@
                     Grid.ColumnSpan="6"
                     ClipToBounds="True">
                 <controls:MiniMapPointsCanvas x:Name="MiniMapPointsCanvasControl"
-                                              Visibility="{Binding Config.MapMaskConfig.MiniMapMaskEnabled, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                              Visibility="{Binding IsMiniMapCanvasVisible, Converter={StaticResource BooleanToVisibilityConverter}}"
                                               PointsSource="{Binding MapPoints}"
                                               LabelsSource="{Binding MapPointLabels}"
                                               IsHitTestVisible="False">

--- a/BetterGenshinImpact/View/Pages/TriggerSettingsPage.xaml
+++ b/BetterGenshinImpact/View/Pages/TriggerSettingsPage.xaml
@@ -1529,6 +1529,69 @@
             </StackPanel>
         </ui:CardExpander>
 
+        <ui:CardExpander Margin="0,0,0,12" ContentPadding="0">
+            <ui:CardExpander.Icon>
+                <ui:SymbolIcon Symbol="Location24" />
+            </ui:CardExpander.Icon>
+            <ui:CardExpander.Header>
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <ui:TextBlock Grid.Row="0"
+                                  Grid.Column="0"
+                                  FontTypography="Body"
+                                  Text="移动轨迹记录"
+                                  TextWrapping="Wrap" />
+                    <ui:TextBlock Grid.Row="1"
+                                  Grid.Column="0"
+                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                  TextWrapping="Wrap">
+                        记录你在提瓦特大陆走过的移动轨迹，并统计每日移动里程（仅支持提瓦特主界面）
+                    </ui:TextBlock>
+                    <ui:ToggleSwitch Grid.Row="0"
+                                     Grid.RowSpan="2"
+                                     Grid.Column="1"
+                                     Margin="0,0,24,0"
+                                     IsChecked="{Binding Config.TravelLogConfig.Enabled, Mode=TwoWay}" />
+                </Grid>
+            </ui:CardExpander.Header>
+            <StackPanel>
+                <Grid Margin="16">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <ui:TextBlock Grid.Row="0"
+                                  Grid.Column="0"
+                                  FontTypography="Body"
+                                  Text="轨迹地图"
+                                  TextWrapping="Wrap" />
+                    <ui:TextBlock Grid.Row="1"
+                                  Grid.Column="0"
+                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                  TextWrapping="Wrap"
+                                  Text="在大地图上查看今日或历史的移动轨迹与里程统计" />
+                    <ui:Button Grid.Row="0"
+                               Grid.RowSpan="2"
+                               Grid.Column="1"
+                               Margin="10,0,24,0"
+                               Content="查看移动轨迹"
+                               Icon="{ui:SymbolIcon Map24}"
+                               Command="{Binding OpenTravelLogWindowCommand}" />
+                </Grid>
+            </StackPanel>
+        </ui:CardExpander>
+
         <!--  一键战斗  -->
         <!--<ui:CardExpander Margin="0,0,0,12" ContentPadding="0" Icon="{ui:SymbolIcon ArrowSync24}">
             <ui:CardExpander.Header>

--- a/BetterGenshinImpact/View/Windows/TravelLogWindow.xaml
+++ b/BetterGenshinImpact/View/Windows/TravelLogWindow.xaml
@@ -1,0 +1,54 @@
+<ui:FluentWindow x:Class="BetterGenshinImpact.View.Windows.TravelLogWindow"
+                 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                 xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+                 xmlns:windows="clr-namespace:BetterGenshinImpact.ViewModel.Windows"
+                 Title="移动轨迹"
+                 Width="1100"
+                 Height="760"
+                 d:DataContext="{d:DesignInstance Type=windows:TravelLogWindowViewModel}"
+                 ui:Design.Background="{DynamicResource ApplicationBackgroundBrush}"
+                 ui:Design.Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                 ExtendsContentIntoTitleBar="True"
+                 FontFamily="{DynamicResource TextThemeFontFamily}"
+                 ResizeMode="CanResizeWithGrip"
+                 WindowBackdropType="Mica"
+                 WindowStartupLocation="CenterScreen"
+                 WindowStyle="SingleBorderWindow"
+                 mc:Ignorable="d">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <ui:TitleBar Title="移动轨迹" Grid.Row="0">
+            <ui:TitleBar.Icon>
+                <ui:ImageIcon Source="pack://application:,,,/Resources/Images/logo.png" />
+            </ui:TitleBar.Icon>
+        </ui:TitleBar>
+
+        <StackPanel Grid.Row="1"
+                    Margin="12,4,12,8"
+                    Orientation="Horizontal">
+            <ComboBox Width="140"
+                      VerticalAlignment="Center"
+                      ItemsSource="{Binding AvailableDates}"
+                      SelectedItem="{Binding SelectedDate, Mode=TwoWay}" />
+            <TextBlock Margin="16,0,0,0"
+                       VerticalAlignment="Center"
+                       FontSize="15"
+                       Text="{Binding StatisticsText, Mode=OneWay}" />
+        </StackPanel>
+
+        <Border Grid.Row="2"
+                Margin="12,0,12,12"
+                CornerRadius="8"
+                ClipToBounds="True">
+            <Image Source="{Binding MapBitmap, Mode=OneWay}" Stretch="Uniform" />
+        </Border>
+    </Grid>
+</ui:FluentWindow>

--- a/BetterGenshinImpact/View/Windows/TravelLogWindow.xaml.cs
+++ b/BetterGenshinImpact/View/Windows/TravelLogWindow.xaml.cs
@@ -1,0 +1,17 @@
+using BetterGenshinImpact.Helpers.Ui;
+using BetterGenshinImpact.ViewModel.Windows;
+
+namespace BetterGenshinImpact.View.Windows;
+
+public partial class TravelLogWindow
+{
+    public TravelLogWindowViewModel ViewModel { get; }
+
+    public TravelLogWindow()
+    {
+        DataContext = ViewModel = new TravelLogWindowViewModel();
+        InitializeComponent();
+        SourceInitialized += (s, e) => WindowHelper.TryApplySystemBackdrop(this);
+        Closed += (s, e) => ViewModel.Dispose();
+    }
+}

--- a/BetterGenshinImpact/ViewModel/MaskWindowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/MaskWindowViewModel.cs
@@ -102,6 +102,12 @@ namespace BetterGenshinImpact.ViewModel
 
         public double MiniMapOverlaySizeRatio => MapAssets.MimiMapRect1080P.Width / 1080d;
 
+        /// <summary>
+        /// 小地图画布是否可见（地图遮罩小地图开关 或 移动轨迹记录开关 任一开启）
+        /// </summary>
+        public bool IsMiniMapCanvasVisible =>
+            (Config?.MapMaskConfig.MiniMapMaskEnabled ?? false) || (Config?.TravelLogConfig.Enabled ?? false);
+
         public sealed record MapPointApiProviderOption(MapPointApiProvider Provider, string DisplayName);
 
         public sealed record MapLanguageOption(string Code, string DisplayName);
@@ -261,6 +267,22 @@ namespace BetterGenshinImpact.ViewModel
                 if (configService != null)
                 {
                     Config = configService.Get();
+
+                    // 小地图画布可见性同时受「地图遮罩小地图」与「移动轨迹记录」开关控制
+                    Config.MapMaskConfig.PropertyChanged += (_, e) =>
+                    {
+                        if (e.PropertyName == nameof(MapMaskConfig.MiniMapMaskEnabled))
+                        {
+                            OnPropertyChanged(nameof(IsMiniMapCanvasVisible));
+                        }
+                    };
+                    Config.TravelLogConfig.PropertyChanged += (_, e) =>
+                    {
+                        if (e.PropertyName == nameof(GameTask.TravelLog.TravelLogConfig.Enabled))
+                        {
+                            OnPropertyChanged(nameof(IsMiniMapCanvasVisible));
+                        }
+                    };
                 }
             }
         }

--- a/BetterGenshinImpact/ViewModel/Pages/TriggerSettingsPageViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/TriggerSettingsPageViewModel.cs
@@ -225,4 +225,21 @@ public partial class TriggerSettingsPageViewModel : ViewModel
     {
         _navigationService.Navigate(typeof(HotKeyPage));
     }
+
+    private TravelLogWindow? _travelLogWindow;
+
+    [RelayCommand]
+    private void OpenTravelLogWindow()
+    {
+        if (_travelLogWindow == null || !_travelLogWindow.IsVisible)
+        {
+            _travelLogWindow = new TravelLogWindow();
+            _travelLogWindow.Closed += (s, e) => _travelLogWindow = null;
+            _travelLogWindow.Show();
+        }
+        else
+        {
+            _travelLogWindow.Activate();
+        }
+    }
 }

--- a/BetterGenshinImpact/ViewModel/Windows/TravelLogWindowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Windows/TravelLogWindowViewModel.cs
@@ -1,0 +1,384 @@
+using BetterGenshinImpact.Core.Config;
+using BetterGenshinImpact.GameTask.Common.BgiVision;
+using BetterGenshinImpact.GameTask.Common.Map.Maps;
+using BetterGenshinImpact.GameTask.Common.Map.Maps.Base;
+using BetterGenshinImpact.GameTask.TravelLog;
+using BetterGenshinImpact.GameTask.TravelLog.Model;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using OpenCvSharp;
+using OpenCvSharp.WpfExtensions;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Windows.Media.Imaging;
+using System.Windows.Threading;
+using BetterGenshinImpact.GameTask;
+using BetterGenshinImpact.GameTask.Common;
+
+namespace BetterGenshinImpact.ViewModel.Windows;
+
+/// <summary>
+/// 移动轨迹查看窗口
+/// 在提瓦特全图上绘制指定日期的移动轨迹与里程统计
+/// </summary>
+public partial class TravelLogWindowViewModel : ObservableObject, IDisposable
+{
+    /// <summary>
+    /// 显示位图宽度。256 级全图为 5632×3840，按 0.5 缩放展示
+    /// </summary>
+    private const int DisplayWidth = 2816;
+
+    /// <summary>
+    /// 2048 级图像坐标 → 256 级图像坐标的缩放
+    /// </summary>
+    private const int Scale2048To256 = 8;
+
+    /// <summary>
+    /// 模板匹配彩图瓦片 1 像素对应的游戏单位数（RoughZoom）
+    /// </summary>
+    private const float ColorTileZoom = 5f;
+
+    [ObservableProperty]
+    private WriteableBitmap? _mapBitmap;
+
+    [ObservableProperty]
+    private List<string> _availableDates = [];
+
+    [ObservableProperty]
+    private string _selectedDate = string.Empty;
+
+    [ObservableProperty]
+    private string _statisticsText = string.Empty;
+
+    private readonly ILogger _logger = TaskControl.Logger;
+
+    /// <summary>
+    /// 缩放后的展示底图
+    /// </summary>
+    private Mat? _displayMap;
+
+    /// <summary>
+    /// 2048 级图像坐标 → 显示位图像素的缩放系数
+    /// </summary>
+    private float _imageToDisplayScale = 1f;
+
+    private readonly DispatcherTimer _refreshTimer;
+
+    private int _lastDrawnVersion = -1;
+
+    private string? _loadedDate;
+
+    private ISceneMap? _teyvatMap;
+
+    private bool _disposed;
+
+    public TravelLogWindowViewModel()
+    {
+        InitDisplayMap();
+
+        AvailableDates = TravelLogService.Instance.ListAvailableDates();
+        SelectedDate = DateTime.Now.ToString("yyyy-MM-dd");
+
+        _refreshTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(3) };
+        _refreshTimer.Tick += (_, _) => Refresh();
+        _refreshTimer.Start();
+
+        Refresh();
+    }
+
+    private void InitDisplayMap()
+    {
+        try
+        {
+            var mapPath = Global.Absolute(@"Assets/Map/Teyvat/Teyvat_0_256.png");
+            if (!File.Exists(mapPath))
+            {
+                _logger.LogWarning("[TravelLog] 地图文件不存在：{Path}", mapPath);
+                return;
+            }
+
+            var matchingMethod = TaskContext.Instance().Config.PathingConditionConfig.MapMatchingMethod;
+            _teyvatMap = MapManager.GetMap(MapTypes.Teyvat, matchingMethod);
+
+            using var fullMap = new Mat(mapPath);
+            _imageToDisplayScale = (float)DisplayWidth / fullMap.Width;
+
+            // 优先用彩色瓦片拼接底图，失败则回退灰度图（默认按彩色模式加载，已是 3 通道）
+            var baseMap = TryBuildColorBaseMap(fullMap.Size()) ?? fullMap.Clone();
+            _displayMap = baseMap.Resize(new OpenCvSharp.Size(DisplayWidth, (int)(baseMap.Height * _imageToDisplayScale)));
+            baseMap.Dispose();
+        }
+        catch (Exception e)
+        {
+            _logger.LogWarning(e, "[TravelLog] 地图底图加载失败");
+        }
+    }
+
+    /// <summary>
+    /// 地图背景瓦片信息（对应 Assets/Map/Teyvat/mapback*_info.json）
+    /// </summary>
+    private sealed class MapBackLayerInfo
+    {
+        public string LayerId { get; set; } = string.Empty;
+        public int Floor { get; set; }
+        public float Scale { get; set; } = 1;
+        public double Left { get; set; }
+        public double Top { get; set; }
+    }
+
+    /// <summary>
+    /// 用 MapBack 彩色瓦片拼接 256 级彩色底图。
+    /// 瓦片锚点（Left/Top）为游戏坐标，瓦片 1 像素 = ColorTileZoom 游戏单位。
+    /// </summary>
+    private Mat? TryBuildColorBaseMap(OpenCvSharp.Size canvasSize)
+    {
+        try
+        {
+            if (_teyvatMap is not SceneBaseMap sceneMap)
+            {
+                return null;
+            }
+
+            var mapDir = Global.Absolute(@"Assets/Map/Teyvat");
+            var layers = new List<MapBackLayerInfo>();
+            foreach (var infoFile in new[] { "mapback_info.json", "mapback_6_0_info.json" })
+            {
+                var infoPath = Path.Combine(mapDir, infoFile);
+                if (File.Exists(infoPath))
+                {
+                    layers.AddRange(JsonConvert.DeserializeObject<List<MapBackLayerInfo>>(File.ReadAllText(infoPath)) ?? []);
+                }
+            }
+
+            if (layers.Count == 0)
+            {
+                return null;
+            }
+
+            // 2048 级地图原点在 256 级图像中的位置
+            var origin = sceneMap.MapOriginInImageCoordinate;
+            var origin256 = new Point2f(origin.X / Scale2048To256, origin.Y / Scale2048To256);
+            // 瓦片像素 → 256 级像素 的缩放（瓦片 1px = ColorTileZoom 游戏单位 = ColorTileZoom*2 个2048像素 = /8 个256像素）
+            var tileScale = ColorTileZoom * 2 / Scale2048To256;
+
+            var canvas = new Mat(canvasSize, MatType.CV_8UC3, new Scalar(214, 207, 188));
+            var seaColorSampled = false;
+
+            foreach (var layer in layers.Where(l => l.Floor == 0))
+            {
+                var tilePath = Path.Combine(mapDir, $"{layer.LayerId}_color.webp");
+                if (!File.Exists(tilePath))
+                {
+                    continue;
+                }
+
+                using var tile = Bv.ImRead(tilePath);
+                if (tile == null || tile.Empty())
+                {
+                    continue;
+                }
+
+                // 第一块瓦片的左上角区域一般是海洋，取均值作为海洋填充色
+                if (!seaColorSampled)
+                {
+                    var sampleRect = new Rect(2, 2, Math.Min(24, tile.Width - 4), Math.Min(24, tile.Height - 4));
+                    using var sample = new Mat(tile, sampleRect);
+                    var mean = Cv2.Mean(sample);
+                    canvas.SetTo(mean);
+                    seaColorSampled = true;
+                }
+
+                // 瓦片左上角对应游戏坐标 (Left, Top)，1 游戏单位 = 2 个 2048 级像素 = 2/8 个 256 级像素
+                var posX = (int)Math.Round(origin256.X - layer.Left * (2d / Scale2048To256));
+                var posY = (int)Math.Round(origin256.Y - layer.Top * (2d / Scale2048To256));
+
+                var dstW = (int)Math.Round(tile.Width * tileScale);
+                var dstH = (int)Math.Round(tile.Height * tileScale);
+                var dstRect = new Rect(posX, posY, dstW, dstH);
+                var canvasRect = new Rect(0, 0, canvas.Width, canvas.Height);
+                var clip = dstRect.Intersect(canvasRect);
+                if (clip.Width <= 0 || clip.Height <= 0)
+                {
+                    continue;
+                }
+
+                // 目标区域被画布裁剪时，源图按同样比例裁剪
+                var srcRect = new Rect(
+                    (int)((clip.X - posX) / tileScale),
+                    (int)((clip.Y - posY) / tileScale),
+                    (int)(clip.Width / tileScale),
+                    (int)(clip.Height / tileScale));
+                srcRect = srcRect.Intersect(new Rect(0, 0, tile.Width, tile.Height));
+                if (srcRect.Width <= 0 || srcRect.Height <= 0)
+                {
+                    continue;
+                }
+
+                using var src = new Mat(tile, srcRect);
+                using var resized = src.Resize(clip.Size);
+                resized.CopyTo(new Mat(canvas, clip));
+            }
+
+            return seaColorSampled ? canvas : null;
+        }
+        catch (Exception e)
+        {
+            _logger.LogWarning(e, "[TravelLog] 彩色地图合成失败，回退灰度底图");
+            return null;
+        }
+    }
+
+    partial void OnSelectedDateChanged(string value)
+    {
+        _lastDrawnVersion = -1; // 强制重绘
+        _loadedDate = null;
+        Refresh();
+    }
+
+    public void Refresh()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        try
+        {
+            var today = DateTime.Now.ToString("yyyy-MM-dd");
+            var isToday = SelectedDate == today;
+
+            TravelLogData data;
+            if (isToday)
+            {
+                var version = TravelLogService.Instance.TodayVersion;
+                if (_loadedDate == SelectedDate && version == _lastDrawnVersion)
+                {
+                    return; // 无新点，跳过重绘
+                }
+                _lastDrawnVersion = version;
+                data = TravelLogService.Instance.GetTodaySnapshot();
+            }
+            else
+            {
+                if (_loadedDate == SelectedDate)
+                {
+                    return; // 历史日期数据不变，避免反复读盘
+                }
+                data = TravelLogService.Instance.LoadByDate(SelectedDate);
+            }
+
+            _loadedDate = SelectedDate;
+            StatisticsText = FormatStatistics(data, isToday);
+            DrawTrajectory(data);
+        }
+        catch (Exception e)
+        {
+            _logger.LogDebug(e, "[TravelLog] 轨迹重绘失败");
+        }
+    }
+
+    private static string FormatStatistics(TravelLogData data, bool isToday)
+    {
+        var meters = data.TotalDistance;
+        var distanceText = meters >= 1000
+            ? $"{meters / 1000:F2} 公里"
+            : $"{meters:F0} 米";
+        var title = isToday ? "今日已移动约" : $"{data.Date} 共移动约";
+        return $"{title} {distanceText} · 共 {data.Points.Count} 个轨迹点";
+    }
+
+    private void DrawTrajectory(TravelLogData data)
+    {
+        if (_displayMap == null || _teyvatMap == null)
+        {
+            return;
+        }
+
+        using var canvas = _displayMap.Clone();
+
+        if (data.Points.Count > 0)
+        {
+            var displayPoints = data.Points
+                .Select(p => ToDisplayPoint(p))
+                .ToList();
+
+            // 按分段绘制轨迹线（传送导致的断段之间不连线）
+            var lineColor = new Scalar(0, 255, 0); // 绿色轨迹
+            foreach (var (start, end) in EnumerateSegmentRanges(data.Points.Count, data.Segments))
+            {
+                if (end - start < 2)
+                {
+                    continue;
+                }
+
+                var pts = displayPoints.GetRange(start, end - start).ToArray();
+                Cv2.Polylines(canvas, [pts], false, lineColor, 2, LineTypes.AntiAlias);
+            }
+
+            // 起点标记（绿点）
+            var first = displayPoints[0];
+            Cv2.Circle(canvas, first, 5, new Scalar(0, 200, 0), -1, LineTypes.AntiAlias);
+
+            // 最新位置标记（红点白边）
+            var last = displayPoints[^1];
+            Cv2.Circle(canvas, last, 6, new Scalar(255, 255, 255), -1, LineTypes.AntiAlias);
+            Cv2.Circle(canvas, last, 4, new Scalar(0, 0, 255), -1, LineTypes.AntiAlias);
+        }
+
+        MapBitmap = canvas.ToWriteableBitmap();
+    }
+
+    /// <summary>
+    /// 游戏坐标 → 显示位图像素坐标
+    /// </summary>
+    private Point ToDisplayPoint(TravelLogPoint p)
+    {
+        // 游戏坐标（1024 级）→ 2048 级图像坐标 → 显示像素
+        var image2048 = _teyvatMap!.ConvertGenshinMapCoordinatesToImageCoordinates(new Point2f(p.X, p.Y));
+        var factor = _imageToDisplayScale / Scale2048To256;
+        return new Point((int)(image2048.X * factor), (int)(image2048.Y * factor));
+    }
+
+    /// <summary>
+    /// 根据分段起始索引列表，枚举每段的 [start, end) 范围
+    /// </summary>
+    private static IEnumerable<(int start, int end)> EnumerateSegmentRanges(int pointCount, List<int> segments)
+    {
+        if (pointCount == 0)
+        {
+            yield break;
+        }
+
+        if (segments.Count == 0)
+        {
+            yield return (0, pointCount);
+            yield break;
+        }
+
+        for (var i = 0; i < segments.Count; i++)
+        {
+            var start = segments[i];
+            var end = i + 1 < segments.Count ? segments[i + 1] : pointCount;
+            if (start < end)
+            {
+                yield return (start, end);
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _refreshTimer.Stop();
+        _displayMap?.Dispose();
+        _displayMap = null;
+    }
+}


### PR DESCRIPTION
- 新增 TravelLog 触发器：主界面下周期性识别小地图位置，记录移动轨迹
- 轨迹数据按天持久化到 User/TravelLog/yyyy-MM-dd.json，支持传送跳变检测与轨迹分段
- 新增移动轨迹查看窗口：彩色拼接全图上绘制轨迹折线与当日里程统计，可切换历史日期
- 小地图遮罩画布叠加实时轨迹折线（无需开启地图遮罩）
- 大地图遮罩画布叠加轨迹折线（配合地图遮罩的可视区域定位）
- 触发器设置页新增「移动轨迹记录」配置卡片

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增移动轨迹记录，可持续记录游戏内移动路线并统计每日里程。
  * 支持按日期查看历史轨迹，并在地图上展示路线、起点和终点。
  * 自动区分正常移动与传送，避免将传送距离计入里程。
  * 在触发器设置中新增启用开关及“查看移动轨迹”入口。
  * 小地图遮罩支持实时显示移动轨迹。
* **改进**
  * 应用退出时自动保存未写入的轨迹数据，降低记录丢失风险。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->