### PR TITLE
refactor(image-region): 统一截图、视图与 Find 返回值的所有权语义

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoFight/AutoFightSeek.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/AutoFightSeek.cs
@@ -606,35 +606,43 @@ namespace BetterGenshinImpact.GameTask.AutoFight
 
                 while (attempt < retryCount)
                 {
-                    using var image2 = model ? CaptureToRectArea() : image ?? CaptureToRectArea();
+                    // model 为 true 时本方法自己截图并负责释放；否则借用调用者传入的 image，不得释放
+                    var ownsImage2 = model;
+                    var image2 = model ? CaptureToRectArea() : image!;
+                    int numLabels2;
+                    try
+                    {
+                        var skillAra = !skills
+                            ? new Rect(image2.Width * 1688 / 1920, image2.Height * 988 / 1080,
+                                image2.Width * 22 / 1920, image2.Height * 12 / 1080) //E技能区域
 
-                    // var image2 = CaptureToRectArea();
+                            : new Rect(image2.Width * 1809 / 1920, image2.Height * 968 / 1080,
+                                image2.Width * 30 / 1920, image2.Height * 15 / 1080); //Q技能区域
 
-                    var skillAra = !skills
-                        ? new Rect(image2.Width * 1688 / 1920, image2.Height * 988 / 1080,
-                            image2.Width * 22 / 1920, image2.Height * 12 / 1080) //E技能区域
-                        
-                        : new Rect(image2.Width * 1809 / 1920, image2.Height * 968 / 1080,
-                            image2.Width * 30 / 1920, image2.Height * 15 / 1080); //Q技能区域
-                    
-                    using var mask2 = OpenCvCommonHelper.Threshold(
-                        image2.DeriveCrop(skillAra).SrcMat,
-                        bloodLower,
-                        bloodLower
-                    );
+                        using var mask2 = OpenCvCommonHelper.Threshold(
+                            image2.DeriveCrop(skillAra).SrcMat,
+                            bloodLower,
+                            bloodLower
+                        );
 
-                    using var labels2 = new Mat();
-                    using var stats2 = new Mat();
-                    using var centroids2 = new Mat();
+                        using var labels2 = new Mat();
+                        using var stats2 = new Mat();
+                        using var centroids2 = new Mat();
 
-                    int numLabels2 = Cv2.ConnectedComponentsWithStats(mask2, labels2, stats2, centroids2,
-                        connectivity: PixelConnectivity.Connectivity4, ltype: MatType.CV_32S);
+                        numLabels2 = Cv2.ConnectedComponentsWithStats(mask2, labels2, stats2, centroids2,
+                            connectivity: PixelConnectivity.Connectivity4, ltype: MatType.CV_32S);
+                    }
+                    finally
+                    {
+                        if (ownsImage2)
+                        {
+                            image2.Dispose();
+                        }
+                    }
 
-                    if (model) image2.Dispose();
-                    
-                    if (needLog) Logger.LogInformation("技能状态：{guardianAvatar.Name} - {skills} 状态 {text}", 
+                    if (needLog) Logger.LogInformation("技能状态：{guardianAvatar.Name} - {skills} 状态 {text}",
                         guardianAvatar.Name, skills?"Q技能":"E技能", numLabels2 > 1?"冷却中":"就绪");
-                    
+
                     // Logger.LogInformation("技能状态：{numLabels2} 数量", numLabels2);
                     if (numLabels2 > 2)
                     {
@@ -650,10 +658,10 @@ namespace BetterGenshinImpact.GameTask.AutoFight
                         {
                             guardianAvatar.ManualSkillCd = 0;
                         }
-                        
+
                         return true;
                     }
-                    
+
                     attempt++;
                    if (retryCount > 1) await Task.Delay(100, ct);
                 }

--- a/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
@@ -219,17 +219,32 @@ public class Avatar
     /// </summary>
     private static bool SwimmingConfirm(Region region)
     {
-        using var imageRegion = region.ToImageRegion();
-        using var cropped = imageRegion.DeriveCrop(1819, 1025, 9, 11);
-        using var mask = OpenCvCommonHelper.Threshold(cropped.SrcMat, new Scalar(242, 223, 39), new Scalar(255, 233, 44));
-        using var labels = new Mat();
-        using var stats = new Mat();
-        using var centroids = new Mat();
+        // 零拷贝视图，像素向 region 借用；PR2 修好 Dispose 派发前不能用 using var，必须显式先子后父释放
+        var imageRegion = region.ToImageRegionView();
+        try
+        {
+            var cropped = imageRegion.DeriveCrop(1819, 1025, 9, 11);
+            try
+            {
+                using var mask = OpenCvCommonHelper.Threshold(cropped.SrcMat, new Scalar(242, 223, 39), new Scalar(255, 233, 44));
+                using var labels = new Mat();
+                using var stats = new Mat();
+                using var centroids = new Mat();
 
-        var numLabels = Cv2.ConnectedComponentsWithStats(mask, labels, stats, centroids,
-            connectivity: PixelConnectivity.Connectivity4, ltype: MatType.CV_32S);
-        
-        return numLabels > 1;
+                var numLabels = Cv2.ConnectedComponentsWithStats(mask, labels, stats, centroids,
+                    connectivity: PixelConnectivity.Connectivity4, ltype: MatType.CV_32S);
+
+                return numLabels > 1;
+            }
+            finally
+            {
+                cropped.Dispose();
+            }
+        }
+        finally
+        {
+            imageRegion.Dispose();
+        }
     }
 
     /// <summary>
@@ -420,7 +435,7 @@ public class Avatar
     {
         // 剪裁出IndexRect区域
         using var indexRa = region.DeriveCrop(rect);
-        using var mat = indexRa.CacheGreyMat;
+        var mat = indexRa.CacheGreyMat; // 借用 indexRa 的缓存，所有权属于 indexRa，不能在这里 Dispose
         var count = OpenCvCommonHelper.CountGrayMatColor(mat, 251, 255);
         if (count * 1.0 / (mat.Width * mat.Height) > 0.5)
         {
@@ -577,8 +592,20 @@ public class Avatar
             return GetSkillCdSeconds();
         }
 
-        using var region = givenRegion ?? CaptureToRectArea();
-        return GetSkillCurrentCd(region);
+        // 只释放自己创建的截图，传入的 givenRegion 属于调用者
+        var ownsRegion = givenRegion is null;
+        var region = givenRegion ?? CaptureToRectArea();
+        try
+        {
+            return GetSkillCurrentCd(region);
+        }
+        finally
+        {
+            if (ownsRegion)
+            {
+                region.Dispose();
+            }
+        }
     }
 
     /// <summary>
@@ -1330,37 +1357,49 @@ public class Avatar
     {
         var results = new List<(int x, int y, int width, int height)>();
 
-        using var image = existingCapture ?? CaptureToRectArea();
-        var bloodLower = new OpenCvSharp.Scalar(255, 90, 90); // BGR 红色
-
-        using var cropped = image.DeriveCrop(0, 0, 1500, 900);
-        using Mat mask = Core.Recognition.OpenCv.OpenCvCommonHelper.Threshold(
-            cropped.SrcMat, bloodLower);
-
-        using Mat labels = new Mat();
-        using Mat stats = new Mat();
-        using Mat centroids = new Mat();
-
-        int numLabels = Cv2.ConnectedComponentsWithStats(
-            mask, labels, stats, centroids,
-            connectivity: PixelConnectivity.Connectivity4, ltype: MatType.CV_32S);
-
-        for (int i = 1; i < numLabels; i++)
+        // 只释放自己创建的截图，传入的 existingCapture 属于调用者
+        var ownsImage = existingCapture is null;
+        var image = existingCapture ?? CaptureToRectArea();
+        try
         {
-            using Mat row = stats.Row(i);
-            if (row.GetArray(out int[] arr))
+            var bloodLower = new OpenCvSharp.Scalar(255, 90, 90); // BGR 红色
+
+            using var cropped = image.DeriveCrop(0, 0, 1500, 900);
+            using Mat mask = Core.Recognition.OpenCv.OpenCvCommonHelper.Threshold(
+                cropped.SrcMat, bloodLower);
+
+            using Mat labels = new Mat();
+            using Mat stats = new Mat();
+            using Mat centroids = new Mat();
+
+            int numLabels = Cv2.ConnectedComponentsWithStats(
+                mask, labels, stats, centroids,
+                connectivity: PixelConnectivity.Connectivity4, ltype: MatType.CV_32S);
+
+            for (int i = 1; i < numLabels; i++)
             {
-                int x = arr[0], y = arr[1], width = arr[2], height = arr[3];
-                if (y < 50)
-                    continue;
-                results.Add((x, y, width, height));
+                using Mat row = stats.Row(i);
+                if (row.GetArray(out int[] arr))
+                {
+                    int x = arr[0], y = arr[1], width = arr[2], height = arr[3];
+                    if (y < 50)
+                        continue;
+                    results.Add((x, y, width, height));
+                }
+            }
+
+            // 自动更新传奇血条动态追踪
+            UpdateLegendaryBarTracker(results.Select(r => r.y));
+
+            return results;
+        }
+        finally
+        {
+            if (ownsImage)
+            {
+                image.Dispose();
             }
         }
-
-        // 自动更新传奇血条动态追踪
-        UpdateLegendaryBarTracker(results.Select(r => r.y));
-
-        return results;
     }
 
     /// <summary>
@@ -1372,8 +1411,21 @@ public class Avatar
     /// </summary>
     public static (int centerX, int centerY, string text)? FindDamageNumber(ImageRegion? existingCapture = null)
     {
-        using var ra = existingCapture ?? CaptureToRectArea();
-        var ocrResults = ra.FindMulti(RecognitionObject.Ocr(450, 240, 1150, 660));
+        // 只释放自己创建的截图，传入的 existingCapture 属于调用者
+        var ownsRa = existingCapture is null;
+        var ra = existingCapture ?? CaptureToRectArea();
+        List<Region> ocrResults;
+        try
+        {
+            ocrResults = ra.FindMulti(RecognitionObject.Ocr(450, 240, 1150, 660));
+        }
+        finally
+        {
+            if (ownsRa)
+            {
+                ra.Dispose();
+            }
+        }
 
         string[] reactionKeywords = ["免疫", "蒸发", "感电", "结晶", "扩散", "绽放", "冻结", "超载", "融化", "燃烧", "超导", "激化"];
         var validItems = new List<(int cx, int cy, int area, string text)>();

--- a/BetterGenshinImpact/GameTask/AutoFight/Model/CombatScenes.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Model/CombatScenes.cs
@@ -472,18 +472,29 @@ public class CombatScenes : IDisposable
             return Avatars[LastActiveAvatarIndex - 1].Name;
         }
 
-        using var imageRegion = region ?? TaskControl.CaptureToRectArea();
-
-        var rectArray = Avatars.Select(t => t.IndexRect).ToArray();
-        int index = PartyAvatarSideIndexHelper.GetAvatarIndexIsActiveWithContext(imageRegion, rectArray, new AvatarActiveCheckContext());
-
-        if (index > 0)
+        // 只释放自己创建的截图，传入的 region 属于调用者
+        var ownsRegion = region is null;
+        var imageRegion = region ?? TaskControl.CaptureToRectArea();
+        try
         {
-            LastActiveAvatarIndex = index;
-            return Avatars[LastActiveAvatarIndex - 1].Name;
-        }
+            var rectArray = Avatars.Select(t => t.IndexRect).ToArray();
+            int index = PartyAvatarSideIndexHelper.GetAvatarIndexIsActiveWithContext(imageRegion, rectArray, new AvatarActiveCheckContext());
 
-        return null;
+            if (index > 0)
+            {
+                LastActiveAvatarIndex = index;
+                return Avatars[LastActiveAvatarIndex - 1].Name;
+            }
+
+            return null;
+        }
+        finally
+        {
+            if (ownsRegion)
+            {
+                imageRegion.Dispose();
+            }
+        }
     }
 
     /// <summary>

--- a/BetterGenshinImpact/GameTask/AutoPathing/SkillBoostHelper.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/SkillBoostHelper.cs
@@ -964,25 +964,33 @@ public partial class PathExecutor
 
     private static bool SwimmingConfirm(Region region)
     {
-        var fullRegion = region.ToImageRegion();
-        bool ownRegion = fullRegion != region;
+        // 零拷贝视图，像素向 region 借用，始终由本方法拥有并释放；
+        // PR2 修好 Dispose 派发前不能用 using var，必须显式先子后父释放
+        var fullRegion = region.ToImageRegionView();
         try
         {
-            using var regionMat = fullRegion.DeriveCrop(1819, 1028, 9, 7);
-            using var mask = OpenCvCommonHelper.Threshold(regionMat.SrcMat,
-                new Scalar(242, 223, 39), new Scalar(255, 233, 44));
-            using var labels = new Mat();
-            using var stats = new Mat();
-            using var centroids = new Mat();
+            var regionMat = fullRegion.DeriveCrop(1819, 1028, 9, 7);
+            try
+            {
+                using var mask = OpenCvCommonHelper.Threshold(regionMat.SrcMat,
+                    new Scalar(242, 223, 39), new Scalar(255, 233, 44));
+                using var labels = new Mat();
+                using var stats = new Mat();
+                using var centroids = new Mat();
 
-            var numLabels = Cv2.ConnectedComponentsWithStats(mask, labels, stats, centroids,
-                connectivity: PixelConnectivity.Connectivity4, ltype: MatType.CV_32S);
+                var numLabels = Cv2.ConnectedComponentsWithStats(mask, labels, stats, centroids,
+                    connectivity: PixelConnectivity.Connectivity4, ltype: MatType.CV_32S);
 
-            return numLabels > 1;
+                return numLabels > 1;
+            }
+            finally
+            {
+                regionMat.Dispose();
+            }
         }
         finally
         {
-            if (ownRegion) fullRegion.Dispose();
+            fullRegion.Dispose();
         }
     }
 

--- a/BetterGenshinImpact/GameTask/AutoSkip/AutoSkipTrigger.cs
+++ b/BetterGenshinImpact/GameTask/AutoSkip/AutoSkipTrigger.cs
@@ -699,8 +699,20 @@ public partial class AutoSkipTrigger : ITaskTrigger
                     // 橙色选项
                     foreach (var item in rs)
                     {
-                        var textMat = item.ToImageRegion().SrcMat;
-                        if (IsOrangeOption(textMat))
+                        // 零拷贝视图，像素向 item 所属截图借用；
+                        // 原写法内联取 SrcMat 会直接丢失临时 ImageRegion 的所有权
+                        bool isOrangeOption;
+                        var textRegionView = item.ToImageRegionView();
+                        try
+                        {
+                            isOrangeOption = IsOrangeOption(textRegionView.SrcMat);
+                        }
+                        finally
+                        {
+                            textRegionView.Dispose();
+                        }
+
+                        if (isOrangeOption)
                         {
                             if (_config.AutoGetDailyRewardsEnabled && (item.Text.Contains("每日") || item.Text.Contains("委托")))
                             {

--- a/BetterGenshinImpact/GameTask/CaptureContent.cs
+++ b/BetterGenshinImpact/GameTask/CaptureContent.cs
@@ -18,31 +18,57 @@ public class CaptureContent : IDisposable
     public int FrameRate => (int)(1000 / TimerInterval);
 
     public ImageRegion CaptureRectArea { get; }
-    
+
+    /// <summary>
+    /// 是否拥有 <see cref="CaptureRectArea"/>。
+    /// 由 Mat 构造时为 true（本对象负责释放）；包装已有 <see cref="ImageRegion"/> 时为 false（只借用）。
+    /// </summary>
+    private readonly bool _ownsCaptureRectArea;
+
     public GameUiCategory CurrentGameUiCategory;
 
+    /// <summary>
+    /// 由一帧截图构造，取得该帧的所有权，必须 Dispose 本对象。
+    /// </summary>
     public CaptureContent(Mat image, int frameIndex, double interval)
     {
         FrameIndex = frameIndex;
         TimerInterval = interval;
+        _ownsCaptureRectArea = true;
         var systemInfo = TaskContext.Instance().SystemInfo;
 
         var gameCaptureRegion = systemInfo.DesktopRectArea.Derive(image, systemInfo.CaptureAreaRect.X, systemInfo.CaptureAreaRect.Y);
-        CaptureRectArea = gameCaptureRegion.DeriveTo1080P();
+        try
+        {
+            CaptureRectArea = gameCaptureRegion.DeriveTo1080P();
+        }
+        catch
+        {
+            // 构造未完成时外层 using 不会生效，必须在这里释放原始帧。
+            // DeriveTo1080P() 的 wrapper 构造失败路径上 gameCaptureRegion 可能已被释放，这里依赖 Dispose 幂等。
+            gameCaptureRegion.Dispose();
+            throw;
+        }
     }
 
     /// <summary>
-    /// 用于兼容新的 ImageRegion
+    /// 用于兼容新的 ImageRegion。
+    /// 只借用传入区域，本对象不拥有它，Dispose 本对象不会释放它。
     /// </summary>
     /// <param name="ra"></param>
     public CaptureContent(ImageRegion ra)
     {
         CaptureRectArea = ra;
+        _ownsCaptureRectArea = false;
     }
 
     public void Dispose()
     {
-        CaptureRectArea.Dispose();
+        if (_ownsCaptureRectArea)
+        {
+            CaptureRectArea.Dispose();
+        }
+
         GC.SuppressFinalize(this);
     }
 }

--- a/BetterGenshinImpact/GameTask/Common/TaskControl.cs
+++ b/BetterGenshinImpact/GameTask/Common/TaskControl.cs
@@ -308,8 +308,18 @@ public class TaskControl
     /// 自动判断当前运行上下文中截图方式，并选择合适的截图方式返回
     /// </summary>
     /// <returns></returns>
+    /// <remarks>
+    /// 所有权：返回值由【调用者】拥有，调用者必须负责 Dispose，否则整帧彩色 Mat、
+    /// 灰度缓存和 ImageSharp 缓存都会滞留到 GC/终结阶段，BitBlt 后端的 HGlobal 缓冲也无法复用。<br/>
+    /// 把已有区域传给辅助方法时属于借用，被调用方不得 Dispose 传入的区域。<br/>
+    /// 注意：在 <see cref="Model.Area.ImageRegion"/> 的 Dispose 派发修复合入前，
+    /// <c>using var</c> 会命中空的 <see cref="Model.Area.Region.Dispose"/>，
+    /// 必须以 <see cref="Model.Area.ImageRegion"/> 静态类型在 finally 中直接调用 Dispose()。
+    /// </remarks>
     public static ImageRegion CaptureToRectArea(bool forceNew = false)
     {
+        // 这里的 CaptureContent 只作为构造帮手，截图所有权直接随返回值转移给调用者，
+        // 因此不能 Dispose 这个临时 content。
         var image = CaptureGameImage(TaskTriggerDispatcher.GlobalGameCapture);
         var content = new CaptureContent(image, 0, 0);
         return content.CaptureRectArea;

--- a/BetterGenshinImpact/GameTask/Model/Area/GameCaptureRegion.cs
+++ b/BetterGenshinImpact/GameTask/Model/Area/GameCaptureRegion.cs
@@ -61,6 +61,13 @@ public class GameCaptureRegion(Mat mat, int initX, int initY, Region? owner = nu
     /// 游戏窗口初始截图大于1080P的统一转换到1080P
     /// </summary>
     /// <returns></returns>
+    /// <remarks>
+    /// 所有权：本方法可能消费 this。<br/>
+    /// Width &lt;= 1920 时直接返回 this；更大时会 Dispose 掉 this 的原始帧并返回一个新区域，
+    /// 此时 this 只作为坐标换算用的 Prev 节点保留（坐标字段是普通 int，不依赖像素）。
+    /// 调用后只允许使用返回值，不得再访问 this 的像素。<br/>
+    /// 异常路径：Resize 失败时 this 仍归调用者所有（不会被释放），中间 Mat 由本方法释放。
+    /// </remarks>
     public ImageRegion DeriveTo1080P()
     {
         if (Width <= 1920)
@@ -71,9 +78,28 @@ public class GameCaptureRegion(Mat mat, int initX, int initY, Region? owner = nu
         var scale = Width / 1920d;
 
         var newMat = new Mat();
-        Cv2.Resize(SrcMat, newMat, new Size(1920, Height / scale));
+        try
+        {
+            Cv2.Resize(SrcMat, newMat, new Size(1920, Height / scale));
+        }
+        catch
+        {
+            // Resize 失败时尚未消费 this，原始帧的所有权仍在调用者手里，只需要清掉本方法自己创建的 Mat
+            newMat.Dispose();
+            throw;
+        }
+
         Dispose();
-        return new ImageRegion(newMat, 0, 0, this, new ScaleConverter(scale));
+        try
+        {
+            return new ImageRegion(newMat, 0, 0, this, new ScaleConverter(scale));
+        }
+        catch
+        {
+            // 包装对象构造失败时 newMat 的所有权还没转移出去
+            newMat.Dispose();
+            throw;
+        }
         // return new ImageRegion(newMat, 0, 0, this, new TranslationConverter(0, 0));
     }
 

--- a/BetterGenshinImpact/GameTask/Model/Area/ImageRegion.cs
+++ b/BetterGenshinImpact/GameTask/Model/Area/ImageRegion.cs
@@ -80,7 +80,17 @@ public class ImageRegion : Region
         {
             throw new ArgumentOutOfRangeException(nameof(rect), $"DeriveCrop 裁剪区域无效: ({x},{y},{w},{h})，图像大小: {SrcMat.Cols}x{SrcMat.Rows}");
         }
-        return new ImageRegion(new Mat(SrcMat, rect), rect.X, rect.Y, this, new TranslationConverter(rect.X, rect.Y));
+        var roi = new Mat(SrcMat, rect);
+        try
+        {
+            return new ImageRegion(roi, rect.X, rect.Y, this, new TranslationConverter(rect.X, rect.Y));
+        }
+        catch
+        {
+            // 包装对象构造失败时 ROI header 的所有权还没转移出去
+            roi.Dispose();
+            throw;
+        }
     }
 
     public ImageRegion DeriveCrop(double dx, double dy, double dw, double dh)
@@ -94,7 +104,17 @@ public class ImageRegion : Region
         {
             throw new ArgumentOutOfRangeException(nameof(rect), $"DeriveCrop 裁剪区域无效: ({x},{y},{w},{h})，图像大小: {SrcMat.Cols}x{SrcMat.Rows}");
         }
-        return new ImageRegion(new Mat(SrcMat, rect), rect.X, rect.Y, this, new TranslationConverter(rect.X, rect.Y));
+        var roi = new Mat(SrcMat, rect);
+        try
+        {
+            return new ImageRegion(roi, rect.X, rect.Y, this, new TranslationConverter(rect.X, rect.Y));
+        }
+        catch
+        {
+            // 包装对象构造失败时 ROI header 的所有权还没转移出去
+            roi.Dispose();
+            throw;
+        }
     }
 
     public ImageRegion DeriveCrop(Rect rect)

--- a/BetterGenshinImpact/GameTask/Model/Area/ImageRegion.cs
+++ b/BetterGenshinImpact/GameTask/Model/Area/ImageRegion.cs
@@ -62,6 +62,12 @@ public class ImageRegion : Region
     /// <summary>
     /// 剪裁派生
     /// </summary>
+    /// <remarks>
+    /// 所有权：调用者拥有返回值的 Mat header，但像素是向本区域借用的（<c>new Mat(SrcMat, rect)</c>，零拷贝）。
+    /// 子区域的使用和释放必须严格嵌套在父区域生命周期内：先 Dispose 子区域，再 Dispose 父区域。
+    /// BitBlt 后端的像素是外部 HGlobal，没有 OpenCV 引用计数，父区域释放后子 ROI 会变成悬空视图。
+    /// 结果需要逃出父区域作用域时，必须使用 <see cref="Region.ToOwnedImageRegion"/> 深拷贝。
+    /// </remarks>
     /// <param name="x"></param>
     /// <param name="y"></param>
     /// <param name="w"></param>
@@ -114,6 +120,11 @@ public class ImageRegion : Region
     /// <param name="successAction">成功找到后做什么</param>
     /// <param name="failAction">失败后做什么</param>
     /// <returns>返回最优的一个识别结果RectArea</returns>
+    /// <remarks>
+    /// 所有权：本方法只借用输入区域，不会 Dispose 它。
+    /// 返回值始终是不拥有像素的普通 <see cref="Region"/>，绝不会是本对象本身，
+    /// 因此 Dispose 返回值不会影响输入区域。
+    /// </remarks>
     /// <exception cref="Exception"></exception>
     public Region Find(RecognitionObject ro, Action<Region>? successAction = null, Action? failAction = null)
     {
@@ -370,9 +381,12 @@ public class ImageRegion : Region
                 }
                 else
                 {
-                    this.Text = text;
-                    successAction?.Invoke(this);
-                    return this;
+                    // 不能返回 this：Find() 的返回值契约是「不拥有像素的普通 Region」，
+                    // 返回 this 会让 using var result = region.Find(...) 误释放调用方的 ImageRegion。
+                    var newRa = Derive(0, 0, Width, Height);
+                    newRa.Text = text;
+                    successAction?.Invoke(newRa);
+                    return newRa;
                 }
             }
             else

--- a/BetterGenshinImpact/GameTask/Model/Area/Region.cs
+++ b/BetterGenshinImpact/GameTask/Model/Area/Region.cs
@@ -313,6 +313,12 @@ public class Region : IDisposable
     /// 请使用 using var newRegion
     /// </summary>
     /// <returns></returns>
+    /// <remarks>
+    /// 该方法所有权语义不明确：本身已经是 <see cref="ImageRegion"/> 时返回 this，否则返回新对象，
+    /// 因此调用者无法判断是否应该 Dispose 返回值，无条件 Dispose 会误释放调用方的区域。
+    /// 请改用 <see cref="ToImageRegionView"/>（零拷贝视图）或 <see cref="ToOwnedImageRegion"/>（深拷贝）。
+    /// </remarks>
+    [Obsolete("所有权语义不明确，可能返回 this。请使用 ToImageRegionView() 或 ToOwnedImageRegion()。")]
     public ImageRegion ToImageRegion()
     {
         if (this is ImageRegion imageRegion)
@@ -324,6 +330,58 @@ public class Region : IDisposable
         var res = ConvertRes<ImageRegion>.ConvertPositionToTargetRegion(0, 0, Width, Height, this);
         var newRegion = new ImageRegion(new Mat(res.TargetRegion.SrcMat, res.ToRect()), X, Y, Prev, PrevConverter);
         return newRegion;
+    }
+
+    /// <summary>
+    /// 生成一个覆盖本区域的 <see cref="ImageRegion"/> 零拷贝视图。
+    /// 始终返回新对象（即使本身已经是 <see cref="ImageRegion"/> 也不会返回 this）。
+    /// </summary>
+    /// <remarks>
+    /// 所有权：调用者拥有返回值的 Mat header，但像素是向上级 <see cref="ImageRegion"/> 借用的。
+    /// 因此视图的使用和释放必须严格嵌套在上级区域生命周期内：先 Dispose 视图，再 Dispose 上级区域。
+    /// 结果需要逃出上级区域作用域时，必须改用 <see cref="ToOwnedImageRegion"/>。
+    /// </remarks>
+    public ImageRegion ToImageRegionView()
+    {
+        var res = ConvertRes<ImageRegion>.ConvertPositionToTargetRegion(0, 0, Width, Height, this);
+        var roi = new Mat(res.TargetRegion.SrcMat, res.ToRect());
+        try
+        {
+            return new ImageRegion(roi, X, Y, Prev, PrevConverter);
+        }
+        catch
+        {
+            roi.Dispose();
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// 生成一个覆盖本区域、拥有独立像素的 <see cref="ImageRegion"/>（深拷贝）。
+    /// </summary>
+    /// <remarks>
+    /// 所有权：返回值完全独立于源区域，可以安全地逃出源区域作用域，由调用者负责 Dispose。
+    /// 代价是一次完整的 <see cref="Mat.Clone()"/>，只在结果确实需要比源区域活得更久时使用；
+    /// 同步读取请使用 <see cref="ToImageRegionView"/>。
+    /// </remarks>
+    public ImageRegion ToOwnedImageRegion()
+    {
+        var res = ConvertRes<ImageRegion>.ConvertPositionToTargetRegion(0, 0, Width, Height, this);
+        Mat owned;
+        using (var roi = new Mat(res.TargetRegion.SrcMat, res.ToRect()))
+        {
+            owned = roi.Clone();
+        }
+
+        try
+        {
+            return new ImageRegion(owned, X, Y, Prev, PrevConverter);
+        }
+        catch
+        {
+            owned.Dispose();
+            throw;
+        }
     }
 
     public bool IsEmpty()

--- a/Test/BetterGenshinImpact.UnitTest/CoreTests/RecognitionTests/ImageRegionFindOwnershipTests.cs
+++ b/Test/BetterGenshinImpact.UnitTest/CoreTests/RecognitionTests/ImageRegionFindOwnershipTests.cs
@@ -1,0 +1,270 @@
+using BetterGenshinImpact.Core.Recognition;
+using BetterGenshinImpact.GameTask.Model.Area;
+using BetterGenshinImpact.UnitTest.GameTaskTests.AutoFishingTests;
+using OpenCvSharp;
+
+namespace BetterGenshinImpact.UnitTest.CoreTests.RecognitionTests;
+
+/// <summary>
+/// PR1 所有权契约回归测试。
+/// 覆盖：Find() 不返回输入区域、ToImageRegionView() 零拷贝视图、ToOwnedImageRegion() 深拷贝、
+/// DeriveTo1080P() 的消费语义与异常安全、缓存 Mat 的归属。
+/// </summary>
+public class ImageRegionFindOwnershipTests
+{
+    private static GameCaptureRegion CreateCapture(int width = 320, int height = 180, Scalar? fill = null)
+    {
+        return new GameCaptureRegion(new Mat(height, width, MatType.CV_8UC3, fill ?? Scalar.Black), 0, 0,
+            drawContent: new FakeDrawContent());
+    }
+
+    private static Mat CreateTemplate()
+    {
+        var template = new Mat(20, 20, MatType.CV_8UC3, Scalar.Black);
+        Cv2.Rectangle(template, new Rect(2, 2, 8, 8), Scalar.White, -1);
+        Cv2.Circle(template, new Point(14, 6), 3, new Scalar(160, 160, 160), -1);
+        Cv2.Line(template, new Point(2, 17), new Point(17, 13), new Scalar(220, 220, 220), 2);
+        return template;
+    }
+
+    [Fact]
+    public void Find_TemplateMatchSuccess_DoesNotReturnInputRegion()
+    {
+        var region = CreateCapture();
+        try
+        {
+            using var template = CreateTemplate();
+            using (var target = new Mat(region.SrcMat, new Rect(40, 30, 20, 20)))
+            {
+                template.CopyTo(target);
+            }
+
+            var ro = new RecognitionObject
+            {
+                Name = "OwnershipTemplate",
+                RecognitionType = RecognitionTypes.TemplateMatch,
+                TemplateImageMat = template.Clone(),
+                Threshold = 0.8
+            }.InitTemplate();
+
+            var result = region.Find(ro);
+
+            Assert.True(result.IsExist());
+            Assert.NotSame(region, result);
+
+            // 识别结果不拥有像素，Dispose 它不能影响输入区域
+            result.Dispose();
+            Assert.False(region.SrcMat.IsDisposed);
+            Assert.Equal(320, region.SrcMat.Width);
+        }
+        finally
+        {
+            region.Dispose();
+        }
+    }
+
+    [Fact]
+    public void Find_TemplateMatchFail_ReturnsEmptyRegionAndKeepsInput()
+    {
+        var region = CreateCapture();
+        try
+        {
+            using var template = CreateTemplate();
+            var ro = new RecognitionObject
+            {
+                Name = "OwnershipTemplateMiss",
+                RecognitionType = RecognitionTypes.TemplateMatch,
+                TemplateImageMat = template.Clone(),
+                Threshold = 0.99
+            }.InitTemplate();
+
+            var result = region.Find(ro);
+
+            Assert.True(result.IsEmpty());
+            Assert.NotSame(region, result);
+            result.Dispose();
+            Assert.False(region.SrcMat.IsDisposed);
+        }
+        finally
+        {
+            region.Dispose();
+        }
+    }
+
+    [Fact]
+    public void ToImageRegionView_OnImageRegion_ReturnsNewObject()
+    {
+        var capture = CreateCapture();
+        try
+        {
+            var view = capture.ToImageRegionView();
+            try
+            {
+                Assert.NotSame(capture, view);
+                Assert.NotSame(capture.SrcMat, view.SrcMat);
+                Assert.Equal(capture.Width, view.Width);
+                Assert.Equal(capture.Height, view.Height);
+            }
+            finally
+            {
+                view.Dispose();
+            }
+
+            // 先释放子视图后，父区域仍然可用
+            Assert.False(capture.SrcMat.IsDisposed);
+            Assert.Equal(320, capture.SrcMat.Width);
+        }
+        finally
+        {
+            capture.Dispose();
+        }
+    }
+
+    [Fact]
+    public void ToImageRegionView_OnDerivedRegion_KeepsCoordinateChain()
+    {
+        var capture = CreateCapture();
+        try
+        {
+            var child = capture.Derive(100, 60, 40, 30);
+            var expected = child.ConvertSelfPositionToGameCaptureRegion();
+
+            var view = child.ToImageRegionView();
+            try
+            {
+                Assert.NotSame(child, view);
+                Assert.Equal(40, view.Width);
+                Assert.Equal(30, view.Height);
+                Assert.Equal(expected, view.ConvertSelfPositionToGameCaptureRegion());
+                Assert.Equal(expected, view.ConvertPositionToGameCaptureRegion(view.X, view.Y, view.Width, view.Height));
+            }
+            finally
+            {
+                view.Dispose();
+            }
+
+            Assert.False(capture.SrcMat.IsDisposed);
+        }
+        finally
+        {
+            capture.Dispose();
+        }
+    }
+
+    [Fact]
+    public void ToImageRegionView_BorrowsParentPixels()
+    {
+        var capture = CreateCapture(64, 48);
+        try
+        {
+            var view = capture.ToImageRegionView();
+            try
+            {
+                capture.SrcMat.SetTo(new Scalar(10, 20, 30));
+                // 零拷贝视图共享父区域像素
+                Assert.Equal(new Vec3b(10, 20, 30), view.SrcMat.At<Vec3b>(0, 0));
+            }
+            finally
+            {
+                view.Dispose();
+            }
+        }
+        finally
+        {
+            capture.Dispose();
+        }
+    }
+
+    [Fact]
+    public void ToOwnedImageRegion_SurvivesSourceDispose()
+    {
+        var capture = CreateCapture(64, 48, new Scalar(10, 20, 30));
+        var child = capture.Derive(8, 8, 16, 16);
+        var owned = child.ToOwnedImageRegion();
+        try
+        {
+            Assert.NotSame(child, owned);
+            Assert.Equal(16, owned.Width);
+
+            capture.Dispose();
+
+            // 深拷贝与源区域生命周期无关
+            Assert.False(owned.SrcMat.IsDisposed);
+            Assert.Equal(new Vec3b(10, 20, 30), owned.SrcMat.At<Vec3b>(0, 0));
+        }
+        finally
+        {
+            owned.Dispose();
+        }
+    }
+
+    [Fact]
+    public void DeriveTo1080P_WithinLimit_ReturnsSelf()
+    {
+        var region = CreateCapture(1920, 1080);
+        try
+        {
+            Assert.Same(region, region.DeriveTo1080P());
+        }
+        finally
+        {
+            region.Dispose();
+        }
+    }
+
+    [Fact]
+    public void DeriveTo1080P_AboveLimit_ConsumesSelfAndReturnsNewRegion()
+    {
+        var region = CreateCapture(2560, 1600);
+        var srcMat = region.SrcMat;
+
+        var result = region.DeriveTo1080P();
+        try
+        {
+            Assert.NotSame(region, result);
+            Assert.Equal(1920, result.Width);
+            // 大于 1080P 时原始帧被本方法消费掉，只保留坐标换算用的 Prev 节点
+            Assert.True(srcMat.IsDisposed);
+            Assert.Same(region, result.Prev);
+        }
+        finally
+        {
+            result.Dispose();
+        }
+    }
+
+    [Fact]
+    public void DeriveTo1080P_WhenResizeFails_DoesNotDisposeSelf()
+    {
+        // Height / scale 归零，Cv2.Resize 的目标尺寸非法，用于触发 Resize 失败路径
+        var region = CreateCapture(2560, 1);
+        try
+        {
+            Assert.ThrowsAny<Exception>(() => region.DeriveTo1080P());
+
+            // Resize 失败时尚未消费 this，原始帧的所有权仍在调用者手里
+            Assert.False(region.SrcMat.IsDisposed);
+            Assert.Equal(2560, region.SrcMat.Width);
+        }
+        finally
+        {
+            region.Dispose();
+        }
+    }
+
+    [Fact]
+    public void CacheMats_AreOwnedByRegion_AndMustNotBeDisposedByCallers()
+    {
+        var region = CreateCapture(64, 48);
+        var grey = region.CacheGreyMat;
+
+        // 同一个区域反复取缓存拿到的是同一个实例（借用值，不是每次新建）
+        Assert.Same(grey, region.CacheGreyMat);
+        Assert.False(grey.IsDisposed);
+
+        region.Dispose();
+
+        // 缓存归区域所有，随区域一起释放；调用方额外 Dispose 会破坏唯一所有者规则
+        Assert.True(grey.IsDisposed);
+    }
+}


### PR DESCRIPTION
# 背景：整个资源生命周期问题

ImageRegion 侧存在一组互相纠缠的资源生命周期缺陷，本 PR 是 8 个修复 PR 中的第 1 个：

- Dispose 派发错误（根因）：Region 实现了 IDisposable，但 Region.Dispose() 是空方法；ImageRegion 用 public new void Dispose() 隐藏而非覆盖基类方法。结果 using var 和 IDisposable 接口调用都派发到空的 Region.Dispose()，导致仓库中约 215 处看似正确的 using 截图实际没有释放彩色 Mat、灰度缓存和 ImageSharp 克隆。
- BitBlt HGlobal 缓冲池无法复用：截图 Mat 不及时释放时，BitBlt 后端只能不断 AllocHGlobal 新的约 6MB 缓冲，直接表现为原生内存快速增长。
- 识别内部临时 Mat 泄漏：Find() / FindMulti() 内部的二值图、ROI header、颜色克隆存在未释放路径。
- 所有权逃逸：七圣召唤返回内部 SrcMat、通知返回 CacheImage、Find() 全区域 OCR 成功时返回 this，都让「谁负责释放」变得不确定。
- 借用 ROI 悬空 / 被写坏：DeriveCrop() 借用父像素，多目标模板匹配把黑色遮盖矩形写回借用的缓存。

# 本 PR 在计划中的位置

- 顺序：第 1 个，是 PR2 的强制前置。必须先统一「借用 / 拥有」语义并消除 Find() 的混合返回所有权，PR2 才能安全地启用真正的多态 Dispose。否则 PR2 让约 215 处 using 同时生效时，「可能借用、可能创建」的代码会从内存泄漏直接变成 ObjectDisposedException 或 use-after-dispose。
- 依赖：无（链条起点）。被依赖：PR2 依赖本 PR 建立的所有权契约，PR3～PR7 的模块清理间接依赖。

# 本 PR 做了什么

1. Find() 不再返回 this（立即生效，不受 PR2 门控）：全区域 Ocr / ColorRangeAndOcr 成功时，改为构造一个覆盖完整范围、不拥有像素的普通 Region 并写入 Text。契约变为「返回值永远不是输入对象本身，Dispose 返回值绝不会释放输入区域」。经审计现有约 73 处 using ... Find(...) 无一命中旧的 return this 分支，因此本改动修复了 PR2 的潜在 double-dispose，且不破坏当前任何调用点。
2. 新增 ToImageRegionView()（零拷贝借用）/ ToOwnedImageRegion()（深拷贝），ToImageRegion() 标记 [Obsolete]。三个同步调用点（Avatar/SkillBoostHelper 的 SwimmingConfirm、AutoSkipTrigger 橙色选项检测）迁移到零拷贝 view，未对全帧引入 Clone。
3. 5 个条件借用 / 拥有点改为 ownsXxx = givenRegion is null 模式，只释放自己创建的截图，绝不释放调用者传入的区域。
4. 借用缓存被 using 释放（Avatar.IsIndexRectWhite）改为普通局部变量。
5. DeriveTo1080P() / CaptureContent 异常安全：Resize 失败时不 Dispose this（仍归调用者），只清理本方法创建的中间 Mat；CaptureContent 新增 _ownsCaptureRectArea 明确所有权（修复 PathExecutor 借用路径在 PR2 后的潜在 double-dispose）。
6. 补充所有权 XML 文档，新增 ImageRegionFindOwnershipTests（10 项测试）。

# 本 PR 明确不做什么

- 不修改全局 Dispose 派发（new → override）——归 PR2。
- 不修 Find()/FindMulti() 内部临时 Mat、Use3Channels 借用别名、多目标匹配 owned scratch、参考搜索 Resize 异常边界——归 PR2。
- 不改 PathExecutor 的截图重赋值未释放——归 PR4；地图遮罩 / NavigationInstance——归 PR3；七圣召唤 / 通知的所有权逃逸——归 PR5 / PR7；BitBltSession 关闭语义——独立后续 PR。

# 过渡期写法的理由

本 PR 新建的 view / owned ImageRegion 及其子区域使用显式 try/finally + Dispose() 而非 using var。原因是 PR2 合并前 using var 会派发到空的 Region.Dispose()（等于不释放），而以 ImageRegion / GameCaptureRegion 静态类型直接调用 Dispose() 能命中隐藏方法从而真正释放。待 PR2 修好多态 Dispose 后，这些显式 finally 可在对应模块清理 PR 中机械地简化回 using。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 明确并优化截图/图像区域的所有权与释放时机，减少误释放与资源泄漏。
  * 新增 `ToImageRegionView()` 零拷贝视图和 `ToOwnedImageRegion()` 独立拷贝区域；将 `ToImageRegion()` 标记为过时，提示改用更安全的转换方式。
* **测试**
  * 新增图像区域识别与所有权契约的单元测试，覆盖成功/失败与异常路径。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->