### PR TITLE
feat/refactor: 添加在大地图点击坐标的方法，获取小地图摄像机角度时不再为负数

### DIFF
--- a/BetterGenshinImpact/Core/Script/Dependence/Genshin.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/Genshin.cs
@@ -124,6 +124,25 @@ public class Genshin
     }
 
     /// <summary>
+    /// 点击大地图上的指定坐标。
+    /// </summary>
+    /// <remarks>
+    /// 该方法会先把目标移动到大地图的可点击安全区域，再执行一次点击。
+    /// 它适合需要“定位后点选”的脚本场景，不是传送接口。
+    /// 为避免初次中心点识别失败，建议先使用 SetBigMapZoomLevel 设置合适的大地图缩放等级。
+    /// </remarks>
+    /// <param name="x">目标X坐标。</param>
+    /// <param name="y">目标Y坐标。</param>
+    /// <param name="forceCountry">强制指定移动大地图时先切换的国家，默认为null。</param>
+    public async Task ClickMapPoint(double x, double y, string? forceCountry = null)
+    {
+        TpTask tpTask = new TpTask(CancellationContext.Instance.Cts.Token);
+        await tpTask.CheckInBigMapUi();
+        await tpTask.SwitchRecentlyCountryMap(x, y, forceCountry);
+        await tpTask.ClickMapPoint(x, y, MapTypes.Teyvat.ToString());
+    }
+
+    /// <summary>
     /// 移动大地图到指定坐标
     /// </summary>
     /// <remarks>

--- a/BetterGenshinImpact/Core/Script/Dependence/Genshin.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/Genshin.cs
@@ -128,8 +128,6 @@ public class Genshin
     /// </summary>
     /// <remarks>
     /// 该方法会先把目标移动到大地图的可点击安全区域，再执行一次点击。
-    /// 它适合需要“定位后点选”的脚本场景，不是传送接口。
-    /// 为避免初次中心点识别失败，建议先使用 SetBigMapZoomLevel 设置合适的大地图缩放等级。
     /// </remarks>
     /// <param name="x">目标X坐标。</param>
     /// <param name="y">目标Y坐标。</param>

--- a/BetterGenshinImpact/GameTask/AutoTrackPath/TpTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoTrackPath/TpTask.cs
@@ -1176,8 +1176,8 @@ public class TpTask
     /// 点击大地图上的指定坐标。
     /// </summary>
     /// <remarks>
-    /// 方法会先复用 <see cref="MoveMapTo(double, double, string, double)"/> 将目标移动到可点击安全区域，
-    /// 再按当前大地图视图把原神地图坐标转换为游戏截图区域坐标并点击。
+    /// 先将目标移动到可点击安全区域，
+    /// 再将原神地图坐标转换为游戏截图区域坐标并点击。
     /// </remarks>
     /// <param name="x">目标 x 坐标。</param>
     /// <param name="y">目标 y 坐标。</param>

--- a/BetterGenshinImpact/GameTask/AutoTrackPath/TpTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoTrackPath/TpTask.cs
@@ -1172,6 +1172,28 @@ public class TpTask
         await MoveMapToCore(x, y, mapName, finalZoomLevel, true, 0);
     }
 
+    /// <summary>
+    /// 点击大地图上的指定坐标。
+    /// </summary>
+    /// <remarks>
+    /// 方法会先复用 <see cref="MoveMapTo(double, double, string, double)"/> 将目标移动到可点击安全区域，
+    /// 再按当前大地图视图把原神地图坐标转换为游戏截图区域坐标并点击。
+    /// </remarks>
+    /// <param name="x">目标 x 坐标。</param>
+    /// <param name="y">目标 y 坐标。</param>
+    /// <param name="mapName">大地图名称。</param>
+    public async Task ClickMapPoint(double x, double y, string mapName)
+    {
+        await MoveMapTo(x, y, mapName);
+        if (!TryGetClickableTargetPosition(mapName, x, y, 0, out _, out var clickX, out var clickY))
+        {
+            throw new Exception($"目标点未移动到可点击区域：map={mapName}, target=({x:0.##},{y:0.##})");
+        }
+
+        using var clickCapture = CaptureToRectArea();
+        clickCapture.ClickTo(clickX, clickY);
+    }
+
     private async Task MoveMapToTeleportClickArea(double x, double y, string mapName, double requiredVisibleRadius)
     {
         await MoveMapToCore(x, y, mapName, MinTeleportZoomLevel, false, requiredVisibleRadius);

--- a/BetterGenshinImpact/GameTask/Common/Map/MiniMap/CameraOrientationCalculator.cs
+++ b/BetterGenshinImpact/GameTask/Common/Map/MiniMap/CameraOrientationCalculator.cs
@@ -117,6 +117,10 @@ public class CameraOrientationCalculator : IDisposable
         Cv2.Integral(resultShift, result);
         Cv2.MinMaxLoc(result, out _, out var maxVal, out _, out var maxLoc);
         var degree = (float)(maxLoc.X - 1) / ThetaLength * 360 / Scale - 45;
+        if (degree < 0)
+        {
+            degree += 360;
+        }
         var rotationConfidence = (float)(maxVal + peakRegionSum) / (PeakWidth * RLength * 255);
         return (degree, rotationConfidence);
     }


### PR DESCRIPTION
## 一
```js
genshin.clickMapPoint(double x, double y, string? forceCountry = null)
```
 - 功能为移动大地图到指定坐标，再鼠标左键点一下。

## 二
将小地图摄像机视角的角度区间表示从【-45, 315 】改成【 0 - 360】，原本正数角度表示的方位没变，不会影响自动秘境的镜头调整。
看了下应该没有引入破坏性改动，脚本仓库也没有使用对应方法的脚本。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增按坐标点击大地图点位的能力，可自动切换至对应国家或地图区域，并执行目标点点击。
  * 支持将地图移动至指定位置后，精确点击可用目标区域。

* **问题修复**
  * 优化小地图方向识别，统一处理负角度，提升旋转方向显示与后续定位的稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->