### PR TITLE
fix: 桑多涅体力识别替代序列冲刺管理，玛薇卡跳飞安全降落

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoPathing/SkillBoostHelper.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/SkillBoostHelper.cs
@@ -1069,7 +1069,10 @@ public partial class PathExecutor
         await Delay(150, ct);
 
         using var screen = CaptureToRectArea();
-        if (Bv.GetMotionStatus(screen) == MotionStatus.Fly)
+        var stamina = DetectStamina(screen);
+        if (Bv.GetMotionStatus(screen) == MotionStatus.Fly
+            || stamina == 0
+            || stamina == 240)
         {
             Simulation.SendInput.SimulateAction(GIActions.NormalAttack);
             await Delay(300, ct);

--- a/BetterGenshinImpact/GameTask/AutoPathing/SkillBoostHelper.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/SkillBoostHelper.cs
@@ -1,4 +1,4 @@
-﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿using System;
+﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -594,6 +594,7 @@ public partial class PathExecutor
                                 Simulation.SendInput.SimulateAction(GIActions.NormalAttack);
                                 await Delay(50, ct);
                                 Simulation.SendInput.SimulateAction(GIActions.NormalAttack);
+                                await Delay(150, ct);
                             }
                             await SafeLanding(ct);
                             Logger.LogInformation("自动赶路：桑多涅接近节点");

--- a/BetterGenshinImpact/GameTask/AutoPathing/SkillBoostHelper.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/SkillBoostHelper.cs
@@ -1,4 +1,4 @@
-﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿using System;
+﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -635,7 +635,7 @@ public partial class PathExecutor
                         return false;
                     }
 
-                    // Step 4: 已上车：体力 < 120 时正常冲刺，否则纯飘
+                    // Step 4: 已上车：体力 < 120 时纯飘（桑多涅技能代步），否则正常步行/冲刺
                     if (state.FlyingState)
                     {
                         if (nextWaypoint?.MoveMode == MoveModeEnum.Fly.Code)

--- a/BetterGenshinImpact/GameTask/AutoPathing/SkillBoostHelper.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/SkillBoostHelper.cs
@@ -1,4 +1,4 @@
-﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿using System;
+﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -52,10 +52,16 @@ public partial class PathExecutor
 
     private string _hurryOnAvatar = "";
     private DateTime _lastJumpFlyTime = DateTime.MinValue;
+    private bool _jumpFlySafetyPending;
     private DateTime _lastMavikaBoardTime = DateTime.MinValue;
     private DateTime _lastSkillCheckTime = DateTime.MinValue;
     private DateTime _lastLandingTime = DateTime.MinValue;
-    private int _sandroneCount;
+    /// <summary>
+    /// 上一帧识别的体力值，用于跨帧 fallback。初始为满值 240。
+    /// </summary>
+    private int _lastStamina = 240;
+    private int _lastWaypointIndex = -1;
+    private readonly List<int> _staminaHistory = new(50);
     private DateTime _lastSandroneSkillTime = DateTime.MinValue;
 
     /// <summary>
@@ -136,9 +142,17 @@ public partial class PathExecutor
         // Logger.LogInformation("[赶路调试] ExecuteHurryOnAsync: avatar={a}, dist={d}, nextDist={nd}, moveMode={m}, type={t}, num={n}, pending={pa}",
         //     avatar.Name, Math.Round(distance, 1), nextDistance, waypoint?.MoveMode, waypoint?.Type, num, state.PendingApproach);
 
+        double interval = PartyConfig.MwkJumpFlyIntervalSeconds > 0 ? PartyConfig.MwkJumpFlyIntervalSeconds : 1;
+
         switch (avatar.Name)
         {
             case "玛薇卡":
+                if (CurWaypoint.Item1 != _lastWaypointIndex)
+                {
+                    _jumpFlySafetyPending = false;
+                    _lastWaypointIndex = CurWaypoint.Item1;
+                }
+
                 if (state.OriginalMoveMode != null)
                 {
                     waypoint.MoveMode = state.OriginalMoveMode;
@@ -197,8 +211,6 @@ public partial class PathExecutor
 
                 if (PartyConfig.MwkJumpFlyEnabled && distance > 2 * PartyConfig.Distance && state.RotationStableCount >= 1)
                 {
-                    var interval = PartyConfig.MwkJumpFlyIntervalSeconds > 0 ? PartyConfig.MwkJumpFlyIntervalSeconds : 2;
-
                     if (!(boarded || GetMavikaColorDifference(screen2) <= 15 && await ReadEskillCdAsync("玛薇卡") < 1))
                     {
                         return false;
@@ -220,6 +232,7 @@ public partial class PathExecutor
                     Simulation.SendInput.SimulateAction(GIActions.Jump);
                     await Delay(150, ct);
                     _lastJumpFlyTime = DateTime.UtcNow;
+                    _jumpFlySafetyPending = true;
 
                     using var jumpCheckRegion = CaptureToRectArea();
                     if (Bv.GetMotionStatus(jumpCheckRegion) == MotionStatus.Fly)
@@ -245,6 +258,16 @@ public partial class PathExecutor
                     }
 
                     return true;
+                }
+
+                // 安全降落：同路段最后一次跳飞后，间隔已过仍可能在空中 → 普攻防摔伤
+                if (_lastJumpFlyTime != DateTime.MinValue
+                    && _jumpFlySafetyPending
+                    && (DateTime.UtcNow - _lastJumpFlyTime).TotalSeconds > interval)
+                {
+                    Simulation.SendInput.SimulateAction(GIActions.NormalAttack);
+                    await Delay(100, ct);
+                    _jumpFlySafetyPending = false;
                 }
 
                 if ((boarded || GetMavikaColorDifference(screen2) <= 15) && distance > PartyConfig.Distance)
@@ -520,6 +543,7 @@ public partial class PathExecutor
                 break;
 
             case "闲云":
+            {
                 if (distance > PartyConfig.Distance
                     && (waypoint?.MoveMode == MoveModeEnum.Run.Code || waypoint?.MoveMode == MoveModeEnum.Dash.Code))
                 {
@@ -529,7 +553,6 @@ public partial class PathExecutor
                     if (cd <= 0 && state.RotationStableCount >= 1)
                     {
                         Simulation.SendInput.SimulateAction(GIActions.ElementalSkill);
-                        var interval = PartyConfig.MwkJumpFlyIntervalSeconds > 0 ? PartyConfig.MwkJumpFlyIntervalSeconds : 1;
                         await Delay((int)(interval / 2.0 * 1000), ct);
                         avatar.LastSkillTime = DateTime.UtcNow;
                         return true;
@@ -538,17 +561,33 @@ public partial class PathExecutor
                     return false;
                 }
                 break;
+            }
 
             case "桑多涅":
                 try
                 {
-                    // ① 小于停止距离 → 尝试主动下车
+                    // Step 1: 状态同步 — 每次进入 reconcile FlyingState 与实际游戏状态
+                    //    FlyingState=true 但实际技能已结束 → 主动降落
+                    //    FlyingState=false 但实际技能已生效 → 同步状态
+                    if (state.FlyingState && !DashAtSecondPlaceExist())
+                    {
+                        state.FlyingState = false;
+                        _lastSandroneSkillTime = DateTime.UtcNow;
+                        await SafeLanding(ct);
+                        Logger.LogInformation("自动赶路：桑多涅技能耗尽，安全降落");
+                        return false;
+                    }
+                    if (!state.FlyingState && DashAtSecondPlaceExist())
+                    {
+                        state.FlyingState = true;
+                    }
+
+                    // Step 2: 小于停止距离 → 主动下车
                     if (state.FlyingState && distance < PartyConfig.ApproachStopDistance)
                     {
                         var needsApproach = ShouldApproach(distance, nextDistance, waypoint, nextWaypoint, avatar.Name);
                         if (needsApproach)
                         {
-                            // Logger.LogInformation("[赶路调试] 桑多涅 触发接近: dist={d}, dashExist={de}", Math.Round(distance, 1), DashAtSecondPlaceExist());
                             state.FlyingState = false;
                             if (DashAtSecondPlaceExist())
                             {
@@ -562,20 +601,7 @@ public partial class PathExecutor
                         }
                     }
 
-                    // ② 飞行态监控区域（≥ ApproachStopDistance）：不主动上下车，持续检测技能是否结束
-                    if (state.FlyingState && distance >= PartyConfig.ApproachStopDistance)
-                    {
-                        if (!DashAtSecondPlaceExist())
-                        {
-                            state.FlyingState = false;
-                            await SafeLanding(ct);
-                            _lastSandroneSkillTime = DateTime.UtcNow;
-                            Logger.LogInformation("自动赶路：桑多涅技能耗尽，安全降落");
-                        }
-                        return true;
-                    }
-
-                    // ③ 大于启用距离且未上车 → 尝试上车
+                    // Step 3: 大于启用距离且未上车 → 尝试上车
                     if (!state.FlyingState
                         && distance > PartyConfig.Distance
                         && (waypoint?.MoveMode == MoveModeEnum.Run.Code || waypoint?.MoveMode == MoveModeEnum.Dash.Code))
@@ -589,15 +615,12 @@ public partial class PathExecutor
                                 var sandroneCd = await ReadEskillCdAsync("桑多涅");
                                 if (sandroneCd <= 0)
                                 {
-                                    // Logger.LogInformation("[赶路调试] 桑多涅 启动E技能: dist={d}, sandroneCd={cd}",
-                                    //     Math.Round(distance, 1), sandroneCd);
                                     Simulation.SendInput.SimulateAction(GIActions.ElementalSkill);
                                     await Delay(150, ct);
                                     if (DashAtSecondPlaceExist())
                                     {
                                         _lastSandroneSkillTime = DateTime.UtcNow;
                                         state.FlyingState = true;
-                                        _sandroneCount++;
                                     }
                                     else
                                     {
@@ -611,14 +634,14 @@ public partial class PathExecutor
                         return false;
                     }
 
-                    // ④ 已上车：跳过行走逻辑
+                    // Step 4: 已上车：体力 < 120 时正常冲刺，否则纯飘
                     if (state.FlyingState)
                     {
                         if (nextWaypoint?.MoveMode == MoveModeEnum.Fly.Code)
                         {
                             return true;
                         }
-                        else if (SandroneShouldSkip(_sandroneCount))
+                        else if (DetectStamina() < 120)
                         {
                             return true;
                         }
@@ -906,14 +929,114 @@ public partial class PathExecutor
         return false;
     }
 
-    private bool SandroneShouldSkip(int count)
+    private int DetectStamina(ImageRegion? existingCapture = null)
     {
-        return count switch
+        // 进入新节点且上一个节点是战斗或传送时重置体力为满值
+        if (CurWaypoint.Item1 != _lastWaypointIndex
+            && CurWaypoint.Item1 > 0)
         {
-            0 => false,
-            1 => false,
-            _ => count % 2 == 0,
-        };
+            var prev = CurWaypoints.Item2[CurWaypoint.Item1 - 1];
+            var isFightOrTeleport = prev.Type == WaypointType.Teleport.Code
+                || prev.Action == ActionEnum.Fight.Code;
+            if (isFightOrTeleport)
+            {
+                _lastStamina = 240;
+                _lastWaypointIndex = CurWaypoint.Item1;
+                RecordStaminaResult(240);
+                return 240;
+            }
+        }
+
+        var ownedCapture = existingCapture == null ? CaptureToRectArea() : null;
+        try
+        {
+            var ra = ownedCapture ?? existingCapture!;
+
+            // 体力条区域：1000,430 - 1100,630（1920×1080）
+            using var crop = ra.DeriveCrop(1000, 430, 100, 200);
+
+            // #FFC700 → BGR(0, 199, 255)，精确匹配，无色差
+            using var mask = new Mat();
+            Cv2.InRange(crop.SrcMat, new Scalar(0, 199, 255), new Scalar(0, 199, 255), mask);
+
+            using var labels = new Mat();
+            using var stats = new Mat();
+            using var centroids = new Mat();
+
+            var numLabels = Cv2.ConnectedComponentsWithStats(mask, labels, stats, centroids,
+                connectivity: PixelConnectivity.Connectivity4, ltype: MatType.CV_32S);
+
+            int totalArea = 0;
+            for (int i = 1; i < numLabels; i++)
+            {
+                var area = stats.At<int>(i, 4); // CC_STAT_AREA = 4
+                if (area >= 21)
+                {
+                    totalArea += area;
+                }
+            }
+
+            if (totalArea > 0)
+            {
+                _lastStamina = totalArea;
+                // Logger.LogInformation("INF 体力识别：{Value}", totalArea);
+                RecordStaminaResult(totalArea);
+                return totalArea;
+            }
+
+            // 无任何有效黄色连通域 → 检查历史趋势强制返回值
+            int forced;
+            if (HasStaminaStreak(0, 20, 39))
+                forced = 0;
+            else if (HasStaminaStreak(240, 20, 39))
+                forced = 240;
+            else
+                forced = _lastStamina > 120 ? 240 : 0;
+
+            // Logger.LogInformation("INF 体力识别：无有效区域，上次={Last}，强制={Forced}", _lastStamina, forced);
+            RecordStaminaResult(forced);
+            return forced;
+        }
+        finally
+        {
+            ownedCapture?.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// 记录体力识别返回值，保留最近至多50次。
+    /// </summary>
+    private void RecordStaminaResult(int value)
+    {
+        _staminaHistory.Add(value);
+        if (_staminaHistory.Count > 50)
+        {
+            _staminaHistory.RemoveRange(0, _staminaHistory.Count - 50);
+        }
+    }
+
+    /// <summary>
+    /// 在最近 lookback 次历史记录中，检查是否存在连续 streakCount 次等于 target 的记录。
+    /// </summary>
+    private bool HasStaminaStreak(int target, int streakCount, int lookback)
+    {
+        var count = _staminaHistory.Count;
+        if (count < streakCount) return false;
+        var start = Math.Max(0, count - lookback);
+        var consecutive = 0;
+        for (int i = start; i < count; i++)
+        {
+            if (_staminaHistory[i] == target)
+            {
+                consecutive++;
+                if (consecutive >= streakCount) return true;
+            }
+            else
+            {
+                consecutive = 0;
+            }
+        }
+        return false;
     }
 
     private bool DashAtSecondPlaceExist()
@@ -940,7 +1063,7 @@ public partial class PathExecutor
 
     private async Task SafeLanding(CancellationToken ct)
     {
-        await Delay(150, ct);
+        await Delay(250, ct);
         Simulation.SendInput.SimulateAction(GIActions.Jump);
         await Delay(150, ct);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - 优化玛薇卡自动跳飞赶路：采用共享跳飞间隔；换路点重置安全降落判定，间隔到达仍待降落时自动普攻落地。
  - 统一闲云跳飞延迟节奏，减少不一致。
  - 重构桑多涅飞行/上车流程：分步骤纠偏与收尾；上车后以体力条识别连续状态，异常强制回退，新节点重置体力。
  - 安全降落等待由150ms调整为250ms，飞行或体力耗尽时优先触发落地。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->