### PR TITLE
fix: 修复进入游戏 choose_enter_game 按钮识别范围，避免误点击

### DIFF
--- a/BetterGenshinImpact/GameTask/GameLoading/Assets/Recognition.json
+++ b/BetterGenshinImpact/GameTask/GameLoading/Assets/Recognition.json
@@ -3,7 +3,7 @@
     "ChooseEnterGame": {
       "type": "TemplateMatch",
       "template": "choose_enter_game.png",
-      "roi": "rect(0, ch / 2, cw, ch / 2)",
+      "roi": "rect(cw * 685 / 1920, ch * 595 / 1080, cw * 549 / 1920, ch * 64 / 1080)",
       "draw": false
     },
     "EnterGame": {


### PR DESCRIPTION
fix https://github.com/babalae/better-genshin-impact/issues/3301

试了一下没什么问题

退出到登录页面 -> 退出登录 -> 保留登录信息 -> 自动点击进入游戏 -> 正常进入游戏

退出到登录页面 -> 退出登录 -> 不保留登录信息 -> 等待用户自行登录 -> 正常进入游戏

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 优化进入游戏界面的识别区域定位，提升不同分辨率下的识别准确性与稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->