### PR TITLE
修复万叶/琴拾取前切换角色失效

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoFight/AutoFightJsonTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/AutoFightJsonTask.cs
@@ -801,6 +801,8 @@ public class AutoFightJsonTask : ISoloTask
                     {
                         Logger.LogInformation("使用 枫原万叶-长E 拾取掉落物");
                         await Delay(200, _ct);
+                        // Ct 可能已被 cts2 取消，临时替换为外部 _ct 以确保切换能正常执行
+                        picker.Ct = _ct;
                         if (picker.TrySwitch(10))
                         {
                             await picker.WaitSkillCd(_ct);
@@ -826,6 +828,7 @@ public class AutoFightJsonTask : ISoloTask
 
                     var find = _taskParam.QinDoublePickUp;
                     await Delay(150, _ct);
+                    picker.Ct = _ct;
                     if (picker.TrySwitch(10))
                     {
                         foreach (var miningActionStr in actionsToUse)

--- a/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
@@ -679,6 +679,8 @@ public class AutoFightTask : ISoloTask
                     {
                         Logger.LogInformation("使用 枫原万叶-长E 拾取掉落物");
                         await Delay(200, ct);
+                        // Ct 可能已被 cts2 取消，临时替换为外部 ct 以确保切换能正常执行
+                        picker.Ct = ct;
                         if (picker.TrySwitch(10))
                         {
                             // 等待元素战技 CD 就绪
@@ -714,6 +716,7 @@ public class AutoFightTask : ISoloTask
 
                     var find = _taskParam.QinDoublePickUp;
                     await Delay(150, ct);
+                    picker.Ct = ct;
                     if (picker.TrySwitch(10))
                     {
                         foreach (var miningActionStr in actionsToUse)


### PR DESCRIPTION
战斗结束后 cts2 被主动取消，导致 avatar.Ct 指向已取消的 token。
TrySwitch 内部首轮检测 Ct.IsCancellationRequested 为 true 后直接返回 false， 切人逻辑被跳过，拾取技能无法在正确角色上执行。

修复方式：在 TrySwitch 前临时将 avatar.Ct 替换为外部未取消的 ct，
使切换检测能正常执行。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 修复使用枫原万叶或琴的长按元素战技拾取掉落物时，因任务取消状态异常导致角色切换或拾取流程可能中断的问题。
  - 优化战后自动拾取时机，提升相关技能执行与掉落物拾取的稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->