### PR TITLE
feat: 状态机基类引入SuccessTo方法，期望不同的状态以支持分支

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoStygianOnslaught/AutoStygianOnslaughtTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoStygianOnslaught/AutoStygianOnslaughtTask.cs
@@ -133,7 +133,7 @@ public class AutoStygianOnslaughtTask : StateMachineBase<StygianState, BvPage>, 
             // 导航阶段
             (StygianState.MainWorld, [StygianState.EventMenu, StygianState.StygianOnslaughtPage]),
             (StygianState.EventMenu, [StygianState.StygianOnslaughtPage]),
-            (StygianState.StygianOnslaughtPage, [StygianState.TeleportMap, StygianState.DomainEntrance]),
+            (StygianState.StygianOnslaughtPage, [StygianState.MainWorld, StygianState.TeleportMap, StygianState.DomainEntrance]),
             (StygianState.TeleportMap, [StygianState.DomainEntrance]),
             (StygianState.DomainEntrance, [StygianState.DifficultySelect]),
             (StygianState.DifficultySelect, [StygianState.DomainLobby]),
@@ -158,9 +158,10 @@ public class AutoStygianOnslaughtTask : StateMachineBase<StygianState, BvPage>, 
         Init();
         Notify.Event(NotificationEvent.DomainStart).Success($"{Name}启动");
 
+        var shouldContinuePostProcessing = true;
         try
         {
-            await DoDomain();
+            shouldContinuePostProcessing = await DoDomain();
         }
         catch (TaskCanceledException)
         {
@@ -171,24 +172,38 @@ public class AutoStygianOnslaughtTask : StateMachineBase<StygianState, BvPage>, 
             Logger.LogInformation(e.Message);
         }
 
+        if (!shouldContinuePostProcessing)
+        {
+            Notify.Event(NotificationEvent.DomainEnd).Success($"{Name}结束");
+            return;
+        }
+
         await Delay(3000, ct);
         await ArtifactSalvage();
         Notify.Event(NotificationEvent.DomainEnd).Success($"{Name}结束");
     }
 
-    private async Task DoDomain()
+    private async Task<bool> DoDomain()
     {
         var page = new BvPage(_ct);
 
         // 阶段1：导航到秘境 - 状态机自动驱动
         // MainWorld → EventMenu → StygianOnslaughtPage → TeleportMap → DomainEntrance → DifficultySelect → DomainLobby → BossSelect → BattleArena
         await new ReturnMainUiTask().Start(_ct);
-        await RunStateMachineUntil(page, StygianState.BattleArena);
+        await RunStateMachineUntil(page, StygianState.StygianOnslaughtPage);
+        await RunStateMachineUntil(page, [StygianState.BattleArena, StygianState.MainWorld]);
+
+        if (CurrentState == StygianState.MainWorld)
+        {
+            Logger.LogInformation($"{Name}：活动已结束，已返回主界面");
+            return false;
+        }
 
         // 阶段2：战斗循环
         await BattleLoopStateMachine(page);
 
         await ExitDomain(page);
+        return true;
     }
 
     #region 状态检测器 - 注册给基类使用（接收 ImageRegion 参数复用截图）
@@ -306,8 +321,9 @@ public class AutoStygianOnslaughtTask : StateMachineBase<StygianState, BvPage>, 
     [StateDetector(StygianState.StygianOnslaughtPage, Order = 140)]
     private bool DetectStygianOnslaughtPage(ImageRegion ra)
     {
-        return ra.FindMulti(RecognitionObject.Ocr(ra.Width * 0.55, ra.Height * 0.3, ra.Width * 0.4, ra.Height * 0.6))
-                 .Any(o => o.Text.Contains("前往挑战"));
+        // 活动详情页右侧主标题：左上角(1135, 278)，右下角(1400, 353)
+        return ra.FindMulti(RecognitionObject.Ocr(1135, 278, 1400 - 1135, 353 - 278))
+                 .Any(o => o.Text.Contains("幽境危战"));
     }
 
     #endregion
@@ -373,6 +389,19 @@ public class AutoStygianOnslaughtTask : StateMachineBase<StygianState, BvPage>, 
     [StateHandler(StygianState.StygianOnslaughtPage, RetryTimes = 10)]
     private async Task<StateHandlerResult> HandleStygianOnslaughtPageState(BvPage page)
     {
+        using (var ra = CaptureToRectArea())
+        {
+            var ocrResult = ra.FindMulti(RecognitionObject.Ocr(ra.Width * 0.32, ra.Height * 0.68, ra.Width * 0.16, ra.Height * 0.1));
+            if (ocrResult.Any(o => o.Text.Contains("紊乱爆发期")) &&
+                ocrResult.Any(o => o.Text.Contains("已结束")))
+            {
+                Logger.LogInformation($"{Name}：检测到紊乱爆发期已结束，按 Esc 返回主界面");
+                Simulation.SendInput.Keyboard.KeyPress(Vanara.PInvoke.User32.VK.VK_ESCAPE);
+                await Delay(300, _ct);
+                return StateHandlerResult.SuccessTo(StygianState.MainWorld);
+            }
+        }
+
         Logger.LogInformation($"{Name}：点击前往挑战");
         var challengeButton = page.GetByText("前往挑战").WithRoi(r => r.CutRight(0.5)).FindAll().FirstOrDefault();
         if (challengeButton == null)
@@ -383,7 +412,9 @@ public class AutoStygianOnslaughtTask : StateMachineBase<StygianState, BvPage>, 
 
         challengeButton.Click();
         await Delay(300, _ct);
-        return StateHandlerResult.Success; // 等待转换到 TeleportMap 或 DomainEntrance
+        return StateHandlerResult.SuccessTo(
+            StygianState.TeleportMap,
+            StygianState.DomainEntrance);
     }
 
     [StateHandler(StygianState.TeleportMap)]

--- a/BetterGenshinImpact/GameTask/Common/StateMachine/README.md
+++ b/BetterGenshinImpact/GameTask/Common/StateMachine/README.md
@@ -87,7 +87,7 @@ private bool DetectEventMenu(ImageRegion ra)
 
 ## Handler
 
-Handler 只负责“在当前状态做一步动作”，动作结果用 `StateHandlerResult` 表达。
+Handler 只负责“在当前状态做一步动作”，动作结果用 `StateHandlerResult` 表达。除 `Success` 外，还可以用 `SuccessTo(...)` 将本次动作的等待目标收窄到当前状态图中的一个或多个合法邻接状态。
 
 ```csharp
 [StateHandler(MyState.MainWorld)]
@@ -111,13 +111,27 @@ private async Task<StateHandlerResult> HandleEventMenu(BvPage page)
     await Delay(300, _ct);
     return StateHandlerResult.Success;
 }
+
+[StateHandler(MyState.TargetPage)]
+private async Task<StateHandlerResult> HandleTargetPage(BvPage page)
+{
+    if (/* 当前页面业务条件成立 */)
+    {
+        Simulation.SendInput.SimulateAction(GIActions.OpenPaimonMenu);
+        return StateHandlerResult.SuccessTo(MyState.MainWorld);
+    }
+
+    page.GetByText("前往").FindAll().First().Click();
+    return StateHandlerResult.SuccessTo(MyState.TeleportMap, MyState.DomainEntrance);
+}
 ```
 
-`StateHandlerResult` 语义如下：
+`SuccessTo(...)` 的目标只表示真实的屏幕状态。当前屏幕中的业务条件不能伪造成一个新的状态；应先执行动作，再等待动作后的真实目标状态。
 
 | 返回值 | 框架行为 | 典型场景 |
 | --- | --- | --- |
-| `Success` | 动作完成，框架等待当前状态的邻接状态出现；如果源状态在动作生效窗口内持续可见，会触发当前状态 retry | 点击按钮、发送交互键后等待页面切换 |
+| `Success` | 动作完成，框架等待当前状态的全部合法邻接状态出现；如果源状态在动作生效窗口内持续可见，会触发当前状态 retry | 点击按钮、发送交互键后等待页面切换 |
+| `SuccessTo(targetStates...)` | 动作完成，框架只等待 Handler 指定的一个或多个合法邻接状态；目标仍需由 Detector 确认 | 同一动作可能进入多个已知页面，但不应接受当前状态的其他出边 |
 | `Wait` | 不计 retry，直接进入下一轮检测 | 加载中、动画中、当前状态无需动作 |
 | `Retry` | 当前状态 retry 次数加一，超限后抛异常 | 按钮没找到、OCR 暂时失败、动作没法确认 |
 | `Fail` | 立即抛异常 | 配置错误、关键条件不满足、无法恢复 |
@@ -242,6 +256,21 @@ retry 预算会被两类事件消耗：
 - 源状态和邻接目标都没检测到：说明可能处于加载、黑屏、动画等中间态，动作生效窗口重置，中间态长超时继续计时。
 - 中间态长超时：直接抛出中间态转换超时异常，不计入当前源状态的 retry 预算。
 
+`SuccessTo(targetStates...)` 使用同一套转场等待机制，但将“邻接目标状态”收窄为 Handler 指定的目标集合。状态机在运行时校验每个目标确实是当前状态的合法邻接状态，并且已注册 Detector；校验失败属于状态图或 Handler 契约错误，不会静默回退到全部邻接状态。
+
+例如同一个活动页可以按业务条件走不同真实屏幕节点：
+
+```csharp
+return StateHandlerResult.SuccessTo(StygianState.MainWorld);
+
+// 或
+return StateHandlerResult.SuccessTo(
+    StygianState.TeleportMap,
+    StygianState.DomainEntrance);
+```
+
+前者适用于执行 Esc 后返回主界面，后者适用于点击“前往挑战”后可能进入传送地图或秘境入口。业务条件本身不需要注册为状态，只负责决定本次动作及其目标集合。
+
 可以在节点上覆盖动作生效窗口：
 
 ```csharp
@@ -251,7 +280,6 @@ private async Task<StateHandlerResult> HandleTeleportMap(BvPage page)
     ...
 }
 ```
-
 ## Handler 内可读状态
 
 Handler 内可以读取当前 retry 信息，用于调整动作强度或打印日志：
@@ -291,6 +319,7 @@ flowchart LR
     MainWorld --> EventMenu
     MainWorld --> StygianOnslaughtPage
     EventMenu --> StygianOnslaughtPage
+    StygianOnslaughtPage --> MainWorld
     StygianOnslaughtPage --> TeleportMap
     StygianOnslaughtPage --> DomainEntrance
     TeleportMap --> DomainEntrance

--- a/BetterGenshinImpact/GameTask/Common/StateMachine/StateMachineBase.cs
+++ b/BetterGenshinImpact/GameTask/Common/StateMachine/StateMachineBase.cs
@@ -13,29 +13,69 @@ namespace BetterGenshinImpact.GameTask.Common.StateMachine;
 using static TaskControl;
 
 /// <summary>
-/// 状态处理器返回结果，决定状态机如何处理当前状态
+/// 状态处理器基础结果。
 /// </summary>
-public enum StateHandlerResult
+public enum StateHandlerStatus
 {
-    /// <summary>
-    /// 成功：操作完成，状态机自动等待邻接状态转换；源状态持续可见超过动作生效窗口后触发当前状态重试
-    /// </summary>
     Success,
-
-    /// <summary>
-    /// 等待：可预期的等待，状态机继续循环重新检测
-    /// </summary>
     Wait,
-
-    /// <summary>
-    /// 重试：意外失败，状态机重试直到超过最大次数
-    /// </summary>
     Retry,
+    Fail
+}
+
+/// <summary>
+/// 状态处理器返回结果，决定状态机如何处理当前状态。
+/// 可通过 SuccessTo 指定本次动作允许到达的邻接状态。
+/// </summary>
+public readonly struct StateHandlerResult
+{
+    private StateHandlerResult(StateHandlerStatus status, IReadOnlyList<Enum> targetStates)
+    {
+        Status = status;
+        TargetStates = targetStates;
+    }
 
     /// <summary>
-    /// 失败：无法恢复的错误，状态机抛出异常
+    /// 基础处理结果。
     /// </summary>
-    Fail
+    public StateHandlerStatus Status { get; }
+
+    /// <summary>
+    /// 本次动作允许到达的目标状态集合。
+    /// 空集合表示使用当前状态的全部邻接状态。
+    /// </summary>
+    public IReadOnlyList<Enum> TargetStates { get; }
+
+    public static StateHandlerResult Success { get; } = Create(StateHandlerStatus.Success);
+
+    public static StateHandlerResult Wait { get; } = Create(StateHandlerStatus.Wait);
+
+    public static StateHandlerResult Retry { get; } = Create(StateHandlerStatus.Retry);
+
+    public static StateHandlerResult Fail { get; } = Create(StateHandlerStatus.Fail);
+
+    /// <summary>
+    /// 创建成功结果，并将目标收窄到当前状态图中的指定邻接状态。
+    /// </summary>
+    public static StateHandlerResult SuccessTo<TState>(params TState[] targetStates)
+        where TState : struct, Enum
+    {
+        if (targetStates == null || targetStates.Length == 0)
+        {
+            throw new ArgumentException("SuccessTo 至少需要一个目标状态", nameof(targetStates));
+        }
+
+        var distinctTargets = targetStates
+            .Cast<Enum>()
+            .Distinct()
+            .ToArray();
+        return new StateHandlerResult(StateHandlerStatus.Success, Array.AsReadOnly(distinctTargets));
+    }
+
+    private static StateHandlerResult Create(StateHandlerStatus status)
+    {
+        return new StateHandlerResult(status, Array.Empty<Enum>());
+    }
 }
 
 /// <summary>
@@ -682,11 +722,13 @@ public abstract class StateMachineBase<TState, TContext> where TState : struct, 
             {
                 var result = await handler(context);
 
-                switch (result)
+                switch (result.Status)
                 {
-                    case StateHandlerResult.Success:
-                        // 成功：等待邻接状态转换；源状态持续可见超过动作生效窗口时触发当前状态重试
-                        var transitionResult = await WaitNextStateTransition(transitionTimeout);
+                    case StateHandlerStatus.Success:
+                        // 成功：等待指定的目标状态，或当前状态的全部邻接状态。
+                        var transitionResult = result.TargetStates.Count > 0
+                            ? await WaitStateTransitionTo(result.TargetStates, transitionTimeout)
+                            : await WaitNextStateTransition(transitionTimeout);
                         switch (transitionResult.Status)
                         {
                             case StateTransitionWaitStatus.ReachedTarget:
@@ -704,19 +746,19 @@ public abstract class StateMachineBase<TState, TContext> where TState : struct, 
                         }
                         break;
 
-                    case StateHandlerResult.Wait:
-                        // 可预期的等待：继续循环，重新检测状态
+                    case StateHandlerStatus.Wait:
+                        // 可预期的等待：状态机继续循环，重新检测状态。
                         Logger.LogDebug("Handler 返回 Wait，状态机继续等待");
                         break;
 
-                    case StateHandlerResult.Retry:
-                        // 意外失败重试：检查重试次数
+                    case StateHandlerStatus.Retry:
+                        // 意外失败重试：检查重试次数。
                         RecordStateRetry("Handler 返回 Retry", retryPolicy, stateRetryStopwatch);
                         nextLoopInterval = retryInterval;
                         break;
 
-                    case StateHandlerResult.Fail:
-                        // 失败：抛出异常
+                    case StateHandlerStatus.Fail:
+                        // 失败：抛出异常。
                         throw new InvalidOperationException($"状态 {CurrentState} 的 Handler 返回失败");
                 }
             }
@@ -912,8 +954,47 @@ public abstract class StateMachineBase<TState, TContext> where TState : struct, 
     }
 
     /// <summary>
-    /// 等待转换到邻接状态（使用状态转换关系）
-    /// 自动使用当前状态注册的邻接状态作为期望状态
+    /// 等待转换到 Handler 指定的目标状态集合。
+    /// </summary>
+    private async Task<StateTransitionWaitResult> WaitStateTransitionTo(IReadOnlyList<Enum> targetStates, int? timeoutMs = null)
+    {
+        var possibleStates = GetPossibleNextStates();
+        if (possibleStates == null || possibleStates.Length == 0)
+        {
+            throw new InvalidOperationException($"当前状态 {CurrentState} 没有注册邻接状态，无法使用 SuccessTo");
+        }
+
+        var typedTargetStates = new TState[targetStates.Count];
+        for (var i = 0; i < targetStates.Count; i++)
+        {
+            if (targetStates[i] is not TState typedState)
+            {
+                throw new InvalidOperationException($"状态 {CurrentState} 的 SuccessTo 目标类型 {targetStates[i].GetType().Name} 与状态机状态类型 {typeof(TState).Name} 不匹配");
+            }
+
+            if (!possibleStates.Contains(typedState))
+            {
+                throw new InvalidOperationException($"状态 {CurrentState} 的 SuccessTo 目标 {typedState} 不是合法邻接状态");
+            }
+
+            if (!_stateDetectors.ContainsKey(typedState))
+            {
+                throw new InvalidOperationException($"状态 {CurrentState} 的 SuccessTo 目标 {typedState} 未注册状态检测器");
+            }
+
+            typedTargetStates[i] = typedState;
+        }
+
+        var observedStates = typedTargetStates
+            .Concat(new[] { CurrentState })
+            .Distinct()
+            .ToArray();
+        return await WaitAnyStateTransition(observedStates, timeoutMs);
+    }
+
+    /// <summary>
+    /// 等待转换到邻接状态（使用状态转换关系）。
+    /// 自动使用当前状态注册的邻接状态作为期望状态。
     /// </summary>
     /// <param name="timeoutMs">超时时间（毫秒）</param>
     /// <returns>转换等待结果</returns>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能改进**
  - 优化「幽境危战」自动流程，支持从活动页面返回主界面后继续正确运行。
  - 活动已结束或进入主界面时，将自动跳过无效的战斗后处理与奖励收尾步骤。
  - 改进活动入口识别与页面导航，减少流程卡住或误判情况。
  - 优化点击“前往挑战”后的转场判断，提升不同页面状态下的执行稳定性。

- **文档**
  - 补充状态转场等待规则及使用说明，明确不同转场场景的处理方式。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->