### PR TITLE
fix: 定位并尝试解决万叶/琴拾取时切换对应角色逻辑没有执行的问题

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoFight/AutoFightJsonTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/AutoFightJsonTask.cs
@@ -790,6 +790,8 @@ public class AutoFightJsonTask : ISoloTask
 
             if (picker != null)
             {
+                Simulation.ReleaseAllKey();
+
                 if (picker.Name == "枫原万叶")
                 {
                     var time = TimeSpan.FromSeconds(picker.GetSkillCdSeconds());

--- a/BetterGenshinImpact/GameTask/AutoFight/AutoFightJsonTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/AutoFightJsonTask.cs
@@ -805,6 +805,7 @@ public class AutoFightJsonTask : ISoloTask
                         await Delay(200, _ct);
                         if (picker.TrySwitch(10))
                         {
+                            picker.Switch();
                             await picker.WaitSkillCd(_ct);
                             await SimulateHoldElementalSkillAsync(800, _ct);
                             await SimulateMouseLeftClickLoopAsync(6, _ct);
@@ -830,6 +831,7 @@ public class AutoFightJsonTask : ISoloTask
                     await Delay(150, _ct);
                     if (picker.TrySwitch(10))
                     {
+                        picker.Switch();
                         foreach (var miningActionStr in actionsToUse)
                         {
                             var pickUpAction = CombatScriptParser.ParseContext(miningActionStr);

--- a/BetterGenshinImpact/GameTask/AutoFight/AutoFightJsonTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/AutoFightJsonTask.cs
@@ -805,7 +805,6 @@ public class AutoFightJsonTask : ISoloTask
                         await Delay(200, _ct);
                         if (picker.TrySwitch(10))
                         {
-                            picker.Switch();
                             await picker.WaitSkillCd(_ct);
                             await SimulateHoldElementalSkillAsync(800, _ct);
                             await SimulateMouseLeftClickLoopAsync(6, _ct);
@@ -831,7 +830,6 @@ public class AutoFightJsonTask : ISoloTask
                     await Delay(150, _ct);
                     if (picker.TrySwitch(10))
                     {
-                        picker.Switch();
                         foreach (var miningActionStr in actionsToUse)
                         {
                             var pickUpAction = CombatScriptParser.ParseContext(miningActionStr);

--- a/BetterGenshinImpact/GameTask/AutoFight/AutoFightJsonTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/AutoFightJsonTask.cs
@@ -827,7 +827,6 @@ public class AutoFightJsonTask : ISoloTask
                         .ToArray();
 
                     var find = _taskParam.QinDoublePickUp;
-                    await Delay(150, _ct);
                     if (picker.TrySwitch(10))
                     {
                         await Delay(100, _ct);

--- a/BetterGenshinImpact/GameTask/AutoFight/AutoFightJsonTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/AutoFightJsonTask.cs
@@ -802,9 +802,9 @@ public class AutoFightJsonTask : ISoloTask
                     if (forcePickup || !shouldSkip)
                     {
                         Logger.LogInformation("使用 枫原万叶-长E 拾取掉落物");
-                        await Delay(200, _ct);
                         if (picker.TrySwitch(10))
                         {
+                            await Delay(100, _ct);
                             await picker.WaitSkillCd(_ct);
                             await SimulateHoldElementalSkillAsync(800, _ct);
                             await SimulateMouseLeftClickLoopAsync(6, _ct);
@@ -830,6 +830,7 @@ public class AutoFightJsonTask : ISoloTask
                     await Delay(150, _ct);
                     if (picker.TrySwitch(10))
                     {
+                        await Delay(100, _ct);
                         foreach (var miningActionStr in actionsToUse)
                         {
                             var pickUpAction = CombatScriptParser.ParseContext(miningActionStr);

--- a/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
@@ -667,6 +667,8 @@ public class AutoFightTask : ISoloTask
             
             if (picker != null)
             {
+                Simulation.ReleaseAllKey();
+
                 if (picker.Name == "枫原万叶")
                 {
                     var time = TimeSpan.FromSeconds(picker.GetSkillCdSeconds());

--- a/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
@@ -715,7 +715,6 @@ public class AutoFightTask : ISoloTask
                         .ToArray();
 
                     var find = _taskParam.QinDoublePickUp;
-                    await Delay(150, ct);
                     if (picker.TrySwitch(10))
                     {
                         await Delay(100, ct);

--- a/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
@@ -683,6 +683,7 @@ public class AutoFightTask : ISoloTask
                         await Delay(200, ct);
                         if (picker.TrySwitch(10))
                         {
+                            picker.Switch();
                             // 等待元素战技 CD 就绪
                             await picker.WaitSkillCd(ct);
                             
@@ -718,6 +719,7 @@ public class AutoFightTask : ISoloTask
                     await Delay(150, ct);
                     if (picker.TrySwitch(10))
                     {
+                        picker.Switch();
                         foreach (var miningActionStr in actionsToUse)
                         {
                             var pickUpAction = CombatScriptParser.ParseContext(miningActionStr);

--- a/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
@@ -680,9 +680,9 @@ public class AutoFightTask : ISoloTask
                     if (forcePickup || !shouldSkip)
                     {
                         Logger.LogInformation("使用 枫原万叶-长E 拾取掉落物");
-                        await Delay(200, ct);
                         if (picker.TrySwitch(10))
                         {
+                            await Delay(100, ct);
                             // 等待元素战技 CD 就绪
                             await picker.WaitSkillCd(ct);
                             
@@ -718,6 +718,7 @@ public class AutoFightTask : ISoloTask
                     await Delay(150, ct);
                     if (picker.TrySwitch(10))
                     {
+                        await Delay(100, ct);
                         foreach (var miningActionStr in actionsToUse)
                         {
                             var pickUpAction = CombatScriptParser.ParseContext(miningActionStr);

--- a/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
@@ -683,7 +683,6 @@ public class AutoFightTask : ISoloTask
                         await Delay(200, ct);
                         if (picker.TrySwitch(10))
                         {
-                            picker.Switch();
                             // 等待元素战技 CD 就绪
                             await picker.WaitSkillCd(ct);
                             
@@ -719,7 +718,6 @@ public class AutoFightTask : ISoloTask
                     await Delay(150, ct);
                     if (picker.TrySwitch(10))
                     {
-                        picker.Switch();
                         foreach (var miningActionStr in actionsToUse)
                         {
                             var pickUpAction = CombatScriptParser.ParseContext(miningActionStr);

--- a/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
@@ -303,9 +303,11 @@ public class Avatar
             using var region = CaptureToRectArea();
             ThrowWhenDefeated(region, Ct);
 
-            // 切换成功
+            // 切换成功——即使检测到已为目标角色，也补发一次按键，
+            // 防止颜色识别假阳性（如方法3偶发误判）导致实际未切到目标
             if (CombatScenes.GetActiveAvatarIndex(region, context) == Index)
             {
+                SimulateSwitchAction(Index);
                 return true;
             }
             else


### PR DESCRIPTION
@this-Fish 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 优化自动战斗后的拾取流程：执行拾取前先清理残留按键状态，降低误触发概率。
  * 提升“枫原万叶/琴”相关拾取与切换的时序稳定性：仅在切换成功后再进入对应等待逻辑，让后续动作触发更一致。
  * 修复可能的切换失败场景：当识别显示“已为目标角色”时，确保补发一次切换按键，避免识别假阳性导致未实际切换。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->