### PR TITLE
AutoBoss 加自定义战斗超时配置

### DIFF
--- a/BetterGenshinImpact/Core/Config/OneDragonFlowConfig.cs
+++ b/BetterGenshinImpact/Core/Config/OneDragonFlowConfig.cs
@@ -32,7 +32,6 @@ public partial class OneDragonFlowConfig : ObservableObject
     /// 任务定义（Id → 任务名），用于支持同名任务重复添加
     /// </summary>
     public Dictionary<string, string> TaskDefinitions { get; set; } = new();
-   
     // 合成树脂的国家
     [ObservableProperty]
     private string _craftingBenchCountry = "枫丹";
@@ -83,7 +82,9 @@ public partial class OneDragonFlowConfig : ObservableObject
 
     [ObservableProperty]
     private bool _autoBossRewardRecognitionEnabled = false;
-
+    
+    [ObservableProperty]
+    private int _autoBossTimeout = 240;
     partial void OnAutoBossSpecifyRunCountChanged(bool value)
     {
         if (value)

--- a/BetterGenshinImpact/GameTask/AutoBoss/AutoBossConfig.cs
+++ b/BetterGenshinImpact/GameTask/AutoBoss/AutoBossConfig.cs
@@ -41,7 +41,12 @@ public partial class AutoBossConfig : ObservableObject
     /// </summary>
     [ObservableProperty]
     private bool _rewardRecognitionEnabled = false;
-
+    
+    /// <summary>
+    /// 战斗超时
+    /// </summary>
+    [ObservableProperty]
+    private int _timeout  = 240;
     /// <summary>
     /// 关闭指定讨伐次数时清空补充树脂开关，避免树脂耗尽模式误用须臾或脆弱树脂。
     /// </summary>

--- a/BetterGenshinImpact/GameTask/AutoBoss/AutoBossParam.cs
+++ b/BetterGenshinImpact/GameTask/AutoBoss/AutoBossParam.cs
@@ -86,7 +86,12 @@ public class AutoBossParam : BaseTaskParam<AutoBossTask>
     /// 是否启用奖励名称识别。默认关闭。
     /// </summary>
     public bool RewardRecognitionEnabled { get; set; }
-
+    
+    /// <summary>
+    /// 战斗超时
+    /// </summary>
+    public int Timeout { get; set; } = 240;
+    
     /// <summary>
     /// 使用当前全局 AutoBoss 配置创建参数，主要用于 JS 无参构造和一条龙默认启动。
     /// </summary>
@@ -143,6 +148,7 @@ public class AutoBossParam : BaseTaskParam<AutoBossTask>
         ReviveRetryCount = config.ReviveRetryCount;
         ReturnToStatueAfterEachRound = config.ReturnToStatueAfterEachRound;
         RewardRecognitionEnabled = config.RewardRecognitionEnabled;
+        Timeout = config.Timeout;
     }
 
     /// <summary>

--- a/BetterGenshinImpact/GameTask/AutoBoss/AutoBossTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoBoss/AutoBossTask.cs
@@ -939,7 +939,7 @@ public class AutoBossTask : ISoloTask<Dictionary<string, int>>
             ExpBasedPickupEnabled = false,
             KazuhaPickupEnabled = false,
             PickDropsAfterFightEnabled = false,
-            Timeout = 600,
+            Timeout = _taskParam.Timeout,
         };
 
         var jsonTask = new AutoFightJsonTask(jsonParam);

--- a/BetterGenshinImpact/GameTask/AutoBoss/AutoBossTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoBoss/AutoBossTask.cs
@@ -167,7 +167,7 @@ public class AutoBossTask : ISoloTask<Dictionary<string, int>>
             }
             
             //5.开始战斗
-            await RunAutoFight(_taskParam.Timeout);
+            await RunAutoFight();
             
             //6.寻路到征讨之花
             await NavigateToReward();
@@ -893,8 +893,7 @@ public class AutoBossTask : ISoloTask<Dictionary<string, int>>
     /// <summary>
     /// 使用所选自动战斗策略执行首领战斗，并复用自动战斗的结束检测。
     /// </summary>
-    /// <param name="taskParamTimeout"></param>
-    private async Task RunAutoFight(int taskParamTimeout)
+    private async Task RunAutoFight()
     {
         _logger.LogInformation("{Name}：执行战斗策略", Name);
 
@@ -907,7 +906,7 @@ public class AutoBossTask : ISoloTask<Dictionary<string, int>>
             var combatScenes = GetCombatScenesWithRetry();
             FindCombatScriptAndSwitchAvatar(combatScenes);
 
-            var taskParam = BuildAutoFightParamForBoss(taskParamTimeout);
+            var taskParam = BuildAutoFightParamForBoss();
             try
             {
                 await new AutoFightTask(taskParam).Start(_ct);
@@ -961,8 +960,7 @@ public class AutoBossTask : ISoloTask<Dictionary<string, int>>
     /// <summary>
     /// 构造 AutoBoss 专用自动战斗参数：复用战斗检测配置，但不执行任何战后拾取。
     /// </summary>
-    /// <param name="taskParamTimeout"></param>
-    private AutoFightParam BuildAutoFightParamForBoss(int taskParamTimeout)
+    private AutoFightParam BuildAutoFightParamForBoss()
     {
         var taskParam = new AutoFightParam(_taskParam.CombatStrategyPath, TaskContext.Instance().Config.AutoFightConfig)
         {
@@ -976,7 +974,6 @@ public class AutoBossTask : ISoloTask<Dictionary<string, int>>
             OnlyPickEliteDropsMode = "DisableAutoPickupForNonElite",
             Timeout = _taskParam.Timeout
         };
-        taskParam.Timeout = taskParamTimeout;
         return taskParam;
     }
 

--- a/BetterGenshinImpact/GameTask/AutoBoss/AutoBossTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoBoss/AutoBossTask.cs
@@ -973,7 +973,8 @@ public class AutoBossTask : ISoloTask<Dictionary<string, int>>
             ExpBasedPickupEnabled = false,
             KazuhaPartyName = string.Empty,
             BattleThresholdForLoot = -1,
-            OnlyPickEliteDropsMode = "DisableAutoPickupForNonElite"
+            OnlyPickEliteDropsMode = "DisableAutoPickupForNonElite",
+            Timeout = _taskParam.Timeout
         };
         taskParam.Timeout = taskParamTimeout;
         return taskParam;

--- a/BetterGenshinImpact/GameTask/AutoBoss/AutoBossTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoBoss/AutoBossTask.cs
@@ -167,7 +167,7 @@ public class AutoBossTask : ISoloTask<Dictionary<string, int>>
             }
             
             //5.开始战斗
-            await RunAutoFight();
+            await RunAutoFight(_taskParam.Timeout);
             
             //6.寻路到征讨之花
             await NavigateToReward();
@@ -893,7 +893,8 @@ public class AutoBossTask : ISoloTask<Dictionary<string, int>>
     /// <summary>
     /// 使用所选自动战斗策略执行首领战斗，并复用自动战斗的结束检测。
     /// </summary>
-    private async Task RunAutoFight()
+    /// <param name="taskParamTimeout"></param>
+    private async Task RunAutoFight(int taskParamTimeout)
     {
         _logger.LogInformation("{Name}：执行战斗策略", Name);
 
@@ -906,7 +907,7 @@ public class AutoBossTask : ISoloTask<Dictionary<string, int>>
             var combatScenes = GetCombatScenesWithRetry();
             FindCombatScriptAndSwitchAvatar(combatScenes);
 
-            var taskParam = BuildAutoFightParamForBoss();
+            var taskParam = BuildAutoFightParamForBoss(taskParamTimeout);
             try
             {
                 await new AutoFightTask(taskParam).Start(_ct);
@@ -960,7 +961,8 @@ public class AutoBossTask : ISoloTask<Dictionary<string, int>>
     /// <summary>
     /// 构造 AutoBoss 专用自动战斗参数：复用战斗检测配置，但不执行任何战后拾取。
     /// </summary>
-    private AutoFightParam BuildAutoFightParamForBoss()
+    /// <param name="taskParamTimeout"></param>
+    private AutoFightParam BuildAutoFightParamForBoss(int taskParamTimeout)
     {
         var taskParam = new AutoFightParam(_taskParam.CombatStrategyPath, TaskContext.Instance().Config.AutoFightConfig)
         {
@@ -973,7 +975,7 @@ public class AutoBossTask : ISoloTask<Dictionary<string, int>>
             BattleThresholdForLoot = -1,
             OnlyPickEliteDropsMode = "DisableAutoPickupForNonElite"
         };
-
+        taskParam.Timeout = taskParamTimeout;
         return taskParam;
     }
 

--- a/BetterGenshinImpact/Model/OneDragonTaskItem.cs
+++ b/BetterGenshinImpact/Model/OneDragonTaskItem.cs
@@ -155,6 +155,8 @@ public partial class OneDragonTaskItem : ObservableObject
                     param.ReviveRetryCount = config.AutoBossReviveRetryCount;
                     param.ReturnToStatueAfterEachRound = config.AutoBossReturnToStatueAfterEachRound;
                     param.RewardRecognitionEnabled = config.AutoBossRewardRecognitionEnabled;
+                    param.RewardRecognitionEnabled = config.AutoBossRewardRecognitionEnabled;
+                    param.Timeout = config.AutoBossTimeout;
                     await new AutoBossTask(param).Start(CancellationContext.Instance.Cts.Token);
                 };
                 break;

--- a/BetterGenshinImpact/View/Pages/TaskSettingsPage.xaml
+++ b/BetterGenshinImpact/View/Pages/TaskSettingsPage.xaml
@@ -1952,6 +1952,39 @@
                                   AcceptsExpression="False"
                                   Value="{Binding Config.AutoBossConfig.ReviveRetryCount, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                 </Grid>
+                
+                <Grid Margin="16">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <ui:TextBlock Grid.Row="0"
+                                  Grid.Column="0"
+                                  FontTypography="Body"
+                                  Text="自动战斗超时(秒)"
+                                  TextWrapping="Wrap" />
+                    <ui:TextBlock Grid.Row="1"
+                                  Grid.Column="0"
+                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                  Text="到达指定时间后，自动停止战斗"
+                                  TextWrapping="Wrap" />
+                    <ui:NumberBox Grid.Row="0"
+                                  Grid.RowSpan="2"
+                                  Grid.Column="1"
+                                  Width="120"
+                                  Margin="0,0,36,0"
+                                  Minimum="0"
+                                  MaxDecimalPlaces="0"
+                                  SmallChange="1"
+                                  LargeChange="3"
+                                  SpinButtonPlacementMode="Hidden"
+                                  AcceptsExpression="False"
+                                  Value="{Binding Config.AutoBossConfig.Timeout, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                </Grid>
             </StackPanel>
         </ui:CardExpander>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 自动首领讨伐新增“自动战斗超时（秒）”设置项，默认 **240** 秒；支持最小 **0**，并使用整数输入。
* **改进**
  * 首领自动战斗与 JSON 策略战斗的超时现在统一使用任务/全局配置的值（不再固定时长）。
  * 设置数值变更后可立即生效。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->