### PR TITLE
fix: 使用 HLS 颜色空间识别传送候选文字

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoTrackPath/TpTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoTrackPath/TpTask.cs
@@ -3143,7 +3143,6 @@ public class TpTask
     private List<MapChooseCandidate> GetMapChooseCandidates(ImageRegion imageRegion)
     {
         var candidates = new List<MapChooseCandidate>();
-        var isHdrCapture = TaskContext.Instance().Config.CaptureMode == nameof(CaptureModes.WindowsGraphicsCaptureHdr);
         const double threshold = 0.65;
 
         for (var i = 0; i < _assets.MapChooseIconGreyMatList.Count; i++)
@@ -3174,9 +3173,11 @@ public class TpTask
                 using var textRa = imageRegion.DeriveCrop(textRect);
                 using var textRegion = textRa.Find(new RecognitionObject
                 {
-                    RecognitionType = isHdrCapture ? RecognitionTypes.Ocr : RecognitionTypes.ColorRangeAndOcr,
-                    LowerColor = new Scalar(249, 249, 249), // 只取白色文字
-                    UpperColor = new Scalar(255, 255, 255),
+                    // RecognitionType = RecognitionTypes.Ocr,
+                    RecognitionType = RecognitionTypes.ColorRangeAndOcr,
+                    ColorConversionCode = ColorConversionCodes.BGR2HLS,
+                    LowerColor = new Scalar(0, 245, 0),
+                    UpperColor = new Scalar(180, 255, 15),
                 });
                 var text = CleanCandidateText(textRegion.Text);
                 if (string.IsNullOrEmpty(text) || text.Length == 1)

--- a/BetterGenshinImpact/GameTask/QuickTeleport/QuickTeleportTrigger.cs
+++ b/BetterGenshinImpact/GameTask/QuickTeleport/QuickTeleportTrigger.cs
@@ -149,9 +149,11 @@ internal class QuickTeleportTrigger : ITaskTrigger
                 using var ra = content.CaptureRectArea.DeriveCrop(assets.MapChooseIconRoi.X + iconRect.X + iconRect.Width, assets.MapChooseIconRoi.Y + iconRect.Y - 8, 200, iconRect.Height + 16);
                 using var textRegion = ra.Find(new RecognitionObject
                 {
-                    RecognitionType = isHdrCapture ? RecognitionTypes.Ocr : RecognitionTypes.ColorRangeAndOcr,
-                    LowerColor = new Scalar(249, 249, 249), // 只取白色文字
-                    UpperColor = new Scalar(255, 255, 255),
+                    // RecognitionType = RecognitionTypes.Ocr,
+                    RecognitionType = RecognitionTypes.ColorRangeAndOcr,
+                    ColorConversionCode = ColorConversionCodes.BGR2HLS,
+                    LowerColor = new Scalar(0, 245, 0),
+                    UpperColor = new Scalar(180, 255, 15),
                 });
                 if (string.IsNullOrEmpty(textRegion.Text) || textRegion.Text.Length == 1)
                 {


### PR DESCRIPTION
## 概述

修复 WindowsGraphicsCapture（HDR）下传送候选列表文字无法识别的问题，并避免通过大幅降低 RGB 阈值引入地图文字和背景噪声。

关联问题：#3133 
关联PR：#3134 #3185

## 背景

在 [辉鸭蛋对 #3134 的评论](https://github.com/babalae/better-genshin-impact/pull/3134#issuecomment-4651054663) 中提到，非 HDR 场景下地图文字颜色约为 `(230, 234, 235)`，如果简单把白色 RGB 下限降到 `120`，画面的大部分内容都会进入白色掩膜，因此不适合用宽松 RGB 阈值处理这一特殊场景。   在这里也再次感谢辉鸭蛋能抽出时间审阅我的PR并指出我疏忽的地方。

我实际测试下来主要是地图中的地名文本容易被宽阈值带入，经过一段时间的探索，我找到了一种能在 SDR 和 HDR 模式下都使候选列表文字正常被提取，同时又不带入地图上非必要文本的方式。

本次改为使用 HLS 颜色空间描述“接近白色”：先将候选文字区域从 BGR 转为 HLS，再统一筛选：

- `L >= 245`
- `S <= 15`
- Hue 不限制

这样可以利用低饱和度区分白色 UI 文字，并保持足够高的明度门槛；不需要按 HDR/SDR 分别放宽 RGB 阈值。

## 修改内容

- 快速传送候选文字 OCR 改用 `BGR2HLS` 和统一的近白色阈值。
- 自动传送任务的候选文字 OCR 使用相同处理，避免两条识别链路行为不一致。

## 实机验证

使用固定位置的 2560×1440 地图画面（那夏镇冒险家协会传送锚点），分别通过 BetterGI 的 BitBlt 和 WindowsGraphicsCaptureHdr 捕获。截图在处理前已裁掉 UID 区域。

- HDR/WGC：原 `RGB 249..255` 掩膜为 0 像素，候选文字完全消失；HLS 阈值保留“传送锚点”“冒险家协会”“晶蝶诱捕装置”。
- SDR/BitBlt：HLS 结果与原严格 RGB 阈值接近。
- HDR 和 SDR 下，HLS 掩膜均未保留“那夏镇”等地图地名。
- `RGB 235..255` 对照会在 SDR 下带入地图文字，验证了不能简单降低 RGB 下限。

以下分别是通过 BitBlt 截取的 SDR 画面和 WGC HDR 截取的 HDR 画面：

<table>
  <thead>
    <tr>
      <th>对比范围</th>
      <th>SDR（BitBlt）</th>
      <th>HDR（WGC HDR）</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <th>全图</th>
      <td><img src="https://github.com/user-attachments/assets/e2530820-07af-47f8-9c40-59024cdd3275" alt="SDR BitBlt 全图对比" width="420"></td>
      <td><img src="https://github.com/user-attachments/assets/5158cf53-fe3c-47e4-8eae-ed7d0d3311f6" alt="HDR WGC HDR 全图对比" width="420"></td>
    </tr>
    <tr>
      <th>候选列表局部</th>
      <td><img src="https://github.com/user-attachments/assets/59d2471e-9b46-403a-9316-eac0a2f14c8e" alt="SDR BitBlt 候选列表局部对比" width="420"></td>
      <td><img src="https://github.com/user-attachments/assets/a38410f9-1731-4e0a-9e95-c8a16bf83d5a" alt="HDR WGC HDR 候选列表局部对比" width="420"></td>
    </tr>
  </tbody>
</table>

可以观察到对于RGB，在原始249阈值下，WGC HDR截图器截出的画面候选列表被完全滤掉了，而在235阈值下Bitbit截取SDR的画面又出现了过多无关地图文本。HLS颜色空间则能在保持SDR和HDR画面不出现无关地图文本的情况下，让WGC HDR截取画面的候选列表正常出现。
## 构建验证

```text
dotnet build BetterGenshinImpact.sln -c Debug
0 errors
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化大地图与快速传送点选项的文字识别，提升不同显示模式下的识别稳定性。
  * 改进地图选项定位与点击判断，减少误识别或无法选择传送点的情况。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->