### PR TITLE
修复：为遮罩指标栏添加独立快捷键

### DIFF
--- a/BetterGenshinImpact/Core/Config/HotKeyConfig.cs
+++ b/BetterGenshinImpact/Core/Config/HotKeyConfig.cs
@@ -232,6 +232,13 @@ public partial class HotKeyConfig : ObservableObject
     [ObservableProperty]
     private string _logBoxDisplayHotkeyType = HotKeyTypeEnum.KeyboardMonitor.ToString();
 
+    // 遮罩指标栏展示
+    [ObservableProperty]
+    private string _overlayMetricsDisplayHotkey = "";
+
+    [ObservableProperty]
+    private string _overlayMetricsDisplayHotkeyType = HotKeyTypeEnum.KeyboardMonitor.ToString();
+
     // 键鼠录制/停止
     [ObservableProperty]
     private string _keyMouseMacroRecordHotkey = "";

--- a/BetterGenshinImpact/ViewModel/Pages/HotKeyPageViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/HotKeyPageViewModel.cs
@@ -388,7 +388,7 @@ public partial class HotKeyPageViewModel : ObservableObject, IViewModel
         systemDirectory.Children.Add(takeScreenshotHotKeySettingModel);
 
         systemDirectory.Children.Add(new HotKeySettingModel(
-            "日志，状态窗与指标栏展示开关",
+            "日志与状态窗口展示开关",
             nameof(Config.HotKeyConfig.LogBoxDisplayHotkey),
             Config.HotKeyConfig.LogBoxDisplayHotkey,
             Config.HotKeyConfig.LogBoxDisplayHotkeyType,
@@ -397,8 +397,17 @@ public partial class HotKeyPageViewModel : ObservableObject, IViewModel
                 TaskContext.Instance().Config.MaskWindowConfig.ShowLogBox = !TaskContext.Instance().Config.MaskWindowConfig.ShowLogBox;
                 // 与状态窗口同步
                 TaskContext.Instance().Config.MaskWindowConfig.ShowStatus = TaskContext.Instance().Config.MaskWindowConfig.ShowLogBox;
-                // 与指标栏同步
-                TaskContext.Instance().Config.MaskWindowConfig.ShowOverlayMetrics = TaskContext.Instance().Config.MaskWindowConfig.ShowLogBox;
+            }
+        ));
+
+        systemDirectory.Children.Add(new HotKeySettingModel(
+            "遮罩指标栏展示开关",
+            nameof(Config.HotKeyConfig.OverlayMetricsDisplayHotkey),
+            Config.HotKeyConfig.OverlayMetricsDisplayHotkey,
+            Config.HotKeyConfig.OverlayMetricsDisplayHotkeyType,
+            (_, _) =>
+            {
+                TaskContext.Instance().Config.MaskWindowConfig.ShowOverlayMetrics = !TaskContext.Instance().Config.MaskWindowConfig.ShowOverlayMetrics;
             }
         ));
 


### PR DESCRIPTION
## 修改内容

- 为遮罩指标栏新增独立快捷键配置，支持键鼠监听与全局热键类型。
- 新快捷键仅切换 `MaskWindowConfig.ShowOverlayMetrics`。
- 恢复“日志与状态窗口展示开关”的独立职责，不再改变指标栏显示状态。

## 问题原因与影响

此前日志/状态快捷键会把指标栏强制同步为日志框状态，导致指标栏原本未开启时也可能被快捷键意外打开。拆分后，用户可以分别控制日志/状态窗口和遮罩指标栏，旧配置缺少新增字段时会继续使用空快捷键默认值。

## 验证

- `dotnet build BetterGenshinImpact/BetterGenshinImpact.csproj -c Debug -p:Platform=x64 -p:RestoreDisableParallel=true -m:1`
- 构建结果：0 个错误；597 个现有警告。
- `git diff --check` 通过。

Fixes #3285


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增“遮罩指标栏展示”快捷键配置，可单独设置及切换指标栏显示状态。
  * 将“日志与状态窗口”和“指标栏”快捷键拆分，分别控制对应显示内容。

* **问题修复**
  * 修复切换日志或状态窗口时错误同步控制指标栏显示的问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->