### PR TITLE
取消js settings持久化时的`hasSettingsBeforeRun`逻辑

### DIFF
--- a/BetterGenshinImpact/Service/ScriptService.cs
+++ b/BetterGenshinImpact/Service/ScriptService.cs
@@ -525,14 +525,13 @@ public partial class ScriptService : IScriptService
 
             _logger.LogInformation("→ 开始执行JS脚本: {Name}", project.Name);
             if (RunnerContext.Instance.IsPreExecution) _logger.LogInformation("此任务为优先执行任务！");
-            var hasSettingsBeforeRun = project.JsScriptSettingsObject != null;
             try
             {
                 await project.Run();
             }
             finally
             {
-                SaveScriptGroupAfterJsRun(project, hasSettingsBeforeRun);
+                SaveScriptGroupAfterJsRun(project);
             }
         }
         else if (project.Type == "KeyMouse")
@@ -555,14 +554,8 @@ public partial class ScriptService : IScriptService
         }
     }
 
-    private void SaveScriptGroupAfterJsRun(ScriptGroupProject project, bool hasSettingsBeforeRun)
+    private void SaveScriptGroupAfterJsRun(ScriptGroupProject project)
     {
-        if (!hasSettingsBeforeRun)
-        {
-            project.JsScriptSettingsObject = null;
-            return;
-        }
-
         var scriptGroup = project.GroupInfo!;
         try
         {


### PR DESCRIPTION
PR #3215 中明确了JS脚本运行时settings修改的持久化时机，但是引入了一个判断`hasSettingsBeforeRun`。

此判断选项会使得JS脚本的setting是否能持久化，取决于脚本是否"hasSettings"，具体来说就是用户是否尝试进行过JS配置。

这使得具体的行为隐晦依赖于用户的某个动作，并且导致JS脚本无法实现"订阅脚本后的首次运行以初始化模式执行任务，然后**自动**切换到常规运行模式"的功能（即Bot review中提到的“导致首次配置无法落盘”）

---

此PR取消了设置持久化时的`hasSettingsBeforeRun`逻辑，以解决前述问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * JavaScript 脚本运行结束后，无论执行成功或发生异常，脚本组设置都会被保存。
  * 简化设置保存逻辑，提升脚本组配置持久化的稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->