### PR TITLE
fix: 修复尘歌壶地图住宅图标点击失效问题

### DIFF
--- a/BetterGenshinImpact/GameTask/Common/Job/GoToSereniteaPotTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/GoToSereniteaPotTask.cs
@@ -118,8 +118,8 @@ internal class GoToSereniteaPotTask
 
         for (int i = 0; i < 5; i++)
         {
-            ra = CaptureToRectArea();
-            var sereniteaPotHomeIcon = ra.Find(ElementRecognition.Get("SereniteaPotHome", ra));
+            using var currentRa = CaptureToRectArea();
+            var sereniteaPotHomeIcon = currentRa.Find(ElementRecognition.Get("SereniteaPotHome", currentRa));
             if (!sereniteaPotHomeIcon.IsExist())
             {
                 Logger.LogInformation("领取尘歌壶奖励:{text}", "住宅图标未找到，调整地图缩放至2。");

--- a/BetterGenshinImpact/GameTask/Common/Job/GoToSereniteaPotTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/GoToSereniteaPotTask.cs
@@ -118,6 +118,7 @@ internal class GoToSereniteaPotTask
 
         for (int i = 0; i < 5; i++)
         {
+            ra = CaptureToRectArea();
             var sereniteaPotHomeIcon = ra.Find(ElementRecognition.Get("SereniteaPotHome", ra));
             if (!sereniteaPotHomeIcon.IsExist())
             {
@@ -128,6 +129,9 @@ internal class GoToSereniteaPotTask
             }
             else
             {
+                await Delay(100, ct);
+                Simulation.ReleaseAllKey();
+                await Delay(200, ct);
                 sereniteaPotHomeIcon.Click();
                 await Delay(500, ct);
                 break;


### PR DESCRIPTION
1. 每次循环迭代前重新截图，避免缩放地图后使用旧截图导致 Find 失败

2. 点击前增加延迟并释放所有按键，防止残留输入占用鼠标左键

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化进入尘歌壶时的画面识别流程，提升住宅图标检测可靠性。
  * 在点击住宅图标前重置按键输入并加入等待间隔，降低操作时序异常的发生。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->