### PR TITLE
fix：GetBigMapScale添加重试机制，防止处于动画时或其他原因识别失败后直接报错

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoTrackPath/TpTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoTrackPath/TpTask.cs
@@ -3445,7 +3445,7 @@ public class TpTask
     /// <returns></returns>
     public double GetBigMapZoomLevel(ImageRegion region)
     {
-        var s = Bv.GetBigMapScale(region);
+        var s = Bv.GetBigMapScale(region, ct);
         // 1~6 的缩放等级
         return (-5 * s) + 6;
     }

--- a/BetterGenshinImpact/GameTask/Common/BgiVision/BvStatus.cs
+++ b/BetterGenshinImpact/GameTask/Common/BgiVision/BvStatus.cs
@@ -211,21 +211,25 @@ public static partial class Bv
         const int maxRetries = 20;
         for (var i = 1; i <= maxRetries; i++)
         {
-            // 首次使用传入的region，重试时重新截图（Region.Dispose为空实现，需手动释放SrcMat）
+            // 首次使用传入的region，重试时重新截图
             ImageRegion? ownedCapture = null;
-            var searchRegion = i == 1 ? region : (ownedCapture = TaskControl.CaptureToRectArea())!;
-            using var scaleRa = searchRegion.Find(RecognitionAssets.Get("QuickTeleport", "MapScaleButton", searchRegion));
-            if (!scaleRa.IsEmpty())
+            try
             {
-                // 原先这里的起止区间和config里写死的值差1
-                var start = TaskContext.Instance().Config.TpConfig.ZoomStartY;
-                var end = TaskContext.Instance().Config.TpConfig.ZoomEndY;
-                var cur = (scaleRa.Y + scaleRa.Height / 2.0) * TaskContext.Instance().SystemInfo.ZoomOutMax1080PRatio; // 转换到1080p坐标系,主要是小于1080p的情况
-                ownedCapture?.Dispose();
-                return (end * 1.0 - cur) / (end - start);
+                var searchRegion = i == 1 ? region : (ownedCapture = TaskControl.CaptureToRectArea())!;
+                using var scaleRa = searchRegion.Find(RecognitionAssets.Get("QuickTeleport", "MapScaleButton", searchRegion));
+                if (!scaleRa.IsEmpty())
+                {
+                    // 原先这里的起止区间和config里写死的值差1
+                    var start = TaskContext.Instance().Config.TpConfig.ZoomStartY;
+                    var end = TaskContext.Instance().Config.TpConfig.ZoomEndY;
+                    var cur = (scaleRa.Y + scaleRa.Height / 2.0) * TaskContext.Instance().SystemInfo.ZoomOutMax1080PRatio; // 转换到1080p坐标系,主要是小于1080p的情况
+                    return (end * 1.0 - cur) / (end - start);
+                }
             }
-
-            ownedCapture?.Dispose();
+            finally
+            {
+                ownedCapture?.Dispose();
+            }
             TaskControl.Logger.LogWarning("未找到MapScaleButton图标，重试第{RetryCount}次", i);
             TaskControl.Sleep(100, ct);
         }

--- a/BetterGenshinImpact/GameTask/Common/BgiVision/BvStatus.cs
+++ b/BetterGenshinImpact/GameTask/Common/BgiVision/BvStatus.cs
@@ -211,9 +211,7 @@ public static partial class Bv
         const int maxRetries = 20;
         for (var i = 1; i <= maxRetries; i++)
         {
-            using var currentRegion = i == 1 ? null : TaskControl.CaptureToRectArea();
-            var searchRegion = currentRegion ?? region;
-            using var scaleRa = searchRegion.Find(RecognitionAssets.Get("QuickTeleport", "MapScaleButton", searchRegion));
+            using var scaleRa = region.Find(RecognitionAssets.Get("QuickTeleport", "MapScaleButton", region));
             if (!scaleRa.IsEmpty())
             {
                 // 原先这里的起止区间和config里写死的值差1

--- a/BetterGenshinImpact/GameTask/Common/BgiVision/BvStatus.cs
+++ b/BetterGenshinImpact/GameTask/Common/BgiVision/BvStatus.cs
@@ -208,7 +208,7 @@ public static partial class Bv
 
     public static double GetBigMapScale(ImageRegion region, CancellationToken ct = default)
     {
-        const int maxRetries = 20;
+        const int maxRetries = 5;
         for (var i = 1; i <= maxRetries; i++)
         {
             // 首次使用传入的region，重试时重新截图

--- a/BetterGenshinImpact/GameTask/Common/BgiVision/BvStatus.cs
+++ b/BetterGenshinImpact/GameTask/Common/BgiVision/BvStatus.cs
@@ -208,18 +208,26 @@ public static partial class Bv
 
     public static double GetBigMapScale(ImageRegion region)
     {
-        using var scaleRa = region.Find(RecognitionAssets.Get("QuickTeleport", "MapScaleButton", region));
-        if (scaleRa.IsEmpty())
+        const int maxRetries = 20;
+        for (var i = 1; i <= maxRetries; i++)
         {
-            throw new Exception("当前未处于大地图界面，不能使用GetBigMapScale方法");
+            using var currentRegion = i == 1 ? null : TaskControl.CaptureToRectArea();
+            var searchRegion = currentRegion ?? region;
+            using var scaleRa = searchRegion.Find(RecognitionAssets.Get("QuickTeleport", "MapScaleButton", searchRegion));
+            if (!scaleRa.IsEmpty())
+            {
+                // 原先这里的起止区间和config里写死的值差1
+                var start = TaskContext.Instance().Config.TpConfig.ZoomStartY;
+                var end = TaskContext.Instance().Config.TpConfig.ZoomEndY;
+                var cur = (scaleRa.Y + scaleRa.Height / 2.0) * TaskContext.Instance().SystemInfo.ZoomOutMax1080PRatio; // 转换到1080p坐标系,主要是小于1080p的情况
+                return (end * 1.0 - cur) / (end - start);
+            }
+
+            TaskControl.Logger.LogWarning("未找到MapScaleButton图标，重试第{RetryCount}次", i);
+            Thread.Sleep(100);
         }
 
-        // 原先这里的起止区间和config里写死的值差1
-        var start = TaskContext.Instance().Config.TpConfig.ZoomStartY;
-        var end = TaskContext.Instance().Config.TpConfig.ZoomEndY;
-        var cur = (scaleRa.Y + scaleRa.Height / 2.0) * TaskContext.Instance().SystemInfo.ZoomOutMax1080PRatio; // 转换到1080p坐标系,主要是小于1080p的情况
-
-        return (end * 1.0 - cur) / (end - start);
+        throw new Exception("当前未处于大地图界面，不能使用GetBigMapScale方法");
     }
 
     public static MotionStatus GetMotionStatus(ImageRegion captureRa)

--- a/BetterGenshinImpact/GameTask/Common/BgiVision/BvStatus.cs
+++ b/BetterGenshinImpact/GameTask/Common/BgiVision/BvStatus.cs
@@ -211,16 +211,21 @@ public static partial class Bv
         const int maxRetries = 20;
         for (var i = 1; i <= maxRetries; i++)
         {
-            using var scaleRa = region.Find(RecognitionAssets.Get("QuickTeleport", "MapScaleButton", region));
+            // 首次使用传入的region，重试时重新截图（Region.Dispose为空实现，需手动释放SrcMat）
+            ImageRegion? ownedCapture = null;
+            var searchRegion = i == 1 ? region : (ownedCapture = TaskControl.CaptureToRectArea())!;
+            using var scaleRa = searchRegion.Find(RecognitionAssets.Get("QuickTeleport", "MapScaleButton", searchRegion));
             if (!scaleRa.IsEmpty())
             {
                 // 原先这里的起止区间和config里写死的值差1
                 var start = TaskContext.Instance().Config.TpConfig.ZoomStartY;
                 var end = TaskContext.Instance().Config.TpConfig.ZoomEndY;
                 var cur = (scaleRa.Y + scaleRa.Height / 2.0) * TaskContext.Instance().SystemInfo.ZoomOutMax1080PRatio; // 转换到1080p坐标系,主要是小于1080p的情况
+                ownedCapture?.SrcMat.Dispose();
                 return (end * 1.0 - cur) / (end - start);
             }
 
+            ownedCapture?.SrcMat.Dispose();
             TaskControl.Logger.LogWarning("未找到MapScaleButton图标，重试第{RetryCount}次", i);
             TaskControl.Sleep(100, ct);
         }

--- a/BetterGenshinImpact/GameTask/Common/BgiVision/BvStatus.cs
+++ b/BetterGenshinImpact/GameTask/Common/BgiVision/BvStatus.cs
@@ -206,7 +206,7 @@ public static partial class Bv
         return ra.IsExist();
     }
 
-    public static double GetBigMapScale(ImageRegion region)
+    public static double GetBigMapScale(ImageRegion region, CancellationToken ct = default)
     {
         const int maxRetries = 20;
         for (var i = 1; i <= maxRetries; i++)
@@ -224,7 +224,7 @@ public static partial class Bv
             }
 
             TaskControl.Logger.LogWarning("未找到MapScaleButton图标，重试第{RetryCount}次", i);
-            Thread.Sleep(100);
+            TaskControl.Sleep(100, ct);
         }
 
         throw new Exception("当前未处于大地图界面，不能使用GetBigMapScale方法");

--- a/BetterGenshinImpact/GameTask/Common/BgiVision/BvStatus.cs
+++ b/BetterGenshinImpact/GameTask/Common/BgiVision/BvStatus.cs
@@ -221,11 +221,11 @@ public static partial class Bv
                 var start = TaskContext.Instance().Config.TpConfig.ZoomStartY;
                 var end = TaskContext.Instance().Config.TpConfig.ZoomEndY;
                 var cur = (scaleRa.Y + scaleRa.Height / 2.0) * TaskContext.Instance().SystemInfo.ZoomOutMax1080PRatio; // 转换到1080p坐标系,主要是小于1080p的情况
-                ownedCapture?.SrcMat.Dispose();
+                ownedCapture?.Dispose();
                 return (end * 1.0 - cur) / (end - start);
             }
 
-            ownedCapture?.SrcMat.Dispose();
+            ownedCapture?.Dispose();
             TaskControl.Logger.LogWarning("未找到MapScaleButton图标，重试第{RetryCount}次", i);
             TaskControl.Sleep(100, ct);
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **问题修复**
  - 提升大地图缩放比例识别的稳定性：首次未命中将最多重试 20 次，重截图后再次查找，降低短暂波动导致的失败。
  - 识别过程支持取消：在识别与等待间隔中可响应取消信号，便于更快中止。
  - 未检测到大地图界面时：会记录告警，并在重试结束后给出明确错误提示。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->