### PR TITLE
拆分 前往合成台 与 前往合成树脂 方法

### DIFF
--- a/BetterGenshinImpact/Core/Script/Dependence/Genshin.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/Genshin.cs
@@ -401,7 +401,17 @@ public class Genshin
     /// <returns></returns>
     public async Task GoToCraftingBench(string country)
     {
-        await new GoToCraftingBenchTask().Start(country, CancellationContext.Instance.Cts.Token);
+        await new GoToCraftingBenchTask().GoToCraftingBench(country, CancellationContext.Instance.Cts.Token);
+    }
+
+    /// <summary>
+    /// 前往合成台合成浓缩树脂
+    /// </summary>
+    /// <param name="country">国家名称</param>
+    /// <returns></returns>
+    public async Task GoCraftResin(string country)
+    {
+        await new GoToCraftingBenchTask().GoCraftResin(country, CancellationContext.Instance.Cts.Token);
     }
 
     /// <summary>

--- a/BetterGenshinImpact/GameTask/Common/Job/GoToCraftingBenchTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/GoToCraftingBenchTask.cs
@@ -45,14 +45,14 @@ public class GoToCraftingBenchTask
         this.craftLocalizedString = stringLocalizer.WithCultureGet(cultureInfo, "合成");
     }
     
-    public async Task Start(string country, CancellationToken ct)
+    public async Task GoCraftResin(string country, CancellationToken ct)
     {
         Logger.LogInformation("→ {Name} 开始", Name);
         for (int i = 0; i < _retryTimes; i++)
         {
             try
             {
-                await DoOnce(country, ct);
+                await GoCraftResinOnce(country, ct);
                 break;
             }
             catch (Exception e)
@@ -74,17 +74,11 @@ public class GoToCraftingBenchTask
         Logger.LogInformation("→ {Name} 结束", Name);
     }
 
-    public async Task DoOnce(string country, CancellationToken ct)
+    public async Task GoCraftResinOnce(string country, CancellationToken ct)
     {
          // 1. 走到合成台并交互
-        await GoToCraftingBench(country, ct);
+        await GoToCraftingBenchOnce(country, ct);
 
-        // 2. 等待合成界面
-        await _chooseTalkOptionTask.SelectLastOptionUntilEnd(ct,
-            region => region.Find(ElementRecognition.Get("BtnWhiteConfirm", region)).IsExist()
-        );
-        await Delay(800, ct);
-        
         // 判断浓缩树脂是否存在
         // TODO 满的情况是怎么样子的
         var ra = CaptureToRectArea();
@@ -207,6 +201,32 @@ public class GoToCraftingBenchTask
     /// <returns></returns>
     public async Task GoToCraftingBench(string country, CancellationToken ct)
     {
+        Logger.LogInformation("→ {Name} 开始", Name);
+        for (int i = 0; i < _retryTimes; i++)
+        {
+            try
+            {
+                await GoToCraftingBenchOnce(country, ct);
+                break;
+            }
+            catch (Exception e)
+            {
+                Logger.LogError("前往合成台执行异常：" + e.Message);
+                if (i == _retryTimes - 1)
+                {
+                    throw;
+                }
+
+                await Delay(1000, ct);
+                Logger.LogInformation("重试前往合成台");
+            }
+        }
+
+        Logger.LogInformation("→ {Name} 结束", Name);
+    }
+
+    public async Task GoToCraftingBenchOnce(string country, CancellationToken ct)
+    {
         var task = PathingTask.BuildFromFilePath(Global.Absolute(@$"GameTask\Common\Element\Assets\Json\合成台_{country}.json"));
         if (task == null)
         {
@@ -250,6 +270,12 @@ public class GoToCraftingBenchTask
             
             }
         }
+
+        // 等待进入合成界面
+        await _chooseTalkOptionTask.SelectLastOptionUntilEnd(ct,
+            region => region.Find(ElementRecognition.Get("BtnWhiteConfirm", region)).IsExist()
+        );
+        await Delay(800, ct);
     }
 
 

--- a/BetterGenshinImpact/Model/OneDragonTaskItem.cs
+++ b/BetterGenshinImpact/Model/OneDragonTaskItem.cs
@@ -79,7 +79,7 @@ public partial class OneDragonTaskItem : ObservableObject
                 {
                     try
                     {
-                        await new GoToCraftingBenchTask().Start(config.CraftingBenchCountry,
+                        await new GoToCraftingBenchTask().GoCraftResin(config.CraftingBenchCountry,
                             CancellationContext.Instance.Cts.Token);
                     }
                     catch (Exception e)


### PR DESCRIPTION
拆分前往合成台与树脂合成方法，搜了下脚本仓库没有用到原方法，本体只有一条龙在用一起改了

- GoToCraftingBench 仅打开并停留在合成界面
- GoCraftResin 承接原浓缩树脂合成流程


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增合成浓缩树脂任务，可根据指定国家前往合成台并完成合成。
  * 合成台交互流程增加等待与重试机制，提升任务执行稳定性。

* **问题修复**
  * 优化“合成树脂”任务的调用流程，减少因交互时机导致的执行失败。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->