### PR TITLE
添加功能——自定义背景使用网络图片，支持可刷新api

### DIFF
--- a/BetterGenshinImpact/App.xaml.cs
+++ b/BetterGenshinImpact/App.xaml.cs
@@ -146,6 +146,7 @@ public partial class App : Application
                 services.AddView<MapPathingPage, MapPathingViewModel>();
                 services.AddView<OneDragonFlowPage, OneDragonFlowViewModel>();
                 services.AddSingleton<PathingConfigViewModel>();
+                services.AddSingleton<WebImageInputViewModel>();
                 // services.AddView<PathingConfigView, PathingConfigViewModel>();
                 services.AddView<KeyBindingsSettingsPage, KeyBindingsSettingsPageViewModel>();
 

--- a/BetterGenshinImpact/App.xaml.cs
+++ b/BetterGenshinImpact/App.xaml.cs
@@ -146,7 +146,8 @@ public partial class App : Application
                 services.AddView<MapPathingPage, MapPathingViewModel>();
                 services.AddView<OneDragonFlowPage, OneDragonFlowViewModel>();
                 services.AddSingleton<PathingConfigViewModel>();
-                services.AddSingleton<WebImageInputViewModel>();
+                services.AddSingleton<IBannerImageService, BannerImageService>();
+                services.AddTransient<WebImageInputViewModel>();
                 // services.AddView<PathingConfigView, PathingConfigViewModel>();
                 services.AddView<KeyBindingsSettingsPage, KeyBindingsSettingsPageViewModel>();
 

--- a/BetterGenshinImpact/Service/BannerImageService.cs
+++ b/BetterGenshinImpact/Service/BannerImageService.cs
@@ -1,0 +1,235 @@
+using BetterGenshinImpact.Core.Config;
+using BetterGenshinImpact.Helpers.Http;
+using BetterGenshinImpact.Service.Interface;
+using SixLabors.ImageSharp;
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BetterGenshinImpact.Service;
+
+public sealed class BannerImageService : IBannerImageService
+{
+    private const int MaxDownloadBytes = 20 * 1024 * 1024;
+    private const long MaxPixelCount = 40_000_000;
+    private static readonly TimeSpan DownloadTimeout = TimeSpan.FromSeconds(30);
+
+    // 创建HTTPClient
+    private readonly HttpClient _httpClient = HttpClientFactory.GetClient(
+        "banner-image",
+        CreateHttpClient);
+    private readonly object _fileCommitLock = new();
+    private long _latestOperationId;
+
+    public string NetworkImagePath { get; } = Global.Absolute("User/Images/custom_banner_url.jpg");
+
+    private string UrlConfigPath { get; } = Global.Absolute("User/Images/custom_banner_url.ini");
+
+    public string? ReadConfiguredUrl()
+    {
+        if (!File.Exists(UrlConfigPath))
+        {
+            return null;
+        }
+
+        var url = File.ReadAllText(UrlConfigPath).Trim();
+        return string.IsNullOrWhiteSpace(url) ? null : url;
+    }
+
+    public void SaveConfiguredUrl(string url)
+    {
+        var directory = Path.GetDirectoryName(UrlConfigPath)
+                        ?? throw new InvalidOperationException("无法确定网络背景配置目录。");
+        Directory.CreateDirectory(directory);
+
+        var tempPath = $"{UrlConfigPath}.{Guid.NewGuid():N}.tmp";
+        try
+        {
+            File.WriteAllText(tempPath, url, new UTF8Encoding(false));
+            lock (_fileCommitLock)
+            {
+                File.Move(tempPath, UrlConfigPath, true);
+            }
+        }
+        finally
+        {
+            TryDeleteFile(tempPath);
+        }
+    }
+
+    public async Task<bool> DownloadAndSaveAsync(string url, CancellationToken cancellationToken = default)
+    {
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri)
+            || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        {
+            throw new ArgumentException("请输入有效的 HTTP/HTTPS 图片地址。", nameof(url));
+        }
+
+        var operationId = Interlocked.Increment(ref _latestOperationId);
+        var directory = Path.GetDirectoryName(NetworkImagePath)
+                        ?? throw new InvalidOperationException("无法确定网络背景图片目录。");
+        Directory.CreateDirectory(directory);
+        var tempPath = $"{NetworkImagePath}.{Guid.NewGuid():N}.tmp";
+
+        using var timeoutCancellationTokenSource = new CancellationTokenSource(DownloadTimeout);
+        using var linkedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(
+            cancellationToken,
+            timeoutCancellationTokenSource.Token);
+        var linkedCancellationToken = linkedCancellationTokenSource.Token;
+
+        try
+        {
+            // 下载图片
+            using var response = await _httpClient.GetAsync(
+                uri,
+                HttpCompletionOption.ResponseHeadersRead,
+                linkedCancellationToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+
+            if (response.Content.Headers.ContentLength > MaxDownloadBytes)
+            {
+                throw new InvalidDataException($"图片大小超过 {MaxDownloadBytes / 1024 / 1024} MB 限制。");
+            }
+
+            await using (var responseStream = await response.Content
+                             .ReadAsStreamAsync(linkedCancellationToken)
+                             .ConfigureAwait(false))
+            await using (var fileStream = new FileStream(
+                             tempPath,
+                             FileMode.CreateNew,
+                             FileAccess.Write,
+                             FileShare.None,
+                             81920,
+                             FileOptions.Asynchronous | FileOptions.SequentialScan))
+            {
+                var buffer = new byte[81920];
+                long totalBytes = 0;
+                int read;
+                while ((read = await responseStream
+                           .ReadAsync(buffer.AsMemory(), linkedCancellationToken)
+                           .ConfigureAwait(false)) > 0)
+                {
+                    totalBytes += read;
+                    if (totalBytes > MaxDownloadBytes)
+                    {
+                        throw new InvalidDataException($"图片大小超过 {MaxDownloadBytes / 1024 / 1024} MB 限制。");
+                    }
+
+                    await fileStream
+                        .WriteAsync(buffer.AsMemory(0, read), linkedCancellationToken)
+                        .ConfigureAwait(false);
+                }
+
+                if (totalBytes == 0)
+                {
+                    throw new InvalidDataException("下载的图片内容为空。");
+                }
+            }
+
+            ValidateImage(tempPath);
+            linkedCancellationToken.ThrowIfCancellationRequested();
+
+            lock (_fileCommitLock)
+            {
+                if (operationId != Volatile.Read(ref _latestOperationId))
+                {
+                    return false;
+                }
+
+                linkedCancellationToken.ThrowIfCancellationRequested();
+                // 保存图片到本地
+                File.Move(tempPath, NetworkImagePath, true);
+            }
+
+            return true;
+        }
+        catch (OperationCanceledException ex) when (
+            timeoutCancellationTokenSource.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            throw new TimeoutException($"图片下载超时（{DownloadTimeout.TotalSeconds:0} 秒）。", ex);
+        }
+        finally
+        {
+            TryDeleteFile(tempPath);
+        }
+    }
+
+    public void InvalidatePendingDownloads()
+    {
+        Interlocked.Increment(ref _latestOperationId);
+    }
+
+    public void ResetNetworkImage()
+    {
+        InvalidatePendingDownloads();
+        lock (_fileCommitLock)
+        {
+            if (File.Exists(UrlConfigPath))
+            {
+                File.Delete(UrlConfigPath);
+            }
+
+            if (File.Exists(NetworkImagePath))
+            {
+                File.Delete(NetworkImagePath);
+            }
+        }
+    }
+
+    private static HttpClient CreateHttpClient()
+    {
+        var client = new HttpClient(new HttpClientHandler
+        {
+            AllowAutoRedirect = true,
+            MaxAutomaticRedirections = 5,
+            UseCookies = false,
+            UseDefaultCredentials = false
+        })
+        {
+            Timeout = Timeout.InfiniteTimeSpan
+        };
+        client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("BetterGI-Banner", "1.0"));
+        return client;
+    }
+
+    private static void ValidateImage(string path)
+    {
+        try
+        {
+            var imageInfo = Image.Identify(path)
+                            ?? throw new InvalidDataException("下载内容不是有效的图片。");
+            var pixelCount = checked((long)imageInfo.Width * imageInfo.Height);
+            if (pixelCount > MaxPixelCount)
+            {
+                throw new InvalidDataException($"图片像素数量超过 {MaxPixelCount:N0} 限制。");
+            }
+        }
+        catch (UnknownImageFormatException ex)
+        {
+            throw new InvalidDataException("下载内容不是支持的图片格式。", ex);
+        }
+    }
+
+    private static void TryDeleteFile(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch (IOException)
+        {
+            // 临时文件清理失败不应覆盖原始下载异常。
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // 临时文件清理失败不应覆盖原始下载异常。
+        }
+    }
+}

--- a/BetterGenshinImpact/Service/Interface/IBannerImageService.cs
+++ b/BetterGenshinImpact/Service/Interface/IBannerImageService.cs
@@ -1,0 +1,19 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BetterGenshinImpact.Service.Interface;
+
+public interface IBannerImageService
+{
+    string NetworkImagePath { get; }
+
+    string? ReadConfiguredUrl();
+
+    void SaveConfiguredUrl(string url);
+
+    Task<bool> DownloadAndSaveAsync(string url, CancellationToken cancellationToken = default);
+
+    void InvalidatePendingDownloads();
+
+    void ResetNetworkImage();
+}

--- a/BetterGenshinImpact/View/Pages/HomePage.xaml
+++ b/BetterGenshinImpact/View/Pages/HomePage.xaml
@@ -29,6 +29,8 @@
             <Border.ContextMenu>
                 <ContextMenu>
                     <ui:MenuItem Header="更换背景图片" Command="{Binding ChangeBannerImageCommand}" Icon="{ui:SymbolIcon Image24}" />
+                    <ui:MenuItem Header="使用网络图片" Command="{Binding ChangeWebBannerImageCommand}" Icon="{ui:SymbolIcon Image24}" />
+                    <ui:MenuItem Header="刷新网络图片" Command="{Binding RefreshWebBannerImageCommand}" Icon="{ui:SymbolIcon ArrowCounterclockwise24}" Visibility="{Binding IsCustomNetworkBanner, Converter={StaticResource BooleanToVisibilityConverter}}"/>
                     <ui:MenuItem Header="恢复默认图片" Command="{Binding ResetBannerImageCommand}" Icon="{ui:SymbolIcon ArrowCounterclockwise24}" />
                 </ContextMenu>
             </Border.ContextMenu>

--- a/BetterGenshinImpact/View/Windows/WebImageInput.xaml
+++ b/BetterGenshinImpact/View/Windows/WebImageInput.xaml
@@ -45,7 +45,7 @@
                                         <TextBox Grid.Column="1"
                                                  MinWidth="160"
                                                  VerticalAlignment="Center"
-                                                 Text="{Binding Url}"/>
+                                                 Text="{Binding Url, UpdateSourceTrigger=PropertyChanged}"/>
                                     </Grid>
             <StackPanel Margin="5"
                         HorizontalAlignment="Right"

--- a/BetterGenshinImpact/View/Windows/WebImageInput.xaml
+++ b/BetterGenshinImpact/View/Windows/WebImageInput.xaml
@@ -1,0 +1,70 @@
+﻿<ui:FluentWindow x:Class="BetterGenshinImpact.View.Windows.WebImageInput"
+                 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                 xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+                 xmlns:windowns="clr-namespace:BetterGenshinImpact.ViewModel.Windows"
+                 xmlns:behavior="clr-namespace:BetterGenshinImpact.View.Behavior"
+                 d:DataContext="{d:DesignInstance Type=windowns:WebImageInputViewModel}"
+                 Width="500"
+                 Height="200"
+                 MinWidth="400"
+                 MinHeight="160"
+                 ui:Design.Background="{DynamicResource ApplicationBackgroundBrush}"
+                 ui:Design.Foreground="{DynamicResource TextFillColorPrimaryBrush}"
+                 ExtendsContentIntoTitleBar="True"
+                 behavior:AutoTranslateInterceptor.EnableAutoTranslate="True"
+                 FontFamily="{DynamicResource TextThemeFontFamily}"
+                 ResizeMode="CanMinimize"
+                 WindowBackdropType="Mica"
+                 WindowStartupLocation="CenterScreen"
+                 WindowStyle="SingleBorderWindow"
+                 xmlns:emoji="clr-namespace:Emoji.Wpf;assembly=Emoji.Wpf"
+                 mc:Ignorable="d">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <StackPanel Grid.Row="1" Margin="12">
+            <emoji:TextBlock Text="请在下方输入网络图片地址 " FontSize="16">
+            </emoji:TextBlock>
+             <Grid Grid.Row="1" Margin="0,10,0,12">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+                                        <ui:TextBlock Grid.Column="0"
+                                                      Margin="0,0,8,0"
+                                                      VerticalAlignment="Center"
+                                                      Foreground="{ui:ThemeResource TextFillColorPrimaryBrush}"
+                                                      Text="图片直链地址：" />
+                                        <!-- 编辑模式：可输入 -->
+                                        <TextBox Grid.Column="1"
+                                                 MinWidth="160"
+                                                 VerticalAlignment="Center"
+                                                 Text="{Binding Url}"/>
+                                    </Grid>
+            <StackPanel Margin="5"
+                        HorizontalAlignment="Right"
+                        Orientation="Horizontal">
+                <ui:Button Name="BtnOk"
+                           Margin="5"
+                           Appearance="Primary"
+                           Content="{Binding ButtonText}"
+                           IsDefault="True" 
+                           IsEnabled="{Binding IsEnabled}"
+                           Command="{Binding SubmitWebImageUrlCommand}"/>
+            </StackPanel>
+        </StackPanel>
+
+        <ui:TitleBar Title="请输入网络图片地址" Grid.Row="0">
+            <ui:TitleBar.Icon>
+                <ui:ImageIcon Source="pack://application:,,,/Resources/Images/logo.png" />
+            </ui:TitleBar.Icon>
+        </ui:TitleBar>
+
+    </Grid>
+</ui:FluentWindow>

--- a/BetterGenshinImpact/View/Windows/WebImageInput.xaml.cs
+++ b/BetterGenshinImpact/View/Windows/WebImageInput.xaml.cs
@@ -1,4 +1,6 @@
-﻿using BetterGenshinImpact.ViewModel.Windows;
+using BetterGenshinImpact.ViewModel.Windows;
+using System;
+
 namespace BetterGenshinImpact.View.Windows;
 
 public partial class WebImageInput
@@ -8,7 +10,17 @@ public partial class WebImageInput
     public WebImageInput(WebImageInputViewModel viewModel)
     {
         DataContext = ViewModel = viewModel;
-        ViewModel.RequestClose += () => Close();
         InitializeComponent();
+        ViewModel.RequestClose += OnRequestClose;
+        Closed += OnClosed;
+    }
+
+    private void OnRequestClose() => Close();
+
+    private void OnClosed(object? sender, EventArgs e)
+    {
+        Closed -= OnClosed;
+        ViewModel.RequestClose -= OnRequestClose;
+        ViewModel.CancelDownload();
     }
 }

--- a/BetterGenshinImpact/View/Windows/WebImageInput.xaml.cs
+++ b/BetterGenshinImpact/View/Windows/WebImageInput.xaml.cs
@@ -1,0 +1,14 @@
+﻿using BetterGenshinImpact.ViewModel.Windows;
+namespace BetterGenshinImpact.View.Windows;
+
+public partial class WebImageInput
+{
+    public WebImageInputViewModel ViewModel { get; }
+
+    public WebImageInput(WebImageInputViewModel viewModel)
+    {
+        DataContext = ViewModel = viewModel;
+        ViewModel.RequestClose += () => Close();
+        InitializeComponent();
+    }
+}

--- a/BetterGenshinImpact/ViewModel/Pages/HomePageViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/HomePageViewModel.cs
@@ -18,6 +18,7 @@ using BetterGenshinImpact.View.Controls.Webview;
 using BetterGenshinImpact.View.Pages.View;
 using BetterGenshinImpact.View.Windows;
 using BetterGenshinImpact.ViewModel.Pages.View;
+using BetterGenshinImpact.ViewModel.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
@@ -33,6 +34,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
@@ -73,6 +75,9 @@ public partial class HomePageViewModel : ViewModel
 
     // 记录上次使用原神的句柄
     private IntPtr _hWnd;
+    
+    // 创建HTTPClient
+    private static readonly HttpClient _httpClient = new();
 
     [ObservableProperty] private InferenceDeviceType[] _inferenceDeviceTypes = Enum.GetValues<InferenceDeviceType>();
 
@@ -80,6 +85,10 @@ public partial class HomePageViewModel : ViewModel
 
     private const string DefaultBannerImagePath = "pack://application:,,,/Resources/Images/banner.jpg";
     private readonly string _customBannerImagePath = Global.Absolute("User/Images/custom_banner.jpg");
+    public static readonly string CustomBannerImageNetworkPath = Global.Absolute("User/Images/custom_banner_url.jpg");
+    public static readonly string CustomBannerImageUrlPath = Global.Absolute("User/Images/custom_banner_url.ini");
+    [ObservableProperty]
+    private bool _isCustomNetworkBanner = false;
     private readonly ChildSessionService _childSessionService;
 
     public HomePageViewModel(
@@ -565,8 +574,36 @@ public partial class HomePageViewModel : ViewModel
 
     private void InitializeBannerImage()
     {
+        WebImageInputViewModel.OnSubmitWebImageUrl += RefreshBannerImage;
         try
         {
+            // 检查url文件
+            if (File.Exists(CustomBannerImageUrlPath))
+            {
+                // 判断是否有内容
+                var url = File.ReadAllText(CustomBannerImageUrlPath);
+                if (!string.IsNullOrEmpty(url))
+                {
+                    _ = DownloadBannerImageAsync(url).ContinueWith(t =>
+                    {
+                        if (t.IsFaulted)
+                        {
+                            var ex = t.Exception?.InnerException ?? t.Exception;
+                            _logger.LogError(ex, "加载自定义背景图片url失败，使用默认图片");
+                            Application.Current.Dispatcher.Invoke(() =>
+                            {
+                                Toast.Error($"加载自定义背景图片url失败：{ex?.Message}");
+                                BannerImageSource = new BitmapImage(new Uri(DefaultBannerImagePath, UriKind.Absolute));
+                            });
+                        }
+                        if (t.Result)
+                        {
+                            UIDispatcherHelper.Invoke(RefreshBannerImage);
+                        }
+                    }, TaskScheduler.Default);
+                    return;
+                }
+            }
             // 检查是否存在自定义图片
             if (File.Exists(_customBannerImagePath))
             {
@@ -590,6 +627,30 @@ public partial class HomePageViewModel : ViewModel
             _logger.LogError(ex, "初始化背景图片失败，使用默认图片");
             BannerImageSource = new BitmapImage(new Uri(DefaultBannerImagePath, UriKind.Absolute));
         }
+    }
+    private async Task<bool> DownloadBannerImageAsync(string url)
+    {
+        // 下载图片
+        var imageBytes = await _httpClient.GetByteArrayAsync(url);
+        if (imageBytes.Length == 0)
+        {
+            return false;
+        }
+        // 保存图片到本地
+        File.WriteAllBytes(CustomBannerImageNetworkPath, imageBytes);
+        return true;
+    }
+    private void RefreshBannerImage()
+    {
+        IsCustomNetworkBanner = true;
+        var bitmap = new BitmapImage();
+        bitmap.BeginInit();
+        bitmap.UriSource = new Uri(Path.GetFullPath(CustomBannerImageNetworkPath));
+        bitmap.CacheOption = BitmapCacheOption.OnLoad;
+        bitmap.CreateOptions = BitmapCreateOptions.IgnoreImageCache;
+        bitmap.EndInit();
+        BannerImageSource = bitmap;
+        _logger.LogInformation("已加载自定义背景图片url");
     }
 
     [RelayCommand]
@@ -639,12 +700,79 @@ public partial class HomePageViewModel : ViewModel
     }
 
     [RelayCommand]
+    private void ChangeWebBannerImage()
+    {
+        try
+        {
+            // 打开窗口
+            var vm = App.GetService<WebImageInputViewModel>();
+            var webImageInput = new WebImageInput(vm!);
+            webImageInput.Owner = Application.Current.MainWindow;
+            webImageInput.ShowDialog();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "更换背景图片失败");
+            Toast.Error($"更换背景图片失败: {ex.Message}");
+        }
+    }
+    [RelayCommand]
+    private void RefreshWebBannerImage()
+    {
+        try
+        {
+            // 检查url文件
+            if (File.Exists(CustomBannerImageUrlPath))
+            {
+                // 判断是否有内容
+                var url = File.ReadAllText(CustomBannerImageUrlPath);
+                if (!string.IsNullOrEmpty(url))
+                {
+                    _ = DownloadBannerImageAsync(url).ContinueWith(t =>
+                    {
+                        if (t.IsFaulted)
+                        {
+                            var ex = t.Exception?.InnerException ?? t.Exception;
+                            _logger.LogError(ex, "下载自定义背景图片url失败");
+                            Application.Current.Dispatcher.Invoke(() =>
+                            {
+                                Toast.Error($"下载自定义背景图片url失败：{ex?.Message}");
+                                BannerImageSource = new BitmapImage(new Uri(DefaultBannerImagePath, UriKind.Absolute));
+                            });
+                        }
+                        if (t.Result)
+                        {
+                            UIDispatcherHelper.Invoke(RefreshBannerImage);
+                        }
+                    }, TaskScheduler.Default);
+                }
+                else
+                {
+                    IsCustomNetworkBanner = false;
+                    ResetBannerImage();
+                }
+            }
+            else
+            {
+                IsCustomNetworkBanner = false;
+                ResetBannerImage();
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "刷新背景图片失败");
+            Toast.Error($"刷新背景图片失败: {ex.Message}");
+        }
+    }
+    [RelayCommand]
     private void ResetBannerImage()
     {
         try
         {
             // 获取自定义图片的完整路径
             var customImageFullPath = Path.GetFullPath(_customBannerImagePath);
+            var customImageUrlFullPath = Path.GetFullPath(CustomBannerImageUrlPath);
+            var customImageNetworkFullPath = Path.GetFullPath(CustomBannerImageNetworkPath);
             _logger.LogInformation("尝试恢复默认背景图片，自定义图片路径: {CustomPath}", customImageFullPath);
 
             // 先切换到默认图片，释放自定义图片的文件锁
@@ -659,8 +787,17 @@ public partial class HomePageViewModel : ViewModel
             if (File.Exists(customImageFullPath))
             {
                 File.Delete(customImageFullPath);
-                Toast.Success("已恢复为默认背景图片！");
             }
+            if (File.Exists(customImageUrlFullPath))
+            {
+                File.Delete(customImageUrlFullPath);
+            }
+            if (File.Exists(customImageNetworkFullPath))
+            {
+                File.Delete(customImageNetworkFullPath);
+            }
+            IsCustomNetworkBanner = false;
+            Toast.Success("已恢复为默认背景图片！");
         }
         catch (Exception ex)
         {

--- a/BetterGenshinImpact/ViewModel/Pages/HomePageViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/HomePageViewModel.cs
@@ -34,9 +34,9 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Reflection;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
@@ -72,12 +72,11 @@ public partial class HomePageViewModel : ViewModel
 
     private readonly TaskTriggerDispatcher _taskDispatcher;
     private readonly MouseKeyMonitor _mouseKeyMonitor = new();
+    private readonly IBannerImageService _bannerImageService;
+    private CancellationTokenSource? _bannerDownloadCancellationTokenSource;
 
     // 记录上次使用原神的句柄
     private IntPtr _hWnd;
-    
-    // 创建HTTPClient
-    private static readonly HttpClient _httpClient = new();
 
     [ObservableProperty] private InferenceDeviceType[] _inferenceDeviceTypes = Enum.GetValues<InferenceDeviceType>();
 
@@ -85,8 +84,6 @@ public partial class HomePageViewModel : ViewModel
 
     private const string DefaultBannerImagePath = "pack://application:,,,/Resources/Images/banner.jpg";
     private readonly string _customBannerImagePath = Global.Absolute("User/Images/custom_banner.jpg");
-    public static readonly string CustomBannerImageNetworkPath = Global.Absolute("User/Images/custom_banner_url.jpg");
-    public static readonly string CustomBannerImageUrlPath = Global.Absolute("User/Images/custom_banner_url.ini");
     [ObservableProperty]
     private bool _isCustomNetworkBanner = false;
     private readonly ChildSessionService _childSessionService;
@@ -94,10 +91,12 @@ public partial class HomePageViewModel : ViewModel
     public HomePageViewModel(
         IConfigService configService,
         TaskTriggerDispatcher taskTriggerDispatcher,
-        ChildSessionService childSessionService)
+        ChildSessionService childSessionService,
+        IBannerImageService bannerImageService)
     {
         _taskDispatcher = taskTriggerDispatcher;
         _childSessionService = childSessionService;
+        _bannerImageService = bannerImageService;
         Config = configService.Get();
         ReadGameInstallPath();
         InitializeBannerImage();
@@ -176,6 +175,7 @@ public partial class HomePageViewModel : ViewModel
 
     private void OnClosed()
     {
+        CancelBannerDownload();
         OnStopTrigger();
         // 等待任务结束
         _maskWindow?.Close();
@@ -574,36 +574,28 @@ public partial class HomePageViewModel : ViewModel
 
     private void InitializeBannerImage()
     {
-        WebImageInputViewModel.OnSubmitWebImageUrl += RefreshBannerImage;
+        LoadFallbackBannerImage();
         try
         {
             // 检查url文件
-            if (File.Exists(CustomBannerImageUrlPath))
+            var url = _bannerImageService.ReadConfiguredUrl();
+            // 判断是否有内容
+            if (!string.IsNullOrEmpty(url))
             {
-                // 判断是否有内容
-                var url = File.ReadAllText(CustomBannerImageUrlPath);
-                if (!string.IsNullOrEmpty(url))
-                {
-                    _ = DownloadBannerImageAsync(url).ContinueWith(t =>
-                    {
-                        if (t.IsFaulted)
-                        {
-                            var ex = t.Exception?.InnerException ?? t.Exception;
-                            _logger.LogError(ex, "加载自定义背景图片url失败，使用默认图片");
-                            Application.Current.Dispatcher.Invoke(() =>
-                            {
-                                Toast.Error($"加载自定义背景图片url失败：{ex?.Message}");
-                                BannerImageSource = new BitmapImage(new Uri(DefaultBannerImagePath, UriKind.Absolute));
-                            });
-                        }
-                        if (t.Result)
-                        {
-                            UIDispatcherHelper.Invoke(RefreshBannerImage);
-                        }
-                    }, TaskScheduler.Default);
-                    return;
-                }
+                _ = DownloadAndApplyBannerImageAsync(url, true);
             }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "初始化背景图片失败，使用现有背景图片");
+        }
+    }
+
+    private void LoadFallbackBannerImage()
+    {
+        IsCustomNetworkBanner = false;
+        try
+        {
             // 检查是否存在自定义图片
             if (File.Exists(_customBannerImagePath))
             {
@@ -628,29 +620,67 @@ public partial class HomePageViewModel : ViewModel
             BannerImageSource = new BitmapImage(new Uri(DefaultBannerImagePath, UriKind.Absolute));
         }
     }
-    private async Task<bool> DownloadBannerImageAsync(string url)
+
+    private async Task DownloadAndApplyBannerImageAsync(string url, bool showErrorToast)
     {
-        // 下载图片
-        var imageBytes = await _httpClient.GetByteArrayAsync(url);
-        if (imageBytes.Length == 0)
+        CancelBannerDownload();
+        var cancellationTokenSource = new CancellationTokenSource();
+        _bannerDownloadCancellationTokenSource = cancellationTokenSource;
+
+        try
         {
-            return false;
+            if (!await _bannerImageService.DownloadAndSaveAsync(url, cancellationTokenSource.Token))
+            {
+                return;
+            }
+
+            cancellationTokenSource.Token.ThrowIfCancellationRequested();
+            RefreshBannerImage();
         }
-        // 保存图片到本地
-        File.WriteAllBytes(CustomBannerImageNetworkPath, imageBytes);
-        return true;
+        catch (OperationCanceledException) when (cancellationTokenSource.IsCancellationRequested)
+        {
+            // 新操作替代旧下载或恢复默认图片时无需提示。
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "下载自定义背景图片url失败，使用现有背景图片");
+            if (showErrorToast)
+            {
+                Toast.Error($"下载自定义背景图片url失败：{ex.Message}");
+            }
+
+            LoadFallbackBannerImage();
+        }
+        finally
+        {
+            if (ReferenceEquals(_bannerDownloadCancellationTokenSource, cancellationTokenSource))
+            {
+                _bannerDownloadCancellationTokenSource = null;
+            }
+
+            cancellationTokenSource.Dispose();
+        }
     }
+
     private void RefreshBannerImage()
     {
         IsCustomNetworkBanner = true;
         var bitmap = new BitmapImage();
         bitmap.BeginInit();
-        bitmap.UriSource = new Uri(Path.GetFullPath(CustomBannerImageNetworkPath));
+        bitmap.UriSource = new Uri(Path.GetFullPath(_bannerImageService.NetworkImagePath));
         bitmap.CacheOption = BitmapCacheOption.OnLoad;
         bitmap.CreateOptions = BitmapCreateOptions.IgnoreImageCache;
         bitmap.EndInit();
         BannerImageSource = bitmap;
         _logger.LogInformation("已加载自定义背景图片url");
+    }
+
+    private void CancelBannerDownload()
+    {
+        var cancellationTokenSource = _bannerDownloadCancellationTokenSource;
+        _bannerDownloadCancellationTokenSource = null;
+        cancellationTokenSource?.Cancel();
+        _bannerImageService.InvalidatePendingDownloads();
     }
 
     [RelayCommand]
@@ -704,11 +734,20 @@ public partial class HomePageViewModel : ViewModel
     {
         try
         {
+            CancelBannerDownload();
             // 打开窗口
             var vm = App.GetService<WebImageInputViewModel>();
             var webImageInput = new WebImageInput(vm!);
             webImageInput.Owner = Application.Current.MainWindow;
-            webImageInput.ShowDialog();
+            vm!.SubmitCompleted += RefreshBannerImage;
+            try
+            {
+                webImageInput.ShowDialog();
+            }
+            finally
+            {
+                vm.SubmitCompleted -= RefreshBannerImage;
+            }
         }
         catch (Exception ex)
         {
@@ -716,46 +755,23 @@ public partial class HomePageViewModel : ViewModel
             Toast.Error($"更换背景图片失败: {ex.Message}");
         }
     }
+
     [RelayCommand]
-    private void RefreshWebBannerImage()
+    private async Task RefreshWebBannerImageAsync()
     {
         try
         {
             // 检查url文件
-            if (File.Exists(CustomBannerImageUrlPath))
+            var url = _bannerImageService.ReadConfiguredUrl();
+            // 判断是否有内容
+            if (!string.IsNullOrEmpty(url))
             {
-                // 判断是否有内容
-                var url = File.ReadAllText(CustomBannerImageUrlPath);
-                if (!string.IsNullOrEmpty(url))
-                {
-                    _ = DownloadBannerImageAsync(url).ContinueWith(t =>
-                    {
-                        if (t.IsFaulted)
-                        {
-                            var ex = t.Exception?.InnerException ?? t.Exception;
-                            _logger.LogError(ex, "下载自定义背景图片url失败");
-                            Application.Current.Dispatcher.Invoke(() =>
-                            {
-                                Toast.Error($"下载自定义背景图片url失败：{ex?.Message}");
-                                BannerImageSource = new BitmapImage(new Uri(DefaultBannerImagePath, UriKind.Absolute));
-                            });
-                        }
-                        if (t.Result)
-                        {
-                            UIDispatcherHelper.Invoke(RefreshBannerImage);
-                        }
-                    }, TaskScheduler.Default);
-                }
-                else
-                {
-                    IsCustomNetworkBanner = false;
-                    ResetBannerImage();
-                }
+                await DownloadAndApplyBannerImageAsync(url, true);
             }
             else
             {
-                IsCustomNetworkBanner = false;
-                ResetBannerImage();
+                CancelBannerDownload();
+                LoadFallbackBannerImage();
             }
         }
         catch (Exception ex)
@@ -764,15 +780,15 @@ public partial class HomePageViewModel : ViewModel
             Toast.Error($"刷新背景图片失败: {ex.Message}");
         }
     }
+
     [RelayCommand]
     private void ResetBannerImage()
     {
         try
         {
+            CancelBannerDownload();
             // 获取自定义图片的完整路径
             var customImageFullPath = Path.GetFullPath(_customBannerImagePath);
-            var customImageUrlFullPath = Path.GetFullPath(CustomBannerImageUrlPath);
-            var customImageNetworkFullPath = Path.GetFullPath(CustomBannerImageNetworkPath);
             _logger.LogInformation("尝试恢复默认背景图片，自定义图片路径: {CustomPath}", customImageFullPath);
 
             // 先切换到默认图片，释放自定义图片的文件锁
@@ -788,14 +804,7 @@ public partial class HomePageViewModel : ViewModel
             {
                 File.Delete(customImageFullPath);
             }
-            if (File.Exists(customImageUrlFullPath))
-            {
-                File.Delete(customImageUrlFullPath);
-            }
-            if (File.Exists(customImageNetworkFullPath))
-            {
-                File.Delete(customImageNetworkFullPath);
-            }
+            _bannerImageService.ResetNetworkImage();
             IsCustomNetworkBanner = false;
             Toast.Success("已恢复为默认背景图片！");
         }

--- a/BetterGenshinImpact/ViewModel/Windows/WebImageInputViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Windows/WebImageInputViewModel.cs
@@ -1,66 +1,114 @@
-﻿using BetterGenshinImpact.Helpers;
-using System;
-using System.IO;
-using System.Net.Http;
-using System.Threading.Tasks;
-using BetterGenshinImpact.View.Pages;
-using BetterGenshinImpact.ViewModel.Pages;
+using BetterGenshinImpact.Service.Interface;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Wpf.Ui.Violeta.Controls;
 
 namespace BetterGenshinImpact.ViewModel.Windows;
-    
-public partial  class WebImageInputViewModel : ViewModel
+
+public partial class WebImageInputViewModel : ViewModel
 {
-    public static event Action OnSubmitWebImageUrl;
+    public event Action? SubmitCompleted;
     public event Action? RequestClose;
-    private readonly HttpClient _httpClient = new();
+
+    private readonly IBannerImageService _bannerImageService;
+    private readonly ILogger<WebImageInputViewModel> _logger = App.GetLogger<WebImageInputViewModel>();
+    private CancellationTokenSource? _downloadCancellationTokenSource;
+
     [ObservableProperty]
-    private string _url = File.Exists(HomePageViewModel.CustomBannerImageUrlPath) ? File.ReadAllText(HomePageViewModel.CustomBannerImageUrlPath) : "";
+    private string _url = "";
+
     [ObservableProperty]
     private string _buttonText = "确定";
+
     [ObservableProperty]
     private bool _isEnabled = true;
-    [RelayCommand]
-    private void SubmitWebImageUrl()
+
+    public WebImageInputViewModel(IBannerImageService bannerImageService)
     {
-        if (string.IsNullOrEmpty(_url))
+        _bannerImageService = bannerImageService;
+        try
+        {
+            Url = _bannerImageService.ReadConfiguredUrl() ?? "";
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "读取网络背景图片地址失败");
+            Toast.Warning($"读取网络背景图片地址失败：{ex.Message}");
+        }
+    }
+
+    [RelayCommand]
+    private async Task SubmitWebImageUrlAsync()
+    {
+        var url = Url.Trim();
+        if (string.IsNullOrEmpty(url))
+        {
+            Toast.Warning("请输入网络图片地址。");
+            return;
+        }
+
+        CancelDownload();
+        var cancellationTokenSource = new CancellationTokenSource();
+        _downloadCancellationTokenSource = cancellationTokenSource;
+        IsEnabled = false;
+        ButtonText = "下载中...";
+
+        try
+        {
+            // 下载图片
+            // 保存图片到本地
+            if (!await _bannerImageService.DownloadAndSaveAsync(url, cancellationTokenSource.Token))
+            {
+                return;
+            }
+
+            cancellationTokenSource.Token.ThrowIfCancellationRequested();
+            // 写入文件
+            _bannerImageService.SaveConfiguredUrl(url);
+            Url = url;
+            SubmitCompleted?.Invoke();
+            RequestClose?.Invoke();
+        }
+        catch (OperationCanceledException) when (cancellationTokenSource.IsCancellationRequested)
+        {
+            // 用户关闭窗口或新下载替代旧下载时无需提示。
+        }
+        catch (ArgumentException ex)
+        {
+            Toast.Warning(ex.Message);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "下载网络背景图片失败");
+            Toast.Error($"图片下载失败：{ex.Message}");
+        }
+        finally
+        {
+            if (ReferenceEquals(_downloadCancellationTokenSource, cancellationTokenSource))
+            {
+                _downloadCancellationTokenSource = null;
+            }
+
+            cancellationTokenSource.Dispose();
+            IsEnabled = true;
+            ButtonText = "确定";
+        }
+    }
+
+    public void CancelDownload()
+    {
+        var cancellationTokenSource = _downloadCancellationTokenSource;
+        if (cancellationTokenSource is null)
         {
             return;
         }
-        _ = DownloadBannerImageAsync(_url).ContinueWith(t =>
-        {
-            if (t.Result)
-            {
-                IsEnabled = true;
-                ButtonText = "确定";
-                // 写入文件
-                File.WriteAllText(HomePageViewModel.CustomBannerImageUrlPath, _url);
-                UIDispatcherHelper.Invoke(() =>
-                {
-                    OnSubmitWebImageUrl?.Invoke();
-                    RequestClose?.Invoke();
-                });
-            }
-            else
-            {
-                IsEnabled = true;
-                ButtonText = "确定";
-            }
-        }, TaskScheduler.Default);
-    }
-    private async Task<bool> DownloadBannerImageAsync(string url)
-    {
-        IsEnabled = false;
-        ButtonText = "下载中...";
-        // 下载图片
-        var imageBytes = await _httpClient.GetByteArrayAsync(url);
-        if (imageBytes.Length == 0)
-        {
-            return false;
-        }
-        // 保存图片到本地
-        File.WriteAllBytes(HomePageViewModel.CustomBannerImageNetworkPath, imageBytes);
-        return true;
+
+        _downloadCancellationTokenSource = null;
+        cancellationTokenSource.Cancel();
+        _bannerImageService.InvalidatePendingDownloads();
     }
 }

--- a/BetterGenshinImpact/ViewModel/Windows/WebImageInputViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Windows/WebImageInputViewModel.cs
@@ -1,0 +1,66 @@
+﻿using BetterGenshinImpact.Helpers;
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using BetterGenshinImpact.View.Pages;
+using BetterGenshinImpact.ViewModel.Pages;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace BetterGenshinImpact.ViewModel.Windows;
+    
+public partial  class WebImageInputViewModel : ViewModel
+{
+    public static event Action OnSubmitWebImageUrl;
+    public event Action? RequestClose;
+    private readonly HttpClient _httpClient = new();
+    [ObservableProperty]
+    private string _url = File.Exists(HomePageViewModel.CustomBannerImageUrlPath) ? File.ReadAllText(HomePageViewModel.CustomBannerImageUrlPath) : "";
+    [ObservableProperty]
+    private string _buttonText = "确定";
+    [ObservableProperty]
+    private bool _isEnabled = true;
+    [RelayCommand]
+    private void SubmitWebImageUrl()
+    {
+        if (string.IsNullOrEmpty(_url))
+        {
+            return;
+        }
+        _ = DownloadBannerImageAsync(_url).ContinueWith(t =>
+        {
+            if (t.Result)
+            {
+                IsEnabled = true;
+                ButtonText = "确定";
+                // 写入文件
+                File.WriteAllText(HomePageViewModel.CustomBannerImageUrlPath, _url);
+                UIDispatcherHelper.Invoke(() =>
+                {
+                    OnSubmitWebImageUrl?.Invoke();
+                    RequestClose?.Invoke();
+                });
+            }
+            else
+            {
+                IsEnabled = true;
+                ButtonText = "确定";
+            }
+        }, TaskScheduler.Default);
+    }
+    private async Task<bool> DownloadBannerImageAsync(string url)
+    {
+        IsEnabled = false;
+        ButtonText = "下载中...";
+        // 下载图片
+        var imageBytes = await _httpClient.GetByteArrayAsync(url);
+        if (imageBytes.Length == 0)
+        {
+            return false;
+        }
+        // 保存图片到本地
+        File.WriteAllBytes(HomePageViewModel.CustomBannerImageNetworkPath, imageBytes);
+        return true;
+    }
+}


### PR DESCRIPTION
添加功能：自定义背景为网络图片，支持动态图片api

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 支持通过主页背景图右键菜单输入网络图片直链。
  * 支持下载并应用网络图片作为自定义背景。
  * 新增“刷新网络图片”选项，可重新加载当前网络背景。
* **错误修复**
  * 网络图片下载失败或取消时显示提示，并自动回退至默认背景。
  * 重置背景时同步清除相关网络图片设置与缓存。
  * 增强网络图片格式、大小及链接有效性校验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->