### PR TITLE
fix: 修复战后扫描拾取掉落物的转向与时长配置

### DIFF
--- a/BetterGenshinImpact/GameTask/Common/Job/ScanPickTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/ScanPickTask.cs
@@ -57,12 +57,14 @@ public class ScanPickTask
         while (!ct.IsCancellationRequested && timeoutStopwatch.Elapsed < finishTime)
         {
             var (hasItems, pickItems) = DetectPickableItems();
+            // 扫圈过程中命中物品时，相机已经发生偏转，需要回正后再移动
+            var cameraRotated = false;
             // Logger.LogInformation("存在可拾取物品: {0}", hasItems);
             if (!hasItems)
             {
                 Simulation.ReleaseAllKey();
                 await ResetCamera(ct);
-                for (var i = 0; i < 10; i++)
+                for (var i = 0; i < 10 && timeoutStopwatch.Elapsed < finishTime; i++)
                 {
                     Simulation.SendInput.Mouse.MoveMouseBy(400, 0);
                     if (i > 5) //前期不考虑移动扫描
@@ -70,11 +72,25 @@ public class ScanPickTask
                     Simulation.SendInput.SimulateAction(GIActions.Drop);
                     await Delay(300, ct);
                     (hasItems, pickItems) = DetectPickableItems();
-                    if (hasItems) break;
+                    if (hasItems)
+                    {
+                        cameraRotated = true;
+                        break;
+                    }
                 }
             }
 
-            if (!hasItems) break;
+            // 一整圈都没有发现物品时，不要提前结束扫描，继续按配置时长扫描
+            if (!hasItems)
+            {
+                continue;
+            }
+
+            // 扫圈中命中物品时相机已偏转，先回正相机，保证移动按键相对视角一致
+            if (cameraRotated)
+            {
+                await ResetCamera(ct);
+            }
 
             // Assume 1080p resolution
             // approximate dist=(x-960)**2+14*(y-888.88)**2
@@ -100,25 +116,24 @@ public class ScanPickTask
     /// <param name="toPickItem">The item to move towards</param>
     private static void MoveTowardsItem(Rect toPickItem)
     {
-        // 对于比较远的物品（Y坐标靠上）先用前进靠近
         // 需要避免两个对向的键同时按下
-        if (toPickItem.Bottom > 560)
+        // 左右转向不再受物品底边 y 坐标限制：无论远近都按物品中心相对屏幕中心（960）的横向偏移转向，
+        // 避免远处斜向掉落物只能直行靠近、无法拾取的问题
+        var itemCenterX = toPickItem.X + toPickItem.Width / 2.0;
+        if (itemCenterX < 880)
         {
-            if (toPickItem.X < 760)
-            {
-                Simulation.SendInput.SimulateAction(GIActions.MoveRight, KeyType.KeyUp);
-                Simulation.SendInput.SimulateAction(GIActions.MoveLeft, KeyType.KeyDown);
-            }
-            else if (toPickItem.X > 1040)
-            {
-                Simulation.SendInput.SimulateAction(GIActions.MoveLeft, KeyType.KeyUp);
-                Simulation.SendInput.SimulateAction(GIActions.MoveRight, KeyType.KeyDown);
-            }
-            else
-            {
-                Simulation.SendInput.SimulateAction(GIActions.MoveLeft, KeyType.KeyUp);
-                Simulation.SendInput.SimulateAction(GIActions.MoveRight, KeyType.KeyUp);
-            }
+            Simulation.SendInput.SimulateAction(GIActions.MoveRight, KeyType.KeyUp);
+            Simulation.SendInput.SimulateAction(GIActions.MoveLeft, KeyType.KeyDown);
+        }
+        else if (itemCenterX > 1040)
+        {
+            Simulation.SendInput.SimulateAction(GIActions.MoveLeft, KeyType.KeyUp);
+            Simulation.SendInput.SimulateAction(GIActions.MoveRight, KeyType.KeyDown);
+        }
+        else
+        {
+            Simulation.SendInput.SimulateAction(GIActions.MoveLeft, KeyType.KeyUp);
+            Simulation.SendInput.SimulateAction(GIActions.MoveRight, KeyType.KeyUp);
         }
 
         if (toPickItem.Bottom < 770)

--- a/BetterGenshinImpact/GameTask/Common/Job/ScanPickTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/ScanPickTask.cs
@@ -57,8 +57,6 @@ public class ScanPickTask
         while (!ct.IsCancellationRequested && timeoutStopwatch.Elapsed < finishTime)
         {
             var (hasItems, pickItems) = DetectPickableItems();
-            // 扫圈过程中命中物品时，相机已经发生偏转，需要回正后再移动
-            var cameraRotated = false;
             // Logger.LogInformation("存在可拾取物品: {0}", hasItems);
             if (!hasItems)
             {
@@ -72,11 +70,7 @@ public class ScanPickTask
                     Simulation.SendInput.SimulateAction(GIActions.Drop);
                     await Delay(300, ct);
                     (hasItems, pickItems) = DetectPickableItems();
-                    if (hasItems)
-                    {
-                        cameraRotated = true;
-                        break;
-                    }
+                    if (hasItems) break;
                 }
             }
 
@@ -86,11 +80,8 @@ public class ScanPickTask
                 continue;
             }
 
-            // 扫圈中命中物品时相机已偏转，先回正相机，保证移动按键相对视角一致
-            if (cameraRotated)
-            {
-                await ResetCamera(ct);
-            }
+            // 扫圈中命中物品时相机已转到物品方向，保持当前视角直接移动；
+            // 检测坐标只在当前视角下有效，回正相机会让物品移出视野、坐标失效
 
             // Assume 1080p resolution
             // approximate dist=(x-960)**2+14*(y-888.88)**2


### PR DESCRIPTION
### 问题
【战斗配置-扫描掉落物】功能：
1. 斜向/远处的掉落物拾取不到：左右转向只在物品框底边 y>560 时生效，远处掉落物只会直线前冲；
2. 扫描时长配置不生效：扫圈半圈没发现物品就无视配置时长提前 break，掉落物捡不干净，且配置的时长被浪费。

### 修改
仅修改 BetterGenshinImpact/GameTask/Common/Job/ScanPickTask.cs：
- 左右转向改为始终按物品中心相对屏幕中心的横向偏移判断，不再受 y 坐标限制；
- 扫圈无物品时改为 continue 持续扫描直至配置时长耗尽，内层扫圈加上超时约束。

### 验证
- 本地 dotnet build BetterGenshinImpact.sln -c Debug 通过；
- 实机测试：视角内斜向掉落物可正常转向拾取；扫描转圈可正确响应配置时长；无叶琴队伍的掉落物拾取成功率明显提升。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化物品扫描流程：未发现物品时将继续扫描至配置时长，并增加超时控制。
  * 改进拾取移动逻辑：根据物品与屏幕中心的相对位置调整左右移动，并依据物品底部位置控制前后移动。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->