### PR TITLE
fix:地图界面或关闭点击穿透时跳过准星绘制，避免拦截鼠标点击

### DIFF
--- a/BetterGenshinImpact/View/MaskWindow.xaml.cs
+++ b/BetterGenshinImpact/View/MaskWindow.xaml.cs
@@ -262,6 +262,8 @@ public partial class MaskWindow : Window
             e.PropertyName == nameof(MaskWindowViewModel.IsMapPointPickerOpen))
         {
             Dispatcher.Invoke(UpdateClickThroughState);
+            // 地图状态变化后重绘，立即移除/恢复准星，避免关闭穿透时旧准星画面残留拦截点击
+            Dispatcher.Invoke(InvalidateVisual);
         }
 
         if (e.PropertyName == nameof(MaskWindowViewModel.IsMapPointPickerOpen))
@@ -659,6 +661,11 @@ public partial class MaskWindow : Window
     {
         var config = _maskWindowConfig;
         if (config == null || !config.CrosshairEnabled) return;
+
+        // 窗口关闭点击穿透时（地图界面/遮罩布局编辑），WPF 分层窗口按像素 alpha 做命中测试，
+        // 准星非透明像素会拦截鼠标点击，故此时跳过准星绘制
+        var editEnabled = TaskContext.Instance().Config.MaskWindowConfig.OverlayLayoutEditEnabled;
+        if (editEnabled || _viewModel?.IsInBigMapUi == true) return;
 
         var centerX = ActualWidth / 2;
         var centerY = ActualHeight / 2;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化地图状态和遮罩布局编辑时的窗口重绘。
  * 在布局编辑或大地图界面中隐藏准星，避免遮挡鼠标点击。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->