### PR TITLE
fix: OverlayMetricsService 硬件采样锁竞争改用 TryEnter 跳过，避免多线程排队等待

### DIFF
--- a/BetterGenshinImpact/Service/OverlayMetricsService.cs
+++ b/BetterGenshinImpact/Service/OverlayMetricsService.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using BetterGenshinImpact.Service.Model;
 using BetterGenshinImpact.Service.Model.OverlayMetric;
 
@@ -242,7 +243,15 @@ public sealed class OverlayMetricsService : IDisposable
 
     private void RefreshHardwareMetrics(MaskWindowConfig config, DateTime now)
     {
-        lock (_hardwareLocker)
+        // 多个 TP Worker 会并发进入本方法（Timer 触发器线程 + 脚本线程）。
+        // LibreHardwareMonitor 传感器采样较慢，用 TryEnter 避免排队等锁；
+        // 抢不到说明上一轮采样还没结束，直接跳过本轮（秒级节流，跳过无影响）。
+        if (!Monitor.TryEnter(_hardwareLocker, 0))
+        {
+            return;
+        }
+
+        try
         {
             var previousRefreshTime = _lastHardwareRefreshTime;
             _lastHardwareRefreshTime = now;
@@ -271,6 +280,10 @@ public sealed class OverlayMetricsService : IDisposable
                 _gpuUsage = gpuEnabled ? gpuUsage : null;
                 _memoryUsage = memoryEnabled ? memoryUsage : null;
             }
+        }
+        finally
+        {
+            Monitor.Exit(_hardwareLocker);
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **性能优化**
  * 优化硬件指标刷新机制，避免采样任务相互阻塞。
  * 当上一轮硬件采样仍在进行时，将自动跳过当前刷新周期，提升应用响应速度与稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->