### PR TITLE
fix(AutoBoss): 在非提瓦特地图正常识别体力，体力不足时正确关闭领奖弹窗

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoBoss/AutoBossTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoBoss/AutoBossTask.cs
@@ -1480,15 +1480,23 @@ public class AutoBossTask : ISoloTask<Dictionary<string, int>>
     {
         var supplementRect = ScaleRect(850, 730, 250, 60);
 
-        while (page.Ocr(supplementRect).Any(region =>
-                   region.Text.Contains("补充", StringComparison.Ordinal)
-                   || region.Text.Contains("原粹", StringComparison.Ordinal)
-                   || region.Text.Contains("树脂", StringComparison.Ordinal)))
+        for (var i = 0; i < 50; i++)
         {
             _ct.ThrowIfCancellationRequested();
+            var promptExists = page.Ocr(supplementRect).Any(region =>
+                region.Text.Contains("补充", StringComparison.Ordinal)
+                || region.Text.Contains("原粹", StringComparison.Ordinal)
+                || region.Text.Contains("树脂", StringComparison.Ordinal));
+            if (!promptExists)
+            {
+                return;
+            }
+
             page.Keyboard.KeyPress(User32.VK.VK_ESCAPE);
             await page.Wait(300);
         }
+
+        throw new TimeoutException("关闭补充原粹树脂提示超时");
     }
 
     /// <summary>

--- a/BetterGenshinImpact/GameTask/AutoBoss/AutoBossTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoBoss/AutoBossTask.cs
@@ -30,6 +30,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using Vanara.PInvoke;
 using static BetterGenshinImpact.GameTask.Common.TaskControl;
 
 namespace BetterGenshinImpact.GameTask.AutoBoss;
@@ -305,7 +306,7 @@ public class AutoBossTask : ISoloTask<Dictionary<string, int>>
     private async Task<OriginalResinInfo> RecognizeOriginalResinInfoFromBigMap()
     {
         using var capture = CaptureToRectArea();
-        using var resinIconSearchRegion = capture.DeriveCrop(ScaleRect(1200, 25, 250, 50));
+        using var resinIconSearchRegion = capture.DeriveCrop(ScaleRect(1200, 25, 580, 50));
         var resinIconRegion = resinIconSearchRegion.Find(LoadRecognitionObject("OriginalResinTopIcon"));
         if (resinIconRegion.IsEmpty())
         {
@@ -543,7 +544,7 @@ public class AutoBossTask : ISoloTask<Dictionary<string, int>>
         }
 
         var openButtonLocator = page.Locator(LoadRecognitionObject("OpenResinSupplementPaneButton"))
-            .WithRoi(ScaleRect(1200, 25, 250, 50))
+            .WithRoi(ScaleRect(1200, 25, 580, 50))
             .WithRetryInterval(300);
 
         try
@@ -1374,6 +1375,7 @@ public class AutoBossTask : ISoloTask<Dictionary<string, int>>
 
         if (!await TryUseOriginalResinOnRewardPrompt(page))
         {
+            await CloseResinSupplementPrompt(page);
             await _returnMainUiTask.Start(_ct);
             return false;
         }
@@ -1468,6 +1470,24 @@ public class AutoBossTask : ISoloTask<Dictionary<string, int>>
             }
 
             return false;
+        }
+    }
+
+    /// <summary>
+    /// 关闭补充原粹树脂提示
+    /// </summary>
+    private async Task CloseResinSupplementPrompt(BvPage page)
+    {
+        var supplementRect = ScaleRect(850, 730, 250, 60);
+
+        while (page.Ocr(supplementRect).Any(region =>
+                   region.Text.Contains("补充", StringComparison.Ordinal)
+                   || region.Text.Contains("原粹", StringComparison.Ordinal)
+                   || region.Text.Contains("树脂", StringComparison.Ordinal)))
+        {
+            _ct.ThrowIfCancellationRequested();
+            page.Keyboard.KeyPress(User32.VK.VK_ESCAPE);
+            await page.Wait(300);
         }
     }
 


### PR DESCRIPTION
Fixes #3385 

正常应该在打开地图识别体力不足后停止挑战，一般不会进入打完首领之后才发现体力不足的情况
但是没考虑渊下宫跟层岩巨渊地图地图内，右上角体力位置会变，这次加大了识别范围，应该不会出现体力不足还去打boss的情况了

只测了渊下宫识别体力正常，弹窗也加了OCR但没测，理论上应该没问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 扩大地图及原粹树脂面板中原粹树脂图标的识别范围，提升识别成功率。
  * 领取奖励失败时，自动处理“补充原粹树脂”提示，减少流程卡住的情况。
  * 通过持续检测提示并按下 ESC，确保相关弹窗能够自动关闭。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->