### PR TITLE
feat: 支持快捷键跳过一条龙当前任务

### DIFF
--- a/BetterGenshinImpact/BetterGenshinImpact_bzribi1r_wpftmp.csproj
+++ b/BetterGenshinImpact/BetterGenshinImpact_bzribi1r_wpftmp.csproj
@@ -1,0 +1,654 @@
+<Project>
+  <PropertyGroup>
+    <AssemblyName>BetterGI</AssemblyName>
+    <IntermediateOutputPath>obj\x64\Debug\</IntermediateOutputPath>
+    <BaseIntermediateOutputPath>obj\</BaseIntermediateOutputPath>
+    <MSBuildProjectExtensionsPath>E:\subject\better-genshin-impact\BetterGenshinImpact\obj\</MSBuildProjectExtensionsPath>
+    <_TargetAssemblyProjectName>BetterGenshinImpact</_TargetAssemblyProjectName>
+    <RootNamespace>BetterGenshinImpact</RootNamespace>
+  </PropertyGroup>
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+  <PropertyGroup>
+    <Version>0.62.1-alpha.3</Version>
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows10.0.22621.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <UseWPF>true</UseWPF>
+    <UseWindowsForms>true</UseWindowsForms>
+    <LangVersion>12.0</LangVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ApplicationIcon>Resources\Images\logo.ico</ApplicationIcon>
+    <Platforms>x64</Platforms>
+    <DebugType>embedded</DebugType>
+  </PropertyGroup>
+  <!--	<ItemGroup>
+		<None Remove="Assets\Images\*.jpg" />
+		<None Remove="Assets\Images\*" />
+		<None Remove="Assets\Images\*.png" />
+		<None Remove="Assets\Images\*.ico" />
+		<None Remove="Assets\Fonts\*.ttf" />
+		<None Remove="Assets\Highlighting\*.xshd" />
+		<None Remove="Assets\Strings\*.html" />
+		<None Remove="Assets\Strings\*.md" />
+		<None Remove="Assets\Audios\*.mp3" />
+		<None Update="Assets\Config\*"/>
+	</ItemGroup>-->
+  <ItemGroup>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="AvalonEdit" Version="6.3.1.120" />
+    <PackageReference Include="BehaviourTree" Version="1.0.73" />
+    <PackageReference Include="BetterGI.VCRuntime" Version="14.44.35208" />
+    <PackageReference Include="BetterGI.Assets.Map" Version="1.0.19" />
+    <PackageReference Include="BetterGI.Assets.Model" Version="1.0.29" />
+    <PackageReference Include="BetterGI.Assets.Other" Version="1.0.17" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
+    <PackageReference Include="DeviceId" Version="6.9.0" />
+    <PackageReference Include="DeviceId.Windows" Version="6.9.0" />
+    <PackageReference Include="DeviceId.Windows.Wmi" Version="6.9.0" />
+    <PackageReference Include="Emoji.Wpf" Version="0.3.4" />
+    <PackageReference Include="HungarianAlgorithm" Version="2.3.5" />
+    <PackageReference Include="LibGit2Sharp" Version="0.31.0" />
+    <PackageReference Include="LazyCache" Version="2.4.0" />
+    <PackageReference Include="LibreHardwareMonitorLib" Version="0.9.6" />
+    <PackageReference Include="MailKit" Version="4.14.0" />
+    <PackageReference Include="Meziantou.Framework.Win32.CredentialManager" Version="1.7.4" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Localization" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.4" />
+    <PackageReference Include="Microsoft.ML.OnnxRuntime.DirectML" Version="1.21.0" />
+    <!--排除掉cpu的runtime dll-->
+    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.21.0" IncludeAssets="none" />
+    <PackageReference Include="Microsoft.ML.OnnxRuntime.Managed" Version="1.21.0" />
+    <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2592.51" />
+    <PackageReference Include="MimeKit" Version="4.15.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Ookii.Dialogs.Wpf" Version="5.0.1" />
+    <PackageReference Include="OpenCvSharp4.WpfExtensions" Version="4.11.0.20250507" />
+    <PackageReference Include="OpenCvSharp4.Extensions" Version="4.11.0.20250507" />
+    <PackageReference Include="OpenCvSharp4.Windows" Version="4.11.0.20250507" />
+    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.122" />
+    <PackageReference Include="Microsoft.ClearScript.V8" Version="7.4.5" />
+    <PackageReference Include="Microsoft.ClearScript.V8.Native.win-x64" Version="7.4.5" />
+    <PackageReference Include="MouseKeyHook" Version="5.7.1" />
+    <PackageReference Include="NCalc" Version="6.2.0" />
+    <PackageReference Include="PresentMonFps" Version="2.0.5" />
+    <PackageReference Include="Sdl.MultiSelectComboBox" Version="1.0.103" />
+    <PackageReference Include="Semver" Version="3.0.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.1" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
+    <PackageReference Include="Serilog.Sinks.RichTextBoxEx.Wpf" Version="1.1.0.1" />
+    <!--		<PackageReference Include="supabase-csharp" Version="0.16.2" />-->
+    <PackageReference Include="System.Drawing.Common" Version="10.0.7" />
+    <PackageReference Include="System.IO.Hashing" Version="9.0.4" />
+    <PackageReference Include="TorchSharp" Version="0.105.0" />
+    <PackageReference Include="Vanara.PInvoke.CoreAudio" Version="4.1.3" />
+    <PackageReference Include="Vanara.PInvoke.NtDll" Version="4.1.3" />
+    <PackageReference Include="Vanara.PInvoke.SHCore" Version="4.1.3" />
+    <PackageReference Include="Vanara.PInvoke.User32" Version="4.1.3" />
+    <PackageReference Include="XamlAnimatedGif" Version="2.3.1" />
+    <PackageReference Include="WPF-UI" Version="4.3.0" />
+    <PackageReference Include="WPF-UI.DependencyInjection" Version="4.3.0" />
+    <PackageReference Include="WPF-UI.Tray" Version="4.3.0" />
+    <PackageReference Include="WPF-UI.Violeta" Version="4.3.0.0" />
+    <PackageReference Include="gong-wpf-dragdrop" Version="3.2.1" />
+    <PackageReference Include="YamlDotNet" Version="16.3.0" />
+    <PackageReference Include="YoloSharp" Version="6.0.3" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(Configuration)' == 'Debug'">
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Fischless.GameCapture\Fischless.GameCapture.csproj" />
+    <ProjectReference Include="..\Fischless.HotkeyCapture\Fischless.HotkeyCapture.csproj" />
+    <ProjectReference Include="..\Fischless.WindowsInput\Fischless.WindowsInput.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="GameTask\**\Recognition.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Assets\Map\**">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Assets\Model\**">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Assets\Config\**">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="GameTask\AutoFight\Assets\1920x1080\**">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="GameTask\AutoFight\Assets\combat_avatar.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="GameTask\AutoFishing\Assets\**">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="GameTask\AutoLeyLineOutcrop\Assets\**">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="GameTask\LogParse\Assets\**">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="GameTask\AutoGeniusInvokation\Assets\1920x1080\**">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="GameTask\AutoGeniusInvokation\Assets\tcg_character_card.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="GameTask\AutoPick\Assets\1920x1080\**">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="GameTask\AutoSkip\Assets\1920x1080\**">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="GameTask\AutoSkip\Assets\*.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="GameTask\AutoTrackPath\Assets\tp.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="GameTask\Common\Element\Assets\1920x1080\**">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="GameTask\Common\Element\Assets\Json\**">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="GameTask\AutoWood\Assets\1920x1080\**">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="GameTask\AutoMusicGame\Assets\1920x1080\**">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="GameTask\GameLoading\Assets\1920x1080\**">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="GameTask\QuickTeleport\Assets\1920x1080\**">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="GameTask\QuickSereniteaPot\Assets\1920x1080\**">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="GameTask\AutoEat\Assets\1920x1080\**">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="GameTask\QuickBuy\Assets\1920x1080\**">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="GameTask\QuickClaimReward\Assets\1920x1080\**">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="GameTask\UseRedeemCode\Assets\1920x1080\**">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="User\**">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="GameTask\LogParse\Assets\log.css">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="GameTask\LogParse\Assets\log.js">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="GameTask\GameLoading\Assets\1920x1080\enter_game.png">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="GameTask\Common\Element\Assets\1920x1080\in_domain.png">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="GameTask\AutoDomain\Assets\1920x1080\**">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="GameTask\AutoBoss\Assets\**">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="User\I18n\en.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="GameTask\OneDragon\" />
+    <Folder Include="GameTask\UseRedeemCode\Assets\1920x1080\" />
+    <Folder Include="Resources\" />
+    <Folder Include="Service\Notification\Builder\" />
+    <Folder Include="User\AutoPathing\" />
+  </ItemGroup>
+  <ItemGroup>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Update="View\Windows\WelcomeDialog.xaml.cs">
+      <SubType>Code</SubType>
+      <DependentUpon>WelcomeDialog.xaml</DependentUpon>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <_DeploymentManifestIconFile Remove="Resources\Images\logo.ico" />
+  </ItemGroup>
+  <ItemGroup>
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.windowsdesktop.app.ref\8.0.25\ref\net8.0\Accessibility.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\behaviourtree\1.0.73\lib\netstandard1.0\BehaviourTree.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\bettergi.assets.map\1.0.19\lib\net8.0\BetterGI.Assets.Map.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\bettergi.assets.model\1.0.29\lib\net8.0\BetterGI.Assets.Model.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\bettergi.assets.other\1.0.17\lib\net8.0\BetterGI.Assets.Other.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\bettergi.vcruntime\14.44.35208\lib\net8.0\BetterGI.VCRuntime.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\blacksharp.core\1.0.7\lib\net8.0\BlackSharp.Core.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\bouncycastle.cryptography\2.6.2\lib\net6.0\BouncyCastle.Cryptography.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.clearscript.core\7.4.5\lib\net5.0\ClearScript.Core.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.clearscript.v8\7.4.5\lib\net5.0\ClearScript.V8.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.clearscript.v8.icudata\7.4.5\lib\netstandard1.0\ClearScript.V8.ICUData.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\clipper2\1.4.0\lib\netstandard2.0\Clipper2Lib.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\communitytoolkit.mvvm\8.2.2\lib\net6.0\CommunityToolkit.Mvvm.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\deviceid\6.9.0\lib\net8.0\DeviceId.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\deviceid.windows\6.9.0\lib\net8.0-windows10.0.17763\DeviceId.Windows.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\deviceid.windows.wmi\6.9.0\lib\net8.0\DeviceId.Windows.Wmi.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.diagnostics.tracing.traceevent\3.1.13\lib\netstandard2.0\Dia2Lib.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\diskinfotoolkit\1.1.2\lib\net8.0\DiskInfoToolkit.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\emoji.wpf\0.3.4\lib\netcoreapp3.1\Emoji.Wpf.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\extendednumerics.bigdecimal\3003.0.0.346\lib\net8.0\ExtendedNumerics.BigDecimal.dll" />
+    <ReferencePath Include="E:\subject\better-genshin-impact\Fischless.GameCapture\bin\x64\Debug\net8.0-windows10.0.22621.0\Fischless.GameCapture.dll" />
+    <ReferencePath Include="E:\subject\better-genshin-impact\Fischless.HotkeyCapture\bin\x64\Debug\net8.0-windows10.0.22621.0\Fischless.HotkeyCapture.dll" />
+    <ReferencePath Include="E:\subject\better-genshin-impact\Fischless.WindowsInput\bin\x64\Debug\netstandard2.0\Fischless.WindowsInput.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\mousekeyhook\5.7.1\lib\net7.0-windows7.0\Gma.System.MouseKeyHook.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\gong-wpf-dragdrop\3.2.1\lib\net6.0-windows7.0\GongSolutions.WPF.DragDrop.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\google.protobuf\3.21.9\lib\net5.0\Google.Protobuf.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\hidsharp\2.6.4\lib\netstandard2.0\HidSharp.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\hungarianalgorithm\2.3.5\lib\netstandard2.1\HungarianAlgorithm.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\avalonedit\6.3.1.120\lib\net8.0-windows7.0\ICSharpCode.AvalonEdit.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\sharpziplib\1.4.0\lib\net6.0\ICSharpCode.SharpZipLib.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\lazycache\2.4.0\lib\netstandard2.0\LazyCache.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\libgit2sharp\0.31.0\lib\net8.0\LibGit2Sharp.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\librehardwaremonitorlib\0.9.6\ref\net8.0\LibreHardwareMonitorLib.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\mailkit\4.14.0\lib\net8.0\MailKit.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\meziantou.framework.win32.credentialmanager\1.7.4\lib\net8.0\Meziantou.Framework.Win32.CredentialManager.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\Microsoft.CSharp.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.diagnostics.tracing.traceevent\3.1.13\lib\netstandard2.0\Microsoft.Diagnostics.FastSerialization.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.diagnostics.tracing.traceevent\3.1.13\lib\netstandard2.0\Microsoft.Diagnostics.Tracing.TraceEvent.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.extensions.caching.abstractions\9.0.4\lib\net8.0\Microsoft.Extensions.Caching.Abstractions.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.extensions.caching.memory\9.0.4\lib\net8.0\Microsoft.Extensions.Caching.Memory.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.extensions.configuration.abstractions\9.0.4\lib\net8.0\Microsoft.Extensions.Configuration.Abstractions.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.extensions.configuration.binder\9.0.4\lib\net8.0\Microsoft.Extensions.Configuration.Binder.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.extensions.configuration.commandline\9.0.4\lib\net8.0\Microsoft.Extensions.Configuration.CommandLine.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.extensions.configuration\9.0.4\lib\net8.0\Microsoft.Extensions.Configuration.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.extensions.configuration.environmentvariables\9.0.4\lib\net8.0\Microsoft.Extensions.Configuration.EnvironmentVariables.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.extensions.configuration.fileextensions\9.0.4\lib\net8.0\Microsoft.Extensions.Configuration.FileExtensions.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.extensions.configuration.json\9.0.4\lib\net8.0\Microsoft.Extensions.Configuration.Json.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.extensions.configuration.usersecrets\9.0.4\lib\net8.0\Microsoft.Extensions.Configuration.UserSecrets.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.extensions.dependencyinjection.abstractions\10.0.7\lib\net8.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.extensions.dependencyinjection\9.0.4\lib\net8.0\Microsoft.Extensions.DependencyInjection.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.extensions.diagnostics.abstractions\9.0.4\lib\net8.0\Microsoft.Extensions.Diagnostics.Abstractions.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.extensions.diagnostics\9.0.4\lib\net8.0\Microsoft.Extensions.Diagnostics.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.extensions.fileproviders.abstractions\9.0.4\lib\net8.0\Microsoft.Extensions.FileProviders.Abstractions.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.extensions.fileproviders.physical\9.0.4\lib\net8.0\Microsoft.Extensions.FileProviders.Physical.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.extensions.filesystemglobbing\9.0.4\lib\net8.0\Microsoft.Extensions.FileSystemGlobbing.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.extensions.hosting.abstractions\9.0.4\lib\net8.0\Microsoft.Extensions.Hosting.Abstractions.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.extensions.hosting\9.0.4\lib\net8.0\Microsoft.Extensions.Hosting.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.extensions.localization.abstractions\9.0.4\lib\netstandard2.0\Microsoft.Extensions.Localization.Abstractions.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.extensions.localization\9.0.4\lib\netstandard2.0\Microsoft.Extensions.Localization.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.extensions.logging.abstractions\10.0.7\lib\net8.0\Microsoft.Extensions.Logging.Abstractions.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.extensions.logging.configuration\9.0.4\lib\net8.0\Microsoft.Extensions.Logging.Configuration.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.extensions.logging.console\9.0.4\lib\net8.0\Microsoft.Extensions.Logging.Console.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.extensions.logging.debug\9.0.4\lib\net8.0\Microsoft.Extensions.Logging.Debug.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.extensions.logging\9.0.4\lib\net8.0\Microsoft.Extensions.Logging.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.extensions.logging.eventlog\9.0.4\lib\net8.0\Microsoft.Extensions.Logging.EventLog.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.extensions.logging.eventsource\9.0.4\lib\net8.0\Microsoft.Extensions.Logging.EventSource.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.extensions.options.configurationextensions\9.0.4\lib\net8.0\Microsoft.Extensions.Options.ConfigurationExtensions.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.extensions.options\9.0.4\lib\net8.0\Microsoft.Extensions.Options.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.extensions.primitives\9.0.4\lib\net8.0\Microsoft.Extensions.Primitives.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.ml.onnxruntime.managed\1.21.0\lib\net8.0\Microsoft.ML.OnnxRuntime.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.toolkit.uwp.notifications\7.1.3\lib\net5.0-windows10.0.17763\Microsoft.Toolkit.Uwp.Notifications.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\Microsoft.VisualBasic.Core.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.windowsdesktop.app.ref\8.0.25\ref\net8.0\Microsoft.VisualBasic.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.windowsdesktop.app.ref\8.0.25\ref\net8.0\Microsoft.VisualBasic.Forms.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.web.webview2\1.0.2592.51\lib\netcoreapp3.0\Microsoft.Web.WebView2.Core.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.web.webview2\1.0.2592.51\lib\netcoreapp3.0\Microsoft.Web.WebView2.WinForms.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.web.webview2\1.0.2592.51\lib\netcoreapp3.0\Microsoft.Web.WebView2.Wpf.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\Microsoft.Win32.Primitives.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.windowsdesktop.app.ref\8.0.25\ref\net8.0\Microsoft.Win32.Registry.AccessControl.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\Microsoft.Win32.Registry.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.win32.systemevents\10.0.7\lib\net8.0\Microsoft.Win32.SystemEvents.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.windows.sdk.net.ref\10.0.22621.57\lib\net8.0\Microsoft.Windows.SDK.NET.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.xaml.behaviors.wpf\1.1.122\lib\net6.0-windows7.0\Microsoft.Xaml.Behaviors.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\mimekit\4.15.1\lib\net8.0\MimeKit.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\mono.posix.netstandard\1.0.0\ref\netstandard2.0\Mono.Posix.NETStandard.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\mscorlib.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\ncalc.core\6.2.0\lib\net8.0\NCalc.Core.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\ncalc\6.2.0\lib\net8.0\NCalc.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\ncalc.domain\6.2.0\lib\net8.0\NCalc.Domain.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\ncalc.parser\6.2.0\lib\net8.0\NCalc.Parser.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\netstandard.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\newtonsoft.json\13.0.3\lib\net6.0\Newtonsoft.Json.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\ookii.dialogs.wpf\5.0.1\lib\net6.0-windows7.0\Ookii.Dialogs.Wpf.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\opencvsharp4\4.11.0.20250507\lib\net6.0\OpenCvSharp.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\opencvsharp4.extensions\4.11.0.20250507\lib\net6.0\OpenCvSharp.Extensions.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\opencvsharp4.wpfextensions\4.11.0.20250507\lib\net6.0\OpenCvSharp.WpfExtensions.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\parlot\1.5.7\lib\net8.0\Parlot.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.windowsdesktop.app.ref\8.0.25\ref\net8.0\PresentationCore.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.windowsdesktop.app.ref\8.0.25\ref\net8.0\PresentationFramework.Aero.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.windowsdesktop.app.ref\8.0.25\ref\net8.0\PresentationFramework.Aero2.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.windowsdesktop.app.ref\8.0.25\ref\net8.0\PresentationFramework.AeroLite.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.windowsdesktop.app.ref\8.0.25\ref\net8.0\PresentationFramework.Classic.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.windowsdesktop.app.ref\8.0.25\ref\net8.0\PresentationFramework.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.windowsdesktop.app.ref\8.0.25\ref\net8.0\PresentationFramework.Luna.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.windowsdesktop.app.ref\8.0.25\ref\net8.0\PresentationFramework.Royale.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.windowsdesktop.app.ref\8.0.25\ref\net8.0\PresentationUI.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\presentmonfps\2.0.5\lib\netstandard2.0\PresentMonFps.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\ramspdtoolkit-ndd\1.4.2\lib\net8.0\RAMSPDToolkit-NDD.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.windowsdesktop.app.ref\8.0.25\ref\net8.0\ReachFramework.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\sdl.multiselectcombobox\1.0.103\lib\net6.0-windows7.0\Sdl.MultiSelectComboBox.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\semver\3.0.0\lib\net5.0\Semver.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\serilog\4.2.0\lib\net8.0\Serilog.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\serilog.extensions.logging\9.0.1\lib\net8.0\Serilog.Extensions.Logging.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\serilog.sinks.console\6.0.0\lib\net8.0\Serilog.Sinks.Console.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\serilog.sinks.file\6.0.0\lib\net8.0\Serilog.Sinks.File.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\serilog.sinks.richtextboxex.wpf\1.1.0.1\lib\net8.0-windows7.0\Serilog.Sinks.RichTextBoxEx.Wpf.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\sharpdx.d3dcompiler\4.2.0\lib\netstandard1.1\SharpDX.D3DCompiler.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\sharpdx.direct3d11\4.2.0\lib\netstandard1.1\SharpDX.Direct3D11.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\sharpdx.directinput\4.2.0\lib\netstandard1.3\SharpDX.DirectInput.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\sharpdx\4.2.0\lib\netstandard1.1\SharpDX.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\sharpdx.dxgi\4.2.0\lib\netstandard1.1\SharpDX.DXGI.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\sixlabors.fonts\2.0.8\lib\net6.0\SixLabors.Fonts.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\sixlabors.imagesharp\3.1.7\lib\net6.0\SixLabors.ImageSharp.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\sixlabors.imagesharp.drawing\2.1.5\lib\net6.0\SixLabors.ImageSharp.Drawing.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\skiasharp\2.88.6\lib\net6.0\SkiaSharp.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\stfu\0.1.1\lib\netcoreapp3.1\Stfu.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.AppContext.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Buffers.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\system.codedom\10.0.2\lib\net8.0\System.CodeDom.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Collections.Concurrent.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Collections.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\system.collections.immutable\10.0.7\lib\net8.0\System.Collections.Immutable.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Collections.NonGeneric.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Collections.Specialized.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.ComponentModel.Annotations.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.ComponentModel.DataAnnotations.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.ComponentModel.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.ComponentModel.EventBasedAsync.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.ComponentModel.Primitives.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.ComponentModel.TypeConverter.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.windowsdesktop.app.ref\8.0.25\ref\net8.0\System.Configuration.ConfigurationManager.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Configuration.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Console.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Core.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Data.Common.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Data.DataSetExtensions.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Data.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.windowsdesktop.app.ref\8.0.25\ref\net8.0\System.Design.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Diagnostics.Contracts.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Diagnostics.Debug.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\system.diagnostics.diagnosticsource\10.0.7\lib\net8.0\System.Diagnostics.DiagnosticSource.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\system.diagnostics.eventlog\9.0.4\lib\net8.0\System.Diagnostics.EventLog.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Diagnostics.FileVersionInfo.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.windowsdesktop.app.ref\8.0.25\ref\net8.0\System.Diagnostics.PerformanceCounter.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Diagnostics.Process.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Diagnostics.StackTrace.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Diagnostics.TextWriterTraceListener.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Diagnostics.Tools.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Diagnostics.TraceSource.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Diagnostics.Tracing.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.windowsdesktop.app.ref\8.0.25\ref\net8.0\System.DirectoryServices.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\system.drawing.common\10.0.7\lib\net8.0\System.Drawing.Common.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.windowsdesktop.app.ref\8.0.25\ref\net8.0\System.Drawing.Design.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.windowsdesktop.app.ref\8.0.25\ref\net8.0\System.Drawing.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Drawing.Primitives.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Dynamic.Runtime.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Formats.Asn1.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Formats.Tar.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Globalization.Calendars.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Globalization.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Globalization.Extensions.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.IO.Compression.Brotli.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.IO.Compression.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.IO.Compression.FileSystem.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.IO.Compression.ZipFile.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.IO.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.IO.FileSystem.AccessControl.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.IO.FileSystem.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.IO.FileSystem.DriveInfo.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.IO.FileSystem.Primitives.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.IO.FileSystem.Watcher.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\system.io.hashing\9.0.4\lib\net8.0\System.IO.Hashing.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.IO.IsolatedStorage.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.IO.MemoryMappedFiles.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.windowsdesktop.app.ref\8.0.25\ref\net8.0\System.IO.Packaging.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\system.io.pipelines\9.0.4\lib\net8.0\System.IO.Pipelines.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.IO.Pipes.AccessControl.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.IO.Pipes.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\system.io.ports\10.0.3\lib\net8.0\System.IO.Ports.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.IO.UnmanagedMemoryStream.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Linq.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Linq.Expressions.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Linq.Parallel.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Linq.Queryable.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\system.management\10.0.2\lib\net8.0\System.Management.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Memory.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Net.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Net.Http.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Net.Http.Json.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Net.HttpListener.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Net.Mail.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Net.NameResolution.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Net.NetworkInformation.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Net.Ping.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Net.Primitives.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Net.Quic.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Net.Requests.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Net.Security.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Net.ServicePoint.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Net.Sockets.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Net.WebClient.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Net.WebHeaderCollection.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Net.WebProxy.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Net.WebSockets.Client.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Net.WebSockets.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Numerics.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\system.numerics.tensors\9.0.0\lib\net8.0\System.Numerics.Tensors.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Numerics.Vectors.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.ObjectModel.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.windowsdesktop.app.ref\8.0.25\ref\net8.0\System.Printing.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\system.drawing.common\10.0.7\lib\net8.0\System.Private.Windows.Core.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\system.drawing.common\10.0.7\lib\net8.0\System.Private.Windows.GdiPlus.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Reflection.DispatchProxy.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Reflection.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Reflection.Emit.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Reflection.Emit.ILGeneration.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Reflection.Emit.Lightweight.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Reflection.Extensions.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Reflection.Metadata.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Reflection.Primitives.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Reflection.TypeExtensions.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.windowsdesktop.app.ref\8.0.25\ref\net8.0\System.Resources.Extensions.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Resources.Reader.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Resources.ResourceManager.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Resources.Writer.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Runtime.CompilerServices.Unsafe.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Runtime.CompilerServices.VisualC.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Runtime.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Runtime.Extensions.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Runtime.Handles.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Runtime.InteropServices.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Runtime.InteropServices.JavaScript.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Runtime.InteropServices.RuntimeInformation.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Runtime.Intrinsics.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Runtime.Loader.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Runtime.Numerics.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Runtime.Serialization.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Runtime.Serialization.Formatters.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Runtime.Serialization.Json.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Runtime.Serialization.Primitives.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Runtime.Serialization.Xml.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Security.AccessControl.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Security.Claims.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Security.Cryptography.Algorithms.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Security.Cryptography.Cng.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Security.Cryptography.Csp.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Security.Cryptography.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Security.Cryptography.Encoding.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Security.Cryptography.OpenSsl.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.windowsdesktop.app.ref\8.0.25\ref\net8.0\System.Security.Cryptography.Pkcs.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Security.Cryptography.Primitives.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.windowsdesktop.app.ref\8.0.25\ref\net8.0\System.Security.Cryptography.ProtectedData.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Security.Cryptography.X509Certificates.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.windowsdesktop.app.ref\8.0.25\ref\net8.0\System.Security.Cryptography.Xml.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Security.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.windowsdesktop.app.ref\8.0.25\ref\net8.0\System.Security.Permissions.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Security.Principal.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Security.Principal.Windows.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Security.SecureString.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.ServiceModel.Web.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.ServiceProcess.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Text.Encoding.CodePages.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Text.Encoding.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Text.Encoding.Extensions.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\system.text.encodings.web\9.0.4\lib\net8.0\System.Text.Encodings.Web.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\system.text.json\9.0.4\lib\net8.0\System.Text.Json.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Text.RegularExpressions.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\system.threading.accesscontrol\10.0.3\lib\net8.0\System.Threading.AccessControl.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Threading.Channels.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Threading.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Threading.Overlapped.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Threading.Tasks.Dataflow.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Threading.Tasks.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Threading.Tasks.Extensions.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Threading.Tasks.Parallel.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Threading.Thread.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Threading.ThreadPool.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Threading.Timer.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Transactions.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Transactions.Local.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.ValueTuple.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Web.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Web.HttpUtility.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.windowsdesktop.app.ref\8.0.25\ref\net8.0\System.Windows.Controls.Ribbon.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Windows.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.windowsdesktop.app.ref\8.0.25\ref\net8.0\System.Windows.Extensions.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.windowsdesktop.app.ref\8.0.25\ref\net8.0\System.Windows.Forms.Design.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.windowsdesktop.app.ref\8.0.25\ref\net8.0\System.Windows.Forms.Design.Editors.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.windowsdesktop.app.ref\8.0.25\ref\net8.0\System.Windows.Forms.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.windowsdesktop.app.ref\8.0.25\ref\net8.0\System.Windows.Forms.Primitives.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.windowsdesktop.app.ref\8.0.25\ref\net8.0\System.Windows.Input.Manipulations.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.windowsdesktop.app.ref\8.0.25\ref\net8.0\System.Windows.Presentation.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.windowsdesktop.app.ref\8.0.25\ref\net8.0\System.Xaml.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Xml.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Xml.Linq.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Xml.ReaderWriter.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Xml.Serialization.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Xml.XDocument.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Xml.XmlDocument.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Xml.XmlSerializer.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Xml.XPath.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\ref\net8.0\System.Xml.XPath.XDocument.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\torchsharp\0.105.0\lib\net6.0\TorchSharp.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.diagnostics.tracing.traceevent\3.1.13\lib\netstandard2.0\TraceReloggerLib.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\emoji.wpf\0.3.4\lib\netcoreapp3.1\Typography.GlyphLayout.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\emoji.wpf\0.3.4\lib\netcoreapp3.1\Typography.OpenFont.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.windowsdesktop.app.ref\8.0.25\ref\net8.0\UIAutomationClient.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.windowsdesktop.app.ref\8.0.25\ref\net8.0\UIAutomationClientSideProviders.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.windowsdesktop.app.ref\8.0.25\ref\net8.0\UIAutomationProvider.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.windowsdesktop.app.ref\8.0.25\ref\net8.0\UIAutomationTypes.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\vanara.core\4.1.3\lib\net8.0-windows7.0\Vanara.Core.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\vanara.pinvoke.comdlg32\4.1.3\lib\net8.0-windows7.0\Vanara.PInvoke.ComDlg32.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\vanara.pinvoke.coreaudio\4.1.3\lib\net8.0-windows7.0\Vanara.PInvoke.CoreAudio.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\vanara.pinvoke.cryptography\4.1.3\lib\net8.0-windows7.0\Vanara.PInvoke.Cryptography.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\vanara.pinvoke.dwmapi\4.1.3\lib\net8.0-windows7.0\Vanara.PInvoke.DwmApi.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\vanara.pinvoke.gdi32\4.1.3\lib\net8.0-windows7.0\Vanara.PInvoke.Gdi32.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\vanara.pinvoke.kernel32\4.1.3\lib\net8.0-windows7.0\Vanara.PInvoke.Kernel32.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\vanara.pinvoke.multimedia\4.1.3\lib\net8.0-windows7.0\Vanara.PInvoke.Multimedia.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\vanara.pinvoke.ntdll\4.1.3\lib\net8.0-windows7.0\Vanara.PInvoke.NtDll.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\vanara.pinvoke.ole\4.1.3\lib\net8.0-windows7.0\Vanara.PInvoke.Ole.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\vanara.pinvoke.rpc\4.1.3\lib\net8.0-windows7.0\Vanara.PInvoke.Rpc.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\vanara.pinvoke.security\4.1.3\lib\net8.0-windows7.0\Vanara.PInvoke.Security.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\vanara.pinvoke.shared\4.1.3\lib\net8.0-windows7.0\Vanara.PInvoke.Shared.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\vanara.pinvoke.shcore\4.1.3\lib\net8.0-windows7.0\Vanara.PInvoke.SHCore.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\vanara.pinvoke.user32\4.1.3\lib\net8.0-windows7.0\Vanara.PInvoke.User32.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\vanara.windows.extensions\4.1.3\lib\net8.0-windows7.0\Vanara.Windows.Extensions.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.windowsdesktop.app.ref\8.0.25\ref\net8.0\WindowsBase.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.windowsdesktop.app.ref\8.0.25\ref\net8.0\WindowsFormsIntegration.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\microsoft.windows.sdk.net.ref\10.0.22621.57\lib\net8.0\WinRT.Runtime.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\wpf-ui.abstractions\4.3.0\lib\net8.0\Wpf.Ui.Abstractions.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\wpf-ui.dependencyinjection\4.3.0\lib\net8.0\Wpf.Ui.DependencyInjection.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\wpf-ui\4.3.0\lib\net8.0-windows7.0\Wpf.Ui.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\wpf-ui.tray\4.3.0\lib\net8.0-windows7.0\Wpf.Ui.Tray.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\wpf-ui.violeta\4.3.0\lib\net8.0-windows7.0\Wpf.Ui.Violeta.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\xamlanimatedgif\2.3.1\lib\net5.0-windows7.0\XamlAnimatedGif.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\yamldotnet\16.3.0\lib\net8.0\YamlDotNet.dll" />
+    <ReferencePath Include="C:\Users\Administrator\.nuget\packages\yolosharp\6.0.3\lib\net8.0\YoloSharp.dll" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\CaptureTestWindow.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\Controls\CascadeSelector.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\HtmlMaskWindow.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\MainWindow.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\MaskWindow.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\Pages\CommonSettingsPage.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\Pages\HomePage.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\Pages\HotkeyPage.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\Pages\JsListPage.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\Pages\KeyBindingsSettingsPage.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\Pages\KeyMouseRecordPage.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\Pages\MacroSettingsPage.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\Pages\MapPathingPage.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\Pages\NotificationSettingsPage.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\Pages\OneDragonFlowPage.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\Pages\OneDragon\CraftPage.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\Pages\OneDragon\DailyCommissionPage.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\Pages\OneDragon\DailyRewardPage.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\Pages\OneDragon\DomainPage.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\Pages\OneDragon\ForgingPage.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\Pages\OneDragon\LeyLineBlossomPage.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\Pages\OneDragon\MailPage.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\Pages\OneDragon\SereniteaPotPage.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\Pages\OneDragon\TcgPage.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\Pages\ScriptControlPage.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\Pages\TaskSettingsPage.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\Pages\TriggerSettingsPage.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\Pages\View\HardwareAccelerationView.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\Pages\View\PathingConfigView.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\Pages\View\ScriptGroupConfigView.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\PickerWindow.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\Windows\AboutWindow.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\Windows\ArtifactOcrDialog.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\Windows\CheckUpdateWindow.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\Windows\Editable\ScriptGroupProjectEditor.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\Windows\FeedWindow.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\Windows\JsonMonoDialog.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\Windows\KeyBindingsWindow.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\Windows\MapLabelSearchWindow.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\Windows\MapPathingDevWindow.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\Windows\MapViewer.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\Windows\PictureInPictureWindow.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\Windows\PromptDialog.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\Windows\RepoUpdateDialog.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\Windows\ScriptRepoWindow.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\Windows\SkillCdConfigWindow.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\Windows\ThemedMessageBox.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\View\Windows\WelcomeDialog.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\App.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\BetterGI_Content.g.cs" />
+    <Compile Include="E:\subject\better-genshin-impact\BetterGenshinImpact\obj\x64\Debug\net8.0-windows10.0.22621.0\GeneratedInternalTypeHelper.g.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="C:\Users\Administrator\.dotnet\sdk\10.0.201\Sdks\Microsoft.NET.Sdk\targets\..\analyzers\Microsoft.CodeAnalysis.CSharp.NetAnalyzers.dll" />
+    <Analyzer Include="C:\Users\Administrator\.dotnet\sdk\10.0.201\Sdks\Microsoft.NET.Sdk\targets\..\analyzers\Microsoft.CodeAnalysis.NetAnalyzers.dll" />
+    <Analyzer Include="C:\Users\Administrator\.nuget\packages\communitytoolkit.mvvm\8.2.2\analyzers\dotnet\roslyn4.3\cs\CommunityToolkit.Mvvm.CodeFixers.dll" />
+    <Analyzer Include="C:\Users\Administrator\.nuget\packages\communitytoolkit.mvvm\8.2.2\analyzers\dotnet\roslyn4.3\cs\CommunityToolkit.Mvvm.SourceGenerators.dll" />
+    <Analyzer Include="C:\Users\Administrator\.nuget\packages\microsoft.extensions.logging.abstractions\10.0.7\analyzers\dotnet\roslyn4.4\cs\Microsoft.Extensions.Logging.Generators.dll" />
+    <Analyzer Include="C:\Users\Administrator\.nuget\packages\microsoft.extensions.options\9.0.4\analyzers\dotnet\roslyn4.4\cs\Microsoft.Extensions.Options.SourceGeneration.dll" />
+    <Analyzer Include="C:\Users\Administrator\.nuget\packages\system.text.json\9.0.4\analyzers\dotnet\roslyn4.4\cs\System.Text.Json.SourceGeneration.dll" />
+    <Analyzer Include="C:\Users\Administrator\.nuget\packages\wpf-ui.violeta\4.3.0\analyzers\dotnet\cs\Wpf.Ui.DependencyPropertyGenerator.dll" />
+    <Analyzer Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\analyzers/dotnet/cs/Microsoft.Interop.ComInterfaceGenerator.dll" />
+    <Analyzer Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\analyzers/dotnet/cs/Microsoft.Interop.JavaScript.JSImportGenerator.dll" />
+    <Analyzer Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\analyzers/dotnet/cs/Microsoft.Interop.LibraryImportGenerator.dll" />
+    <Analyzer Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\analyzers/dotnet/cs/Microsoft.Interop.SourceGeneration.dll" />
+    <Analyzer Include="C:\Users\Administrator\.nuget\packages\microsoft.netcore.app.ref\8.0.25\analyzers/dotnet/cs/System.Text.RegularExpressions.Generator.dll" />
+    <Analyzer Include="C:\Users\Administrator\.nuget\packages\microsoft.windowsdesktop.app.ref\8.0.25\analyzers/dotnet/System.Windows.Forms.Analyzers.dll" />
+    <Analyzer Include="C:\Users\Administrator\.nuget\packages\microsoft.windowsdesktop.app.ref\8.0.25\analyzers/dotnet/cs/System.Windows.Forms.Analyzers.CSharp.dll" />
+    <Analyzer Include="C:\Users\Administrator\.nuget\packages\microsoft.windows.sdk.net.ref\10.0.22621.57\analyzers/dotnet/cs/WinRT.SourceGenerator.dll" />
+  </ItemGroup>
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+</Project>

--- a/BetterGenshinImpact/Core/Config/HotKeyConfig.cs
+++ b/BetterGenshinImpact/Core/Config/HotKeyConfig.cs
@@ -257,6 +257,13 @@ public partial class HotKeyConfig : ObservableObject
 
     [ObservableProperty]
     private string _cancelTaskHotkeyType = HotKeyTypeEnum.KeyboardMonitor.ToString();
+
+    // 跳过一条龙当前任务，保留旧字段名以兼容已有快捷键配置
+    [ObservableProperty]
+    private string _skipCurrentConfigGroupHotkey = "";
+
+    [ObservableProperty]
+    private string _skipCurrentConfigGroupHotkeyType = HotKeyTypeEnum.KeyboardMonitor.ToString();
     
     // 停止任意独立任务
     [ObservableProperty]

--- a/BetterGenshinImpact/GameTask/RunnerContext.cs
+++ b/BetterGenshinImpact/GameTask/RunnerContext.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using BetterGenshinImpact.Core.Script;
 using BetterGenshinImpact.GameTask.AutoFight.Model;
 using BetterGenshinImpact.GameTask.AutoPathing.Suspend;
 using BetterGenshinImpact.GameTask.Common.Job;
@@ -16,10 +17,85 @@ namespace BetterGenshinImpact.GameTask;
 /// </summary>
 public class RunnerContext : Singleton<RunnerContext>
 {
+    private readonly object _oneDragonTaskSync = new();
+    private bool _isOneDragonTaskRunning;
+    private bool _skipCurrentOneDragonTaskRequested;
+
     /// <summary>
     /// 是否是连续执行配置组的场景
     /// </summary>
     public bool IsContinuousRunGroup { get; set; }
+
+    /// <summary>
+    /// 是否已请求跳过当前一条龙任务。
+    /// </summary>
+    public bool IsSkipCurrentOneDragonTaskRequested
+    {
+        get
+        {
+            lock (_oneDragonTaskSync)
+            {
+                return _skipCurrentOneDragonTaskRequested;
+            }
+        }
+    }
+
+    public void BeginOneDragonTaskExecution()
+    {
+        lock (_oneDragonTaskSync)
+        {
+            _skipCurrentOneDragonTaskRequested = false;
+            _isOneDragonTaskRunning = true;
+        }
+    }
+
+    public void EndOneDragonTaskExecution()
+    {
+        lock (_oneDragonTaskSync)
+        {
+            _isOneDragonTaskRunning = false;
+        }
+    }
+
+    public bool RequestSkipCurrentOneDragonTask()
+    {
+        CancellationTokenSource? ctsToCancel = null;
+        lock (_oneDragonTaskSync)
+        {
+            if (!_isOneDragonTaskRunning)
+            {
+                return false;
+            }
+
+            if (!_skipCurrentOneDragonTaskRequested)
+            {
+                _skipCurrentOneDragonTaskRequested = true;
+                IsSuspend = false;
+                ctsToCancel = CancellationContext.Instance.Cts;
+            }
+        }
+
+        try
+        {
+            ctsToCancel?.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+            // 当前任务可能刚好结束，旧令牌已释放时无需继续取消。
+        }
+
+        return true;
+    }
+
+    public bool ConsumeSkipCurrentOneDragonTaskRequest()
+    {
+        lock (_oneDragonTaskSync)
+        {
+            var requested = _skipCurrentOneDragonTaskRequested;
+            _skipCurrentOneDragonTaskRequested = false;
+            return requested;
+        }
+    }
     
     public TaskProgress.TaskProgress? taskProgress  { get; set; }
     
@@ -131,6 +207,12 @@ public class RunnerContext : Singleton<RunnerContext>
     /// </summary>
     public void Reset()
     {
+        lock (_oneDragonTaskSync)
+        {
+            _isOneDragonTaskRunning = false;
+            _skipCurrentOneDragonTaskRequested = false;
+        }
+
         IsContinuousRunGroup = false;
         PartyName = null;
         _combatScenes = null;

--- a/BetterGenshinImpact/GameTask/TaskRunner.cs
+++ b/BetterGenshinImpact/GameTask/TaskRunner.cs
@@ -72,6 +72,11 @@ public class TaskRunner
 
             await action();
         }
+        catch (NormalEndException e) when (RunnerContext.Instance.IsSkipCurrentOneDragonTaskRequested &&
+                                           !CancellationContext.Instance.IsManualStop)
+        {
+            _logger.LogInformation("当前一条龙任务收到跳过请求: {Msg}", e.Message);
+        }
         catch (NormalEndException e)
         {
             Notify.Event(NotificationEvent.TaskCancel).Success("任务手动取消，或正常结束");
@@ -81,6 +86,11 @@ public class TaskRunner
                 // 连续执行时，抛出异常，终止执行
                 throw;
             }
+        }
+        catch (OperationCanceledException) when (RunnerContext.Instance.IsSkipCurrentOneDragonTaskRequested &&
+                                                  !CancellationContext.Instance.IsManualStop)
+        {
+            _logger.LogInformation("当前一条龙任务收到跳过请求，结束当前任务");
         }
         catch (OperationCanceledException)
         {

--- a/BetterGenshinImpact/Service/ExternalControlService.cs
+++ b/BetterGenshinImpact/Service/ExternalControlService.cs
@@ -1,0 +1,174 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using BetterGenshinImpact.Core.Config;
+using BetterGenshinImpact.Core.Script;
+using BetterGenshinImpact.GameTask;
+using Microsoft.Extensions.Logging;
+
+namespace BetterGenshinImpact.Service;
+
+/// <summary>
+/// 外部进程控制入口（Go / 脚本等）。
+/// 约定：写入 {BetterGI}\User\control\command.json
+/// {
+///   "cmd": "skip_current_task"
+/// }
+/// BGI 轮询消费后删除文件。
+/// </summary>
+public static class ExternalControlService
+{
+    private static readonly ILogger Logger = App.GetLogger<LoggerTag>();
+    private static readonly object Gate = new();
+    private static CancellationTokenSource? _loopCts;
+    private static Task? _loopTask;
+
+    public static string ControlDir => Global.Absolute(@"User\control");
+    public static string CommandFilePath => Path.Combine(ControlDir, "command.json");
+
+    public static void Start()
+    {
+        lock (Gate)
+        {
+            if (_loopTask is { IsCompleted: false })
+            {
+                return;
+            }
+
+            Directory.CreateDirectory(ControlDir);
+            _loopCts = new CancellationTokenSource();
+            var token = _loopCts.Token;
+            _loopTask = Task.Run(() => PollLoopAsync(token), token);
+            Logger.LogInformation("外部控制服务已启动，监听: {Path}", CommandFilePath);
+        }
+    }
+
+    public static void Stop()
+    {
+        lock (Gate)
+        {
+            try
+            {
+                _loopCts?.Cancel();
+            }
+            catch
+            {
+                // ignore
+            }
+
+            _loopCts = null;
+            _loopTask = null;
+        }
+    }
+
+    private static async Task PollLoopAsync(CancellationToken token)
+    {
+        while (!token.IsCancellationRequested)
+        {
+            try
+            {
+                TryConsumeCommand();
+            }
+            catch (Exception e)
+            {
+                Logger.LogDebug(e, "处理外部控制命令失败");
+            }
+
+            try
+            {
+                await Task.Delay(300, token);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+        }
+    }
+
+    private static void TryConsumeCommand()
+    {
+        if (!File.Exists(CommandFilePath))
+        {
+            return;
+        }
+
+        string json;
+        try
+        {
+            json = File.ReadAllText(CommandFilePath);
+        }
+        catch (IOException)
+        {
+            // 可能正在被外部写入，下一拍再读
+            return;
+        }
+
+        try
+        {
+            File.Delete(CommandFilePath);
+        }
+        catch
+        {
+            // 删除失败也不重复执行：先解析再尽力删
+        }
+
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return;
+        }
+
+        ExternalControlCommand? cmd;
+        try
+        {
+            cmd = JsonSerializer.Deserialize<ExternalControlCommand>(json, new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            });
+        }
+        catch (Exception e)
+        {
+            Logger.LogWarning(e, "外部控制命令 JSON 无效: {Json}", json);
+            return;
+        }
+
+        if (cmd == null || string.IsNullOrWhiteSpace(cmd.Cmd))
+        {
+            return;
+        }
+
+        switch (cmd.Cmd.Trim().ToLowerInvariant())
+        {
+            case "skip_current_task":
+            case "skip_task":
+            case "next_task":
+            case "skip_current_group":
+            case "skip_group":
+            case "next_group":
+                Logger.LogInformation("收到外部命令: 跳过当前一条龙任务，继续下一个任务");
+                if (!RunnerContext.Instance.RequestSkipCurrentOneDragonTask())
+                {
+                    Logger.LogWarning("跳过一条龙任务命令未执行：当前没有正在执行的一条龙任务");
+                }
+                break;
+            case "stop":
+            case "manual_stop":
+                Logger.LogInformation("收到外部命令: 停止全部任务");
+                CancellationContext.Instance.ManualCancel();
+                break;
+            default:
+                Logger.LogWarning("未知外部控制命令: {Cmd}", cmd.Cmd);
+                break;
+        }
+    }
+
+    private sealed class ExternalControlCommand
+    {
+        public string? Cmd { get; set; }
+    }
+
+    private sealed class LoggerTag
+    {
+    }
+}

--- a/BetterGenshinImpact/Service/Interface/IScriptService.cs
+++ b/BetterGenshinImpact/Service/Interface/IScriptService.cs
@@ -7,5 +7,6 @@ namespace BetterGenshinImpact.Service.Interface;
 
 public interface IScriptService
 {
-    Task RunMulti(IEnumerable<ScriptGroupProject> projectList, string? groupName = null,TaskProgress? taskProgress = null);
+    Task<bool> RunMulti(IEnumerable<ScriptGroupProject> projectList, string? groupName = null,
+        TaskProgress? taskProgress = null, bool allowSkipCurrentOneDragonTask = false);
 }

--- a/BetterGenshinImpact/Service/ScriptService.cs
+++ b/BetterGenshinImpact/Service/ScriptService.cs
@@ -117,7 +117,8 @@ public partial class ScriptService : IScriptService
     //优先执行的配置组，统计每个project执行次数
     private readonly Dictionary<string, int> _projectExecutionCount = new();
     
-    public async Task RunMulti(IEnumerable<ScriptGroupProject> projectList, string? groupName = null,TaskProgress? taskProgress = null)
+    public async Task<bool> RunMulti(IEnumerable<ScriptGroupProject> projectList, string? groupName = null,
+        TaskProgress? taskProgress = null, bool allowSkipCurrentOneDragonTask = false)
     {
         groupName ??= "默认";
 
@@ -147,7 +148,7 @@ public partial class ScriptService : IScriptService
         if (CancellationContext.Instance.IsCancellationRequested)
         {
             _logger.LogInformation("配置组 {Name} 在启动阶段被取消", groupName);
-            return;
+            return false;
         }
         
         
@@ -177,11 +178,18 @@ public partial class ScriptService : IScriptService
         await new TaskRunner()
             .RunThreadAsync(async () =>
             {
-                var stopwatch = new Stopwatch();
-                int projectIndex = -1;
-                for (int x = 0; x < list.Count; x++)
+                if (allowSkipCurrentOneDragonTask)
                 {
-                    var project = list[x];
+                    RunnerContext.Instance.BeginOneDragonTaskExecution();
+                }
+
+                try
+                {
+                    var stopwatch = new Stopwatch();
+                    int projectIndex = -1;
+                    for (int x = 0; x < list.Count; x++)
+                    {
+                        var project = list[x];
                     //正常情况下，只有一个真正执行的project，存在其他优先执行配置组情况下，会有多个任务。
                     List<ScriptGroupProject> exeProjects = [project];
                     RunnerContext.Instance.IsPreExecution = false;
@@ -423,9 +431,25 @@ public partial class ScriptService : IScriptService
                                 SystemControl.RestartApplication(["--TaskProgress", taskProgress.Name]);
                             }
                         }
+                        }
+                    }
+                }
+                finally
+                {
+                    if (allowSkipCurrentOneDragonTask)
+                    {
+                        RunnerContext.Instance.EndOneDragonTaskExecution();
                     }
                 }
             });
+
+        var isCurrentOneDragonTaskSkipped = allowSkipCurrentOneDragonTask &&
+                                            RunnerContext.Instance.ConsumeSkipCurrentOneDragonTaskRequest() &&
+                                            !CancellationContext.Instance.IsManualStop;
+        if (isCurrentOneDragonTaskSkipped)
+        {
+            _logger.LogInformation("一条龙任务 {Name} 已通过快捷键跳过，准备执行下一个任务", groupName);
+        }
         
 
         // 还原定时器
@@ -440,7 +464,9 @@ public partial class ScriptService : IScriptService
         {
             if (CancellationContext.Instance.IsManualStop is false)
             {
-                Notify.Event(NotificationEvent.GroupEnd).Success($"配置组{groupName}结束");
+                Notify.Event(NotificationEvent.GroupEnd).Success(isCurrentOneDragonTaskSkipped
+                    ? $"配置组{groupName}已跳过"
+                    : $"配置组{groupName}结束");
             }
         }
 
@@ -449,6 +475,7 @@ public partial class ScriptService : IScriptService
             taskProgress.Next = null;
         }
 
+        return isCurrentOneDragonTaskSkipped;
     }
 
     private List<ScriptGroupProject> ReloadScriptProjects(IEnumerable<ScriptGroupProject> projectList)

--- a/BetterGenshinImpact/ViewModel/Pages/HotKeyPageViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/HotKeyPageViewModel.cs
@@ -372,6 +372,23 @@ public partial class HotKeyPageViewModel : ObservableObject, IViewModel
             }
         ));
         systemDirectory.Children.Add(new HotKeySettingModel(
+            "跳过一条龙当前任务",
+            nameof(Config.HotKeyConfig.SkipCurrentConfigGroupHotkey),
+            Config.HotKeyConfig.SkipCurrentConfigGroupHotkey,
+            Config.HotKeyConfig.SkipCurrentConfigGroupHotkeyType,
+            (_, _) =>
+            {
+                if (RunnerContext.Instance.RequestSkipCurrentOneDragonTask())
+                {
+                    _logger.LogInformation("检测到跳过一条龙当前任务快捷键{Key}按下，结束当前任务并继续下一个任务", Config.HotKeyConfig.SkipCurrentConfigGroupHotkey);
+                }
+                else
+                {
+                    _logger.LogInformation("检测到跳过一条龙当前任务快捷键{Key}按下，但当前没有正在执行的一条龙任务", Config.HotKeyConfig.SkipCurrentConfigGroupHotkey);
+                }
+            }
+        ));
+        systemDirectory.Children.Add(new HotKeySettingModel(
             "暂停当前脚本/独立任务",
             nameof(Config.HotKeyConfig.SuspendHotkey),
             Config.HotKeyConfig.SuspendHotkey,

--- a/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
@@ -613,6 +613,7 @@ public partial class OneDragonFlowViewModel : ViewModel
         Notify.Event(NotificationEvent.DragonStart).Success("一条龙启动");
         foreach (var task in taskListCopy)
         {
+            var isCurrentTaskSkipped = false;
             if (task is { IsEnabled: true, Action: not null })
             {
                 if (ScriptGroupsdefault.Any(defaultSg => defaultSg.Name == task.Name))
@@ -620,9 +621,19 @@ public partial class OneDragonFlowViewModel : ViewModel
                     _logger.LogInformation($"一条龙任务执行: {finishOneTaskcount++}/{enabledoneTaskCount}");
                     await new TaskRunner().RunThreadAsync(async () =>
                     {
-                        await task.Action();
-                        await Task.Delay(1000);
+                        RunnerContext.Instance.BeginOneDragonTaskExecution();
+                        try
+                        {
+                            await task.Action();
+                            await Task.Delay(1000);
+                        }
+                        finally
+                        {
+                            RunnerContext.Instance.EndOneDragonTaskExecution();
+                        }
                     });
+                    isCurrentTaskSkipped = RunnerContext.Instance.ConsumeSkipCurrentOneDragonTaskRequest() &&
+                                           !CancellationContext.Instance.IsManualStop;
                 }
                 else
                 {
@@ -643,7 +654,9 @@ public partial class OneDragonFlowViewModel : ViewModel
                             string filePath = Path.Combine(_basePath, _scriptGroupPath, $"{task.Name}.json");
                             var group = ScriptGroup.FromJson(await File.ReadAllTextAsync(filePath));
                             IScriptService? scriptService = App.GetService<IScriptService>();
-                            await scriptService!.RunMulti(ScriptControlViewModel.GetNextProjects(group), group.Name);
+                            isCurrentTaskSkipped = await scriptService!.RunMulti(
+                                ScriptControlViewModel.GetNextProjects(group), group.Name,
+                                allowSkipCurrentOneDragonTask: true);
                             await Task.Delay(1000);
                         }
                     }
@@ -654,7 +667,7 @@ public partial class OneDragonFlowViewModel : ViewModel
                     }
                 }
                 // 如果任务已经被取消，中断所有任务
-                if (CancellationContext.Instance.Cts.IsCancellationRequested)
+                if (CancellationContext.Instance.Cts.IsCancellationRequested && !isCurrentTaskSkipped)
                 {
                     _logger.LogInformation("任务被取消，退出执行");
                     if (CancellationContext.Instance.IsManualStop is false)


### PR DESCRIPTION
- 新增可配置的一条龙当前任务跳过快捷键
- 同时支持内置任务和配置组任务
- 区分快捷键跳过与手动停止，跳过后继续执行下一项
- 修复任务切换时可能误取消下一项的并发竞态

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增“跳过一条龙当前任务”快捷键。
  - 支持通过外部命令跳过当前任务、跳过当前任务组或停止全部任务。
  - 跳过任务后将记录相应状态并继续后续流程。

- **改进**
  - 优化任务取消与跳过逻辑，手动停止不会被误判为跳过。
  - 增强外部控制命令对无效内容和异常情况的处理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->