### PR TITLE
feat(BvFlow): 新增BvFlow链式流程 API

### DIFF
--- a/BetterGenshinImpact/Core/BgiVision/BvFlow.cs
+++ b/BetterGenshinImpact/Core/BgiVision/BvFlow.cs
@@ -285,7 +285,21 @@ public sealed class BvFlow
         {
             attempts++;
             await snapshot.Action(context);
-            await _services.Delay(snapshot.RetryInterval);
+
+            var remainingMilliseconds = snapshot.Timeout - _services.GetElapsedMilliseconds(startedAt);
+            if (remainingMilliseconds <= 0)
+            {
+                throw new TimeoutException(
+                    $"动作 {snapshot.Description} 执行 {attempts} 次后，等待 {snapshot.TargetDescription} 超时（{snapshot.Timeout}ms）");
+            }
+
+            await _services.Delay(GetDelayMilliseconds(snapshot.RetryInterval, remainingMilliseconds));
+
+            if (_services.GetElapsedMilliseconds(startedAt) >= snapshot.Timeout)
+            {
+                throw new TimeoutException(
+                    $"动作 {snapshot.Description} 执行 {attempts} 次后，等待 {snapshot.TargetDescription} 超时（{snapshot.Timeout}ms）");
+            }
 
             var results = _services.FindAll(snapshot.Target);
             var succeeded = snapshot.WaitForDisappear ? results.Count == 0 : results.Count > 0;
@@ -295,12 +309,6 @@ public sealed class BvFlow
                     ? null
                     : _services.GetMatchRect(results.First());
                 return;
-            }
-
-            if (_services.GetElapsedMilliseconds(startedAt) >= snapshot.Timeout)
-            {
-                throw new TimeoutException(
-                    $"动作 {snapshot.Description} 执行 {attempts} 次后，等待 {snapshot.TargetDescription} 超时（{snapshot.Timeout}ms）");
             }
         }
     }
@@ -333,6 +341,12 @@ public sealed class BvFlow
 
         while (true)
         {
+            var elapsedMilliseconds = _services.GetElapsedMilliseconds(startedAt);
+            if (elapsedMilliseconds >= timeout)
+            {
+                throw new TimeoutException($"等待 {targetDescription} 超时（{timeout}ms）");
+            }
+
             var results = _services.FindAll(target);
             var succeeded = waitForDisappear ? results.Count == 0 : results.Count > 0;
             if (succeeded)
@@ -343,13 +357,19 @@ public sealed class BvFlow
                 return;
             }
 
-            if (_services.GetElapsedMilliseconds(startedAt) >= timeout)
+            var remainingMilliseconds = timeout - _services.GetElapsedMilliseconds(startedAt);
+            if (remainingMilliseconds <= 0)
             {
                 throw new TimeoutException($"等待 {targetDescription} 超时（{timeout}ms）");
             }
 
-            await _services.Delay(retryInterval);
+            await _services.Delay(GetDelayMilliseconds(retryInterval, remainingMilliseconds));
         }
+    }
+
+    private static int GetDelayMilliseconds(int retryInterval, double remainingMilliseconds)
+    {
+        return Math.Min(retryInterval, Math.Max(1, (int)Math.Ceiling(remainingMilliseconds)));
     }
 
     private BvFlow AddStep(string description, Func<BvFlowExecutionContext, Task> action)

--- a/BetterGenshinImpact/Core/BgiVision/BvFlow.cs
+++ b/BetterGenshinImpact/Core/BgiVision/BvFlow.cs
@@ -359,6 +359,7 @@ public sealed class BvFlow
             }
 
             var result = FindTargets(snapshot.Targets, snapshot.Condition);
+            _services.ThrowIfCancellationRequested();
             if (_services.GetElapsedMilliseconds(startedAt) >= snapshot.Timeout)
             {
                 throw new TimeoutException(
@@ -406,6 +407,7 @@ public sealed class BvFlow
 
         while (true)
         {
+            _services.ThrowIfCancellationRequested();
             var elapsedMilliseconds = _services.GetElapsedMilliseconds(startedAt);
             if (elapsedMilliseconds >= timeout)
             {
@@ -413,6 +415,7 @@ public sealed class BvFlow
             }
 
             var result = FindTargets(targets, condition);
+            _services.ThrowIfCancellationRequested();
             if (_services.GetElapsedMilliseconds(startedAt) >= timeout)
             {
                 throw new TimeoutException($"等待 {targetDescription} 超时（{timeout}ms）");

--- a/BetterGenshinImpact/Core/BgiVision/BvFlow.cs
+++ b/BetterGenshinImpact/Core/BgiVision/BvFlow.cs
@@ -155,16 +155,37 @@ public sealed class BvFlow
         return WaitUntil(CreateTextLocator(text, rect), timeout, retryInterval);
     }
 
+    public BvFlow WaitUntilAnyText(
+        object texts,
+        Rect rect = default,
+        int? timeout = null,
+        int? retryInterval = null)
+    {
+        return WaitUntil(CreateAnyTextLocator(texts, rect), timeout, retryInterval);
+    }
+
     public BvFlow WaitUntil(BvLocator target, int? timeout = null, int? retryInterval = null)
     {
         ArgumentNullException.ThrowIfNull(target);
-        return AddWaitStep(target, false, timeout, retryInterval);
+        return AddWaitStep([target.Clone()], BvFlowCondition.AnyAppear, timeout, retryInterval);
+    }
+
+    public BvFlow WaitUntilAny(object targets, int? timeout = null, int? retryInterval = null)
+    {
+        return AddWaitStep(ParseTargets(targets, nameof(targets)), BvFlowCondition.AnyAppear,
+            timeout, retryInterval);
     }
 
     public BvFlow WaitUntilDisappear(BvLocator target, int? timeout = null, int? retryInterval = null)
     {
         ArgumentNullException.ThrowIfNull(target);
-        return AddWaitStep(target, true, timeout, retryInterval);
+        return AddWaitStep([target.Clone()], BvFlowCondition.AllDisappear, timeout, retryInterval);
+    }
+
+    public BvFlow WaitUntilAllDisappear(object targets, int? timeout = null, int? retryInterval = null)
+    {
+        return AddWaitStep(ParseTargets(targets, nameof(targets)), BvFlowCondition.AllDisappear,
+            timeout, retryInterval);
     }
 
     public BvFlow Wait(int milliseconds)
@@ -247,6 +268,18 @@ public sealed class BvFlow
         });
     }
 
+    internal BvLocator CreateAnyTextLocator(object texts, Rect rect)
+    {
+        return _page.GetByAnyText(texts, rect);
+    }
+
+    internal static IReadOnlyList<BvLocator> ParseTargets(object targets, string paramName)
+    {
+        return BvPage.ParseCollection<BvLocator>(targets, paramName)
+            .Select(target => target.Clone())
+            .ToArray();
+    }
+
     internal static int ValidatePositive(int value, string paramName)
     {
         if (value <= 0)
@@ -301,19 +334,22 @@ public sealed class BvFlow
                     $"动作 {snapshot.Description} 执行 {attempts} 次后，等待 {snapshot.TargetDescription} 超时（{snapshot.Timeout}ms）");
             }
 
-            var results = _services.FindAll(snapshot.Target);
-            var succeeded = snapshot.WaitForDisappear ? results.Count == 0 : results.Count > 0;
-            if (succeeded)
+            var result = FindTargets(snapshot.Targets, snapshot.Condition);
+            if (result.Succeeded)
             {
-                context.LastMatchRect = snapshot.WaitForDisappear
+                context.LastMatchRect = result.Match is null
                     ? null
-                    : _services.GetMatchRect(results.First());
+                    : _services.GetMatchRect(result.Match);
                 return;
             }
         }
     }
 
-    private BvFlow AddWaitStep(BvLocator target, bool waitForDisappear, int? timeout, int? retryInterval)
+    private BvFlow AddWaitStep(
+        IReadOnlyList<BvLocator> targets,
+        BvFlowCondition condition,
+        int? timeout,
+        int? retryInterval)
     {
         var actualTimeout = timeout is { } timeoutValue
             ? ValidatePositive(timeoutValue, nameof(timeout))
@@ -321,18 +357,17 @@ public sealed class BvFlow
         var actualRetryInterval = retryInterval is { } retryIntervalValue
             ? ValidatePositive(retryIntervalValue, nameof(retryInterval))
             : DefaultRetryInterval;
-        var clonedTarget = target.Clone();
-        var targetDescription = BvFlowAction.DescribeTarget(clonedTarget.RecognitionObject, waitForDisappear);
+        var targetDescription = BvFlowAction.DescribeTargets(targets, condition);
 
         return AddStep($"WaitUntil {targetDescription}",
-            context => ExecuteWaitStep(clonedTarget, targetDescription, waitForDisappear,
+            context => ExecuteWaitStep(targets, targetDescription, condition,
                 actualTimeout, actualRetryInterval, context));
     }
 
     private async Task ExecuteWaitStep(
-        BvLocator target,
+        IReadOnlyList<BvLocator> targets,
         string targetDescription,
-        bool waitForDisappear,
+        BvFlowCondition condition,
         int timeout,
         int retryInterval,
         BvFlowExecutionContext context)
@@ -347,13 +382,12 @@ public sealed class BvFlow
                 throw new TimeoutException($"等待 {targetDescription} 超时（{timeout}ms）");
             }
 
-            var results = _services.FindAll(target);
-            var succeeded = waitForDisappear ? results.Count == 0 : results.Count > 0;
-            if (succeeded)
+            var result = FindTargets(targets, condition);
+            if (result.Succeeded)
             {
-                context.LastMatchRect = waitForDisappear
+                context.LastMatchRect = result.Match is null
                     ? null
-                    : _services.GetMatchRect(results.First());
+                    : _services.GetMatchRect(result.Match);
                 return;
             }
 
@@ -365,6 +399,27 @@ public sealed class BvFlow
 
             await _services.Delay(GetDelayMilliseconds(retryInterval, remainingMilliseconds));
         }
+    }
+
+    private BvFlowConditionResult FindTargets(
+        IReadOnlyList<BvLocator> targets,
+        BvFlowCondition condition)
+    {
+        var results = _services.FindAll(targets);
+        if (condition == BvFlowCondition.AllDisappear)
+        {
+            return new BvFlowConditionResult(results.All(matches => matches.Count == 0), null);
+        }
+
+        foreach (var matches in results)
+        {
+            if (matches.Count > 0)
+            {
+                return new BvFlowConditionResult(true, matches[0]);
+            }
+        }
+
+        return new BvFlowConditionResult(false, null);
     }
 
     private static int GetDelayMilliseconds(int retryInterval, double remainingMilliseconds)
@@ -397,6 +452,8 @@ public sealed class BvFlow
     }
 
     private sealed record BvFlowStep(string Description, Func<BvFlowExecutionContext, Task> Action);
+
+    private sealed record BvFlowConditionResult(bool Succeeded, Region? Match);
 }
 
 internal sealed class BvFlowExecutionContext
@@ -416,7 +473,7 @@ internal sealed class BvFlowExecutionContext
 
 internal sealed class BvFlowServices
 {
-    public required Func<BvLocator, List<Region>> FindAll { get; set; }
+    public required Func<IReadOnlyList<BvLocator>, IReadOnlyList<List<Region>>> FindAll { get; set; }
     public required Func<Region, Rect> GetMatchRect { get; set; }
     public required Func<int, Task> Delay { get; set; }
     public required Func<long> GetTimestamp { get; set; }
@@ -432,7 +489,7 @@ internal sealed class BvFlowServices
     {
         return new BvFlowServices
         {
-            FindAll = locator => locator.FindAll(),
+            FindAll = BvLocator.FindAll,
             GetMatchRect = region =>
             {
                 var rect = region.ConvertSelfPositionToGameCaptureRegion();

--- a/BetterGenshinImpact/Core/BgiVision/BvFlow.cs
+++ b/BetterGenshinImpact/Core/BgiVision/BvFlow.cs
@@ -1,11 +1,14 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using BetterGenshinImpact.Core.Recognition;
 using BetterGenshinImpact.Core.Simulator;
 using BetterGenshinImpact.GameTask;
+using BetterGenshinImpact.GameTask.AutoGeniusInvokation.Exception;
 using BetterGenshinImpact.GameTask.Model.Area;
 using BetterGenshinImpact.Helpers;
 using OpenCvSharp;
@@ -65,7 +68,17 @@ public sealed class BvFlow
         ArgumentNullException.ThrowIfNull(action);
         return CreateAction("Do", async _ =>
         {
-            object? result = action is Delegate callback ? callback.DynamicInvoke() : action();
+            object? result;
+            try
+            {
+                result = action is Delegate callback ? callback.DynamicInvoke() : action();
+            }
+            catch (TargetInvocationException ex) when (ex.InnerException is not null)
+            {
+                ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+                throw;
+            }
+
             if (result is Task task)
             {
                 await task;
@@ -220,9 +233,14 @@ public sealed class BvFlow
                 var step = steps[i];
                 try
                 {
+                    _services.ThrowIfCancellationRequested();
                     await step.Action(context);
                 }
                 catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (NormalEndException)
                 {
                     throw;
                 }
@@ -243,6 +261,11 @@ public sealed class BvFlow
     internal BvFlow AddActionStep(BvFlowActionSnapshot snapshot)
     {
         return AddStep(snapshot.Description, context => ExecuteActionStep(snapshot, context));
+    }
+
+    internal BvFlow AddOnceActionStep(string description, Func<BvFlowExecutionContext, Task> action)
+    {
+        return AddStep(description, action);
     }
 
     internal BvFlowAction CreateAction(string description, Func<BvFlowExecutionContext, Task> action)
@@ -316,6 +339,7 @@ public sealed class BvFlow
 
         while (true)
         {
+            _services.ThrowIfCancellationRequested();
             attempts++;
             await snapshot.Action(context);
 
@@ -335,6 +359,12 @@ public sealed class BvFlow
             }
 
             var result = FindTargets(snapshot.Targets, snapshot.Condition);
+            if (_services.GetElapsedMilliseconds(startedAt) >= snapshot.Timeout)
+            {
+                throw new TimeoutException(
+                    $"动作 {snapshot.Description} 执行 {attempts} 次后，等待 {snapshot.TargetDescription} 超时（{snapshot.Timeout}ms）");
+            }
+
             if (result.Succeeded)
             {
                 context.LastMatchRect = result.Match is null
@@ -383,6 +413,11 @@ public sealed class BvFlow
             }
 
             var result = FindTargets(targets, condition);
+            if (_services.GetElapsedMilliseconds(startedAt) >= timeout)
+            {
+                throw new TimeoutException($"等待 {targetDescription} 超时（{timeout}ms）");
+            }
+
             if (result.Succeeded)
             {
                 context.LastMatchRect = result.Match is null
@@ -405,21 +440,7 @@ public sealed class BvFlow
         IReadOnlyList<BvLocator> targets,
         BvFlowCondition condition)
     {
-        var results = _services.FindAll(targets);
-        if (condition == BvFlowCondition.AllDisappear)
-        {
-            return new BvFlowConditionResult(results.All(matches => matches.Count == 0), null);
-        }
-
-        foreach (var matches in results)
-        {
-            if (matches.Count > 0)
-            {
-                return new BvFlowConditionResult(true, matches[0]);
-            }
-        }
-
-        return new BvFlowConditionResult(false, null);
+        return _services.FindTargets(targets, condition);
     }
 
     private static int GetDelayMilliseconds(int retryInterval, double remainingMilliseconds)
@@ -453,8 +474,9 @@ public sealed class BvFlow
 
     private sealed record BvFlowStep(string Description, Func<BvFlowExecutionContext, Task> Action);
 
-    private sealed record BvFlowConditionResult(bool Succeeded, Region? Match);
 }
+
+internal sealed record BvFlowConditionResult(bool Succeeded, Region? Match);
 
 internal sealed class BvFlowExecutionContext
 {
@@ -473,7 +495,8 @@ internal sealed class BvFlowExecutionContext
 
 internal sealed class BvFlowServices
 {
-    public required Func<IReadOnlyList<BvLocator>, IReadOnlyList<List<Region>>> FindAll { get; set; }
+    public required Action ThrowIfCancellationRequested { get; set; }
+    public required Func<IReadOnlyList<BvLocator>, BvFlowCondition, BvFlowConditionResult> FindTargets { get; set; }
     public required Func<Region, Rect> GetMatchRect { get; set; }
     public required Func<int, Task> Delay { get; set; }
     public required Func<long> GetTimestamp { get; set; }
@@ -489,10 +512,15 @@ internal sealed class BvFlowServices
     {
         return new BvFlowServices
         {
-            FindAll = BvLocator.FindAll,
+            ThrowIfCancellationRequested = page.ThrowIfCancellationRequested,
+            FindTargets = (targets, condition) =>
+            {
+                using var screen = page.Screenshot();
+                return EvaluateTargets(targets, condition, target => target.FindAll(screen));
+            },
             GetMatchRect = region =>
             {
-                var rect = region.ConvertSelfPositionToGameCaptureRegion();
+                var rect = region.ConvertPositionToGameCaptureRegion(0, 0, region.Width, region.Height);
                 var scale = TaskContext.Instance().SystemInfo.ScaleTo1080PRatio;
                 return new Rect(
                     (int)Math.Round(rect.X / scale),
@@ -533,5 +561,29 @@ internal sealed class BvFlowServices
                 }
             }
         };
+    }
+
+    internal static BvFlowConditionResult EvaluateTargets(
+        IReadOnlyList<BvLocator> targets,
+        BvFlowCondition condition,
+        Func<BvLocator, List<Region>> findAll)
+    {
+        foreach (var target in targets)
+        {
+            var matches = findAll(target);
+            if (condition == BvFlowCondition.AnyAppear && matches.Count > 0)
+            {
+                return new BvFlowConditionResult(true, matches[0]);
+            }
+
+            if (condition == BvFlowCondition.AllDisappear && matches.Count > 0)
+            {
+                return new BvFlowConditionResult(false, null);
+            }
+        }
+
+        return condition == BvFlowCondition.AllDisappear
+            ? new BvFlowConditionResult(true, null)
+            : new BvFlowConditionResult(false, null);
     }
 }

--- a/BetterGenshinImpact/Core/BgiVision/BvFlow.cs
+++ b/BetterGenshinImpact/Core/BgiVision/BvFlow.cs
@@ -1,0 +1,460 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using BetterGenshinImpact.Core.Recognition;
+using BetterGenshinImpact.Core.Simulator;
+using BetterGenshinImpact.GameTask;
+using BetterGenshinImpact.GameTask.Model.Area;
+using BetterGenshinImpact.Helpers;
+using OpenCvSharp;
+
+namespace BetterGenshinImpact.Core.BgiVision;
+
+public sealed class BvFlow
+{
+    private readonly BvPage _page;
+    private readonly BvFlowServices _services;
+    private readonly List<BvFlowStep> _steps = [];
+    private readonly object _syncRoot = new();
+    private bool _hasSteps;
+    private bool _hasStarted;
+    private int _isRunning;
+
+    internal int DefaultTimeout { get; private set; }
+    internal int DefaultRetryInterval { get; private set; }
+
+    internal BvFlow(BvPage page, int defaultTimeout, int defaultRetryInterval)
+        : this(page, defaultTimeout, defaultRetryInterval, BvFlowServices.Create(page))
+    {
+    }
+
+    internal BvFlow(BvPage page, int defaultTimeout, int defaultRetryInterval, BvFlowServices services)
+    {
+        _page = page;
+        _services = services;
+        DefaultTimeout = ValidatePositive(defaultTimeout, nameof(defaultTimeout));
+        DefaultRetryInterval = ValidatePositive(defaultRetryInterval, nameof(defaultRetryInterval));
+    }
+
+    public BvFlow WithDefaultTimeout(int milliseconds)
+    {
+        var timeout = ValidatePositive(milliseconds, nameof(milliseconds));
+        lock (_syncRoot)
+        {
+            EnsureDefaultsCanChange();
+            DefaultTimeout = timeout;
+        }
+        return this;
+    }
+
+    public BvFlow WithDefaultRetryInterval(int milliseconds)
+    {
+        var retryInterval = ValidatePositive(milliseconds, nameof(milliseconds));
+        lock (_syncRoot)
+        {
+            EnsureDefaultsCanChange();
+            DefaultRetryInterval = retryInterval;
+        }
+        return this;
+    }
+
+    public BvFlowAction Do(dynamic action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        return CreateAction("Do", async _ =>
+        {
+            object? result = action is Delegate callback ? callback.DynamicInvoke() : action();
+            if (result is Task task)
+            {
+                await task;
+            }
+        });
+    }
+
+    public BvFlowAction KeyPress(string key)
+    {
+        var virtualKey = User32Helper.ToVk(key);
+        return CreateAction($"KeyPress({key})", _ =>
+        {
+            _services.KeyPress(virtualKey);
+            return Task.CompletedTask;
+        });
+    }
+
+    public BvFlowAction Click()
+    {
+        return CreateImplicitPointAction("Click(previous)", _services.LeftClick);
+    }
+
+    public BvFlowAction Click(double x, double y)
+    {
+        return CreatePointAction($"Click({x}, {y})", x, y, _services.LeftClick);
+    }
+
+    public BvFlowAction RightClick()
+    {
+        return CreateImplicitPointAction("RightClick(previous)", _services.RightClick);
+    }
+
+    public BvFlowAction RightClick(double x, double y)
+    {
+        return CreatePointAction($"RightClick({x}, {y})", x, y, _services.RightClick);
+    }
+
+    public BvFlowAction MiddleClick()
+    {
+        return CreateImplicitPointAction("MiddleClick(previous)", _services.MiddleClick);
+    }
+
+    public BvFlowAction MiddleClick(double x, double y)
+    {
+        return CreatePointAction($"MiddleClick({x}, {y})", x, y, _services.MiddleClick);
+    }
+
+    public BvFlowAction MoveTo()
+    {
+        return CreateImplicitPointAction("MoveTo(previous)", _services.MoveTo);
+    }
+
+    public BvFlowAction MoveTo(double x, double y)
+    {
+        return CreatePointAction($"MoveTo({x}, {y})", x, y, _services.MoveTo);
+    }
+
+    public BvFlowAction Drag(double fromX, double fromY, double toX, double toY, int duration = 300)
+    {
+        ValidatePositive(duration, nameof(duration));
+        return CreateAction($"Drag({fromX}, {fromY}, {toX}, {toY})",
+            _ => _services.Drag(fromX, fromY, toX, toY, duration));
+    }
+
+    public BvFlowAction DragTo(double toX, double toY, int duration = 300)
+    {
+        ValidatePositive(duration, nameof(duration));
+        return CreateAction($"DragTo({toX}, {toY})", context =>
+        {
+            var (fromX, fromY) = context.GetLastMatchCenter();
+            return _services.Drag(fromX, fromY, toX, toY, duration);
+        });
+    }
+
+    public BvFlowAction DragFrom(double fromX, double fromY, int duration = 300)
+    {
+        ValidatePositive(duration, nameof(duration));
+        return CreateAction($"DragFrom({fromX}, {fromY})", context =>
+        {
+            var (toX, toY) = context.GetLastMatchCenter();
+            return _services.Drag(fromX, fromY, toX, toY, duration);
+        });
+    }
+
+    public BvFlow WaitUntilText(string text, Rect rect = default, int? timeout = null, int? retryInterval = null)
+    {
+        return WaitUntil(CreateTextLocator(text, rect), timeout, retryInterval);
+    }
+
+    public BvFlow WaitUntil(BvLocator target, int? timeout = null, int? retryInterval = null)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        return AddWaitStep(target, false, timeout, retryInterval);
+    }
+
+    public BvFlow WaitUntilDisappear(BvLocator target, int? timeout = null, int? retryInterval = null)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        return AddWaitStep(target, true, timeout, retryInterval);
+    }
+
+    public BvFlow Wait(int milliseconds)
+    {
+        if (milliseconds < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(milliseconds), "milliseconds 不能小于 0");
+        }
+
+        return AddStep($"Wait({milliseconds})", _ => _services.Delay(milliseconds));
+    }
+
+    public async Task<BvPage> Run()
+    {
+        if (Interlocked.CompareExchange(ref _isRunning, 1, 0) != 0)
+        {
+            throw new InvalidOperationException("同一个 BvFlow 不能并发执行");
+        }
+
+        try
+        {
+            BvFlowStep[] steps;
+            lock (_syncRoot)
+            {
+                _hasStarted = true;
+                steps = _steps.ToArray();
+            }
+
+            var context = new BvFlowExecutionContext();
+            for (var i = 0; i < steps.Length; i++)
+            {
+                var step = steps[i];
+                try
+                {
+                    await step.Action(context);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    throw new InvalidOperationException($"BvFlow 第 {i + 1} 步执行失败：{step.Description}", ex);
+                }
+            }
+
+            return _page;
+        }
+        finally
+        {
+            Volatile.Write(ref _isRunning, 0);
+        }
+    }
+
+    internal BvFlow AddActionStep(BvFlowActionSnapshot snapshot)
+    {
+        return AddStep(snapshot.Description, context => ExecuteActionStep(snapshot, context));
+    }
+
+    internal BvFlowAction CreateAction(string description, Func<BvFlowExecutionContext, Task> action)
+    {
+        lock (_syncRoot)
+        {
+            if (_hasStarted)
+            {
+                throw new InvalidOperationException("BvFlow 已经开始执行，不能再添加步骤");
+            }
+        }
+
+        return new BvFlowAction(this, description, action);
+    }
+
+    internal BvLocator CreateTextLocator(string text, Rect rect)
+    {
+        return _page.Locator(new RecognitionObject
+        {
+            RecognitionType = RecognitionTypes.Ocr,
+            RegionOfInterest = rect,
+            Text = text
+        });
+    }
+
+    internal static int ValidatePositive(int value, string paramName)
+    {
+        if (value <= 0)
+        {
+            throw new ArgumentOutOfRangeException(paramName, $"{paramName} 必须大于 0");
+        }
+
+        return value;
+    }
+
+    private BvFlowAction CreateImplicitPointAction(string description, Action<double, double> action)
+    {
+        return CreateAction(description, context =>
+        {
+            var (x, y) = context.GetLastMatchCenter();
+            action(x, y);
+            return Task.CompletedTask;
+        });
+    }
+
+    private BvFlowAction CreatePointAction(string description, double x, double y, Action<double, double> action)
+    {
+        return CreateAction(description, _ =>
+        {
+            action(x, y);
+            return Task.CompletedTask;
+        });
+    }
+
+    private async Task ExecuteActionStep(BvFlowActionSnapshot snapshot, BvFlowExecutionContext context)
+    {
+        var startedAt = _services.GetTimestamp();
+        var attempts = 0;
+
+        while (true)
+        {
+            attempts++;
+            await snapshot.Action(context);
+            await _services.Delay(snapshot.RetryInterval);
+
+            var results = _services.FindAll(snapshot.Target);
+            var succeeded = snapshot.WaitForDisappear ? results.Count == 0 : results.Count > 0;
+            if (succeeded)
+            {
+                context.LastMatchRect = snapshot.WaitForDisappear
+                    ? null
+                    : _services.GetMatchRect(results.First());
+                return;
+            }
+
+            if (_services.GetElapsedMilliseconds(startedAt) >= snapshot.Timeout)
+            {
+                throw new TimeoutException(
+                    $"动作 {snapshot.Description} 执行 {attempts} 次后，等待 {snapshot.TargetDescription} 超时（{snapshot.Timeout}ms）");
+            }
+        }
+    }
+
+    private BvFlow AddWaitStep(BvLocator target, bool waitForDisappear, int? timeout, int? retryInterval)
+    {
+        var actualTimeout = timeout is { } timeoutValue
+            ? ValidatePositive(timeoutValue, nameof(timeout))
+            : DefaultTimeout;
+        var actualRetryInterval = retryInterval is { } retryIntervalValue
+            ? ValidatePositive(retryIntervalValue, nameof(retryInterval))
+            : DefaultRetryInterval;
+        var clonedTarget = target.Clone();
+        var targetDescription = BvFlowAction.DescribeTarget(clonedTarget.RecognitionObject, waitForDisappear);
+
+        return AddStep($"WaitUntil {targetDescription}",
+            context => ExecuteWaitStep(clonedTarget, targetDescription, waitForDisappear,
+                actualTimeout, actualRetryInterval, context));
+    }
+
+    private async Task ExecuteWaitStep(
+        BvLocator target,
+        string targetDescription,
+        bool waitForDisappear,
+        int timeout,
+        int retryInterval,
+        BvFlowExecutionContext context)
+    {
+        var startedAt = _services.GetTimestamp();
+
+        while (true)
+        {
+            var results = _services.FindAll(target);
+            var succeeded = waitForDisappear ? results.Count == 0 : results.Count > 0;
+            if (succeeded)
+            {
+                context.LastMatchRect = waitForDisappear
+                    ? null
+                    : _services.GetMatchRect(results.First());
+                return;
+            }
+
+            if (_services.GetElapsedMilliseconds(startedAt) >= timeout)
+            {
+                throw new TimeoutException($"等待 {targetDescription} 超时（{timeout}ms）");
+            }
+
+            await _services.Delay(retryInterval);
+        }
+    }
+
+    private BvFlow AddStep(string description, Func<BvFlowExecutionContext, Task> action)
+    {
+        lock (_syncRoot)
+        {
+            if (_hasStarted)
+            {
+                throw new InvalidOperationException("BvFlow 已经开始执行，不能再添加步骤");
+            }
+
+            _hasSteps = true;
+            _steps.Add(new BvFlowStep(description, action));
+        }
+
+        return this;
+    }
+
+    private void EnsureDefaultsCanChange()
+    {
+        if (_hasSteps)
+        {
+            throw new InvalidOperationException("添加流程步骤后不能修改流程默认配置");
+        }
+    }
+
+    private sealed record BvFlowStep(string Description, Func<BvFlowExecutionContext, Task> Action);
+}
+
+internal sealed class BvFlowExecutionContext
+{
+    public Rect? LastMatchRect { get; set; }
+
+    public (double X, double Y) GetLastMatchCenter()
+    {
+        if (LastMatchRect is not { } rect)
+        {
+            throw new InvalidOperationException("没有可用的上一步识别位置，无法执行隐式坐标操作");
+        }
+
+        return (rect.X + rect.Width / 2d, rect.Y + rect.Height / 2d);
+    }
+}
+
+internal sealed class BvFlowServices
+{
+    public required Func<BvLocator, List<Region>> FindAll { get; set; }
+    public required Func<Region, Rect> GetMatchRect { get; set; }
+    public required Func<int, Task> Delay { get; set; }
+    public required Func<long> GetTimestamp { get; set; }
+    public required Func<long, double> GetElapsedMilliseconds { get; set; }
+    public required Action<Vanara.PInvoke.User32.VK> KeyPress { get; set; }
+    public required Action<double, double> LeftClick { get; set; }
+    public required Action<double, double> RightClick { get; set; }
+    public required Action<double, double> MiddleClick { get; set; }
+    public required Action<double, double> MoveTo { get; set; }
+    public required Func<double, double, double, double, int, Task> Drag { get; set; }
+
+    public static BvFlowServices Create(BvPage page)
+    {
+        return new BvFlowServices
+        {
+            FindAll = locator => locator.FindAll(),
+            GetMatchRect = region =>
+            {
+                var rect = region.ConvertSelfPositionToGameCaptureRegion();
+                var scale = TaskContext.Instance().SystemInfo.ScaleTo1080PRatio;
+                return new Rect(
+                    (int)Math.Round(rect.X / scale),
+                    (int)Math.Round(rect.Y / scale),
+                    (int)Math.Round(rect.Width / scale),
+                    (int)Math.Round(rect.Height / scale));
+            },
+            Delay = async milliseconds => await page.Wait(milliseconds),
+            GetTimestamp = System.Diagnostics.Stopwatch.GetTimestamp,
+            GetElapsedMilliseconds = startedAt => System.Diagnostics.Stopwatch.GetElapsedTime(startedAt).TotalMilliseconds,
+            KeyPress = key => Simulation.SendInput.Keyboard.KeyPress(key),
+            LeftClick = GameCaptureRegion.GameRegion1080PPosClick,
+            RightClick = (x, y) =>
+            {
+                GameCaptureRegion.GameRegion1080PPosMove(x, y);
+                Simulation.SendInput.Mouse.RightButtonClick();
+            },
+            MiddleClick = (x, y) =>
+            {
+                GameCaptureRegion.GameRegion1080PPosMove(x, y);
+                Simulation.SendInput.Mouse.MiddleButtonClick();
+            },
+            MoveTo = GameCaptureRegion.GameRegion1080PPosMove,
+            Drag = async (fromX, fromY, toX, toY, duration) =>
+            {
+                GameCaptureRegion.GameRegion1080PPosMove(fromX, fromY);
+                Simulation.SendInput.Mouse.LeftButtonDown();
+                try
+                {
+                    var firstDelay = duration / 2;
+                    await page.Wait(firstDelay);
+                    GameCaptureRegion.GameRegion1080PPosMove(toX, toY);
+                    await page.Wait(duration - firstDelay);
+                }
+                finally
+                {
+                    Simulation.SendInput.Mouse.LeftButtonUp();
+                }
+            }
+        };
+    }
+}

--- a/BetterGenshinImpact/Core/BgiVision/BvFlowAction.cs
+++ b/BetterGenshinImpact/Core/BgiVision/BvFlowAction.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using BetterGenshinImpact.Core.Recognition;
 using BetterGenshinImpact.GameTask.Model.Area;
+using BetterGenshinImpact.Helpers;
 using OpenCvSharp;
 
 namespace BetterGenshinImpact.Core.BgiVision;
@@ -13,6 +14,7 @@ public sealed class BvFlowAction
     private readonly BvFlow _flow;
     private readonly string _description;
     private readonly Func<BvFlowExecutionContext, Task> _action;
+    private readonly object _syncRoot = new();
     private int? _timeout;
     private int? _retryInterval;
     private bool _completed;
@@ -26,16 +28,149 @@ public sealed class BvFlowAction
 
     public BvFlowAction WithTimeout(int milliseconds)
     {
-        EnsureNotCompleted();
-        _timeout = BvFlow.ValidatePositive(milliseconds, nameof(milliseconds));
+        var timeout = BvFlow.ValidatePositive(milliseconds, nameof(milliseconds));
+        lock (_syncRoot)
+        {
+            EnsureNotCompleted();
+            _timeout = timeout;
+        }
         return this;
     }
 
     public BvFlowAction WithRetryInterval(int milliseconds)
     {
-        EnsureNotCompleted();
-        _retryInterval = BvFlow.ValidatePositive(milliseconds, nameof(milliseconds));
+        var retryInterval = BvFlow.ValidatePositive(milliseconds, nameof(milliseconds));
+        lock (_syncRoot)
+        {
+            EnsureNotCompleted();
+            _retryInterval = retryInterval;
+        }
         return this;
+    }
+
+    public BvFlowAction Do(dynamic action)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        return CompleteOnce().Do(action);
+    }
+
+    public BvFlowAction KeyPress(string key)
+    {
+        _ = User32Helper.ToVk(key);
+        return CompleteOnce().KeyPress(key);
+    }
+
+    public BvFlowAction Click()
+    {
+        return CompleteOnce().Click();
+    }
+
+    public BvFlowAction Click(double x, double y)
+    {
+        return CompleteOnce().Click(x, y);
+    }
+
+    public BvFlowAction RightClick()
+    {
+        return CompleteOnce().RightClick();
+    }
+
+    public BvFlowAction RightClick(double x, double y)
+    {
+        return CompleteOnce().RightClick(x, y);
+    }
+
+    public BvFlowAction MiddleClick()
+    {
+        return CompleteOnce().MiddleClick();
+    }
+
+    public BvFlowAction MiddleClick(double x, double y)
+    {
+        return CompleteOnce().MiddleClick(x, y);
+    }
+
+    public BvFlowAction MoveTo()
+    {
+        return CompleteOnce().MoveTo();
+    }
+
+    public BvFlowAction MoveTo(double x, double y)
+    {
+        return CompleteOnce().MoveTo(x, y);
+    }
+
+    public BvFlowAction Drag(double fromX, double fromY, double toX, double toY, int duration = 300)
+    {
+        BvFlow.ValidatePositive(duration, nameof(duration));
+        return CompleteOnce().Drag(fromX, fromY, toX, toY, duration);
+    }
+
+    public BvFlowAction DragTo(double toX, double toY, int duration = 300)
+    {
+        BvFlow.ValidatePositive(duration, nameof(duration));
+        return CompleteOnce().DragTo(toX, toY, duration);
+    }
+
+    public BvFlowAction DragFrom(double fromX, double fromY, int duration = 300)
+    {
+        BvFlow.ValidatePositive(duration, nameof(duration));
+        return CompleteOnce().DragFrom(fromX, fromY, duration);
+    }
+
+    public BvFlow WaitUntilText(string text, Rect rect = default, int? timeout = null, int? retryInterval = null)
+    {
+        ValidateWaitOptions(timeout, retryInterval);
+        return CompleteOnce().WaitUntilText(text, rect, timeout, retryInterval);
+    }
+
+    public BvFlow WaitUntilAnyText(
+        object texts,
+        Rect rect = default,
+        int? timeout = null,
+        int? retryInterval = null)
+    {
+        _ = _flow.CreateAnyTextLocator(texts, rect);
+        ValidateWaitOptions(timeout, retryInterval);
+        return CompleteOnce().WaitUntilAnyText(texts, rect, timeout, retryInterval);
+    }
+
+    public BvFlow WaitUntil(BvLocator target, int? timeout = null, int? retryInterval = null)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        ValidateWaitOptions(timeout, retryInterval);
+        return CompleteOnce().WaitUntil(target, timeout, retryInterval);
+    }
+
+    public BvFlow WaitUntilAny(object targets, int? timeout = null, int? retryInterval = null)
+    {
+        _ = BvFlow.ParseTargets(targets, nameof(targets));
+        ValidateWaitOptions(timeout, retryInterval);
+        return CompleteOnce().WaitUntilAny(targets, timeout, retryInterval);
+    }
+
+    public BvFlow WaitUntilDisappear(BvLocator target, int? timeout = null, int? retryInterval = null)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        ValidateWaitOptions(timeout, retryInterval);
+        return CompleteOnce().WaitUntilDisappear(target, timeout, retryInterval);
+    }
+
+    public BvFlow WaitUntilAllDisappear(object targets, int? timeout = null, int? retryInterval = null)
+    {
+        _ = BvFlow.ParseTargets(targets, nameof(targets));
+        ValidateWaitOptions(timeout, retryInterval);
+        return CompleteOnce().WaitUntilAllDisappear(targets, timeout, retryInterval);
+    }
+
+    public BvFlow Wait(int milliseconds)
+    {
+        if (milliseconds < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(milliseconds), "milliseconds 不能小于 0");
+        }
+
+        return CompleteOnce().Wait(milliseconds);
     }
 
     public BvFlow UntilText(string text, Rect rect = default)
@@ -70,10 +205,39 @@ public sealed class BvFlowAction
         return Complete(BvFlow.ParseTargets(targets, nameof(targets)), BvFlowCondition.AllDisappear);
     }
 
+    public Task<BvPage> Run()
+    {
+        return CompleteOnce().Run();
+    }
+
+    private BvFlow CompleteOnce()
+    {
+        lock (_syncRoot)
+        {
+            EnsureNotCompleted();
+            if (_timeout is not null || _retryInterval is not null)
+            {
+                throw new InvalidOperationException(
+                    "一次性动作不支持 WithTimeout 或 WithRetryInterval，请使用 Until 系列方法设置重试条件");
+            }
+
+            _completed = true;
+        }
+
+        return _flow.AddOnceActionStep(_description, _action);
+    }
+
     private BvFlow Complete(IReadOnlyList<BvLocator> targets, BvFlowCondition condition)
     {
-        EnsureNotCompleted();
-        _completed = true;
+        int timeout;
+        int retryInterval;
+        lock (_syncRoot)
+        {
+            EnsureNotCompleted();
+            _completed = true;
+            timeout = _timeout ?? _flow.DefaultTimeout;
+            retryInterval = _retryInterval ?? _flow.DefaultRetryInterval;
+        }
 
         var targetDescription = DescribeTargets(targets, condition);
         return _flow.AddActionStep(new BvFlowActionSnapshot(
@@ -81,8 +245,8 @@ public sealed class BvFlowAction
             _action,
             targets,
             targetDescription,
-            _timeout ?? _flow.DefaultTimeout,
-            _retryInterval ?? _flow.DefaultRetryInterval,
+            timeout,
+            retryInterval,
             condition));
     }
 
@@ -91,6 +255,19 @@ public sealed class BvFlowAction
         if (_completed)
         {
             throw new InvalidOperationException("当前动作已经设置完成条件，不能再次修改或添加");
+        }
+    }
+
+    private static void ValidateWaitOptions(int? timeout, int? retryInterval)
+    {
+        if (timeout is { } timeoutValue)
+        {
+            BvFlow.ValidatePositive(timeoutValue, nameof(timeout));
+        }
+
+        if (retryInterval is { } retryIntervalValue)
+        {
+            BvFlow.ValidatePositive(retryIntervalValue, nameof(retryInterval));
         }
     }
 

--- a/BetterGenshinImpact/Core/BgiVision/BvFlowAction.cs
+++ b/BetterGenshinImpact/Core/BgiVision/BvFlowAction.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using BetterGenshinImpact.Core.Recognition;
 using BetterGenshinImpact.GameTask.Model.Area;
@@ -42,32 +43,47 @@ public sealed class BvFlowAction
         return Until(_flow.CreateTextLocator(text, rect));
     }
 
+    public BvFlow UntilAnyText(object texts, Rect rect = default)
+    {
+        return Until(_flow.CreateAnyTextLocator(texts, rect));
+    }
+
     public BvFlow Until(BvLocator target)
     {
         ArgumentNullException.ThrowIfNull(target);
-        return Complete(target.Clone(), false);
+        return Complete([target.Clone()], BvFlowCondition.AnyAppear);
+    }
+
+    public BvFlow UntilAny(object targets)
+    {
+        return Complete(BvFlow.ParseTargets(targets, nameof(targets)), BvFlowCondition.AnyAppear);
     }
 
     public BvFlow UntilDisappear(BvLocator target)
     {
         ArgumentNullException.ThrowIfNull(target);
-        return Complete(target.Clone(), true);
+        return Complete([target.Clone()], BvFlowCondition.AllDisappear);
     }
 
-    private BvFlow Complete(BvLocator target, bool waitForDisappear)
+    public BvFlow UntilAllDisappear(object targets)
+    {
+        return Complete(BvFlow.ParseTargets(targets, nameof(targets)), BvFlowCondition.AllDisappear);
+    }
+
+    private BvFlow Complete(IReadOnlyList<BvLocator> targets, BvFlowCondition condition)
     {
         EnsureNotCompleted();
         _completed = true;
 
-        var targetDescription = DescribeTarget(target.RecognitionObject, waitForDisappear);
+        var targetDescription = DescribeTargets(targets, condition);
         return _flow.AddActionStep(new BvFlowActionSnapshot(
             _description,
             _action,
-            target,
+            targets,
             targetDescription,
             _timeout ?? _flow.DefaultTimeout,
             _retryInterval ?? _flow.DefaultRetryInterval,
-            waitForDisappear));
+            condition));
     }
 
     private void EnsureNotCompleted()
@@ -78,23 +94,51 @@ public sealed class BvFlowAction
         }
     }
 
-    internal static string DescribeTarget(RecognitionObject recognitionObject, bool waitForDisappear)
+    internal static string DescribeTargets(IReadOnlyList<BvLocator> targets, BvFlowCondition condition)
     {
-        var target = recognitionObject.RecognitionType switch
+        var descriptions = targets.Select(DescribeTarget);
+        var targetDescription = targets.Count == 1
+            ? descriptions.First()
+            : $"目标[{string.Join(" | ", descriptions)}]";
+        if (condition == BvFlowCondition.AllDisappear)
         {
-            RecognitionTypes.Ocr => $"文字[{recognitionObject.Text}]",
-            RecognitionTypes.TemplateMatch => $"图像[{recognitionObject.Name}]",
+            return targets.Count == 1
+                ? $"{targetDescription}消失"
+                : $"{targetDescription}全部消失";
+        }
+
+        return targets.Count == 1 && targets[0].AnyTexts.Count == 0
+            ? $"{targetDescription}出现"
+            : $"{targetDescription}中的任意一个出现";
+    }
+
+    private static string DescribeTarget(BvLocator locator)
+    {
+        if (locator.AnyTexts.Count > 0)
+        {
+            return $"文字[{string.Join('|', locator.AnyTexts)}]";
+        }
+
+        return locator.RecognitionObject.RecognitionType switch
+        {
+            RecognitionTypes.Ocr => $"文字[{locator.RecognitionObject.Text}]",
+            RecognitionTypes.TemplateMatch => $"图像[{locator.RecognitionObject.Name}]",
             _ => "识别元素"
         };
-        return waitForDisappear ? $"{target}消失" : $"{target}出现";
     }
+}
+
+internal enum BvFlowCondition
+{
+    AnyAppear,
+    AllDisappear
 }
 
 internal sealed record BvFlowActionSnapshot(
     string Description,
     Func<BvFlowExecutionContext, Task> Action,
-    BvLocator Target,
+    IReadOnlyList<BvLocator> Targets,
     string TargetDescription,
     int Timeout,
     int RetryInterval,
-    bool WaitForDisappear);
+    BvFlowCondition Condition);

--- a/BetterGenshinImpact/Core/BgiVision/BvFlowAction.cs
+++ b/BetterGenshinImpact/Core/BgiVision/BvFlowAction.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using BetterGenshinImpact.Core.Recognition;
+using BetterGenshinImpact.GameTask.Model.Area;
+using OpenCvSharp;
+
+namespace BetterGenshinImpact.Core.BgiVision;
+
+public sealed class BvFlowAction
+{
+    private readonly BvFlow _flow;
+    private readonly string _description;
+    private readonly Func<BvFlowExecutionContext, Task> _action;
+    private int? _timeout;
+    private int? _retryInterval;
+    private bool _completed;
+
+    internal BvFlowAction(BvFlow flow, string description, Func<BvFlowExecutionContext, Task> action)
+    {
+        _flow = flow;
+        _description = description;
+        _action = action;
+    }
+
+    public BvFlowAction WithTimeout(int milliseconds)
+    {
+        EnsureNotCompleted();
+        _timeout = BvFlow.ValidatePositive(milliseconds, nameof(milliseconds));
+        return this;
+    }
+
+    public BvFlowAction WithRetryInterval(int milliseconds)
+    {
+        EnsureNotCompleted();
+        _retryInterval = BvFlow.ValidatePositive(milliseconds, nameof(milliseconds));
+        return this;
+    }
+
+    public BvFlow UntilText(string text, Rect rect = default)
+    {
+        return Until(_flow.CreateTextLocator(text, rect));
+    }
+
+    public BvFlow Until(BvLocator target)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        return Complete(target.Clone(), false);
+    }
+
+    public BvFlow UntilDisappear(BvLocator target)
+    {
+        ArgumentNullException.ThrowIfNull(target);
+        return Complete(target.Clone(), true);
+    }
+
+    private BvFlow Complete(BvLocator target, bool waitForDisappear)
+    {
+        EnsureNotCompleted();
+        _completed = true;
+
+        var targetDescription = DescribeTarget(target.RecognitionObject, waitForDisappear);
+        return _flow.AddActionStep(new BvFlowActionSnapshot(
+            _description,
+            _action,
+            target,
+            targetDescription,
+            _timeout ?? _flow.DefaultTimeout,
+            _retryInterval ?? _flow.DefaultRetryInterval,
+            waitForDisappear));
+    }
+
+    private void EnsureNotCompleted()
+    {
+        if (_completed)
+        {
+            throw new InvalidOperationException("当前动作已经设置完成条件，不能再次修改或添加");
+        }
+    }
+
+    internal static string DescribeTarget(RecognitionObject recognitionObject, bool waitForDisappear)
+    {
+        var target = recognitionObject.RecognitionType switch
+        {
+            RecognitionTypes.Ocr => $"文字[{recognitionObject.Text}]",
+            RecognitionTypes.TemplateMatch => $"图像[{recognitionObject.Name}]",
+            _ => "识别元素"
+        };
+        return waitForDisappear ? $"{target}消失" : $"{target}出现";
+    }
+}
+
+internal sealed record BvFlowActionSnapshot(
+    string Description,
+    Func<BvFlowExecutionContext, Task> Action,
+    BvLocator Target,
+    string TargetDescription,
+    int Timeout,
+    int RetryInterval,
+    bool WaitForDisappear);

--- a/BetterGenshinImpact/Core/BgiVision/BvLocator.cs
+++ b/BetterGenshinImpact/Core/BgiVision/BvLocator.cs
@@ -21,6 +21,7 @@ public class BvLocator
 {
     private static readonly ILogger Logger = App.GetLogger<BvLocator>();
     private readonly CancellationToken _cancellationToken;
+    private readonly IReadOnlyList<string> _anyTexts;
     private int? _timeout;
     private int? _retryInterval;
 
@@ -33,14 +34,25 @@ public class BvLocator
     public static int DefaultRetryInterval { get; set; } = 250;
 
     public BvLocator(RecognitionObject recognitionObject, CancellationToken cancellationToken)
+        : this(recognitionObject, cancellationToken, [])
+    {
+    }
+
+    internal BvLocator(
+        RecognitionObject recognitionObject,
+        CancellationToken cancellationToken,
+        IReadOnlyList<string> anyTexts)
     {
         RecognitionObject = recognitionObject.Clone();
         _cancellationToken = cancellationToken;
+        _anyTexts = anyTexts.ToArray();
     }
+
+    internal IReadOnlyList<string> AnyTexts => _anyTexts;
 
     internal BvLocator Clone()
     {
-        return new BvLocator(RecognitionObject, _cancellationToken);
+        return new BvLocator(RecognitionObject, _cancellationToken, _anyTexts);
     }
 
     /// <summary>
@@ -52,7 +64,11 @@ public class BvLocator
     public List<Region> FindAll()
     {
         using var screen = CaptureToRectArea();
+        return FindAll(screen);
+    }
 
+    internal List<Region> FindAll(ImageRegion screen)
+    {
         if (RecognitionObject.RecognitionType == RecognitionTypes.TemplateMatch)
         {
             var region = screen.Find(RecognitionObject);
@@ -66,17 +82,34 @@ public class BvLocator
         else if (RecognitionObject.RecognitionType == RecognitionTypes.Ocr)
         {
             var results = screen.FindMulti(RecognitionObject);
-            if (!string.IsNullOrEmpty(RecognitionObject.Text))
-            {
-                return results.FindAll(r => r.Text.Contains(RecognitionObject.Text));
-            }
-
-            return results;
+            return FilterOcrResults(results, _anyTexts, RecognitionObject.Text);
         }
         else
         {
             throw new NotSupportedException($"不被 Locator 支持的识别类型: {RecognitionObject.RecognitionType}");
         }
+    }
+
+    internal static IReadOnlyList<List<Region>> FindAll(IReadOnlyList<BvLocator> locators)
+    {
+        using var screen = CaptureToRectArea();
+        return locators.Select(locator => locator.FindAll(screen)).ToArray();
+    }
+
+    internal static List<Region> FilterOcrResults(
+        List<Region> results,
+        IReadOnlyList<string> anyTexts,
+        string text)
+    {
+        if (anyTexts.Count > 0)
+        {
+            return results.FindAll(region =>
+                anyTexts.Any(candidate => region.Text.Contains(candidate, StringComparison.Ordinal)));
+        }
+
+        return string.IsNullOrEmpty(text)
+            ? results
+            : results.FindAll(region => region.Text.Contains(text, StringComparison.Ordinal));
     }
 
     public bool IsExist()
@@ -92,7 +125,7 @@ public class BvLocator
     public async Task<Region> ClickUntilDisappears(int? timeout = null)
     {
         var region = (await WaitFor(timeout)).First().Click();
-        await new BvLocator(RecognitionObject, _cancellationToken)
+        await Clone()
             .WithRetryAction(resList => { resList.First().Click(); }).WaitForDisappear();
         return region;
     }
@@ -135,6 +168,12 @@ public class BvLocator
     {
         if (RecognitionObject.RecognitionType == RecognitionTypes.Ocr)
         {
+            if (_anyTexts.Count > 0)
+            {
+                return new TimeoutException(
+                    $"识别任意文字[{string.Join('|', _anyTexts)}]在 {actualTimeout}ms 后超时未出现！");
+            }
+
             return new TimeoutException($"识别文字[{RecognitionObject.Text}]在 {actualTimeout}ms 后超时未出现！");
         }
         else if (RecognitionObject.RecognitionType == RecognitionTypes.TemplateMatch)

--- a/BetterGenshinImpact/Core/BgiVision/BvLocator.cs
+++ b/BetterGenshinImpact/Core/BgiVision/BvLocator.cs
@@ -90,12 +90,6 @@ public class BvLocator
         }
     }
 
-    internal static IReadOnlyList<List<Region>> FindAll(IReadOnlyList<BvLocator> locators)
-    {
-        using var screen = CaptureToRectArea();
-        return locators.Select(locator => locator.FindAll(screen)).ToArray();
-    }
-
     internal static List<Region> FilterOcrResults(
         List<Region> results,
         IReadOnlyList<string> anyTexts,

--- a/BetterGenshinImpact/Core/BgiVision/BvLocator.cs
+++ b/BetterGenshinImpact/Core/BgiVision/BvLocator.cs
@@ -38,6 +38,11 @@ public class BvLocator
         _cancellationToken = cancellationToken;
     }
 
+    internal BvLocator Clone()
+    {
+        return new BvLocator(RecognitionObject, _cancellationToken);
+    }
+
     /// <summary>
     /// 根据传入的位置信息定位元素
     /// 不建议外部调用使用

--- a/BetterGenshinImpact/Core/BgiVision/BvPage.cs
+++ b/BetterGenshinImpact/Core/BgiVision/BvPage.cs
@@ -35,6 +35,11 @@ public class BvPage
         _cancellationToken = cancellationToken;
     }
 
+    public BvFlow Flow()
+    {
+        return new BvFlow(this, DefaultTimeout, DefaultRetryInterval);
+    }
+
     /// <summary>
     /// 截图
     /// </summary>

--- a/BetterGenshinImpact/Core/BgiVision/BvPage.cs
+++ b/BetterGenshinImpact/Core/BgiVision/BvPage.cs
@@ -1,4 +1,7 @@
+using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using BetterGenshinImpact.Core.Recognition;
@@ -102,6 +105,22 @@ public class BvPage
         return Locator(text, rect);
     }
 
+    public BvLocator GetByAnyText(object texts, Rect rect = default)
+    {
+        var matchTexts = ParseCollection<string>(texts, nameof(texts));
+        if (matchTexts.Any(string.IsNullOrWhiteSpace))
+        {
+            throw new ArgumentException("候选文本不能包含空字符串或纯空白字符串", nameof(texts));
+        }
+
+        matchTexts = matchTexts.Distinct(StringComparer.Ordinal).ToList();
+        return new BvLocator(new RecognitionObject
+        {
+            RecognitionType = RecognitionTypes.Ocr,
+            RegionOfInterest = rect
+        }, _cancellationToken, matchTexts);
+    }
+
     public BvLocator GetByImage(BvImage image)
     {
         return Locator(image);
@@ -122,5 +141,32 @@ public class BvPage
     public void Click(double x, double y)
     {
         GameCaptureRegion.GameRegion1080PPosClick(x, y);
+    }
+
+    internal static List<T> ParseCollection<T>(object values, string paramName)
+    {
+        ArgumentNullException.ThrowIfNull(values, paramName);
+        if (values is string || values is not IEnumerable enumerable)
+        {
+            throw new ArgumentException($"{paramName} 必须是集合或 JS Array", paramName);
+        }
+
+        List<T> result = [];
+        foreach (var value in enumerable)
+        {
+            if (value is not T typedValue)
+            {
+                throw new ArgumentException($"{paramName} 中的每个元素都必须是 {typeof(T).Name}", paramName);
+            }
+
+            result.Add(typedValue);
+        }
+
+        if (result.Count == 0)
+        {
+            throw new ArgumentException($"{paramName} 不能为空", paramName);
+        }
+
+        return result;
     }
 }

--- a/BetterGenshinImpact/Core/BgiVision/BvPage.cs
+++ b/BetterGenshinImpact/Core/BgiVision/BvPage.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using BetterGenshinImpact.Core.Recognition;
 using BetterGenshinImpact.Core.Simulator;
+using BetterGenshinImpact.GameTask.AutoGeniusInvokation.Exception;
 using BetterGenshinImpact.GameTask.Common;
 using BetterGenshinImpact.GameTask.Model.Area;
 using Fischless.WindowsInput;
@@ -61,6 +62,14 @@ public class BvPage
     {
         await TaskControl.Delay(milliseconds, _cancellationToken);
         return this;
+    }
+
+    internal void ThrowIfCancellationRequested()
+    {
+        if (_cancellationToken.IsCancellationRequested)
+        {
+            throw new NormalEndException("取消自动任务");
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## 功能说明

为 JavaScript 脚本新增 `BvFlow` 链式流程 API，用于简化“执行操作并重试，直到目标状态出现”的交互流程。

支持动作重试、纯等待识别、多目标识别、多候选文本、隐式坐标操作以及独立的超时和重试间隔配置。

## 简单示例

```javascript
const page = new BvPage();

const achievementRect = new Rect(632, 441, 68, 28);

await page.flow()
    //按esc直到出现 成 or 就，
    .keyPress("escape").untilAnyText( ["成", "就"],achievementRect)
    
   //click直接点击上一个识别到的对象位置，直到出现天地万象，click支持传参点击特定位置
    .click().untilText("天地万象" )
   
    // 点击天地万象的位置
    .click()
   
    // 等到出现达成成就，
    .waitUntilText("达成成就").do(async () => { await genshin.returnMainUi() })

    .run();
```

## 默认配置

`withDefaultTimeout()` 和 `withDefaultRetryInterval()` 不是必填项。创建流程时会读取 `BvPage` 的默认配置：

```csharp
page.DefaultTimeout = 10000;
page.DefaultRetryInterval = 1000;
```

- 每个步骤默认超时为 `10000ms`。
- 每次动作后的默认等待间隔为 `1000ms`。
- `withTimeout()` 和 `withRetryInterval()` 只覆盖当前动作。
- `withDefaultTimeout()` 和 `withDefaultRetryInterval()` 覆盖整条流程，且必须在添加任何步骤前调用。

## 主要 API

### 流程配置与执行

- `page.flow()`
- `withDefaultTimeout()`
- `withDefaultRetryInterval()`
- `run()`

### 动作

- `do()`
- `keyPress()`
- `click()`、`rightClick()`、`middleClick()`
- `moveTo()`
- `drag()`、`dragTo()`、`dragFrom()`
- `wait()`

### 动作完成条件

- `untilText()`
- `untilAnyText()`
- `until()`
- `untilAny()`
- `untilDisappear()`
- `untilAllDisappear()`

### 无操作等待

- `waitUntilText()`
- `waitUntilAnyText()`
- `waitUntil()`
- `waitUntilAny()`
- `waitUntilDisappear()`
- `waitUntilAllDisappear()`

## 多目标与多文本

`getByAnyText()` 对指定 ROI 只执行一次 OCR，任意候选文本命中即成功：

```javascript
const resinText = page.getByAnyText(
    ["补充", "原粹", "树脂"],
    resinRect
);
```

`waitUntilAny()` 和 `untilAny()` 支持传入多个 `BvLocator`：

```javascript
.waitUntilAny([
    page.getByText("成就", achievementRect),
    page.getByAnyText(["补充", "树脂"], resinRect)
])
```

多个定位器每轮共用同一张截图，并按数组顺序识别：

- `AnyAppear` 在首个目标命中后停止。
- `AllDisappear` 在发现任一目标仍存在后停止。

## 坐标行为

- 识别成功后缓存首个匹配区域的 1080P 坐标。
- 空参数 `click()`、`rightClick()`、`middleClick()` 和 `moveTo()` 使用上一次识别区域中心。
- `dragTo()` 从上一次识别位置拖到指定坐标。
- `dragFrom()` 从指定坐标拖到上一次识别位置。
- 目标全部消失后清除缓存坐标。
- 无缓存时使用隐式坐标操作会抛出异常。

## 超时行为

- 动作执行、重试等待和目标识别均计入超时时间。
- 重试等待按照剩余时间截断。
- 识别完成后再次检查截止时间，不接受超时后返回的成功结果。
- 超时、非法参数和步骤失败会通过带步骤信息的异常报告。
- `OperationCanceledException` 保持原样传播。






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增视觉自动化流程编排，支持按顺序执行键鼠操作、拖拽及等待步骤。
  * 支持配置超时、重试间隔和取消操作，并可根据文本、图像或定位器条件继续执行。
  * 支持等待目标出现或消失，以及基于多个候选文本或目标进行识别。
  * 新增页面流程创建入口和多文本定位能力。
* **改进**
  * 优化文本识别与定位逻辑，提升多候选文本匹配及错误提示的准确性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->