### PR TITLE
补全火元素采集动作前置校验  

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
@@ -500,7 +500,8 @@ public partial class PathExecutor
         {
             { ActionEnum.HydroCollect.Code, ElementalType.Hydro },
             { ActionEnum.ElectroCollect.Code, ElementalType.Electro },
-            { ActionEnum.AnemoCollect.Code, ElementalType.Anemo }
+            { ActionEnum.AnemoCollect.Code, ElementalType.Anemo },
+            { ActionEnum.PyroCollect.Code, ElementalType.Pyro }
         };
 
         foreach (var (action, el) in map)


### PR DESCRIPTION
Closes #3402 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 优化火元素采集动作的配置校验，确保执行相关任务前已正确配置火元素角色。
  * 将火元素采集动作纳入角色元素匹配检查，减少任务执行失败。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->