### PR TITLE
feat: 支持运行中不关闭 BGI 热激活启动一条龙

### DIFF
--- a/BetterGenshinImpact/ViewModel/Pages/HomePageViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/HomePageViewModel.cs
@@ -170,6 +170,13 @@ public partial class HomePageViewModel : ViewModel, IDisposable
         {
             _ = OnStartTriggerAsync();
         }
+        else if (commandLineOptions.Action == CommandLineAction.StartOneDragon)
+        {
+            // 热激活：不关闭 BGI 启动一条龙（若已有任务运行会先终止）。
+            // 冷启动时 OnLoaded 已走同一条路径，此处统一入口。
+            var oneDragonFlowViewModel = App.GetService<OneDragonFlowViewModel>();
+            _ = oneDragonFlowViewModel?.StartFromCommandLineAsync(commandLineOptions.OneDragonConfigName);
+        }
 
         // TODO: 多实例独立任务选择面板入口预留。
         // 后续在此判断可用子实例，并由选择面板决定 task.* 请求的目标实例。

--- a/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
@@ -13,6 +13,7 @@ using BetterGenshinImpact.Core.Config;
 using BetterGenshinImpact.Core.Script;
 using BetterGenshinImpact.Core.Script.Group;
 using BetterGenshinImpact.GameTask;
+using BetterGenshinImpact.GameTask.Common;
 using BetterGenshinImpact.GameTask.Common.Element.Assets;
 using BetterGenshinImpact.GameTask.Common.Job;
 using BetterGenshinImpact.Helpers;
@@ -516,28 +517,58 @@ public partial class OneDragonFlowViewModel : ViewModel
         if (cmdOptions.Action == CommandLineAction.StartOneDragon)
         {
             // 通过命令行参数启动一条龙。
-            if (cmdOptions.OneDragonConfigName != null)
-            {
-                // 从命令行参数中提取一条龙配置名称。
-                _logger.LogInformation($"参数指定的一条龙配置：{cmdOptions.OneDragonConfigName}");
-                var argsOneDragonConfig = ConfigList.FirstOrDefault(x =>
-                    string.Equals(x.Name, cmdOptions.OneDragonConfigName, StringComparison.Ordinal));
-                if (argsOneDragonConfig != null)
-                {
-                    // 设定配置，配置下拉框会选定。
-                    SelectedConfig = argsOneDragonConfig;
-                    // 调用选定更新函数。
-                    OnConfigDropDownChanged();
-                }
-                else
-                {
-                    _logger.LogWarning("未找到，请检查。");
-                }
-            }
-            // 异步执行一条龙
-            Toast.Information($"命令行一条龙「{SelectedConfig.Name}」。");
-            OnOneKeyExecute();
+            _ = StartFromCommandLineAsync(cmdOptions.OneDragonConfigName);
         }
+    }
+
+    /// <summary>
+    /// 从命令行参数/热激活启动一条龙。
+    /// 若当前已有独立任务在运行，先请求终止并等待其完全结束，再启动新的一条龙。
+    /// </summary>
+    /// <param name="configName">一条龙配置名称，为空时使用当前选中配置。</param>
+    public async Task StartFromCommandLineAsync(string? configName)
+    {
+        // 任务锁被持有说明有独立任务正在运行（一条龙、调度组等），先终止并等待其完全结束，
+        // 避免与即将启动的一条龙抢占截图器、按键等资源。
+        if (TaskControl.TaskSemaphore.CurrentCount == 0)
+        {
+            _logger.LogInformation("检测到正在运行的任务，先终止后再启动一条龙");
+            CancellationContext.Instance.Cancel();
+            if (!await TaskControl.TaskSemaphore.WaitAsync(TimeSpan.FromSeconds(60)))
+            {
+                _logger.LogWarning("等待现有任务结束超时，放弃启动一条龙");
+                return;
+            }
+
+            // 仅用于确认任务已结束，随即释放，由下方启动流程自行抢锁。
+            TaskControl.TaskSemaphore.Release();
+        }
+
+        // 确保配置列表已加载（热激活时页面可能从未打开过）。
+        OnNavigatedTo();
+
+        // 从命令行参数中提取一条龙配置名称。
+        if (configName != null)
+        {
+            _logger.LogInformation($"参数指定的一条龙配置：{configName}");
+            var argsOneDragonConfig = ConfigList.FirstOrDefault(x =>
+                string.Equals(x.Name, configName, StringComparison.Ordinal));
+            if (argsOneDragonConfig != null)
+            {
+                // 设定配置，配置下拉框会选定。
+                SelectedConfig = argsOneDragonConfig;
+                // 调用选定更新函数。
+                OnConfigDropDownChanged();
+            }
+            else
+            {
+                _logger.LogWarning("未找到一条龙配置「{Config}」", configName);
+            }
+        }
+
+        // 异步执行一条龙
+        Toast.Information($"命令行一条龙「{SelectedConfig.Name}」。");
+        await OnOneKeyExecute();
     }
 
     [RelayCommand]


### PR DESCRIPTION
HomePageViewModel.HandleActivation 增加 StartOneDragon 分支，热激活（命名管道 activation.dispatch）收到 startOneDragon 参数时触发一条龙。

OneDragonFlowViewModel 新增 StartFromCommandLineAsync：若有任务运行先请求终止并等待其完全结束（超时 60s 放弃），再启动新的一条龙；OnLoaded 冷启动路径改为复用同一方法。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 支持通过命令行启动指定配置的一条龙流程。
  * 未指定配置时使用默认配置，指定名称后可直接运行对应配置。
* **改进**
  * 启动前会检测正在运行的任务并进行处理，避免流程重复执行。
  * 启动过程会等待任务资源，最长等待 60 秒。
  * 配置加载完成后再启动流程；找不到指定配置时会记录警告。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->