### PR TITLE
feat: 自动进入游戏改为三态配置（始终/不执行/仅BGI自启原神时）

### DIFF
--- a/BetterGenshinImpact/Core/Config/GenshinStartConfig.cs
+++ b/BetterGenshinImpact/Core/Config/GenshinStartConfig.cs
@@ -1,7 +1,27 @@
 using CommunityToolkit.Mvvm.ComponentModel;
+using Newtonsoft.Json;
 using System;
+using System.ComponentModel;
 
 namespace BetterGenshinImpact.Core.Config;
+
+/// <summary>
+///     自动进入游戏模式
+/// </summary>
+public enum AutoEnterGameMode
+{
+    /// <summary>始终执行：任何情况下都自动进入游戏（原"开启"行为）</summary>
+    [Description("始终执行")]
+    Always,
+
+    /// <summary>不执行：不自动进入游戏（原"关闭"行为）</summary>
+    [Description("不执行")]
+    Never,
+
+    /// <summary>仅联动启动时执行：只在 BGI 自己启动原神后自动进入游戏</summary>
+    [Description("仅BGI自启原神时执行")]
+    OnlyWhenLinkedStart,
+}
 
 /// <summary>
 ///     原神启动配置
@@ -16,10 +36,25 @@ public partial class GenshinStartConfig : ObservableObject
     // private bool _autoClickBlessingOfTheWelkinMoonEnabled;
 
     /// <summary>
-    ///     自动进入游戏（开门）
+    ///     自动进入游戏（开门）模式
     /// </summary>
     [ObservableProperty]
-    private bool _autoEnterGameEnabled = true;
+    private AutoEnterGameMode _autoEnterGameMode = AutoEnterGameMode.Always;
+
+    /// <summary>
+    ///     兼容旧配置：旧版本 AutoEnterGameEnabled(bool) 自动迁移到 AutoEnterGameMode
+    /// </summary>
+    [JsonProperty("AutoEnterGameEnabled")]
+    private bool? AutoEnterGameEnabledLegacy
+    {
+        set
+        {
+            if (value != null)
+            {
+                AutoEnterGameMode = value.Value ? AutoEnterGameMode.Always : AutoEnterGameMode.Never;
+            }
+        }
+    }
 
     /// <summary>
     ///     原神启动参数

--- a/BetterGenshinImpact/Core/Config/GenshinStartConfig.cs
+++ b/BetterGenshinImpact/Core/Config/GenshinStartConfig.cs
@@ -42,21 +42,6 @@ public partial class GenshinStartConfig : ObservableObject
     private AutoEnterGameMode _autoEnterGameMode = AutoEnterGameMode.Always;
 
     /// <summary>
-    ///     兼容旧配置：旧版本 AutoEnterGameEnabled(bool) 自动迁移到 AutoEnterGameMode
-    /// </summary>
-    [JsonProperty("AutoEnterGameEnabled")]
-    private bool? AutoEnterGameEnabledLegacy
-    {
-        set
-        {
-            if (value != null)
-            {
-                AutoEnterGameMode = value.Value ? AutoEnterGameMode.Always : AutoEnterGameMode.Never;
-            }
-        }
-    }
-
-    /// <summary>
     ///     原神启动参数
     /// </summary>
     [ObservableProperty]

--- a/BetterGenshinImpact/GameTask/GameLoading/GameLoading.cs
+++ b/BetterGenshinImpact/GameTask/GameLoading/GameLoading.cs
@@ -70,7 +70,7 @@ public class GameLoadingTrigger : ITaskTrigger
 
     public void Init()
     {
-        if (!_config.AutoEnterGameEnabled)
+        if (_config.AutoEnterGameMode == AutoEnterGameMode.Never)
         {
             InnerSetEnabled(false);
         }
@@ -245,6 +245,13 @@ public class GameLoadingTrigger : ITaskTrigger
         if ((DateTime.Now - _triggerStartTime).TotalMinutes >= 5)
         {
             InnerSetEnabled(false);
+            return;
+        }
+
+        // 仅联动启动模式：捕获已有原神（非 BGI 启动）时跳过自动进入游戏流程
+        if (_config.AutoEnterGameMode == AutoEnterGameMode.OnlyWhenLinkedStart
+            && !TaskContext.Instance().GenshinStartedByLinkedStart)
+        {
             return;
         }
         

--- a/BetterGenshinImpact/GameTask/TaskContext.cs
+++ b/BetterGenshinImpact/GameTask/TaskContext.cs
@@ -77,6 +77,11 @@ namespace BetterGenshinImpact.GameTask
         /// </summary>
         public DateTime LinkedStartGenshinTime { get; set; } = DateTime.MinValue;
 
+        /// <summary>
+        /// 本次截图器启动时原神是否由 BGI 联动启动（"自动进入游戏-仅BGI自启原神时执行"模式的判断依据）
+        /// </summary>
+        public bool GenshinStartedByLinkedStart { get; set; }
+
         public List<string> GetGenshinGameProcessNameList()
         {
             if (IsInitialized)

--- a/BetterGenshinImpact/GameTask/TaskTriggerDispatcher.cs
+++ b/BetterGenshinImpact/GameTask/TaskTriggerDispatcher.cs
@@ -102,7 +102,7 @@ namespace BetterGenshinImpact.GameTask
 
             // 初始化触发器(一定要在任务上下文初始化完毕后使用)
             _captureTriggerScheduler.SetTriggers(GameTaskManager.LoadInitialTriggers());
-            GameLoadingTrigger.GlobalEnabled = TaskContext.Instance().Config.GenshinStartConfig.AutoEnterGameEnabled;
+            GameLoadingTrigger.GlobalEnabled = TaskContext.Instance().Config.GenshinStartConfig.AutoEnterGameMode != AutoEnterGameMode.Never;
 
             // if (GraphicsCapture.IsHdrEnabled(hWnd))
             // {

--- a/BetterGenshinImpact/Service/ConfigService.cs
+++ b/BetterGenshinImpact/Service/ConfigService.cs
@@ -80,6 +80,20 @@ public class ConfigService : IConfigService
                 return new AllConfig();
             }
 
+            // 旧版本配置迁移：autoEnterGameEnabled(bool) → autoEnterGameMode
+            // 仅在 autoEnterGameMode 未显式设置（保持默认值 Always）时读取旧字段，避免覆盖新配置
+            if (config.GenshinStartConfig.AutoEnterGameMode == AutoEnterGameMode.Always)
+            {
+                using var doc = JsonDocument.Parse(json);
+                if (doc.RootElement.TryGetProperty("genshinStartConfig", out var gsc)
+                    && gsc.TryGetProperty("autoEnterGameEnabled", out var legacy)
+                    && legacy.ValueKind is JsonValueKind.True or JsonValueKind.False)
+                {
+                    config.GenshinStartConfig.AutoEnterGameMode =
+                        legacy.GetBoolean() ? AutoEnterGameMode.Always : AutoEnterGameMode.Never;
+                }
+            }
+
             Config = config;
             return config;
         }

--- a/BetterGenshinImpact/Service/ScriptService.cs
+++ b/BetterGenshinImpact/Service/ScriptService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -414,7 +414,7 @@ public partial class ScriptService : IScriptService
                                 Notify.Event(NotificationEvent.GroupEnd).Error("调度器任务出现未预期的异常，自动重启bgi");
                                 if (autoconfig.RestartGameTogether
                                     && TaskContext.Instance().Config.GenshinStartConfig.LinkedStartEnabled
-                                    && TaskContext.Instance().Config.GenshinStartConfig.AutoEnterGameEnabled)
+                                    && TaskContext.Instance().Config.GenshinStartConfig.AutoEnterGameMode != AutoEnterGameMode.Never)
                                 {
                                     SystemControl.CloseGame();
                                     Thread.Sleep(2000);

--- a/BetterGenshinImpact/View/Pages/HomePage.xaml
+++ b/BetterGenshinImpact/View/Pages/HomePage.xaml
@@ -483,7 +483,7 @@
                     <ui:TextBlock Grid.Row="1"
                                   Grid.Column="0"
                                   Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
-                                  Text="原神启动后自动进入游戏（自动开门、领取月卡）；「仅BGI自启原神时执行」模式下，捕获已有原神将跳过该流程"
+                                  Text="原神启动后自动进入游戏（自动开门、领取月卡）"
                                   TextWrapping="Wrap" />
                     <ComboBox Grid.Row="0"
                               Grid.RowSpan="2"

--- a/BetterGenshinImpact/View/Pages/HomePage.xaml
+++ b/BetterGenshinImpact/View/Pages/HomePage.xaml
@@ -483,13 +483,17 @@
                     <ui:TextBlock Grid.Row="1"
                                   Grid.Column="0"
                                   Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
-                                  Text="原神启动后自动进入游戏（自动开门、领取月卡）"
+                                  Text="原神启动后自动进入游戏（自动开门、领取月卡）；「仅BGI自启原神时执行」模式下，捕获已有原神将跳过该流程"
                                   TextWrapping="Wrap" />
-                    <ui:ToggleSwitch Grid.Row="0"
-                                     Grid.RowSpan="2"
-                                     Grid.Column="1"
-                                     Margin="0,0,36,0"
-                                     IsChecked="{Binding Config.GenshinStartConfig.AutoEnterGameEnabled, Mode=TwoWay}" />
+                    <ComboBox Grid.Row="0"
+                              Grid.RowSpan="2"
+                              Grid.Column="1"
+                              Width="160"
+                              Margin="0,0,36,0"
+                              ItemsSource="{Binding AutoEnterGameModes}"
+                              DisplayMemberPath="DisplayName"
+                              SelectedValuePath="Value"
+                              SelectedValue="{Binding Config.GenshinStartConfig.AutoEnterGameMode, Mode=TwoWay}" />
                 </Grid>
                 <Separator Margin="-18,0" BorderThickness="0,1,0,0" />
                 <Grid Margin="16">

--- a/BetterGenshinImpact/ViewModel/Pages/HomePageViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/HomePageViewModel.cs
@@ -55,6 +55,8 @@ public partial class HomePageViewModel : ViewModel, IDisposable
     private bool _disposed;
     [ObservableProperty] private IEnumerable<EnumItem<CaptureModes>> _modeNames = EnumExtensions.ToEnumItems<CaptureModes>();
 
+    [ObservableProperty] private IEnumerable<EnumItem<AutoEnterGameMode>> _autoEnterGameModes = EnumExtensions.ToEnumItems<AutoEnterGameMode>();
+
     [ObservableProperty] private string? _selectedMode = CaptureModes.BitBlt.ToString();
 
     [ObservableProperty] private bool _taskDispatcherEnabled = false;
@@ -285,6 +287,7 @@ public partial class HomePageViewModel : ViewModel, IDisposable
                 if (hWnd != IntPtr.Zero)
                 {
                     TaskContext.Instance().LinkedStartGenshinTime = DateTime.Now; // 标识关联启动原神的时间
+                    TaskContext.Instance().GenshinStartedByLinkedStart = true; // 标识本次原神由 BGI 联动启动
                 }
                 else
                 {
@@ -297,6 +300,11 @@ public partial class HomePageViewModel : ViewModel, IDisposable
                 await ThemedMessageBox.ErrorAsync("未找到原神窗口，请先启动原神！");
                 return;
             }
+        }
+        else
+        {
+            // 捕获已有原神进程，非 BGI 联动启动
+            TaskContext.Instance().GenshinStartedByLinkedStart = false;
         }
 
         Start(hWnd);

--- a/BetterGenshinImpact/ViewModel/Pages/HomePageViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/HomePageViewModel.cs
@@ -247,6 +247,8 @@ public partial class HomePageViewModel : ViewModel, IDisposable
             if (hWnd != IntPtr.Zero)
             {
                 _hWnd = hWnd;
+                // 手动选择的是已有窗口，非 BGI 联动启动，重置标志避免"仅BGI自启原神时执行"误判
+                TaskContext.Instance().GenshinStartedByLinkedStart = false;
                 Start(hWnd);
             }
             else


### PR DESCRIPTION
AutoEnterGameEnabled(bool) 迁移为 AutoEnterGameMode 枚举，旧配置通过 JsonProperty 兼容自动迁移。

新增 GenshinStartedByLinkedStart 标志：BGI 联动启动原神时自动进入游戏流程照常执行，捕获已有原神进程时跳过（仅BGI自启原神时执行模式）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * “自动进入游戏”新增三种模式：始终执行、从不执行，以及仅在通过联动启动游戏时执行。
  * 启动流程可识别游戏的启动方式，并根据所选模式执行自动进入游戏。
  * 设置界面改用模式选择菜单，配置更加灵活直观。

* **改进**
  * 原有自动进入游戏设置将自动兼容迁移至新的模式选项。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->