### PR TITLE
fix(automation): 传播托管任务失败并强化清理 (#3443)

### DIFF
--- a/BetterGenshinImpact/Core/Script/Dependence/AutoPathingScript.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/AutoPathingScript.cs
@@ -13,12 +13,23 @@ public class AutoPathingScript
     private object? _config = null;
     private string _rootPath;
     private readonly LimitedFile _autoPathingFile;
+    private readonly Action<string, Exception> _logFailure;
 
     public AutoPathingScript(string rootPath, object? config)
+        : this(rootPath, config, new LimitedFile(Global.Absolute(@"User\AutoPathing")), LogFailure)
+    {
+    }
+
+    internal AutoPathingScript(
+        string rootPath,
+        object? config,
+        LimitedFile autoPathingFile,
+        Action<string, Exception> logFailure)
     {
         _config = config;
         _rootPath = rootPath;
-        _autoPathingFile = new LimitedFile(Global.Absolute(@"User\AutoPathing"));
+        _autoPathingFile = autoPathingFile;
+        _logFailure = logFailure;
     }
 
     public async Task Run(string json)
@@ -36,23 +47,25 @@ public class AutoPathingScript
         }
         catch (Exception e)
         {
-            TaskControl.Logger.LogDebug(e,"执行地图追踪时候发生错误");
-            TaskControl.Logger.LogError("执行地图追踪时候发生错误: {Msg}",e.Message);
+            _logFailure("执行地图追踪时候发生错误", e);
+            throw;
         }
     }
 
     public async Task RunFile(string path)
     {
+        string json;
         try
         {
-            var json = await new LimitedFile(_rootPath).ReadText(path);
-            await Run(json);
+            json = await new LimitedFile(_rootPath).ReadTextOrThrow(path);
         }
         catch (Exception e)
         {
-            TaskControl.Logger.LogDebug(e,"读取文件时发生错误");
-            TaskControl.Logger.LogError("读取文件时发生错误: {Msg}",e.Message);
+            _logFailure("读取文件时发生错误", e);
+            throw;
         }
+
+        await Run(json);
     }
 
     /// <summary>
@@ -61,7 +74,7 @@ public class AutoPathingScript
     /// <param name="path">在 `\User\AutoPathing` 目录下获取文件</param>
     public async Task RunFileFromUser(string path)
     {
-        var json = await AutoPathingFile.ReadText(path);
+        var json = await AutoPathingFile.ReadTextOrThrow(path);
         await Run(json);
     }
 
@@ -102,7 +115,20 @@ public class AutoPathingScript
     public string ReadTextSync(string subPath) => AutoPathingFile.ReadTextSync(subPath);
 
     /// <summary>
+    /// 读取 AutoPathing 目录下指定文件的文本内容，读取失败时保留原始异常。
+    /// </summary>
+    /// <param name="subPath">相对于 User\AutoPathing 的文件路径</param>
+    /// <returns>文件文本内容</returns>
+    public string ReadTextSyncOrThrow(string subPath) => AutoPathingFile.ReadTextSyncOrThrow(subPath);
+
+    /// <summary>
     /// LimitedFile 实例，用于操作 AutoPathing 目录
     /// </summary>
     private LimitedFile AutoPathingFile => _autoPathingFile;
+
+    private static void LogFailure(string message, Exception exception)
+    {
+        TaskControl.Logger.LogDebug(exception, message);
+        TaskControl.Logger.LogError("{Message}: {ExceptionMessage}", message, exception.Message);
+    }
 }

--- a/BetterGenshinImpact/Core/Script/Dependence/LimitedFile.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/LimitedFile.cs
@@ -163,6 +163,17 @@ public class LimitedFile(string rootPath)
     }
 
     /// <summary>
+    /// Read all text from a file and preserve the original exception on failure.
+    /// </summary>
+    /// <param name="path">File path.</param>
+    /// <returns>Text read from file.</returns>
+    public string ReadTextSyncOrThrow(string path)
+    {
+        path = NormalizePath(path);
+        return File.ReadAllText(path);
+    }
+
+    /// <summary>
     /// Read all text from a file.
     /// </summary>
     /// <param name="path">File path.</param>
@@ -181,6 +192,17 @@ public class LimitedFile(string rootPath)
             TaskControl.Logger.LogError("ReadText 异常: {Message}", ex.Message);
             return string.Empty;
         }
+    }
+
+    /// <summary>
+    /// Read all text from a file asynchronously and preserve the original exception on failure.
+    /// </summary>
+    /// <param name="path">File path.</param>
+    /// <returns>Text read from file.</returns>
+    public async Task<string> ReadTextOrThrow(string path)
+    {
+        path = NormalizePath(path);
+        return await File.ReadAllTextAsync(path);
     }
 
     /// <summary>

--- a/BetterGenshinImpact/GameTask/Common/Job/CheckRewardsTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/CheckRewardsTask.cs
@@ -77,6 +77,7 @@ public class CheckRewardsTask
             {
                 Logger.LogWarning("检查每日奖励结果：{Msg}，请手动检查！", "未领取");
                 Notify.Event(NotificationEvent.DailyReward).Error("检查到每日奖励未领取，请手动查看！");
+                throw new InvalidOperationException("检查到每日奖励未领取");
             }
             await Delay(200, ct);
             await new ReturnMainUiTask().Start(ct);
@@ -85,6 +86,7 @@ public class CheckRewardsTask
         {
             Logger.LogDebug(e, "检查奖励并通知的任务异常");
             Logger.LogError("检查奖励并通知的任务异常: {Msg}", e.Message);
+            throw;
         }
     }
 }

--- a/BetterGenshinImpact/GameTask/Common/Job/ClaimEncounterPointsRewardsTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/ClaimEncounterPointsRewardsTask.cs
@@ -43,6 +43,7 @@ public class ClaimEncounterPointsRewardsTask
         {
             Logger.LogDebug(e, "领取长效历练点奖励异常");
             Logger.LogError("领取长效历练点奖励异常: {Msg}", e.Message);
+            throw;
         }
     }
 

--- a/BetterGenshinImpact/GameTask/TaskRunner.cs
+++ b/BetterGenshinImpact/GameTask/TaskRunner.cs
@@ -5,6 +5,9 @@ using BetterGenshinImpact.View;
 using BetterGenshinImpact.View.Drawable;
 using Microsoft.Extensions.Logging;
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
 using BetterGenshinImpact.Core.Simulator;
@@ -44,8 +47,9 @@ public class TaskRunner
     /// <param name="action"></param>
     /// <param name="resetCancellationContext">任务开始时是否重建 CancellationContext。</param>
     /// <param name="clearCancellationContextOnLockFailure">获取信号量锁失败时是否清理 CancellationContext。</param>
+    /// <param name="propagateExceptions">是否向调用方传播未预期的任务异常。</param>
     /// <returns></returns>
-    public async Task RunCurrentAsync(Func<Task> action, bool resetCancellationContext = true, bool clearCancellationContextOnLockFailure = false)
+    public async Task RunCurrentAsync(Func<Task> action, bool resetCancellationContext = true, bool clearCancellationContextOnLockFailure = false, bool propagateExceptions = false)
     {
         // 加锁
         var hasLock = await TaskSemaphore.WaitAsync(0);
@@ -56,8 +60,10 @@ public class TaskRunner
             {
                 CancellationContext.Instance.Clear();
             }
+            TaskRunnerFailurePolicy.ThrowIfLockUnavailable(propagateExceptions);
             return;
         }
+        Exception? executionException = null;
         try
         {
             _logger.LogInformation("→ {Text}", _name + "任务启动！");
@@ -76,41 +82,56 @@ public class TaskRunner
         {
             Notify.Event(NotificationEvent.TaskCancel).Success("任务手动取消，或正常结束");
             _logger.LogInformation("任务中断:{Msg}", e.Message);
-            if (RunnerContext.Instance.IsContinuousRunGroup)
-            {
-                // 连续执行时，抛出异常，终止执行
-                throw;
-            }
+            executionException = TaskRunnerFailurePolicy.GetTerminationException(
+                e,
+                RunnerContext.Instance.IsContinuousRunGroup,
+                propagateExceptions);
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException e)
         {
             Notify.Event(NotificationEvent.TaskCancel).Success("任务被手动取消");
             _logger.LogInformation("任务中断:{Msg}", "任务被取消");
-            if (RunnerContext.Instance.IsContinuousRunGroup)
-            {
-                // 连续执行时，抛出异常，终止执行
-                throw;
-            }
+            executionException = TaskRunnerFailurePolicy.GetTerminationException(
+                e,
+                RunnerContext.Instance.IsContinuousRunGroup,
+                propagateExceptions);
         }
         catch (Exception e)
         {
             Notify.Event(NotificationEvent.TaskError).Error("任务执行异常", e);
-            _logger.LogError(e.Message);
-            _logger.LogDebug(e.StackTrace);
+            _logger.LogError(e, "任务执行异常: {Message}", e.Message);
+            if (propagateExceptions)
+            {
+                executionException = e;
+            }
         }
         finally
         {
-            End();
-            _logger.LogInformation("→ {Text}", _name + "任务结束");
-
-            CancellationContext.Instance.Clear();
-            RunnerContext.Instance.Clear();
-
-            // 释放锁
-            if (hasLock)
+            IReadOnlyList<Exception> cleanupFailures;
+            try
             {
-                TaskSemaphore.Release();
+                cleanupFailures = TaskRunnerCleanup.RunAll(
+                [
+                    ("任务资源", End),
+                    ("结束日志", () => _logger.LogInformation("→ {Text}", _name + "任务结束")),
+                    ("取消上下文", CancellationContext.Instance.Clear),
+                    ("运行上下文", RunnerContext.Instance.Clear)
+                ],
+                LogCleanupFailure);
             }
+            finally
+            {
+                // 信号量必须由最外层 finally 释放，不能被任何清理异常阻断。
+                if (hasLock)
+                {
+                    TaskSemaphore.Release();
+                }
+            }
+
+            TaskRunnerFailurePolicy.ThrowAfterCleanup(
+                executionException,
+                cleanupFailures,
+                propagateExceptions);
         }
     }
 
@@ -119,9 +140,9 @@ public class TaskRunner
         Task.Run(() => RunCurrentAsync(action));
     }
 
-    public async Task RunThreadAsync(Func<Task> action)
+    public async Task RunThreadAsync(Func<Task> action, bool propagateExceptions = false)
     {
-        await Task.Run(() => RunCurrentAsync(action));
+        await Task.Run(() => RunCurrentAsync(action, propagateExceptions: propagateExceptions));
     }
 
     public async Task RunSoloTaskAsync(ISoloTask soloTask)
@@ -183,14 +204,132 @@ public class TaskRunner
             return;
         }
 
-        Simulation.ReleaseAllKey();
-
-        // 还原实时任务触发器
-        TaskTriggerDispatcher.Instance().ClearTriggers();
-        TaskTriggerDispatcher.Instance().SetTriggers(GameTaskManager.LoadInitialTriggers());
-
-        VisionContext.Instance().DrawContent.ClearAll();
-        HtmlMaskWindow.CloseAll();
+        var cleanupFailures = TaskRunnerCleanup.RunAll(
+        [
+            ("释放模拟输入", Simulation.ReleaseAllKey),
+            ("还原实时任务触发器", () =>
+            {
+                TaskTriggerDispatcher.Instance().ClearTriggers();
+                TaskTriggerDispatcher.Instance().SetTriggers(GameTaskManager.LoadInitialTriggers());
+            }),
+            ("清理绘制内容", VisionContext.Instance().DrawContent.ClearAll),
+            ("关闭 HTML 遮罩", HtmlMaskWindow.CloseAll)
+        ],
+        LogCleanupFailure);
+        TaskRunnerFailurePolicy.ThrowCleanupFailures(cleanupFailures);
     }
 
+    private void LogCleanupFailure(string step, Exception exception)
+    {
+        _logger.LogError(exception, "任务结束清理失败，步骤: {Step}", step);
+    }
+
+}
+
+internal static class TaskRunnerCleanup
+{
+    internal static IReadOnlyList<Exception> RunAll(
+        IEnumerable<(string Name, Action Action)> steps,
+        Action<string, Exception> onFailure)
+    {
+        var failures = new List<Exception>();
+        foreach (var (name, action) in steps)
+        {
+            try
+            {
+                action();
+            }
+            catch (Exception exception)
+            {
+                failures.Add(exception);
+                try
+                {
+                    onFailure(name, exception);
+                }
+                catch
+                {
+                    // 清理诊断本身失败时仍需继续执行后续清理步骤。
+                }
+            }
+        }
+
+        return failures;
+    }
+}
+
+internal static class TaskRunnerFailurePolicy
+{
+    internal static void ThrowIfStartupCancelled(
+        CancellationToken cancellationToken,
+        bool propagateExceptions,
+        bool isContinuousRunGroup = false)
+    {
+        if (propagateExceptions || isContinuousRunGroup)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+    }
+
+    internal static void ThrowIfTaskCancelled(
+        CancellationToken cancellationToken,
+        bool propagateExceptions,
+        bool isContinuousRunGroup = false)
+    {
+        ThrowIfStartupCancelled(
+            cancellationToken,
+            propagateExceptions,
+            isContinuousRunGroup);
+    }
+
+    internal static Exception? GetTerminationException(
+        Exception exception,
+        bool isContinuousRunGroup,
+        bool propagateExceptions)
+    {
+        return isContinuousRunGroup || propagateExceptions ? exception : null;
+    }
+
+    internal static void ThrowIfLockUnavailable(bool propagateExceptions)
+    {
+        if (propagateExceptions)
+        {
+            throw new InvalidOperationException("任务启动失败：当前存在正在运行中的独立任务。");
+        }
+    }
+
+    internal static void ThrowAfterCleanup(
+        Exception? executionException,
+        IReadOnlyList<Exception> cleanupFailures,
+        bool propagateCleanupFailures)
+    {
+        if (executionException is NormalEndException or OperationCanceledException)
+        {
+            ExceptionDispatchInfo.Capture(executionException).Throw();
+        }
+
+        if (executionException is not null && propagateCleanupFailures && cleanupFailures.Count > 0)
+        {
+            throw new AggregateException(
+                "任务执行和清理均失败。",
+                new[] { executionException }.Concat(cleanupFailures));
+        }
+
+        if (executionException is not null)
+        {
+            ExceptionDispatchInfo.Capture(executionException).Throw();
+        }
+
+        if (propagateCleanupFailures)
+        {
+            ThrowCleanupFailures(cleanupFailures);
+        }
+    }
+
+    internal static void ThrowCleanupFailures(IReadOnlyList<Exception> cleanupFailures)
+    {
+        if (cleanupFailures.Count > 0)
+        {
+            throw new AggregateException("任务结束清理失败。", cleanupFailures);
+        }
+    }
 }

--- a/BetterGenshinImpact/Service/ApplicationHostService.cs
+++ b/BetterGenshinImpact/Service/ApplicationHostService.cs
@@ -9,8 +9,10 @@ using System.Threading.Tasks;
 using System.Windows;
 using BetterGenshinImpact.Core.Script;
 using BetterGenshinImpact.GameTask;
+using BetterGenshinImpact.GameTask.AutoGeniusInvokation.Exception;
 using BetterGenshinImpact.Helpers;
 using BetterGenshinImpact.Service.Instance;
+using Microsoft.Extensions.Logging;
 using Wpf.Ui;
 
 namespace BetterGenshinImpact.Service;
@@ -23,6 +25,7 @@ public class ApplicationHostService(
     InstanceService instanceService) : IHostedService
 {
     private INavigationWindow? _navigationWindow;
+    private readonly ILogger<ApplicationHostService> _logger = App.GetLogger<ApplicationHostService>();
 
     /// <summary>
     /// Triggered when the application host is ready to start the service.
@@ -74,26 +77,36 @@ public class ApplicationHostService(
                     case CommandLineAction.StartOneDragon:
                         // 通过命令行参数启动「一条龙」 => 跳转到一条龙配置页。
                         _ = _navigationWindow.Navigate(typeof(OneDragonFlowPage));
-                        // 后续代码在 OneDragonFlowViewModel / OnLoaded 中。
+                        var oneDragon = App.GetService<OneDragonFlowViewModel>();
+                        if (oneDragon != null)
+                        {
+                            _ = ObserveCommandLineTaskAsync(
+                                oneDragon.RunCommandLineAsync(cmdOptions.OneDragonConfigName),
+                                "一条龙");
+                        }
                         break;
 
                     case CommandLineAction.StartGroups:
                         // 通过命令行参数启动「调度组」 => 跳转到调度器配置页。
                         _ = _navigationWindow.Navigate(typeof(ScriptControlPage));
-                        if (cmdOptions.GroupNames.Length > 0)
+                        var scriptGroupScheduler = App.GetService<ScriptControlViewModel>();
+                        if (scriptGroupScheduler != null)
                         {
-                            var scheduler = App.GetService<ScriptControlViewModel>();
-                            scheduler?.OnStartMultiScriptGroupWithNamesAsync(cmdOptions.GroupNames);
+                            _ = ObserveCommandLineTaskAsync(
+                                scriptGroupScheduler.OnStartMultiScriptGroupWithNamesAsync(cmdOptions.GroupNames),
+                                "配置组");
                         }
                         break;
 
                     case CommandLineAction.TaskProgress:
                         // 通过命令行参数启动「任务进度」 => 跳转到调度器配置页。
                         _ = _navigationWindow.Navigate(typeof(ScriptControlPage));
-                        if (cmdOptions.GroupNames.Length > 0)
+                        var taskProgressScheduler = App.GetService<ScriptControlViewModel>();
+                        if (taskProgressScheduler != null)
                         {
-                            var scheduler = App.GetService<ScriptControlViewModel>();
-                            scheduler?.OnStartMultiScriptTaskProgressAsync(cmdOptions.GroupNames);
+                            _ = ObserveCommandLineTaskAsync(
+                                taskProgressScheduler.OnStartMultiScriptTaskProgressAsync(cmdOptions.GroupNames),
+                                "任务进度");
                         }
                         break;
 
@@ -112,5 +125,36 @@ public class ApplicationHostService(
         }
         //
         await Task.CompletedTask;
+    }
+
+    private async Task ObserveCommandLineTaskAsync(Task task, string taskName)
+    {
+        try
+        {
+            await task;
+        }
+        catch (OperationCanceledException exception)
+        {
+            _logger.LogInformation(exception, "命令行{TaskName}已取消", taskName);
+        }
+        catch (NormalEndException exception)
+        {
+            _logger.LogInformation(exception, "命令行{TaskName}已正常结束", taskName);
+        }
+        catch (Exception exception)
+        {
+            _logger.LogError(exception, "命令行{TaskName}执行失败", taskName);
+            CommandLineTaskFailurePolicy.MarkFailed(exitCode => Environment.ExitCode = exitCode);
+        }
+    }
+}
+
+internal static class CommandLineTaskFailurePolicy
+{
+    internal const int FailureExitCode = 1;
+
+    internal static void MarkFailed(Action<int> setExitCode)
+    {
+        setExitCode(FailureExitCode);
     }
 }

--- a/BetterGenshinImpact/Service/Instance/MessageHandlers/InstanceRequestHandler.cs
+++ b/BetterGenshinImpact/Service/Instance/MessageHandlers/InstanceRequestHandler.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using BetterGenshinImpact.Helpers;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 
@@ -121,6 +122,7 @@ internal sealed class InstanceRequestHandler
         var activation =
             request.Data?.ToObject<ActivationDispatchRequest>(InstanceIpcProtocol.Serializer)
             ?? throw new ArgumentException("激活请求缺少命令行参数。");
+        ActivationForwardingPolicy.ThrowIfManagedAutomation(activation.Arguments);
         _enqueueActivation(activation.Arguments);
         return CacheActivationResponse(
             request.RequestId,
@@ -202,6 +204,7 @@ internal sealed class InstanceRequestHandler
                 return cachedResponse;
             }
 
+            ActivationForwardingPolicy.ThrowIfManagedAutomation(open.Arguments);
             _enqueueActivation(open.Arguments);
             return CacheActivationResponse(
                 request.RequestId,
@@ -244,6 +247,7 @@ internal sealed class InstanceRequestHandler
                 return cachedResponse;
             }
 
+            ActivationForwardingPolicy.ThrowIfManagedAutomation(open.Arguments);
             try
             {
                 var activationResponse = await duplicate.Connection.SendRequestAsync(
@@ -456,5 +460,17 @@ internal sealed class InstanceRequestHandler
 
         throw new InvalidOperationException(
             response.ErrorMessage ?? response.ErrorCode ?? "实例 IPC 请求失败。");
+    }
+}
+
+internal static class ActivationForwardingPolicy
+{
+    internal static void ThrowIfManagedAutomation(string[] arguments)
+    {
+        if (CommandLineOptions.Parse(arguments).ShouldDeferGameStart)
+        {
+            throw new InvalidOperationException(
+                "已有 BetterGI 实例时无法转发托管自动化任务，请先退出现有实例后重试。");
+        }
     }
 }

--- a/BetterGenshinImpact/Service/Interface/IScriptService.cs
+++ b/BetterGenshinImpact/Service/Interface/IScriptService.cs
@@ -7,5 +7,5 @@ namespace BetterGenshinImpact.Service.Interface;
 
 public interface IScriptService
 {
-    Task RunMulti(IEnumerable<ScriptGroupProject> projectList, string? groupName = null,TaskProgress? taskProgress = null);
+    Task RunMulti(IEnumerable<ScriptGroupProject> projectList, string? groupName = null, TaskProgress? taskProgress = null, bool propagateExceptions = false);
 }

--- a/BetterGenshinImpact/Service/ScriptService.cs
+++ b/BetterGenshinImpact/Service/ScriptService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Runtime.ExceptionServices;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -117,7 +118,7 @@ public partial class ScriptService : IScriptService
     //优先执行的配置组，统计每个project执行次数
     private readonly Dictionary<string, int> _projectExecutionCount = new();
     
-    public async Task RunMulti(IEnumerable<ScriptGroupProject> projectList, string? groupName = null,TaskProgress? taskProgress = null)
+    public async Task RunMulti(IEnumerable<ScriptGroupProject> projectList, string? groupName = null, TaskProgress? taskProgress = null, bool propagateExceptions = false)
     {
         groupName ??= "默认";
 
@@ -147,6 +148,9 @@ public partial class ScriptService : IScriptService
         if (CancellationContext.Instance.IsCancellationRequested)
         {
             _logger.LogInformation("配置组 {Name} 在启动阶段被取消", groupName);
+            TaskRunnerFailurePolicy.ThrowIfStartupCancelled(
+                CancellationContext.Instance.Cts.Token,
+                propagateExceptions);
             return;
         }
         
@@ -295,7 +299,10 @@ public partial class ScriptService : IScriptService
 
                         if (CancellationContext.Instance.Cts.IsCancellationRequested)
                         {
-                            // _logger.LogInformation("执行被取消");
+                            TaskRunnerFailurePolicy.ThrowIfStartupCancelled(
+                                CancellationContext.Instance.Cts.Token,
+                                propagateExceptions,
+                                RunnerContext.Instance.IsContinuousRunGroup);
                             break;
                         }
 
@@ -331,6 +338,7 @@ public partial class ScriptService : IScriptService
                         }
 
 
+                        Exception? executionException = null;
                         for (var i = 0; i < exeProject.RunNum; i++)
                         {
                             try
@@ -343,7 +351,12 @@ public partial class ScriptService : IScriptService
                                 stopwatch.Reset();
                                 stopwatch.Start();
 
+                                var projectCancellationToken = CancellationContext.Instance.Cts.Token;
                                 await ExecuteProject(exeProject);
+                                TaskRunnerFailurePolicy.ThrowIfTaskCancelled(
+                                    projectCancellationToken,
+                                    propagateExceptions,
+                                    RunnerContext.Instance.IsContinuousRunGroup);
 
                                 //多次执行时及时中断
                                 if (exeProject.RunNum > 1 && ShouldSkipTask(exeProject))
@@ -368,6 +381,10 @@ public partial class ScriptService : IScriptService
                                 {
                                     taskProgress.CurrentScriptGroupProjectInfo.Status = 2;
                                 }
+                                if (propagateExceptions)
+                                {
+                                    executionException = e;
+                                }
                             }
                             finally
                             {
@@ -379,6 +396,11 @@ public partial class ScriptService : IScriptService
                                 _logger.LogInformation("------------------------------");
                             }
 
+                            if (executionException is not null)
+                            {
+                                break;
+                            }
+
                             await Task.Delay(1000);
                         }
 
@@ -386,23 +408,7 @@ public partial class ScriptService : IScriptService
                         {
                             if (taskProgress.CurrentScriptGroupProjectInfo != null)
                             {
-                                taskProgress.CurrentScriptGroupProjectInfo.TaskEnd = true;
-                                taskProgress.CurrentScriptGroupProjectInfo.EndTime = DateTime.Now;
-                                if (taskProgress.CurrentScriptGroupProjectInfo.Status == 1)
-                                {
-                                    taskProgress.ConsecutiveFailureCount = 0;
-                                    taskProgress.LastSuccessScriptGroupProjectInfo =
-                                        taskProgress.CurrentScriptGroupProjectInfo;
-                                    taskProgress.LastScriptGroupName = taskProgress.CurrentScriptGroupName;
-                                }
-
-                                //累计连续失败次数
-                                if (taskProgress.CurrentScriptGroupProjectInfo.Status == 2)
-                                {
-                                    taskProgress.ConsecutiveFailureCount++;
-                                }
-
-                                taskProgress?.History?.Add(taskProgress.CurrentScriptGroupProjectInfo);
+                                ScriptTaskProgressFinalizer.CompleteCurrentProject(taskProgress, DateTime.Now);
                                 TaskProgressManager.SaveTaskProgress(taskProgress);
                             }
 
@@ -423,9 +429,14 @@ public partial class ScriptService : IScriptService
                                 SystemControl.RestartApplication(["--TaskProgress", taskProgress.Name]);
                             }
                         }
+
+                        if (executionException is not null)
+                        {
+                            ExceptionDispatchInfo.Capture(executionException).Throw();
+                        }
                     }
                 }
-            });
+            }, propagateExceptions);
         
 
         // 还原定时器
@@ -678,5 +689,32 @@ public partial class ScriptService : IScriptService
             await pendingUpdate;
             ScriptRepoUpdater.Instance.CommandLineAutoUpdateTask = null;
         }
+    }
+}
+
+internal static class ScriptTaskProgressFinalizer
+{
+    internal static void CompleteCurrentProject(TaskProgress taskProgress, DateTime endTime)
+    {
+        var projectInfo = taskProgress.CurrentScriptGroupProjectInfo;
+        if (projectInfo is null)
+        {
+            return;
+        }
+
+        projectInfo.TaskEnd = true;
+        projectInfo.EndTime = endTime;
+        if (projectInfo.Status == 1)
+        {
+            taskProgress.ConsecutiveFailureCount = 0;
+            taskProgress.LastSuccessScriptGroupProjectInfo = projectInfo;
+            taskProgress.LastScriptGroupName = taskProgress.CurrentScriptGroupName;
+        }
+        else if (projectInfo.Status == 2)
+        {
+            taskProgress.ConsecutiveFailureCount++;
+        }
+
+        taskProgress.History?.Add(projectInfo);
     }
 }

--- a/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml
+++ b/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml
@@ -23,12 +23,6 @@
              Foreground="{DynamicResource TextFillColorPrimaryBrush}"
              mc:Ignorable="d">
 
-    <b:Interaction.Triggers>
-        <b:EventTrigger EventName="Loaded">
-            <b:InvokeCommandAction Command="{Binding LoadedCommand}" CommandParameter="{Binding}" />
-        </b:EventTrigger>
-    </b:Interaction.Triggers>
-    
     <Grid Margin="22,16,8,12">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*" MaxWidth="300" />

--- a/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
@@ -7,12 +7,15 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
+using System.Runtime.ExceptionServices;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using BetterGenshinImpact.Core.Config;
 using BetterGenshinImpact.Core.Script;
 using BetterGenshinImpact.Core.Script.Group;
 using BetterGenshinImpact.GameTask;
+using BetterGenshinImpact.GameTask.AutoGeniusInvokation.Exception;
 using BetterGenshinImpact.GameTask.Common.Element.Assets;
 using BetterGenshinImpact.GameTask.Common.Job;
 using BetterGenshinImpact.Helpers;
@@ -500,48 +503,45 @@ public partial class OneDragonFlowViewModel : ViewModel
         }
     }
     
-    private bool _autoRun = true;
-    
-    [RelayCommand]
-    private void OnLoaded()
+    internal async Task RunCommandLineAsync(string? configName)
     {
-        // 组件首次加载时运行一次。
-        if (!_autoRun)
+        if (SelectedConfig is null)
         {
-            return;
+            InitConfigList();
         }
-        _autoRun = false;
-        //
-        var cmdOptions = CommandLineOptions.Instance;
-        if (cmdOptions.Action == CommandLineAction.StartOneDragon)
+
+        if (configName != null)
         {
-            // 通过命令行参数启动一条龙。
-            if (cmdOptions.OneDragonConfigName != null)
+            _logger.LogInformation("参数指定的一条龙配置：{ConfigName}", configName);
+            var commandLineConfig = ConfigList.FirstOrDefault(x =>
+                string.Equals(x.Name, configName, StringComparison.Ordinal));
+            if (commandLineConfig != null)
             {
-                // 从命令行参数中提取一条龙配置名称。
-                _logger.LogInformation($"参数指定的一条龙配置：{cmdOptions.OneDragonConfigName}");
-                var argsOneDragonConfig = ConfigList.FirstOrDefault(x =>
-                    string.Equals(x.Name, cmdOptions.OneDragonConfigName, StringComparison.Ordinal));
-                if (argsOneDragonConfig != null)
-                {
-                    // 设定配置，配置下拉框会选定。
-                    SelectedConfig = argsOneDragonConfig;
-                    // 调用选定更新函数。
-                    OnConfigDropDownChanged();
-                }
-                else
-                {
-                    _logger.LogWarning("未找到，请检查。");
-                }
+                SelectedConfig = commandLineConfig;
+                OnConfigDropDownChanged();
             }
-            // 异步执行一条龙
-            Toast.Information($"命令行一条龙「{SelectedConfig.Name}」。");
-            OnOneKeyExecute();
+            else
+            {
+                throw new InvalidOperationException($"未找到一条龙配置：{configName}");
+            }
         }
+
+        if (SelectedConfig is null)
+        {
+            throw new InvalidOperationException("没有可用的一条龙配置。");
+        }
+
+        Toast.Information($"命令行一条龙「{SelectedConfig.Name}」。");
+        await RunOneDragonAsync(propagateExceptions: true);
     }
 
     [RelayCommand]
     public async Task OnOneKeyExecute()
+    {
+        await RunOneDragonAsync(propagateExceptions: false);
+    }
+
+    internal async Task RunOneDragonAsync(bool propagateExceptions)
     {
         _logger.LogInformation($"启用一条龙配置：{SelectedConfig.Name}");
 
@@ -597,6 +597,9 @@ public partial class OneDragonFlowViewModel : ViewModel
         if (CancellationContext.Instance.IsCancellationRequested)
         {
             _logger.LogInformation("一条龙在启动阶段被取消");
+            TaskRunnerFailurePolicy.ThrowIfStartupCancelled(
+                CancellationContext.Instance.Cts.Token,
+                propagateExceptions);
             return;
         }
 
@@ -618,11 +621,16 @@ public partial class OneDragonFlowViewModel : ViewModel
                 if (ScriptGroupsdefault.Any(defaultSg => defaultSg.Name == task.Name))
                 {
                     _logger.LogInformation($"一条龙任务执行: {finishOneTaskcount++}/{enabledoneTaskCount}");
+                    CancellationToken taskCancellationToken = default;
                     await new TaskRunner().RunThreadAsync(async () =>
                     {
+                        taskCancellationToken = CancellationContext.Instance.Cts.Token;
                         await task.Action();
                         await Task.Delay(1000);
-                    });
+                    }, propagateExceptions);
+                    TaskRunnerFailurePolicy.ThrowIfTaskCancelled(
+                        taskCancellationToken,
+                        propagateExceptions);
                 }
                 else
                 {
@@ -643,7 +651,10 @@ public partial class OneDragonFlowViewModel : ViewModel
                             string filePath = Path.Combine(_basePath, _scriptGroupPath, $"{task.Name}.json");
                             var group = ScriptGroup.FromJson(await File.ReadAllTextAsync(filePath));
                             IScriptService? scriptService = App.GetService<IScriptService>();
-                            await scriptService!.RunMulti(ScriptControlViewModel.GetNextProjects(group), group.Name);
+                            await scriptService!.RunMulti(
+                                ScriptControlViewModel.GetNextProjects(group),
+                                group.Name,
+                                propagateExceptions: propagateExceptions);
                             await Task.Delay(1000);
                         }
                     }
@@ -651,6 +662,10 @@ public partial class OneDragonFlowViewModel : ViewModel
                     {
                         _logger.LogDebug(e, "执行配置组任务时失败");
                         Toast.Error("执行配置组任务时失败");
+                        if (propagateExceptions)
+                        {
+                            throw;
+                        }
                     }
                 }
                 // 如果任务已经被取消，中断所有任务
@@ -669,36 +684,48 @@ public partial class OneDragonFlowViewModel : ViewModel
         // 检查和最终结束的任务
         await new TaskRunner().RunThreadAsync(async () =>
         {
-            await new CheckRewardsTask().Start(CancellationContext.Instance.Cts.Token);
-            await Task.Delay(500);
-            if (CancellationContext.Instance.IsManualStop is false)
+            await OneDragonFinalizer.RunAsync(async () =>
             {
-                Notify.Event(NotificationEvent.DragonEnd).Success("一条龙和配置组任务结束");
-            }
-            _logger.LogInformation("一条龙和配置组任务结束");
-
-            // 执行完成后操作
-            if (SelectedConfig != null && !string.IsNullOrEmpty(SelectedConfig.CompletionAction))
-            {
-                switch (SelectedConfig.CompletionAction)
+                await new CheckRewardsTask().Start(CancellationContext.Instance.Cts.Token);
+                await Task.Delay(500);
+                if (CancellationContext.Instance.IsManualStop is false)
                 {
-                    case "关闭游戏":
-                        SystemControl.CloseGame();
-                        break;
-                    case "关闭软件":
-                        Application.Current.Dispatcher.Invoke(() => { Application.Current.Shutdown(); });
-                        break;
-                    case "关闭游戏和软件":
-                        SystemControl.CloseGame();
-                        Application.Current.Dispatcher.Invoke(() => { Application.Current.Shutdown(); });
-                        break;
-                    case "关机":
-                        SystemControl.CloseGame();
-                        SystemControl.Shutdown();
-                        break;
+                    Notify.Event(NotificationEvent.DragonEnd).Success("一条龙和配置组任务结束");
                 }
+                _logger.LogInformation("一条龙和配置组任务结束");
+            }, ExecuteCompletionAction, exception =>
+            {
+                _logger.LogError(exception, "一条龙收尾检查失败，将按配置执行完成动作");
+                if (propagateExceptions)
+                {
+                    CommandLineTaskFailurePolicy.MarkFailed(exitCode => Environment.ExitCode = exitCode);
+                }
+            });
+        }, propagateExceptions);
+    }
+
+    private void ExecuteCompletionAction()
+    {
+        if (SelectedConfig != null && !string.IsNullOrEmpty(SelectedConfig.CompletionAction))
+        {
+            switch (SelectedConfig.CompletionAction)
+            {
+                case "关闭游戏":
+                    SystemControl.CloseGame();
+                    break;
+                case "关闭软件":
+                    Application.Current.Dispatcher.Invoke(() => { Application.Current.Shutdown(); });
+                    break;
+                case "关闭游戏和软件":
+                    SystemControl.CloseGame();
+                    Application.Current.Dispatcher.Invoke(() => { Application.Current.Shutdown(); });
+                    break;
+                case "关机":
+                    SystemControl.CloseGame();
+                    SystemControl.Shutdown();
+                    break;
             }
-        });
+        }
     }
 
     /// <summary>
@@ -974,6 +1001,40 @@ public partial class OneDragonFlowViewModel : ViewModel
         {
             _logger.LogError(e, "重命名配置时失败");
             Toast.Error("重命名配置时失败");
+        }
+    }
+}
+
+internal static class OneDragonFinalizer
+{
+    internal static async Task RunAsync(
+        Func<Task> finalCheck,
+        Action completionAction,
+        Action<Exception>? onFinalCheckFailure = null)
+    {
+        Exception? finalCheckException = null;
+        try
+        {
+            await finalCheck();
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException and not NormalEndException)
+        {
+            finalCheckException = exception;
+            onFinalCheckFailure?.Invoke(exception);
+        }
+
+        try
+        {
+            completionAction();
+        }
+        catch (Exception completionException) when (finalCheckException is not null)
+        {
+            throw new AggregateException("一条龙收尾检查和完成动作均执行失败。", finalCheckException, completionException);
+        }
+
+        if (finalCheckException is not null)
+        {
+            ExceptionDispatchInfo.Capture(finalCheckException).Throw();
         }
     }
 }

--- a/BetterGenshinImpact/ViewModel/Pages/ScriptControlViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/ScriptControlViewModel.cs
@@ -2194,7 +2194,10 @@ public partial class ScriptControlViewModel : ViewModel
         }
     }
 
-    public async Task OnContinueTaskProgressAsync(string name, List<TaskProgress>? taskProgresses = null)
+    public async Task OnContinueTaskProgressAsync(
+        string name,
+        List<TaskProgress>? taskProgresses = null,
+        bool propagateExceptions = false)
     {
         if (taskProgresses == null)
         {
@@ -2223,17 +2226,21 @@ public partial class ScriptControlViewModel : ViewModel
             TaskProgressManager.GenerNextProjectInfo(taskProgress, sg);
             if (taskProgress.Next == null)
             {
-                _logger.LogWarning("无法定位到下一个要执行的项目：next为空（" + taskProgress.Name + ")");
+                var message = $"无法定位到下一个要执行的项目：next为空（{taskProgress.Name}）";
+                _logger.LogWarning("{Message}", message);
+                TaskProgressResumeFailurePolicy.ThrowIfManaged(message, propagateExceptions);
             }
             else
             {
-                await StartGroups(sg, taskProgress);
+                await StartGroups(sg, taskProgress, propagateExceptions: propagateExceptions);
             }
 
         }
         else
         {
-            _logger.LogWarning("无法定位到下一个要执行的项目:taskProgress为空");
+            var message = $"无法定位任务进度记录：taskProgress为空（{name}）";
+            _logger.LogWarning("{Message}", message);
+            TaskProgressResumeFailurePolicy.ThrowIfManaged(message, propagateExceptions);
         }
     }
 
@@ -2254,7 +2261,7 @@ public partial class ScriptControlViewModel : ViewModel
             taskProgressName = names[0];
         }
 
-        await OnContinueTaskProgressAsync(taskProgressName);
+        await OnContinueTaskProgressAsync(taskProgressName, propagateExceptions: true);
     }
 
     [RelayCommand]
@@ -2398,31 +2405,28 @@ public partial class ScriptControlViewModel : ViewModel
         {
             ReadScriptGroup();
         }
-        List<ScriptGroup> scriptGroups = new List<ScriptGroup>();
-        foreach (var name in names)
-        {
-            try
-            {
-                var group = ScriptGroups.First(x => x.Name == name);
-                scriptGroups.Add(group);
-            }
-            catch (InvalidOperationException)
-            {
-                _logger.LogWarning("传入的配置组名称不存在:{Name}", name);
-            }
-        }
 
-        if (scriptGroups.Count > 0)
+        var requestedNames = names.ToList();
+        var missingNames = ManagedScriptGroupSelectionPolicy.GetMissingNames(
+            requestedNames,
+            ScriptGroups.Select(group => group.Name));
+        foreach (var missingName in missingNames)
         {
-            await StartGroups(scriptGroups);
+            _logger.LogWarning("传入的配置组名称不存在:{Name}", missingName);
         }
-        else
-        {
-            _logger.LogWarning("需要执行的配置组为空");
-        }
+        ManagedScriptGroupSelectionPolicy.ThrowIfInvalid(requestedNames, missingNames);
+
+        var scriptGroups = requestedNames
+            .Select(name => ScriptGroups.First(group => group.Name == name))
+            .ToList();
+        await StartGroups(scriptGroups, propagateExceptions: true);
     }
 
-    public async Task StartGroups(List<ScriptGroup> scriptGroups, TaskProgress? taskProgress = null, bool loop = false)
+    public async Task StartGroups(
+        List<ScriptGroup> scriptGroups,
+        TaskProgress? taskProgress = null,
+        bool loop = false,
+        bool propagateExceptions = false)
     {
         _logger.LogInformation("开始连续执行选中配置组:{Names}", string.Join(",", scriptGroups.Select(x => x.Name)));
         try
@@ -2451,7 +2455,11 @@ public partial class ScriptControlViewModel : ViewModel
                 }
                 taskProgress.CurrentScriptGroupName = scriptGroup.Name;
                 TaskProgressManager.SaveTaskProgress(taskProgress);
-                await _scriptService.RunMulti(GetNextProjects(scriptGroup), scriptGroup.Name, taskProgress);
+                await _scriptService.RunMulti(
+                    GetNextProjects(scriptGroup),
+                    scriptGroup.Name,
+                    taskProgress,
+                    propagateExceptions);
                 await Task.Delay(2000);
             }
 
@@ -2461,7 +2469,7 @@ public partial class ScriptControlViewModel : ViewModel
                 taskProgress.LastScriptGroupName = null;
                 taskProgress.LastSuccessScriptGroupProjectInfo = null;
                 taskProgress.Next = null;
-                await StartGroups(scriptGroups, taskProgress);
+                await StartGroups(scriptGroups, taskProgress, propagateExceptions: propagateExceptions);
             }
             else
             {
@@ -2477,6 +2485,10 @@ public partial class ScriptControlViewModel : ViewModel
         catch (Exception e)
         {
             Debug.WriteLine(e.Message);
+            if (propagateExceptions)
+            {
+                throw;
+            }
         }
         finally
         {
@@ -2484,5 +2496,46 @@ public partial class ScriptControlViewModel : ViewModel
         }
 
 
+    }
+}
+
+internal static class TaskProgressResumeFailurePolicy
+{
+    internal static void ThrowIfManaged(string message, bool propagateExceptions)
+    {
+        if (propagateExceptions)
+        {
+            throw new InvalidOperationException(message);
+        }
+    }
+}
+
+internal static class ManagedScriptGroupSelectionPolicy
+{
+    internal static IReadOnlyList<string> GetMissingNames(
+        IEnumerable<string> requestedNames,
+        IEnumerable<string> availableNames)
+    {
+        var availableNameSet = availableNames.ToHashSet(StringComparer.Ordinal);
+        return requestedNames
+            .Where(name => !availableNameSet.Contains(name))
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+    }
+
+    internal static void ThrowIfInvalid(
+        IReadOnlyCollection<string> requestedNames,
+        IReadOnlyCollection<string> missingNames)
+    {
+        if (requestedNames.Count == 0)
+        {
+            throw new InvalidOperationException("需要执行的配置组为空。");
+        }
+
+        if (missingNames.Count > 0)
+        {
+            throw new InvalidOperationException(
+                $"传入的配置组名称不存在：{string.Join("、", missingNames)}");
+        }
     }
 }

--- a/Fischless.WindowsInput/AssemblyInfo.cs
+++ b/Fischless.WindowsInput/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("BetterGenshinImpact.UnitTest")]

--- a/Fischless.WindowsInput/WindowsInputMessageDispatcher.cs
+++ b/Fischless.WindowsInput/WindowsInputMessageDispatcher.cs
@@ -1,4 +1,6 @@
-﻿using System.Runtime.InteropServices;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
 using Vanara.PInvoke;
 
 namespace Fischless.WindowsInput;
@@ -19,9 +21,31 @@ internal class WindowsInputMessageDispatcher : IInputMessageDispatcher
 
         uint num = User32.SendInput((uint)inputs.Length, inputs, Marshal.SizeOf(typeof(User32.INPUT)));
 
-        if (num != (ulong)(long)inputs.Length)
+        if (num != inputs.Length)
         {
-            throw new Exception("模拟键鼠消息发送失败！常见原因：1.你未以管理员权限运行程序；2.存在安全软件拦截（比如360）");
+            var errorCode = Marshal.GetLastWin32Error();
+            using var process = Process.GetCurrentProcess();
+            throw new InvalidOperationException(CreateFailureMessage(
+                inputs.Length,
+                num,
+                errorCode,
+                new Win32Exception(errorCode).Message,
+                process.Id,
+                process.SessionId));
         }
+    }
+
+    internal static string CreateFailureMessage(
+        int requested,
+        uint sent,
+        int errorCode,
+        string errorMessage,
+        int processId,
+        int sessionId)
+    {
+        return $"模拟键鼠消息发送失败: requested={requested}, sent={sent}, "
+               + $"win32Error={errorCode} ({errorMessage}), pid={processId}, sessionId={sessionId}. "
+               + "常见原因包括权限级别不一致或安全软件拦截；UIPI 拦截时 SendInput 可能返回 0，"
+               + "但 GetLastError 不一定提供有效原因。";
     }
 }

--- a/Test/BetterGenshinImpact.UnitTest/BetterGenshinImpact.UnitTest.csproj
+++ b/Test/BetterGenshinImpact.UnitTest/BetterGenshinImpact.UnitTest.csproj
@@ -25,6 +25,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\BetterGenshinImpact\BetterGenshinImpact.csproj"/>
+        <ProjectReference Include="..\..\Fischless.WindowsInput\Fischless.WindowsInput.csproj"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/Test/BetterGenshinImpact.UnitTest/CoreTests/InputTests/WindowsInputMessageDispatcherTests.cs
+++ b/Test/BetterGenshinImpact.UnitTest/CoreTests/InputTests/WindowsInputMessageDispatcherTests.cs
@@ -1,0 +1,27 @@
+using Fischless.WindowsInput;
+
+namespace BetterGenshinImpact.UnitTest.CoreTests.InputTests;
+
+public class WindowsInputMessageDispatcherTests
+{
+    [Fact]
+    public void FailureMessageContainsNativeDiagnosticsAndUipiCaveat()
+    {
+        var message = WindowsInputMessageDispatcher.CreateFailureMessage(
+            requested: 3,
+            sent: 0,
+            errorCode: 5,
+            errorMessage: "Access is denied.",
+            processId: 1234,
+            sessionId: 7);
+
+        Assert.Contains("requested=3", message);
+        Assert.Contains("sent=0", message);
+        Assert.Contains("win32Error=5", message);
+        Assert.Contains("Access is denied.", message);
+        Assert.Contains("pid=1234", message);
+        Assert.Contains("sessionId=7", message);
+        Assert.Contains("UIPI", message);
+        Assert.Contains("GetLastError", message);
+    }
+}

--- a/Test/BetterGenshinImpact.UnitTest/CoreTests/ScriptTests/LimitedFileTests.cs
+++ b/Test/BetterGenshinImpact.UnitTest/CoreTests/ScriptTests/LimitedFileTests.cs
@@ -1,0 +1,74 @@
+using BetterGenshinImpact.Core.Script.Dependence;
+
+namespace BetterGenshinImpact.UnitTest.CoreTests.ScriptTests;
+
+public sealed class LimitedFileTests : IDisposable
+{
+    private readonly string _rootPath = Path.Combine(Path.GetTempPath(), $"bgi-limited-file-{Guid.NewGuid():N}");
+
+    public LimitedFileTests()
+    {
+        Directory.CreateDirectory(_rootPath);
+    }
+
+    [Fact]
+    public void ReadTextSyncOrThrowReturnsFileContent()
+    {
+        File.WriteAllText(Path.Combine(_rootPath, "route.json"), "{\"name\":\"test\"}");
+
+        var content = new LimitedFile(_rootPath).ReadTextSyncOrThrow("route.json");
+
+        Assert.Equal("{\"name\":\"test\"}", content);
+    }
+
+    [Fact]
+    public void ReadTextSyncOrThrowPreservesMissingFileException()
+    {
+        var exception = Assert.Throws<FileNotFoundException>(() =>
+            new LimitedFile(_rootPath).ReadTextSyncOrThrow("missing.json"));
+
+        Assert.EndsWith("missing.json", exception.FileName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task AutoPathingRunFilePreservesMissingFileException()
+    {
+        var exception = await Assert.ThrowsAsync<FileNotFoundException>(() =>
+            new AutoPathingScript(_rootPath, config: null, new LimitedFile(_rootPath), (_, _) => { })
+                .RunFile("missing-route.json"));
+
+        Assert.EndsWith("missing-route.json", exception.FileName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task AutoPathingRunFileFromUserPreservesMissingFileException()
+    {
+        var exception = await Assert.ThrowsAsync<FileNotFoundException>(() =>
+            new AutoPathingScript(_rootPath, config: null, new LimitedFile(_rootPath), (_, _) => { })
+                .RunFileFromUser("missing-user-route.json"));
+
+        Assert.EndsWith("missing-user-route.json", exception.FileName, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task AutoPathingRunFileDoesNotReportExecutionFailureAsReadFailure()
+    {
+        File.WriteAllText(Path.Combine(_rootPath, "invalid-route.json"), "not-json");
+        var failureMessages = new List<string>();
+
+        await Assert.ThrowsAnyAsync<Exception>(() =>
+            new AutoPathingScript(
+                    _rootPath,
+                    config: null,
+                    new LimitedFile(_rootPath),
+                    (message, _) => failureMessages.Add(message))
+                .RunFile("invalid-route.json"));
+
+        Assert.Equal(["执行地图追踪时候发生错误"], failureMessages);
+    }
+
+    public void Dispose()
+    {
+        Directory.Delete(_rootPath, recursive: true);
+    }
+}

--- a/Test/BetterGenshinImpact.UnitTest/GameTaskTests/TaskRunnerTests.cs
+++ b/Test/BetterGenshinImpact.UnitTest/GameTaskTests/TaskRunnerTests.cs
@@ -1,0 +1,376 @@
+using System.Reflection;
+using BetterGenshinImpact.GameTask;
+using BetterGenshinImpact.GameTask.AutoGeniusInvokation.Exception;
+using BetterGenshinImpact.GameTask.TaskProgress;
+using BetterGenshinImpact.Service;
+using BetterGenshinImpact.Service.Interface;
+using BetterGenshinImpact.ViewModel.Pages;
+
+namespace BetterGenshinImpact.UnitTest.GameTaskTests;
+
+public class TaskRunnerTests
+{
+    [Fact]
+    public void CleanupContinuesAfterAnEarlierStepFails()
+    {
+        var completed = new List<string>();
+        var failures = new List<(string Name, Exception Exception)>();
+        var expected = new InvalidOperationException("release input failed");
+
+        var cleanupFailures = TaskRunnerCleanup.RunAll(
+        [
+            ("release input", () => throw expected),
+            ("restore triggers", () => completed.Add("restore triggers")),
+            ("clear contexts", () => completed.Add("clear contexts"))
+        ],
+        (name, exception) => failures.Add((name, exception)));
+
+        Assert.Equal(["restore triggers", "clear contexts"], completed);
+        var failure = Assert.Single(failures);
+        Assert.Equal("release input", failure.Name);
+        Assert.Same(expected, failure.Exception);
+        Assert.Equal([expected], cleanupFailures);
+    }
+
+    [Fact]
+    public void ManagedExecutionContractsExposeOptInExceptionPropagation()
+    {
+        var runThreadAsync = typeof(TaskRunner).GetMethod(nameof(TaskRunner.RunThreadAsync));
+        var runnerParameter = Assert.Single(runThreadAsync!.GetParameters().Skip(1));
+        Assert.Equal("propagateExceptions", runnerParameter.Name);
+        Assert.Equal(false, runnerParameter.DefaultValue);
+
+        var runMulti = typeof(IScriptService).GetMethod(nameof(IScriptService.RunMulti));
+        var serviceParameter = runMulti!.GetParameters().Last();
+        Assert.Equal("propagateExceptions", serviceParameter.Name);
+        Assert.Equal(false, serviceParameter.DefaultValue);
+
+        var runOneDragonAsync = typeof(OneDragonFlowViewModel).GetMethod(
+            "RunOneDragonAsync",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        var oneDragonParameter = Assert.Single(runOneDragonAsync!.GetParameters());
+        Assert.Equal("propagateExceptions", oneDragonParameter.Name);
+
+        var commandLineRun = typeof(OneDragonFlowViewModel).GetMethod(
+            "RunCommandLineAsync",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.Equal(typeof(Task), commandLineRun!.ReturnType);
+        Assert.Null(typeof(OneDragonFlowViewModel).GetMethod(
+            "OnLoaded",
+            BindingFlags.Instance | BindingFlags.NonPublic));
+
+        var startGroups = typeof(ScriptControlViewModel).GetMethod(nameof(ScriptControlViewModel.StartGroups));
+        var startGroupsParameter = startGroups!.GetParameters().Last();
+        Assert.Equal("propagateExceptions", startGroupsParameter.Name);
+        Assert.Equal(false, startGroupsParameter.DefaultValue);
+    }
+
+    [Fact]
+    public void PropagationModeReportsLockContentionAsFailure()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            TaskRunnerFailurePolicy.ThrowIfLockUnavailable(propagateExceptions: true));
+
+        Assert.Contains("存在正在运行中的独立任务", exception.Message);
+        TaskRunnerFailurePolicy.ThrowIfLockUnavailable(propagateExceptions: false);
+    }
+
+    [Theory]
+    [MemberData(nameof(NormalTerminationPropagationModes))]
+    public void NormalTerminationPropagationHonorsManagedAndContinuousModes(
+        Exception exception,
+        bool isContinuousRunGroup,
+        bool propagateExceptions,
+        bool shouldPropagate)
+    {
+        var result = TaskRunnerFailurePolicy.GetTerminationException(
+                exception,
+                isContinuousRunGroup,
+                propagateExceptions);
+
+        if (shouldPropagate)
+        {
+            Assert.Same(exception, result);
+        }
+        else
+        {
+            Assert.Null(result);
+        }
+    }
+
+    public static TheoryData<Exception, bool, bool, bool> NormalTerminationPropagationModes => new()
+    {
+        { new NormalEndException("managed normal end"), false, true, true },
+        { new OperationCanceledException("managed cancellation"), false, true, true },
+        { new NormalEndException("continuous normal end"), true, false, true },
+        { new OperationCanceledException("continuous cancellation"), true, false, true },
+        { new NormalEndException("manual normal end"), false, false, false },
+        { new OperationCanceledException("manual cancellation"), false, false, false }
+    };
+
+    [Fact]
+    public void ManagedStartupCancellationPreservesCancellationToken()
+    {
+        using var cancellationSource = new CancellationTokenSource();
+        cancellationSource.Cancel();
+
+        var exception = Assert.Throws<OperationCanceledException>(() =>
+            TaskRunnerFailurePolicy.ThrowIfStartupCancelled(
+                cancellationSource.Token,
+                propagateExceptions: true));
+
+        Assert.Equal(cancellationSource.Token, exception.CancellationToken);
+    }
+
+    [Fact]
+    public void ManualStartupCancellationKeepsCompatibilityBehavior()
+    {
+        using var cancellationSource = new CancellationTokenSource();
+        cancellationSource.Cancel();
+
+        TaskRunnerFailurePolicy.ThrowIfStartupCancelled(
+            cancellationSource.Token,
+            propagateExceptions: false);
+    }
+
+    [Fact]
+    public void ContinuousGroupCancellationPreservesCancellationToken()
+    {
+        using var cancellationSource = new CancellationTokenSource();
+        cancellationSource.Cancel();
+
+        var exception = Assert.Throws<OperationCanceledException>(() =>
+            TaskRunnerFailurePolicy.ThrowIfStartupCancelled(
+                cancellationSource.Token,
+                propagateExceptions: false,
+                isContinuousRunGroup: true));
+
+        Assert.Equal(cancellationSource.Token, exception.CancellationToken);
+    }
+
+    [Fact]
+    public void CompletedTaskCancellationCheckUsesCapturedToken()
+    {
+        using var taskCancellationSource = new CancellationTokenSource();
+        using var replacementCancellationSource = new CancellationTokenSource();
+        var taskCancellationToken = taskCancellationSource.Token;
+        taskCancellationSource.Cancel();
+
+        var exception = Assert.Throws<OperationCanceledException>(() =>
+            TaskRunnerFailurePolicy.ThrowIfTaskCancelled(
+                taskCancellationToken,
+                propagateExceptions: true));
+
+        Assert.False(replacementCancellationSource.IsCancellationRequested);
+        Assert.Equal(taskCancellationToken, exception.CancellationToken);
+    }
+
+    [Theory]
+    [InlineData("无法定位任务进度记录：taskProgress为空（missing）")]
+    [InlineData("无法定位到下一个要执行的项目：next为空（daily）")]
+    public void ManagedTaskProgressResumeReportsMissingStateAsFailure(string message)
+    {
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            TaskProgressResumeFailurePolicy.ThrowIfManaged(message, propagateExceptions: true));
+
+        Assert.Equal(message, exception.Message);
+    }
+
+    [Theory]
+    [InlineData("无法定位任务进度记录：taskProgress为空（missing）")]
+    [InlineData("无法定位到下一个要执行的项目：next为空（daily）")]
+    public void ManualTaskProgressResumeKeepsCompatibilityBehavior(string message)
+    {
+        TaskProgressResumeFailurePolicy.ThrowIfManaged(message, propagateExceptions: false);
+    }
+
+    [Fact]
+    public void ManagedScriptGroupSelectionReportsAllMissingNamesBeforeExecution()
+    {
+        var requestedNames = new[] { "daily", "missing-a", "missing-b", "missing-a" };
+        var missingNames = ManagedScriptGroupSelectionPolicy.GetMissingNames(
+            requestedNames,
+            ["daily"]);
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            ManagedScriptGroupSelectionPolicy.ThrowIfInvalid(requestedNames, missingNames));
+
+        Assert.Equal(["missing-a", "missing-b"], missingNames);
+        Assert.Contains("missing-a、missing-b", exception.Message);
+    }
+
+    [Fact]
+    public void ManagedScriptGroupSelectionRejectsEmptyRequests()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            ManagedScriptGroupSelectionPolicy.ThrowIfInvalid([], []));
+
+        Assert.Contains("配置组为空", exception.Message);
+    }
+
+    [Fact]
+    public void ManagedScriptGroupSelectionAcceptsCompleteRequests()
+    {
+        var requestedNames = new[] { "daily", "weekly" };
+        var missingNames = ManagedScriptGroupSelectionPolicy.GetMissingNames(
+            requestedNames,
+            ["daily", "weekly"]);
+
+        ManagedScriptGroupSelectionPolicy.ThrowIfInvalid(requestedNames, missingNames);
+        Assert.Empty(missingNames);
+    }
+
+    [Fact]
+    public void CommandLineFailureSetsNonZeroExitCode()
+    {
+        var exitCode = 0;
+
+        CommandLineTaskFailurePolicy.MarkFailed(value => exitCode = value);
+
+        Assert.Equal(CommandLineTaskFailurePolicy.FailureExitCode, exitCode);
+        Assert.NotEqual(0, exitCode);
+    }
+
+    [Fact]
+    public void PropagationModeReportsCleanupFailuresAfterAllStepsRun()
+    {
+        var completed = false;
+        var cleanupException = new InvalidOperationException("release input failed");
+        var failures = TaskRunnerCleanup.RunAll(
+        [
+            ("release input", () => throw cleanupException),
+            ("clear context", () => completed = true)
+        ],
+        (_, _) => { });
+
+        var exception = Assert.Throws<AggregateException>(() =>
+            TaskRunnerFailurePolicy.ThrowAfterCleanup(null, failures, propagateCleanupFailures: true));
+
+        Assert.True(completed);
+        Assert.Equal([cleanupException], exception.InnerExceptions);
+    }
+
+    [Fact]
+    public void PropagationModeReportsExecutionAndCleanupFailuresTogether()
+    {
+        var executionException = new InvalidOperationException("script failed");
+        var cleanupException = new InvalidOperationException("release input failed");
+
+        var exception = Assert.Throws<AggregateException>(() =>
+            TaskRunnerFailurePolicy.ThrowAfterCleanup(
+                executionException,
+                [cleanupException],
+                propagateCleanupFailures: true));
+
+        Assert.Equal([executionException, cleanupException], exception.InnerExceptions);
+    }
+
+    [Theory]
+    [MemberData(nameof(NormalTerminationExceptions))]
+    public void CleanupFailureDoesNotReplaceNormalTermination(Exception executionException)
+    {
+        var exception = Assert.Throws(
+            executionException.GetType(),
+            () => TaskRunnerFailurePolicy.ThrowAfterCleanup(
+                executionException,
+                [new InvalidOperationException("release input failed")],
+                propagateCleanupFailures: true));
+
+        Assert.Same(executionException, exception);
+    }
+
+    public static TheoryData<Exception> NormalTerminationExceptions => new()
+    {
+        new NormalEndException("normal end"),
+        new OperationCanceledException("cancelled")
+    };
+
+    [Fact]
+    public void CompatibilityModeDoesNotPropagateCleanupFailure()
+    {
+        TaskRunnerFailurePolicy.ThrowAfterCleanup(
+            null,
+            [new InvalidOperationException("release input failed")],
+            propagateCleanupFailures: false);
+    }
+
+    [Fact]
+    public async Task OneDragonFinalizerRunsCompletionActionWhenFinalCheckFails()
+    {
+        var expected = new InvalidOperationException("daily reward was not claimed");
+        var events = new List<string>();
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            OneDragonFinalizer.RunAsync(
+                () => Task.FromException(expected),
+                () => events.Add("completion action"),
+                observedException =>
+                {
+                    Assert.Same(expected, observedException);
+                    events.Add("failure recorded");
+                }));
+
+        Assert.Equal(["failure recorded", "completion action"], events);
+        Assert.Same(expected, exception);
+    }
+
+    [Fact]
+    public async Task OneDragonFinalizerReportsBothFailures()
+    {
+        var finalCheckException = new InvalidOperationException("daily reward was not claimed");
+        var completionException = new InvalidOperationException("failed to close the game");
+
+        var exception = await Assert.ThrowsAsync<AggregateException>(() =>
+            OneDragonFinalizer.RunAsync(
+                () => Task.FromException(finalCheckException),
+                () => throw completionException));
+
+        Assert.Equal([finalCheckException, completionException], exception.InnerExceptions);
+    }
+
+    [Fact]
+    public async Task OneDragonFinalizerDoesNotRunCompletionActionAfterCancellation()
+    {
+        var completionActionRan = false;
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            OneDragonFinalizer.RunAsync(
+                () => Task.FromException(new OperationCanceledException()),
+                () => completionActionRan = true));
+
+        Assert.False(completionActionRan);
+    }
+
+    [Fact]
+    public async Task OneDragonFinalizerDoesNotRunCompletionActionAfterNormalEnd()
+    {
+        var completionActionRan = false;
+
+        await Assert.ThrowsAsync<NormalEndException>(() =>
+            OneDragonFinalizer.RunAsync(
+                () => Task.FromException(new NormalEndException("cancel automation")),
+                () => completionActionRan = true));
+
+        Assert.False(completionActionRan);
+    }
+
+    [Fact]
+    public void ScriptProgressFinalizerPersistsFailureStateBeforePropagation()
+    {
+        var endTime = new DateTime(2026, 8, 12, 19, 0, 0);
+        var projectInfo = new TaskProgress.ScriptGroupProjectInfo { Status = 2 };
+        var progress = new TaskProgress
+        {
+            CurrentScriptGroupName = "daily",
+            CurrentScriptGroupProjectInfo = projectInfo,
+            ConsecutiveFailureCount = 2
+        };
+
+        ScriptTaskProgressFinalizer.CompleteCurrentProject(progress, endTime);
+
+        Assert.True(projectInfo.TaskEnd);
+        Assert.Equal(endTime, projectInfo.EndTime);
+        Assert.Equal(3, progress.ConsecutiveFailureCount);
+        Assert.Same(projectInfo, Assert.Single(progress.History!));
+    }
+}

--- a/Test/BetterGenshinImpact.UnitTest/ServiceTests/Instance/InstanceIpcProtocolTests.cs
+++ b/Test/BetterGenshinImpact.UnitTest/ServiceTests/Instance/InstanceIpcProtocolTests.cs
@@ -4,6 +4,7 @@ using System.IO.Pipes;
 using BetterGenshinImpact.Core.Monitor;
 using BetterGenshinImpact.Helpers;
 using BetterGenshinImpact.Service.Instance;
+using BetterGenshinImpact.Service.Instance.MessageHandlers;
 
 namespace BetterGenshinImpact.UnitTest.ServiceTests.Instance;
 
@@ -74,6 +75,30 @@ public class InstanceIpcProtocolTests
         Assert.Equal(BetterGiInstanceType.Primary, options.InstanceType);
         Assert.False(options.HasExplicitInstanceType);
         Assert.Equal(CommandLineAction.None, options.Action);
+    }
+
+    [Theory]
+    [InlineData("bettergi://startOneDragon")]
+    [InlineData("--startGroups")]
+    [InlineData("--TaskProgress")]
+    [InlineData("--instance", "childSession", "bettergi://startOneDragon")]
+    public void ActivationForwarding_ShouldRejectManagedAutomation(params string[] arguments)
+    {
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            ActivationForwardingPolicy.ThrowIfManagedAutomation(
+                ["BetterGI.exe", .. arguments]));
+
+        Assert.Contains("已有 BetterGI 实例", exception.Message);
+        Assert.Contains("无法转发托管自动化任务", exception.Message);
+    }
+
+    [Theory]
+    [InlineData()]
+    [InlineData("bettergi://start")]
+    public void ActivationForwarding_ShouldAllowWindowActivation(params string[] arguments)
+    {
+        ActivationForwardingPolicy.ThrowIfManagedAutomation(
+            ["BetterGI.exe", .. arguments]);
     }
 
     [Fact]


### PR DESCRIPTION
### 目标

修复托管自动化任务在脚本失败、任务锁冲突、路线读取失败、奖励未领取、启动或运行中取消、请求配置缺失、任务进度缺失、资源清理失败以及已有实例无法承接命令行任务时仍被上层视为成功的问题，同时避免单个清理步骤失败阻断后续清理与信号量释放。

### 变更范围

- 为 `TaskRunner`、脚本组和一条龙增加显式异常传播模式；手动执行继续保持默认兼容行为，命令行托管入口会传播并观察真实失败。
- 托管模式会保留 `NormalEndException` 和 `OperationCanceledException` 原始类型；连续配置组保持原有传播行为，手动独立任务仍按兼容模式结束。
- 托管一条龙和配置组在进入主任务前取消时保留取消 token；项目或一条龙任务吞掉取消并正常返回时，也使用本轮捕获的 token 传播取消并阻止后续任务继续。
- `--startGroups` 会在执行前完整校验空请求和所有配置组名称；`--TaskProgress` 找不到进度记录或无法生成 `Next` 时明确失败，裸参数会恢复 `latest`，手动 UI 恢复入口继续只记录警告。
- 已有 BetterGI 实例时继续允许普通窗口激活，但明确拒绝无法返回最终结果的 `startOneDragon`、`--startGroups` 和 `--TaskProgress` 转发，使启动进程以非零状态退出。
- 将任务结束清理拆成逐项容错步骤；托管模式在全部清理和信号量释放后传播清理异常，取消和正常结束优先保持原异常类型。
- 在传播脚本异常前完成失败进度、连续失败计数和历史持久化，并让路线文件读取、解析和执行失败保留原始异常及准确日志归因。
- 命令行指定的一条龙配置不存在时明确失败；托管失败设置非零进程退出码，奖励检查失败会在执行用户配置的完成动作前记录错误和失败退出状态。
- 增强 `SendInput` 的 Win32、PID、Session 与 UIPI 诊断，并补充异常传播、取消 token 保留、IPC 转发拒绝、托管请求校验、进度恢复、清理连续性、严格文件读取、输入诊断、一条龙收尾动作和失败进度的单元测试。

### 验证证据

- [x] `dotnet test Test\BetterGenshinImpact.UnitTest\BetterGenshinImpact.UnitTest.csproj -c Debug --no-restore --filter "FullyQualifiedName~TaskRunnerTests|FullyQualifiedName~LimitedFileTests|FullyQualifiedName~InstanceIpcProtocolTests" --verbosity quiet -p:WarningLevel=0`：最终 head `bc1476c5054a6da87025ed4a3838f618f03241f1` 定向测试 55/55 通过。
- [x] `dotnet build BetterGenshinImpact.sln -c Debug --no-restore --verbosity minimal`：最终 head `bc1476c5054a6da87025ed4a3838f618f03241f1` 本地构建通过，0 错误、625 个仓库既有警告。
- [x] `Run-LocalPatchGate.cmd`：安装树离线补丁总门禁通过，四个受保护的路线与账户数据文件哈希未变化。

### 风险与开放门禁

- [x] 分支基于 `origin/main`，与上游无冲突且只包含一个功能提交。
- [x] 审查提出的托管入口传播、启动及运行中取消、请求配置校验、失败进度持久化、清理失败传播、路线严格读取、取消语义、配置校验、准确日志归因、非零退出状态、进度缺失失败、完成动作前错误记录和已有实例静默成功问题均已处理。
- [ ] 隔离工作树缺少完整测试集所需的 `Assets` 图片夹具，相关 OpenCV 测试会读取空图像；本次功能域由 55 个定向测试覆盖。
- [ ] 本机高权限自动化会话仍占用安装目录中的 `BetterGI.exe`，非提升会话无法安全替换；本 PR 不包含 live EXE 部署验证。
- [x] 最终 head `bc1476c5` 的 AppVeyor build `54534221`、CodeRabbit、Greptile 与 Codex 复审均已通过，且没有未解决审查线程。
- [ ] 当前账号 `hcy0317` 对上游仓库仅有读取权限，GitHub REST 合并返回 404、auto-merge 返回 `does not have the correct permissions to execute MergePullRequest`；需上游维护者执行 squash merge。
