### PR TITLE
fix: ppocr v6区域识别失败

### DIFF
--- a/BetterGenshinImpact/Core/Recognition/OCR/IOcrService.cs
+++ b/BetterGenshinImpact/Core/Recognition/OCR/IOcrService.cs
@@ -2,11 +2,16 @@
 
 namespace BetterGenshinImpact.Core.Recognition.OCR;
 
+/// <summary>
+///     单次 OCR 检测参数覆盖。
+/// </summary>
+public readonly record struct OcrDetectionOptions(float? UnclipRatio = null);
+
 public interface IOcrService
 {
     public string Ocr(Mat mat);
 
     public string OcrWithoutDetector(Mat mat);
 
-    public OcrResult OcrResult(Mat mat);
+    public OcrResult OcrResult(Mat mat, OcrDetectionOptions? detectionOptions = null);
 }

--- a/BetterGenshinImpact/Core/Recognition/OCR/Paddle/Det.cs
+++ b/BetterGenshinImpact/Core/Recognition/OCR/Paddle/Det.cs
@@ -57,8 +57,9 @@ public class Det(BgiOnnxModel model, OcrVersionConfig config, BgiOnnxFactory bgi
         GC.SuppressFinalize(this);
     }
 
-    public RotatedRect[] Run(Mat src)
+    public RotatedRect[] Run(Mat src, float? unclipRatio = null)
     {
+        var effectiveUnclipRatio = unclipRatio ?? UnclipRatio;
         using var pred = RunRaw(src, out var resizedSize);
         using Mat cbuf = new();
         //OpenCvSharp.OpenCVException: 0 <= _colRange.start && _colRange.start <= _colRange.end && _colRange.end <= m.cols
@@ -95,8 +96,8 @@ public class Det(BgiOnnxModel model, OcrVersionConfig config, BgiOnnxFactory bgi
             {
                 var minEdge = Math.Min(rect.Size.Width, rect.Size.Height);
                 Size2f newSize = new(
-                    rect.Size.Width + UnclipRatio * minEdge,
-                    rect.Size.Height + UnclipRatio * minEdge);
+                    rect.Size.Width + effectiveUnclipRatio * minEdge,
+                    rect.Size.Height + effectiveUnclipRatio * minEdge);
                 RotatedRect largerRect = new(rect.Center, newSize, rect.Angle);
                 return largerRect;
             })

--- a/BetterGenshinImpact/Core/Recognition/OCR/Paddle/PaddleOcrService.cs
+++ b/BetterGenshinImpact/Core/Recognition/OCR/Paddle/PaddleOcrService.cs
@@ -272,15 +272,15 @@ public class PaddleOcrService : IOcrService, IDisposable
     /// <summary>
     ///     推荐传入三通道BGR mat，虽然四通道和单通道也做了兼容，但是三通道最快
     /// </summary>
-    public OcrResult OcrResult(Mat mat)
+    public OcrResult OcrResult(Mat mat, OcrDetectionOptions? detectionOptions = null)
     {
         if (mat.Channels() == 4)
         {
             using var mat3 = mat.CvtColor(ColorConversionCodes.BGRA2BGR);
-            return _OcrResult(mat3);
+            return _OcrResult(mat3, detectionOptions);
         }
 
-        return _OcrResult(mat);
+        return _OcrResult(mat, detectionOptions);
     }
 
     /// <summary>
@@ -295,10 +295,10 @@ public class PaddleOcrService : IOcrService, IDisposable
         return str;
     }
 
-    private OcrResult _OcrResult(Mat mat)
+    private OcrResult _OcrResult(Mat mat, OcrDetectionOptions? detectionOptions = null)
     {
         var startTime = Stopwatch.GetTimestamp();
-        var result = RunAll(mat);
+        var result = RunAll(mat, detectionOptions: detectionOptions);
         var time = Stopwatch.GetElapsedTime(startTime);
         // Debug.WriteLine($"PaddleOcr 耗时 {time.TotalMilliseconds}ms 结果: {result.Text}");
         return result;
@@ -307,9 +307,12 @@ public class PaddleOcrService : IOcrService, IDisposable
     /// <summary>
     ///     推荐传入三通道BGR mat，虽然四通道和单通道也做了兼容，但是三通道最快
     /// </summary>
-    private OcrResult RunAll(Mat src, int recognizeBatchSize = 0)
+    private OcrResult RunAll(
+        Mat src,
+        int recognizeBatchSize = 0,
+        OcrDetectionOptions? detectionOptions = null)
     {
-        var rects = _localDetModel.Run(src);
+        var rects = _localDetModel.Run(src, detectionOptions?.UnclipRatio);
         Mat[] mats =
             rects.Select(rect =>
                 {

--- a/BetterGenshinImpact/Core/Recognition/RecognitionObject.cs
+++ b/BetterGenshinImpact/Core/Recognition/RecognitionObject.cs
@@ -193,6 +193,11 @@ public class RecognitionObject
     public OcrEngineTypes OcrEngine { get; set; } = OcrEngineTypes.Paddle;
 
     /// <summary>
+    ///     覆盖当前识别对象的检测框扩张比例。
+    /// </summary>
+    public float? OcrDetUnclipRatio { get; set; }
+
+    /// <summary>
     ///     部分文字识别结果不准确，进行替换。可选。
     /// </summary>
     public Dictionary<string, string[]> ReplaceDictionary { get; set; } = [];
@@ -300,6 +305,7 @@ public class RecognitionObject
             
             // OCR相关属性
             OcrEngine = this.OcrEngine,
+            OcrDetUnclipRatio = this.OcrDetUnclipRatio,
             ReplaceDictionary = this.ReplaceDictionary,  // 不克隆字典，因为字典通常是不可变的
             AllContainMatchText = this.AllContainMatchText, // 不克隆
             OneContainMatchText = this.OneContainMatchText, // 不克隆

--- a/BetterGenshinImpact/GameTask/AutoTrackPath/TpTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoTrackPath/TpTask.cs
@@ -2429,8 +2429,19 @@ public class TpTask
         {
             RecognitionType = RecognitionTypes.Ocr,
             RegionOfInterest = new Rect(imageRegion.Width * 2 / 3, 0, imageRegion.Width / 3, imageRegion.Height),
+            OcrDetUnclipRatio = GetSwitchAreaOcrDetUnclipRatio(),
             ReplaceDictionary = GetSwitchAreaOcrReplaceDictionary(),
         });
+    }
+
+    /// <summary>
+    ///     仅地图地区识别使用 PP-OCRv6 时缩小检测框扩张范围。
+    /// </summary>
+    private static float? GetSwitchAreaOcrDetUnclipRatio()
+    {
+        return TaskContext.Instance().Config.OtherConfig.OcrConfig.PaddleOcrModelConfig == PaddleOcrModelConfig.V6
+            ? 1.0f
+            : null;
     }
 
     private static Dictionary<string, string[]> GetSwitchAreaOcrReplaceDictionary()

--- a/BetterGenshinImpact/GameTask/Model/Area/ImageRegion.cs
+++ b/BetterGenshinImpact/GameTask/Model/Area/ImageRegion.cs
@@ -238,7 +238,7 @@ public class ImageRegion : Region
                 : null;
             var roi = ownedRoi ?? SrcMat;
 
-            var result = OcrFactory.Paddle.OcrResult(roi);
+            var result = OcrFactory.Paddle.OcrResult(roi, GetOcrDetectionOptions(ro));
             var text = StringUtils.RemoveAllSpace(result.Text);
             text = ApplyTextReplacements(text, ro.ReplaceDictionary);
 
@@ -326,7 +326,7 @@ public class ImageRegion : Region
 
                 Cv2.InRange(roi, ro.LowerColor, ro.UpperColor, roi);
             }
-            var result = OcrFactory.Paddle.OcrResult(roi);
+            var result = OcrFactory.Paddle.OcrResult(roi, GetOcrDetectionOptions(ro));
             var text = StringUtils.RemoveAllSpace(result.Text);
             text = ApplyTextReplacements(text, ro.ReplaceDictionary);
 
@@ -500,7 +500,7 @@ public class ImageRegion : Region
                 : null;
             var roi = ownedRoi ?? SrcMat;
 
-            var result = OcrFactory.Paddle.OcrResult(roi);
+            var result = OcrFactory.Paddle.OcrResult(roi, GetOcrDetectionOptions(ro));
             var resRaList = new List<Region>();
             foreach (var ocrRegion in result.Regions)
             {
@@ -576,6 +576,13 @@ public class ImageRegion : Region
         }
 
         return text;
+    }
+
+    private static OcrDetectionOptions? GetOcrDetectionOptions(RecognitionObject ro)
+    {
+        return ro.OcrDetUnclipRatio is { } unclipRatio
+            ? new OcrDetectionOptions(unclipRatio)
+            : null;
     }
 
     public override void Dispose()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - OCR 识别支持针对单次检测调整检测框扩张比例。
  - 可为特定识别场景配置独立的 OCR 检测参数。
  - 使用 PP-OCRv6 时自动应用更合适的检测框设置。

- **改进**
  - 未配置专用参数时，OCR 继续使用原有默认行为。
  - 识别对象克隆时会保留 OCR 检测配置。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->