### PR TITLE
fix: 支持点击暂停弹出页自动关闭

### DIFF
--- a/BetterGenshinImpact/Core/Monitor/MouseKeyMonitor.cs
+++ b/BetterGenshinImpact/Core/Monitor/MouseKeyMonitor.cs
@@ -2,6 +2,7 @@ using BetterGenshinImpact.Core.Config;
 using BetterGenshinImpact.Core.Recorder;
 using BetterGenshinImpact.Core.Simulator;
 using BetterGenshinImpact.GameTask;
+using BetterGenshinImpact.GameTask.AutoSkip;
 using BetterGenshinImpact.Model;
 using Gma.System.MouseKeyHook;
 using System;
@@ -214,9 +215,20 @@ public partial class MouseKeyMonitor : IDisposable
         // Debug.WriteLine("MouseDown: {0}; \t Location: {1};\t System Timestamp: {2}", e.Button, e.Location, e.Timestamp);
         GlobalKeyMouseRecord.Instance.GlobalHookMouseDown(e, DateTime.UtcNow);
 
-        if (e.Button != MouseButtons.Left)
-            if (MouseHook.AllMouseHooks.TryGetValue(e.Button, out var hook))
-                hook.MouseDown(sender, e);
+        if (e.Button == MouseButtons.Left)
+        {
+            if (SystemControl.IsGenshinImpactActive())
+            {
+                PopupClosePauseController.RecordLeftButtonDown(e.Location);
+            }
+
+            return;
+        }
+
+        if (MouseHook.AllMouseHooks.TryGetValue(e.Button, out var hook))
+        {
+            hook.MouseDown(sender, e);
+        }
     }
 
     private void GlobalHookMouseUpExt(object? sender, MouseEventExtArgs e)
@@ -243,6 +255,7 @@ public partial class MouseKeyMonitor : IDisposable
 
     public void Unsubscribe()
     {
+        PopupClosePauseController.Reset();
         _spaceTimer.Stop();
         _fTimer.Stop();
         _firstSpaceKeyDownTime = DateTime.MaxValue;

--- a/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
@@ -1413,27 +1413,36 @@ public partial class PathExecutor
 
             int noDisabledUiButtonTimes = 0;
 
-            while (true)
+            try
             {
-                using var captureContent = new CaptureContent(CaptureToRectArea());
-                var currentCapture = captureContent.CaptureRectArea;
-                disabledUiButtonRa = currentCapture.Find(GetAutoSkipRecognitionObject("DisabledUiButton", currentCapture));
-                if (disabledUiButtonRa.IsExist())
+                while (true)
                 {
-                    _autoSkipTrigger.OnCapture(captureContent);
-                    noDisabledUiButtonTimes = 0;
-                }
-                else
-                {
-                    noDisabledUiButtonTimes++;
-                    if (noDisabledUiButtonTimes > 10)
+                    using var captureContent = new CaptureContent(CaptureToRectArea());
+                    var currentCapture = captureContent.CaptureRectArea;
+                    disabledUiButtonRa = currentCapture.Find(GetAutoSkipRecognitionObject("DisabledUiButton", currentCapture));
+                    if (disabledUiButtonRa.IsExist())
                     {
-                        Logger.LogInformation("自动剧情结束");
-                        break;
+                        _autoSkipTrigger.OnCapture(captureContent);
+                        noDisabledUiButtonTimes = 0;
                     }
-                }
+                    else
+                    {
+                        noDisabledUiButtonTimes++;
+                        _autoSkipTrigger.HandlePopupClose(captureContent, allowAutomaticClose: true);
 
-                await Delay(210, ct);
+                        if (!_autoSkipTrigger.ShouldContinuePopupCloseTracking && noDisabledUiButtonTimes > 10)
+                        {
+                            Logger.LogInformation("自动剧情结束");
+                            break;
+                        }
+                    }
+
+                    await Delay(210, ct);
+                }
+            }
+            finally
+            {
+                _autoSkipTrigger.StopPopupCloseTracking();
             }
         }
     }

--- a/BetterGenshinImpact/GameTask/AutoSkip/AutoSkipTrigger.cs
+++ b/BetterGenshinImpact/GameTask/AutoSkip/AutoSkipTrigger.cs
@@ -53,6 +53,7 @@ public partial class AutoSkipTrigger : ITaskTrigger
             if (!value)
             {
                 ReleaseChooseOptionWait("触发器关闭");
+                StopPopupCloseTracking();
             }
         }
     }
@@ -181,6 +182,32 @@ public partial class AutoSkipTrigger : ITaskTrigger
     private DateTime _prevGetDailyRewardsTime = DateTime.MinValue;
 
     private DateTime _prevClickTime = DateTime.MinValue;
+    private bool _wasPopupClosePausedByUser;
+    internal bool ShouldContinuePopupCloseTracking => _wasPopupClosePausedByUser
+                                                     || PopupClosePauseController.IsPausedByUser(this)
+                                                     || PopupClosePauseController.HasPendingClick(this);
+
+    internal void StartPopupCloseTracking()
+    {
+        PopupClosePauseController.StartTracking(this);
+    }
+
+    internal void HandlePopupClose(CaptureContent content, bool allowAutomaticClose)
+    {
+        if (_config.ClosePopupPagedEnabled)
+        {
+            StartPopupCloseTracking();
+        }
+
+        ClosePopupPage(content, allowAutomaticClose);
+    }
+
+    internal void StopPopupCloseTracking()
+    {
+        PopupClosePauseController.StopTracking(this);
+        _wasPopupClosePausedByUser = false;
+    }
+
     private DateTime _prevBringToFrontTime = DateTime.MinValue;
     private DateTime _chooseOptionDelayUntil = DateTime.MinValue;
     private DateTime _chooseOptionWaitRecheckUntil = DateTime.MinValue;
@@ -188,6 +215,15 @@ public partial class AutoSkipTrigger : ITaskTrigger
 
     public void OnCapture(CaptureContent content)
     {
+        if (_config.ClosePopupPagedEnabled)
+        {
+            StartPopupCloseTracking();
+        }
+        else
+        {
+            StopPopupCloseTracking();
+        }
+
         RefreshOperationMode();
         if (!_config.AutoWaitDialogueOptionVoiceEnabled)
         {
@@ -244,6 +280,10 @@ public partial class AutoSkipTrigger : ITaskTrigger
                 CloseItemPopup(content);
                 CloseCharacterPopup(content);
             }
+            else
+            {
+                ClearPopupClosePause();
+            }
 
             // 自动剧情点击3s内判断
             if ((DateTime.Now - _prevPlayingTime).TotalMilliseconds < 3000)
@@ -259,6 +299,14 @@ public partial class AutoSkipTrigger : ITaskTrigger
                     return;
                 }
             }
+        }
+        else if (ShouldContinuePopupCloseTracking)
+        {
+            HandlePopupClose(content, allowAutomaticClose: false);
+        }
+        else
+        {
+            ClearPopupClosePause();
         }
 
         if (isPlaying)
@@ -1004,23 +1052,86 @@ public partial class AutoSkipTrigger : ITaskTrigger
     /// 关闭弹出页
     /// </summary>
     /// <param name="content"></param>
-    private void ClosePopupPage(CaptureContent content)
+    private void ClosePopupPage(CaptureContent content, bool allowAutomaticClose = true)
     {
         if (!_config.ClosePopupPagedEnabled)
         {
+            ClearPopupClosePause();
             return;
         }
-        
+
         content.CaptureRectArea.Find(GetRecognitionObject("PageClose", content.CaptureRectArea), pageCloseRoRa =>
         {
-            if (!Bv.IsInBigMapUi(content.CaptureRectArea))
+            try
             {
-                TaskContext.Instance().PostMessageSimulator.KeyPress(User32.VK.VK_ESCAPE);
+                if (Bv.IsInBigMapUi(content.CaptureRectArea))
+                {
+                    ClearPopupClosePause();
+                    return;
+                }
 
+                var closeButtonRect = pageCloseRoRa.ConvertPositionToGameCaptureRegion(
+                    0,
+                    0,
+                    pageCloseRoRa.Width,
+                    pageCloseRoRa.Height);
+                var captureAreaRect = TaskContext.Instance().SystemInfo.CaptureAreaRect;
+                var gameRect = new System.Drawing.Rectangle(
+                    captureAreaRect.X,
+                    captureAreaRect.Y,
+                    captureAreaRect.Width,
+                    captureAreaRect.Height);
+                var targetRect = new System.Drawing.Rectangle(
+                    gameRect.X + closeButtonRect.X,
+                    gameRect.Y + closeButtonRect.Y,
+                    closeButtonRect.Width,
+                    closeButtonRect.Height);
+
+                var pauseState = PopupClosePauseController.ObserveTarget(this, targetRect, gameRect);
+                if (!pauseState.IsOwner)
+                {
+                    return;
+                }
+
+                if (pauseState.IsPausedByUser)
+                {
+                    if (!_wasPopupClosePausedByUser)
+                    {
+                        AutoSkipLog("用户点击弹出页顶部区域，暂停自动关闭当前弹出页");
+                    }
+
+                    _wasPopupClosePausedByUser = true;
+                    return;
+                }
+
+                _wasPopupClosePausedByUser = false;
+                if (!allowAutomaticClose)
+                {
+                    return;
+                }
+
+                TaskContext.Instance().PostMessageSimulator.KeyPress(User32.VK.VK_ESCAPE);
                 AutoSkipLog("关闭弹出页");
+            }
+            finally
+            {
                 pageCloseRoRa.Dispose();
             }
+        }, () =>
+        {
+            if (_wasPopupClosePausedByUser)
+            {
+                AutoSkipLog("弹出页关闭标志已丢失，恢复自动关闭");
+            }
+
+            ClearPopupClosePause();
         });
+    }
+
+    private void ClearPopupClosePause()
+    {
+        PopupClosePauseController.MarkTargetMissing(this);
+        _wasPopupClosePausedByUser = false;
     }
     
     private DateTime _prevCloseItemTime = DateTime.MinValue;

--- a/BetterGenshinImpact/GameTask/AutoSkip/PopupClosePauseController.cs
+++ b/BetterGenshinImpact/GameTask/AutoSkip/PopupClosePauseController.cs
@@ -1,0 +1,213 @@
+using System;
+using System.Drawing;
+
+namespace BetterGenshinImpact.GameTask.AutoSkip;
+
+internal readonly record struct PopupClosePauseState(bool IsOwner, bool IsPausedByUser);
+
+/// <summary>
+/// 跟踪当前弹出页关闭按钮，并通过全局鼠标旁听为当前目标提供一次性的自动关闭暂停。
+/// </summary>
+internal static class PopupClosePauseController
+{
+    private static readonly object SyncRoot = new();
+    private static readonly TimeSpan PendingClickWindow = TimeSpan.FromSeconds(2);
+
+    private static object? _trackingOwner;
+    private static object? _owner;
+    private static Rectangle? _targetRect;
+    private static Rectangle _hitRect;
+    private static object? _pendingClickOwner;
+    private static Point? _pendingClickPoint;
+    private static DateTime _pendingClickAtUtc;
+    private static bool _isPausedByUser;
+
+    public static void StartTracking(object owner)
+    {
+        lock (SyncRoot)
+        {
+            if (_trackingOwner == null
+                || ReferenceEquals(_trackingOwner, owner)
+                || (!_targetRect.HasValue && !_pendingClickPoint.HasValue))
+            {
+                _trackingOwner = owner;
+            }
+        }
+    }
+
+    public static PopupClosePauseState ObserveTarget(object owner, Rectangle targetRect, Rectangle gameRect)
+    {
+        return ObserveTarget(owner, targetRect, gameRect, DateTime.UtcNow);
+    }
+
+    internal static PopupClosePauseState ObserveTarget(object owner, Rectangle targetRect, Rectangle gameRect, DateTime observedAtUtc)
+    {
+        lock (SyncRoot)
+        {
+            var isSameTarget = _targetRect.HasValue && IsSameTarget(_targetRect.Value, targetRect);
+            if (_owner != null && !ReferenceEquals(_owner, owner) && isSameTarget)
+            {
+                return new PopupClosePauseState(false, _isPausedByUser);
+            }
+
+            var hitRect = BuildHitRect(targetRect, gameRect);
+            var timeSinceClick = observedAtUtc - _pendingClickAtUtc;
+            var hasPendingClick = _pendingClickPoint.HasValue
+                                  && timeSinceClick >= TimeSpan.Zero
+                                  && timeSinceClick <= PendingClickWindow;
+            if (hasPendingClick
+                && _pendingClickOwner != null
+                && !ReferenceEquals(_pendingClickOwner, owner))
+            {
+                return new PopupClosePauseState(false, false);
+            }
+
+            if (!hasPendingClick && _pendingClickPoint.HasValue)
+            {
+                ClearPendingClickCore();
+            }
+
+            if (!isSameTarget)
+            {
+                _isPausedByUser = hasPendingClick && hitRect.Contains(_pendingClickPoint!.Value);
+                if (hasPendingClick)
+                {
+                    ClearPendingClickCore();
+                }
+            }
+
+            _owner = owner;
+            _targetRect = targetRect;
+            _hitRect = hitRect;
+
+            return new PopupClosePauseState(true, _isPausedByUser);
+        }
+    }
+
+    public static void RecordLeftButtonDown(Point point)
+    {
+        RecordLeftButtonDown(point, DateTime.UtcNow);
+    }
+
+    internal static void RecordLeftButtonDown(Point point, DateTime clickedAtUtc)
+    {
+        lock (SyncRoot)
+        {
+            if (_targetRect.HasValue)
+            {
+                if (!_hitRect.Contains(point))
+                {
+                    return;
+                }
+
+                _isPausedByUser = true;
+                _pendingClickOwner = _owner;
+            }
+            else
+            {
+                if (_trackingOwner == null)
+                {
+                    return;
+                }
+
+                _pendingClickOwner = _trackingOwner;
+            }
+
+            _pendingClickPoint = point;
+            _pendingClickAtUtc = clickedAtUtc;
+        }
+    }
+
+    public static bool IsPausedByUser(object owner)
+    {
+        lock (SyncRoot)
+        {
+            return ReferenceEquals(_owner, owner) && _isPausedByUser;
+        }
+    }
+
+    public static bool HasPendingClick(object owner)
+    {
+        lock (SyncRoot)
+        {
+            return ReferenceEquals(_pendingClickOwner, owner)
+                   && _pendingClickPoint.HasValue
+                   && DateTime.UtcNow - _pendingClickAtUtc <= PendingClickWindow;
+        }
+    }
+
+    public static void MarkTargetMissing(object owner)
+    {
+        lock (SyncRoot)
+        {
+            if (ReferenceEquals(_owner, owner))
+            {
+                ClearTargetCore();
+            }
+        }
+    }
+
+    public static void StopTracking(object owner)
+    {
+        lock (SyncRoot)
+        {
+            if (ReferenceEquals(_owner, owner))
+            {
+                ClearTargetCore();
+            }
+
+            if (ReferenceEquals(_pendingClickOwner, owner))
+            {
+                ClearPendingClickCore();
+            }
+
+            if (ReferenceEquals(_trackingOwner, owner))
+            {
+                _trackingOwner = null;
+            }
+        }
+    }
+
+    public static void Reset()
+    {
+        lock (SyncRoot)
+        {
+            _trackingOwner = null;
+            ClearTargetCore();
+            ClearPendingClickCore();
+        }
+    }
+
+    private static void ClearTargetCore()
+    {
+        _owner = null;
+        _targetRect = null;
+        _hitRect = Rectangle.Empty;
+        _isPausedByUser = false;
+    }
+
+    private static void ClearPendingClickCore()
+    {
+        _pendingClickOwner = null;
+        _pendingClickPoint = null;
+        _pendingClickAtUtc = default;
+    }
+
+    private static Rectangle BuildHitRect(Rectangle targetRect, Rectangle gameRect)
+    {
+        var hitHeight = Math.Max(targetRect.Height, (int)Math.Ceiling(targetRect.Height * 1.5));
+        hitHeight = Math.Min(hitHeight, gameRect.Height);
+
+        var top = targetRect.Top - (hitHeight - targetRect.Height) / 2;
+        top = Math.Clamp(top, gameRect.Top, gameRect.Bottom - hitHeight);
+
+        return new Rectangle(gameRect.Left, top, gameRect.Width, hitHeight);
+    }
+
+    private static bool IsSameTarget(Rectangle first, Rectangle second)
+    {
+        var tolerance = Math.Max(4, Math.Min(first.Width, first.Height) / 2);
+        return Math.Abs(first.Left + first.Width / 2 - (second.Left + second.Width / 2)) <= tolerance
+               && Math.Abs(first.Top + first.Height / 2 - (second.Top + second.Height / 2)) <= tolerance;
+    }
+}

--- a/BetterGenshinImpact/GameTask/TaskTriggerDispatcher.cs
+++ b/BetterGenshinImpact/GameTask/TaskTriggerDispatcher.cs
@@ -12,6 +12,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Windows;
+using BetterGenshinImpact.GameTask.AutoSkip;
 using BetterGenshinImpact.GameTask.Common.BgiVision;
 using BetterGenshinImpact.GameTask.GameLoading;
 using Fischless.GameCapture.Graphics;
@@ -99,6 +100,7 @@ namespace BetterGenshinImpact.GameTask
         {
             lock (_triggerListLocker)
             {
+                DisableRemovedAutoSkipTriggers([]);
                 GameTaskManager.ClearTriggers();
                 _triggers?.Clear();
             }
@@ -108,6 +110,7 @@ namespace BetterGenshinImpact.GameTask
         {
             lock (_triggerListLocker)
             {
+                DisableRemovedAutoSkipTriggers(list);
                 _triggers = list;
             }
         }
@@ -126,6 +129,22 @@ namespace BetterGenshinImpact.GameTask
             }
         }
 
+        private void DisableRemovedAutoSkipTriggers(IReadOnlyCollection<ITaskTrigger> nextTriggers)
+        {
+            if (_triggers == null)
+            {
+                return;
+            }
+
+            foreach (var trigger in _triggers.OfType<AutoSkipTrigger>())
+            {
+                if (!nextTriggers.Contains(trigger))
+                {
+                    trigger.IsEnabled = false;
+                }
+            }
+        }
+
         public void Start(IntPtr hWnd, CaptureModes mode, int interval = 50)
         {
             // 初始化截图器
@@ -138,7 +157,7 @@ namespace BetterGenshinImpact.GameTask
             TaskContext.Instance().Init(hWnd);
 
             // 初始化触发器(一定要在任务上下文初始化完毕后使用)
-            _triggers = GameTaskManager.LoadInitialTriggers();
+            SetTriggers(GameTaskManager.LoadInitialTriggers());
             GameLoadingTrigger.GlobalEnabled = TaskContext.Instance().Config.GenshinStartConfig.AutoEnterGameEnabled;
 
             // if (GraphicsCapture.IsHdrEnabled(hWnd))
@@ -172,6 +191,10 @@ namespace BetterGenshinImpact.GameTask
         public void Stop()
         {
             _timer.Stop();
+            lock (_triggerListLocker)
+            {
+                DisableRemovedAutoSkipTriggers([]);
+            }
             ChatUiHotkeyGuard.Reset();
             GameCapture?.Stop();
             _gameRect = RECT.Empty;
@@ -204,6 +227,17 @@ namespace BetterGenshinImpact.GameTask
             if (_timer.Enabled)
             {
                 _timer.Stop();
+            }
+
+            lock (_triggerListLocker)
+            {
+                if (_triggers != null)
+                {
+                    foreach (var trigger in _triggers.OfType<AutoSkipTrigger>())
+                    {
+                        trigger.StopPopupCloseTracking();
+                    }
+                }
             }
 
             ChatUiHotkeyGuard.Reset();

--- a/Test/BetterGenshinImpact.UnitTest/GameTaskTests/AutoSkipTests/PopupClosePauseControllerTests.cs
+++ b/Test/BetterGenshinImpact.UnitTest/GameTaskTests/AutoSkipTests/PopupClosePauseControllerTests.cs
@@ -1,0 +1,209 @@
+using BetterGenshinImpact.GameTask.AutoSkip;
+using System.Drawing;
+
+namespace BetterGenshinImpact.UnitTest.GameTaskTests.AutoSkipTests;
+
+public class PopupClosePauseControllerTests : IDisposable
+{
+    private static readonly Rectangle GameRect = new(100, 200, 1920, 1080);
+    private static readonly Rectangle TargetRect = new(1950, 220, 36, 36);
+    private readonly object _owner = new();
+
+    public PopupClosePauseControllerTests()
+    {
+        PopupClosePauseController.Reset();
+    }
+
+    [Fact]
+    public void ClickOutsideHitRect_ShouldNotPauseTarget()
+    {
+        PopupClosePauseController.ObserveTarget(_owner, TargetRect, GameRect);
+
+        PopupClosePauseController.RecordLeftButtonDown(new Point(GameRect.Left + 100, TargetRect.Bottom + 100));
+
+        var state = PopupClosePauseController.ObserveTarget(_owner, TargetRect, GameRect);
+        Assert.False(state.IsPausedByUser);
+    }
+
+    [Fact]
+    public void ClickInsideFullWidthHitRect_ShouldPauseSameTarget()
+    {
+        PopupClosePauseController.ObserveTarget(_owner, TargetRect, GameRect);
+
+        PopupClosePauseController.RecordLeftButtonDown(new Point(GameRect.Left + 100, TargetRect.Top));
+
+        var state = PopupClosePauseController.ObserveTarget(_owner, TargetRect, GameRect);
+        Assert.True(state.IsPausedByUser);
+    }
+
+    [Fact]
+    public void TargetMissing_ThenNewTargetWithinClickWindow_ShouldPauseNewTarget()
+    {
+        var clickedAt = DateTime.UtcNow;
+        PopupClosePauseController.ObserveTarget(_owner, TargetRect, GameRect, clickedAt);
+        PopupClosePauseController.RecordLeftButtonDown(new Point(GameRect.Left + 100, TargetRect.Top), clickedAt);
+
+        PopupClosePauseController.MarkTargetMissing(_owner);
+        var state = PopupClosePauseController.ObserveTarget(_owner, TargetRect, GameRect, clickedAt.AddMilliseconds(1500));
+
+        Assert.True(state.IsPausedByUser);
+    }
+
+    [Fact]
+    public void TargetMissing_ThenNewTargetAfterClickWindow_ShouldNotPauseNewTarget()
+    {
+        var clickedAt = DateTime.UtcNow;
+        PopupClosePauseController.ObserveTarget(_owner, TargetRect, GameRect, clickedAt);
+        PopupClosePauseController.RecordLeftButtonDown(new Point(GameRect.Left + 100, TargetRect.Top), clickedAt);
+
+        PopupClosePauseController.MarkTargetMissing(_owner);
+        var state = PopupClosePauseController.ObserveTarget(_owner, TargetRect, GameRect, clickedAt.AddSeconds(3));
+
+        Assert.False(state.IsPausedByUser);
+    }
+
+    [Fact]
+    public void ClickWithoutActiveTracking_ShouldBeIgnored()
+    {
+        var clickedAt = DateTime.UtcNow;
+        PopupClosePauseController.RecordLeftButtonDown(new Point(GameRect.Left + 100, TargetRect.Top), clickedAt);
+
+        var state = PopupClosePauseController.ObserveTarget(_owner, TargetRect, GameRect, clickedAt.AddMilliseconds(500));
+
+        Assert.False(state.IsPausedByUser);
+    }
+
+    [Fact]
+    public void ClickBeforeFirstObservation_InsideFutureHitRect_ShouldPauseTarget()
+    {
+        var clickedAt = DateTime.UtcNow;
+        PopupClosePauseController.StartTracking(_owner);
+        PopupClosePauseController.RecordLeftButtonDown(new Point(GameRect.Left + 100, TargetRect.Top), clickedAt);
+
+        var state = PopupClosePauseController.ObserveTarget(_owner, TargetRect, GameRect, clickedAt.AddMilliseconds(500));
+
+        Assert.True(state.IsPausedByUser);
+    }
+
+    [Fact]
+    public void ClickBeforeFirstObservation_OutsideFutureHitRect_ShouldNotPauseTarget()
+    {
+        var clickedAt = DateTime.UtcNow;
+        PopupClosePauseController.StartTracking(_owner);
+        PopupClosePauseController.RecordLeftButtonDown(new Point(GameRect.Left + 100, TargetRect.Bottom + 100), clickedAt);
+
+        var state = PopupClosePauseController.ObserveTarget(_owner, TargetRect, GameRect, clickedAt.AddMilliseconds(500));
+
+        Assert.False(state.IsPausedByUser);
+    }
+
+    [Fact]
+    public void NewTargetWithoutPrecedingClick_ShouldNotPauseOrDelay()
+    {
+        var state = PopupClosePauseController.ObserveTarget(_owner, TargetRect, GameRect);
+
+        Assert.False(state.IsPausedByUser);
+    }
+
+    [Fact]
+    public void ClickOutsideCurrentHitRect_ShouldNotCreatePendingClickForNewTarget()
+    {
+        var clickedAt = DateTime.UtcNow;
+        PopupClosePauseController.ObserveTarget(_owner, TargetRect, GameRect, clickedAt);
+        PopupClosePauseController.RecordLeftButtonDown(new Point(GameRect.Left + 100, TargetRect.Bottom + 100), clickedAt);
+
+        PopupClosePauseController.MarkTargetMissing(_owner);
+        var state = PopupClosePauseController.ObserveTarget(_owner, TargetRect, GameRect, clickedAt.AddMilliseconds(500));
+
+        Assert.False(state.IsPausedByUser);
+    }
+
+    [Fact]
+    public void StopTracking_ShouldClearPendingClick()
+    {
+        var clickedAt = DateTime.UtcNow;
+        PopupClosePauseController.ObserveTarget(_owner, TargetRect, GameRect, clickedAt);
+        PopupClosePauseController.RecordLeftButtonDown(new Point(GameRect.Left + 100, TargetRect.Top), clickedAt);
+
+        PopupClosePauseController.StopTracking(_owner);
+        var state = PopupClosePauseController.ObserveTarget(_owner, TargetRect, GameRect, clickedAt.AddMilliseconds(500));
+
+        Assert.False(state.IsPausedByUser);
+    }
+
+    [Fact]
+    public void StopTracking_ShouldClearClickRecordedBeforeFirstObservation()
+    {
+        var clickedAt = DateTime.UtcNow;
+        PopupClosePauseController.StartTracking(_owner);
+        PopupClosePauseController.RecordLeftButtonDown(new Point(GameRect.Left + 100, TargetRect.Top), clickedAt);
+
+        PopupClosePauseController.StopTracking(_owner);
+        var state = PopupClosePauseController.ObserveTarget(_owner, TargetRect, GameRect, clickedAt.AddMilliseconds(500));
+
+        Assert.False(state.IsPausedByUser);
+    }
+
+    [Fact]
+    public void NonTrackingOwnerStop_ShouldNotClearClickRecordedBeforeFirstObservation()
+    {
+        var clickedAt = DateTime.UtcNow;
+        PopupClosePauseController.StartTracking(_owner);
+        PopupClosePauseController.RecordLeftButtonDown(new Point(GameRect.Left + 100, TargetRect.Top), clickedAt);
+
+        PopupClosePauseController.StopTracking(new object());
+        var state = PopupClosePauseController.ObserveTarget(_owner, TargetRect, GameRect, clickedAt.AddMilliseconds(500));
+
+        Assert.True(state.IsPausedByUser);
+    }
+
+    [Fact]
+    public void AnotherOwnerStartTracking_ShouldNotStealPendingClick()
+    {
+        var clickedAt = DateTime.UtcNow;
+        PopupClosePauseController.StartTracking(_owner);
+        PopupClosePauseController.RecordLeftButtonDown(new Point(GameRect.Left + 100, TargetRect.Top), clickedAt);
+
+        var otherOwner = new object();
+        PopupClosePauseController.StartTracking(otherOwner);
+
+        var otherState = PopupClosePauseController.ObserveTarget(otherOwner, TargetRect, GameRect, clickedAt.AddMilliseconds(500));
+        var ownerState = PopupClosePauseController.ObserveTarget(_owner, TargetRect, GameRect, clickedAt.AddMilliseconds(500));
+
+        Assert.False(otherState.IsOwner);
+        Assert.True(ownerState.IsPausedByUser);
+    }
+
+    [Fact]
+    public void NonOwnerMissing_ShouldNotClearCurrentTarget()
+    {
+        PopupClosePauseController.ObserveTarget(_owner, TargetRect, GameRect);
+        PopupClosePauseController.RecordLeftButtonDown(new Point(GameRect.Left + 100, TargetRect.Top));
+
+        PopupClosePauseController.MarkTargetMissing(new object());
+        var state = PopupClosePauseController.ObserveTarget(_owner, TargetRect, GameRect);
+
+        Assert.True(state.IsOwner);
+        Assert.True(state.IsPausedByUser);
+    }
+
+    [Fact]
+    public void AnotherOwnerObservingSameTarget_ShouldNotTakeOwnership()
+    {
+        PopupClosePauseController.ObserveTarget(_owner, TargetRect, GameRect);
+        PopupClosePauseController.RecordLeftButtonDown(new Point(GameRect.Left + 100, TargetRect.Top));
+
+        var otherOwner = new object();
+        var state = PopupClosePauseController.ObserveTarget(otherOwner, TargetRect, GameRect);
+
+        Assert.False(state.IsOwner);
+        Assert.True(state.IsPausedByUser);
+        Assert.True(PopupClosePauseController.IsPausedByUser(_owner));
+        Assert.False(PopupClosePauseController.IsPausedByUser(otherOwner));
+    }
+
+    public void Dispose()
+    {
+        PopupClosePauseController.Reset();
+    }
+}


### PR DESCRIPTION
## 修改内容

- 复用现有全局鼠标 Hook，旁听原神前台的左键点击，不消费或重放输入。
- 根据 `PageClose` 识别目标生成游戏窗口全宽、按钮高度 1.5 倍的逻辑点击区域。
- 用户点击有效区域后，暂停 BGI 对当前弹出页自动发送 `Esc`；目标丢失或移动后恢复。
- 点击后的 2 秒内若出现新的 `PageClose`，允许新目标继承暂停，覆盖点击早于首次识别帧的场景。
- 补充普通 `AutoSkipTrigger`、`PathExecutor` 临时实例、触发器替换/停止和键鼠录制暂停时的所有权与状态清理。
- 不包含悬浮层可视化改动。

## 验证

- `dotnet build BetterGenshinImpact.sln -c Debug`：通过，0 错误。
- `PopupClosePauseControllerTests`：15/15 通过。
- `git diff --check`：通过。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 优化自动跳过功能，新增弹窗关闭跟踪。
  * 记录用户鼠标点击并识别目标区域，避免误将用户操作判定为自动关闭。
  * 支持用户暂停、目标切换及弹窗消失后的状态清理。

* **问题修复**
  * 改善自动跳过触发器启停和替换时的状态管理。
  * 提升弹窗关闭识别资源释放及恢复日志记录的稳定性。

* **测试**
  * 增加点击命中、目标切换、暂停状态及多任务场景的覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->