### PR TITLE
fix: 角色养成选择使用名称 OCR 兜底

### DIFF
--- a/BetterGenshinImpact/GameTask/CharacterDevelopment/CharacterSelectionHelper.cs
+++ b/BetterGenshinImpact/GameTask/CharacterDevelopment/CharacterSelectionHelper.cs
@@ -36,9 +36,19 @@ internal sealed record CharacterSelectionTarget(
     public bool Matches(string? characterName) =>
         characterName != null && CandidateNames.Contains(characterName, StringComparer.Ordinal);
 
-    public bool MatchesDisplayText(string? text) =>
-        !string.IsNullOrWhiteSpace(text)
-        && CandidateNames.Any(candidate => text.Contains(candidate, StringComparison.Ordinal));
+    public bool MatchesDisplayText(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return false;
+        }
+
+        var normalizedText = NormalizeDisplayText(text);
+        return CandidateNames.Any(candidate => normalizedText.Contains(candidate, StringComparison.Ordinal));
+    }
+
+    internal static string NormalizeDisplayText(string text) =>
+        string.Concat(text.Where(character => !char.IsWhiteSpace(character)));
 }
 
 /// <summary>
@@ -54,7 +64,14 @@ internal static class CharacterSelectionHelper
     /// <summary>头像 embedding 余弦相似度的最低接受分数。</summary>
     internal const double MatchThreshold = 0.7;
     private const int EmptyDetectionRetryCount = 3;
+    private const int DisplayNameMaxOcrAttempts = 6;
+    private const int DisplayNameRequiredStableOcrCount = 2;
+    private const int DisplayNameInitialDelayMilliseconds = 500;
+    private const int DisplayNameOcrRetryDelayMilliseconds = 150;
+    private const int CardDetectionRefreshDelayMilliseconds = 300;
+    private const int CharacterElementSize1080 = 48;
     private static readonly Rect GridRoi1080 = new(40, 76, 641, 897);
+    private static readonly Rect DisplayNameRoi1080 = new(1466, 131, 244, 38);
 
     public static CharacterSelectionTarget CreateTarget(string name)
     {
@@ -207,7 +224,8 @@ internal static class CharacterSelectionHelper
     }
 
     /// <summary>
-    /// 在角色列表中检测卡片、运行头像模型并点击目标角色；当前页未命中时继续向下滚动。
+    /// 在角色列表中检测卡片，以头像模型结果排序后逐个点击，并以右侧角色名 OCR 作最终确认；
+    /// 当前页未命中时继续向下滚动。
     /// </summary>
     public static async Task<AvatarGridIconCandidate?> FindAndClickAvatar(
         CharacterSelectionTarget target,
@@ -220,6 +238,21 @@ internal static class CharacterSelectionHelper
         var scroller = new GridScroller(gridParams, logger, Simulation.SendInput, ct);
         var gridRoi = Rect1080(assetScale, GridRoi1080.X, GridRoi1080.Y, GridRoi1080.Width, GridRoi1080.Height);
 
+        if (!target.SkipDisplayNameConfirmation)
+        {
+            var currentDisplayName = await ReadStableDisplayName(assetScale, logger, ct);
+            logger.LogInformation(
+                "角色养成识别：当前选中角色的实际名称 OCR={DisplayName}",
+                currentDisplayName ?? "<未稳定>");
+            if (target.MatchesDisplayText(currentDisplayName))
+            {
+                return new AvatarGridIconCandidate(
+                    target.PrimaryCandidateName,
+                    recognizer.GetElementType(target.PrimaryCandidateName),
+                    1d);
+            }
+        }
+
         while (true)
         {
             ct.ThrowIfCancellationRequested();
@@ -230,7 +263,7 @@ internal static class CharacterSelectionHelper
                 var cards = DetectCharacterCards(
                     gridRegion.SrcMat, assetScale, out var rejectedCount, out var connectedComponentCount);
                 logger.LogDebug(
-                    "角色养成识别：白色底栏连通域 {ConnectedComponentCount} 个，生成 {CardCount} 个合法卡片，边界丢弃 {RejectedCount} 个（第 {Attempt}/{RetryCount} 次）",
+                    "角色养成识别：初次检测到白色底栏连通域 {ConnectedComponentCount} 个，生成 {CardCount} 个合法卡片，边界丢弃 {RejectedCount} 个（第 {Attempt}/{RetryCount} 次）",
                     connectedComponentCount, cards.Count, rejectedCount, attempt, EmptyDetectionRetryCount);
 
                 if (cards.Count == 0)
@@ -244,20 +277,94 @@ internal static class CharacterSelectionHelper
                     throw new InvalidOperationException("未检测到合法角色卡片。");
                 }
 
-                foreach (var card in cards.OrderBy(card => card.CardRect.Y).ThenBy(card => card.CardRect.X))
+                var firstCard = cards
+                    .OrderBy(card => card.CardRect.Y)
+                    .ThenBy(card => card.CardRect.X)
+                    .First();
+                using (var firstCardRegion = gridRegion.DeriveCrop(firstCard.CardRect))
                 {
-                    using var cardRegion = gridRegion.DeriveCrop(card.CardRect);
+                    firstCardRegion.Click();
+                }
+                await Delay(CardDetectionRefreshDelayMilliseconds, ct);
+
+                using (var refreshedCapture = CaptureToRectArea())
+                using (var refreshedGridRegion = refreshedCapture.DeriveCrop(gridRoi))
+                {
+                    var refreshedCards = DetectCharacterCards(
+                        refreshedGridRegion.SrcMat,
+                        assetScale,
+                        out var refreshedRejectedCount,
+                        out var refreshedConnectedComponentCount);
+                    cards = MergeCharacterCards(cards, refreshedCards, assetScale);
+                    logger.LogDebug(
+                        "角色养成识别：切换选中态后检测到白色底栏连通域 {ConnectedComponentCount} 个、合法卡片 {RefreshedCardCount} 个，合并后共 {MergedCardCount} 个，边界丢弃 {RejectedCount} 个",
+                        refreshedConnectedComponentCount,
+                        refreshedCards.Count,
+                        cards.Count,
+                        refreshedRejectedCount);
+                }
+
+                var orderedCards = cards
+                    .OrderBy(card => card.CardRect.Y)
+                    .ThenBy(card => card.CardRect.X)
+                    .ToList();
+                var candidates = new List<AvatarGridIconCandidate>(orderedCards.Count);
+                logger.LogDebug("角色养成识别：当前页共检测到 {CardCount} 个候选角色框", orderedCards.Count);
+                for (var index = 0; index < orderedCards.Count; index++)
+                {
+                    var card = orderedCards[index];
                     using var avatar = gridRegion.SrcMat.SubMat(card.AvatarRect);
                     using var element = gridRegion.SrcMat.SubMat(card.ElementRect);
                     var candidate = recognizer.Recognize(avatar, element, target.RecognizeElementType);
-                    logger.LogDebug("角色养成识别：识别头像 {CharacterName}，元素={ElementType}，score={Score:0.000}",
-                        candidate.CharacterName, candidate.ElementType, candidate.Score);
-                    if (target.Matches(candidate.CharacterName) && candidate.Score >= MatchThreshold)
+                    candidates.Add(candidate);
+                    logger.LogDebug(
+                        "角色养成识别：候选框 {CardNumber}/{CardCount}，位置=({X},{Y},{Width},{Height})，头像预测={CharacterName}，元素={ElementType}，score={Score:0.000}",
+                        index + 1,
+                        orderedCards.Count,
+                        card.CardRect.X,
+                        card.CardRect.Y,
+                        card.CardRect.Width,
+                        card.CardRect.Height,
+                        candidate.CharacterName,
+                        candidate.ElementType,
+                        candidate.Score);
+                }
+
+                var verificationOrder = OrderCandidateIndicesForVerification(target, candidates);
+                foreach (var index in verificationOrder)
+                {
+                    var candidate = candidates[index];
+                    if (target.SkipDisplayNameConfirmation
+                        && (!target.Matches(candidate.CharacterName) || candidate.Score < MatchThreshold))
                     {
-                        cardRegion.Click();
-                        await Delay(300, ct);
+                        continue;
+                    }
+
+                    using var cardRegion = gridRegion.DeriveCrop(orderedCards[index].CardRect);
+                    cardRegion.Click();
+                    await Delay(DisplayNameInitialDelayMilliseconds, ct);
+
+                    if (target.SkipDisplayNameConfirmation)
+                    {
                         return candidate;
                     }
+
+                    var displayName = await ReadStableDisplayName(assetScale, logger, ct);
+                    logger.LogInformation(
+                        "角色养成识别：候选框 {CardNumber}/{CardCount} 的实际角色名 OCR={DisplayName}",
+                        index + 1,
+                        orderedCards.Count,
+                        displayName ?? "<未稳定>");
+                    if (!target.MatchesDisplayText(displayName))
+                    {
+                        continue;
+                    }
+
+                    return candidate with
+                    {
+                        CharacterName = target.PrimaryCandidateName,
+                        ElementType = recognizer.GetElementType(target.PrimaryCandidateName)
+                    };
                 }
 
                 break;
@@ -275,6 +382,75 @@ internal static class CharacterSelectionHelper
     }
 
     /// <summary>
+    /// 头像模型只负责安排验证顺序：达到原接受阈值的目标预测优先，其余卡片保持视觉顺序；
+    /// 最终命中仍由显示名称 OCR 决定。
+    /// </summary>
+    internal static IReadOnlyList<int> OrderCandidateIndicesForVerification(
+        CharacterSelectionTarget target,
+        IReadOnlyList<AvatarGridIconCandidate> candidates)
+    {
+        return Enumerable.Range(0, candidates.Count)
+            .OrderByDescending(index => IsConfidentTargetPrediction(target, candidates[index]))
+            .ThenByDescending(index => IsConfidentTargetPrediction(target, candidates[index])
+                ? ComparableScore(candidates[index].Score)
+                : double.MinValue)
+            .ThenBy(index => index)
+            .ToList();
+    }
+
+    private static bool IsConfidentTargetPrediction(
+        CharacterSelectionTarget target,
+        AvatarGridIconCandidate candidate) =>
+        target.Matches(candidate.CharacterName) && candidate.Score >= MatchThreshold;
+
+    private static double ComparableScore(double score) =>
+        double.IsFinite(score) ? score : double.MinValue;
+
+    private static async Task<string?> ReadStableDisplayName(
+        double assetScale,
+        ILogger logger,
+        CancellationToken ct)
+    {
+        var stableValues = new StableValueAccumulator<string>(DisplayNameRequiredStableOcrCount);
+        var lastText = string.Empty;
+        for (var attempt = 1; attempt <= DisplayNameMaxOcrAttempts; attempt++)
+        {
+            using var capture = CaptureToRectArea();
+            using var region = capture.DeriveCrop(Rect1080(
+                assetScale,
+                DisplayNameRoi1080.X,
+                DisplayNameRoi1080.Y,
+                DisplayNameRoi1080.Width,
+                DisplayNameRoi1080.Height));
+            lastText = CharacterSelectionTarget.NormalizeDisplayText(
+                OcrFactory.Paddle.OcrResult(region.SrcMat).Text.Trim());
+            if (!string.IsNullOrWhiteSpace(lastText))
+            {
+                if (stableValues.Add(lastText))
+                {
+                    return lastText;
+                }
+            }
+            else
+            {
+                stableValues.Reset();
+            }
+
+            if (attempt < DisplayNameMaxOcrAttempts)
+            {
+                await Delay(DisplayNameOcrRetryDelayMilliseconds, ct);
+            }
+        }
+
+        logger.LogDebug(
+            "角色养成识别：显示名称 OCR 未达到连续 {RequiredCount} 次一致，最大连续次数={MaxCount}，末次结果={LastText}",
+            DisplayNameRequiredStableOcrCount,
+            stableValues.MaxConsecutiveCount,
+            lastText);
+        return null;
+    }
+
+    /// <summary>
     /// 通过角色卡片底部白色区域检测当前画面中的真实卡片。
     /// </summary>
     /// <remarks>
@@ -287,9 +463,8 @@ internal static class CharacterSelectionHelper
         out int rejectedCount,
         out int connectedComponentCount)
     {
-        const int elementSize1080 = 48;
-        var elementSize = Math.Max(1, (int)Math.Round(elementSize1080 * assetScale));
-        return FixedSizeGridCardDetector
+        var elementSize = Math.Max(1, (int)Math.Round(CharacterElementSize1080 * assetScale));
+        var detectedCards = FixedSizeGridCardDetector
             .Detect(
                 gridMat,
                 assetScale,
@@ -300,6 +475,35 @@ internal static class CharacterSelectionHelper
                 card.CardRect,
                 card.AvatarRect,
                 new Rect(card.CardRect.X, card.CardRect.Y, elementSize, elementSize)))
+            .ToList();
+        return detectedCards;
+    }
+
+    /// <summary>
+    /// 合并切换选中态前后的卡片检测结果。选中卡片的底栏不是白色，需通过两帧并集找回。
+    /// </summary>
+    internal static List<CharacterCardRect> MergeCharacterCards(
+        IReadOnlyList<CharacterCardRect> first,
+        IReadOnlyList<CharacterCardRect> second,
+        double assetScale)
+    {
+        var tolerance = Math.Max(3, (int)Math.Round(8 * assetScale));
+        var merged = first.ToList();
+        foreach (var candidate in second)
+        {
+            if (merged.Any(existing =>
+                    Math.Abs(existing.CardRect.X - candidate.CardRect.X) <= tolerance
+                    && Math.Abs(existing.CardRect.Y - candidate.CardRect.Y) <= tolerance))
+            {
+                continue;
+            }
+
+            merged.Add(candidate);
+        }
+
+        return merged
+            .OrderBy(card => card.CardRect.Y)
+            .ThenBy(card => card.CardRect.X)
             .ToList();
     }
 

--- a/Test/BetterGenshinImpact.UnitTest/GameTaskTests/CharacterDevelopmentTests/CharacterSelectionHelperTests.cs
+++ b/Test/BetterGenshinImpact.UnitTest/GameTaskTests/CharacterDevelopmentTests/CharacterSelectionHelperTests.cs
@@ -1,0 +1,103 @@
+using BetterGenshinImpact.GameTask.CharacterDevelopment;
+using BetterGenshinImpact.GameTask.Common.Job;
+using OpenCvSharp;
+
+namespace BetterGenshinImpact.UnitTest.GameTaskTests.CharacterDevelopmentTests;
+
+public class CharacterSelectionHelperTests
+{
+    [Fact]
+    public void OrderCandidateIndicesForVerification_PrioritizesOnlyConfidentTargetPredictions()
+    {
+        var target = CharacterSelectionHelper.CreateTarget("梦见月瑞希");
+        AvatarGridIconCandidate[] candidates =
+        [
+            new("爱诺", "水", 0.110),
+            new("梦见月瑞希", "风", 0.320),
+            new("可莉", "火", double.NaN),
+            new("梦见月瑞希", "风", 0.810),
+            new("烟绯", "火", 0.112)
+        ];
+
+        var result = CharacterSelectionHelper.OrderCandidateIndicesForVerification(target, candidates);
+
+        Assert.Equal([3, 0, 1, 2, 4], result);
+    }
+
+    [Fact]
+    public void OrderCandidateIndicesForVerification_KeepsVisualOrderWhenNoPredictionIsConfident()
+    {
+        var target = CharacterSelectionHelper.CreateTarget("梦见月瑞希");
+        AvatarGridIconCandidate[] candidates =
+        [
+            new("梦见月瑞希", "风", double.NaN),
+            new("梦见月瑞希", "风", 0.200),
+            new("爱诺", "水", 0.900)
+        ];
+
+        var result = CharacterSelectionHelper.OrderCandidateIndicesForVerification(target, candidates);
+
+        Assert.Equal([0, 1, 2], result);
+    }
+
+    [Theory]
+    [InlineData("梦见月瑞希", true)]
+    [InlineData("梦见月 瑞希", true)]
+    [InlineData("\r\n梦见月瑞希\t", true)]
+    [InlineData("爱诺", false)]
+    public void MatchesDisplayText_IgnoresOcrWhitespace(string text, bool expected)
+    {
+        var target = CharacterSelectionHelper.CreateTarget("梦见月瑞希");
+
+        Assert.Equal(expected, target.MatchesDisplayText(text));
+    }
+
+    [Fact]
+    public void MergeCharacterCards_RestoresCardsHiddenByOppositeSelectionStates()
+    {
+        CharacterCardRect[] first =
+        [
+            Card(133, 32), Card(261, 32), Card(391, 32), Card(519, 32),
+            Card(4, 189), Card(133, 189), Card(261, 189), Card(391, 189)
+        ];
+        CharacterCardRect[] second =
+        [
+            Card(4, 32), Card(261, 32), Card(391, 32), Card(519, 32),
+            Card(4, 189), Card(133, 189), Card(261, 189), Card(391, 189)
+        ];
+
+        var result = CharacterSelectionHelper.MergeCharacterCards(first, second, 1);
+
+        Assert.Equal(9, result.Count);
+        Assert.Equal(
+            [(4, 32), (133, 32), (261, 32), (391, 32), (519, 32), (4, 189), (133, 189), (261, 189), (391, 189)],
+            result.Select(card => (card.CardRect.X, card.CardRect.Y)));
+    }
+
+    [Fact]
+    public void MergeCharacterCards_DeduplicatesSmallCoordinateJitter()
+    {
+        CharacterCardRect[] first = [Card(4, 32), Card(133, 32)];
+        CharacterCardRect[] second = [Card(7, 35), Card(136, 29)];
+
+        var result = CharacterSelectionHelper.MergeCharacterCards(first, second, 1);
+
+        Assert.Equal(2, result.Count);
+    }
+
+    [Fact]
+    public void MergeCharacterCards_KeepsVisualOrder()
+    {
+        CharacterCardRect[] first = [Card(261, 189), Card(391, 32)];
+        CharacterCardRect[] second = [Card(4, 189), Card(133, 32)];
+
+        var result = CharacterSelectionHelper.MergeCharacterCards(first, second, 1);
+
+        Assert.Equal(
+            [(133, 32), (391, 32), (4, 189), (261, 189)],
+            result.Select(card => (card.CardRect.X, card.CardRect.Y)));
+    }
+
+    private static CharacterCardRect Card(int x, int y) =>
+        new(new Rect(x, y, 115, 140), new Rect(x, y, 115, 115), new Rect(x, y, 48, 48));
+}


### PR DESCRIPTION
## 问题

在 BetterGI v0.63.0 的真实账号上调用 `characterDevelopmentTask.GetCharacter("梦见月瑞希")` 时，账号实际拥有该角色，但选择阶段会失败：

- 筛选条件为风元素、法器；界面实际有 9 个可见角色框。
- 原底栏检测得到 17 个连通域、只生成 8 个角色框；左上角选中态角色因底栏颜色不同被漏检。
- 头像模型在该页面给出的结果置信度很低且与实际角色不符，例如爱诺 0.110、烟绯 0.112、可莉约 0.17，无法达到 0.7 阈值。
- 最终滚动到底部并报“未找到目标角色 梦见月瑞希”。

以上为脱敏后的原始失败案例；PR 不包含账号 UID 或游戏截图。

## 修复

- 普通角色先 OCR 右侧当前选中角色名，已经命中时直接返回。
- 点击一个已检测角色后重新检测，并合并切换选中态前后的结果，找回底栏非白色的选中角色框，不再依赖固定网格猜测。
- 头像模型只作为加速器：仅置信度达到原阈值的目标预测优先验证，其余候选保持视觉顺序。
- 逐个点击候选角色，以右侧显示名称 OCR 作为最终裁决；名称需连续两次一致，最多尝试六次，并忽略 OCR 产生的空白字符。
- 旅行者、空、荧、流浪者等可能显示自定义名称的特殊角色保留原头像模型判定路径。
- 增加候选位置、头像预测和实际 OCR 名称日志，便于后续诊断。

## 实机验证

最终实现的一次完整回归中：

- 初次检测 8 个角色框；切换选中态后检测 9 个；两帧合并为 9 个真实角色框。
- 视觉顺序 OCR 映射为：哥伦比娅、爱可菲、玛薇卡、伊涅芙、梦见月瑞希、砂糖、伊法、蓝砚、鹿野院平藏。
- 目标在第 5 格，逐卡 OCR 正确命中。
- 正式 `GetCharacter` 返回：梦见月瑞希、等级 70、武器祭礼残章、天赋 1/1/1，状态机到达 `Completed`。
- 调试配置在完成后自动退出原神。

## 测试

- `CharacterSelectionHelperTests`：Debug 9/9 通过。
- `CharacterSelectionHelperTests`：Release 9/9 通过。
- 已变基到最新 `upstream/main`（0.63.2-alpha.2）并重新恢复依赖、编译通过。

