### PR TITLE
feat:获取剪切板兑换码时去除url

### DIFF
--- a/BetterGenshinImpact/GameTask/UseRedeemCode/RedeemCodeManager.cs
+++ b/BetterGenshinImpact/GameTask/UseRedeemCode/RedeemCodeManager.cs
@@ -14,6 +14,9 @@ public class RedeemCodeManager
 {
     public static HashSet<string> CancelClipboardHash { get; } = [];
 
+    private static readonly Regex UrlStripRegex =
+        new(@"https?://\S+", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+    
     public static void AddNotDetectClipboardText(string clipboardText)
     {
         var md5Hash = MD5Helper.ComputeMD5(clipboardText);
@@ -32,8 +35,9 @@ public class RedeemCodeManager
         {
             return;
         }
-        
-        var codes = ExtractAllCodes(clipboardText);
+
+        var cleanedText = UrlStripRegex.Replace(clipboardText, "");  
+        var codes = ExtractAllCodes(cleanedText);
         if (codes.Count == 0)
         {
             return;


### PR DESCRIPTION
自己工作需要复制的url刚好会被正则匹配到，一般也不会有人把兑换码和url复制在一块吧

---

https://www.kujiale.com/pub/tool/render/image/display/3FOEWEJCE8GD?type=2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化兑换码提取逻辑，自动移除剪贴板文本中的 HTTP/HTTPS 链接，减少链接内容对兑换码识别的干扰。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->