### PR TITLE
fix(ui): 最大化时 MessageBox 相对父窗口居中

### DIFF
--- a/BetterGenshinImpact/Core/Script/ScriptRepoUpdater.cs
+++ b/BetterGenshinImpact/Core/Script/ScriptRepoUpdater.cs
@@ -2133,6 +2133,7 @@ public class ScriptRepoUpdater : Singleton<ScriptRepoUpdater>
                     WindowStartupLocation = WindowStartupLocation.CenterOwner,
                 };
                 uiMessageBox.SourceInitialized += (s, e) => WindowHelper.TryApplySystemBackdrop(uiMessageBox);
+                WindowHelper.CenterOnVisibleOwner(uiMessageBox);
 
                 var result = await uiMessageBox.ShowDialogAsync();
                 if (result == Wpf.Ui.Controls.MessageBoxResult.Primary)

--- a/BetterGenshinImpact/Helpers/Ui/WindowHelper.cs
+++ b/BetterGenshinImpact/Helpers/Ui/WindowHelper.cs
@@ -113,4 +113,31 @@ public class WindowHelper
             _ => Color.FromArgb(255, 32, 32, 32)
         };
     }
+
+    /// <summary>
+    /// 按父窗口当前可见区域居中。尚未 Loaded 时会在 Loaded 后再执行。
+    /// </summary>
+    public static void CenterOnVisibleOwner(System.Windows.Window window)
+    {
+        if (!window.IsLoaded)
+        {
+            window.Loaded += (_, _) => CenterOnVisibleOwner(window);
+            return;
+        }
+
+        var owner = window.Owner ?? System.Windows.Application.Current?.MainWindow;
+        if (owner is null || !owner.IsVisible || owner.WindowState == System.Windows.WindowState.Minimized)
+        {
+            return;
+        }
+
+        if (System.Windows.PresentationSource.FromVisual(owner)?.CompositionTarget is not { } ct)
+        {
+            return;
+        }
+
+        var origin = ct.TransformFromDevice.Transform(owner.PointToScreen(default));
+        window.Left = origin.X + (owner.ActualWidth - window.ActualWidth) / 2;
+        window.Top = origin.Y + (owner.ActualHeight - window.ActualHeight) / 2;
+    }
 }

--- a/BetterGenshinImpact/ViewModel/Pages/JsListViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/JsListViewModel.cs
@@ -16,7 +16,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
-using BetterGenshinImpact.Helpers;
+using BetterGenshinImpact.Helpers.Ui;
 using BetterGenshinImpact.View.Controls.Drawer;
 using BetterGenshinImpact.View.Controls.Markdown;
 using BetterGenshinImpact.View.Controls.Webview;
@@ -154,6 +154,7 @@ public partial class JsListViewModel : ViewModel
             Owner = Application.Current.MainWindow,
             WindowStartupLocation = WindowStartupLocation.CenterOwner,
         };
+        WindowHelper.CenterOnVisibleOwner(messageBox);
 
         var result = await messageBox.ShowDialogAsync();
         if (result == Wpf.Ui.Controls.MessageBoxResult.Primary)

--- a/BetterGenshinImpact/ViewModel/Pages/MapPathingViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/MapPathingViewModel.cs
@@ -230,6 +230,7 @@ public partial class MapPathingViewModel : ViewModel
             Owner = Application.Current.MainWindow,
             WindowStartupLocation = WindowStartupLocation.CenterOwner,
         };
+        WindowHelper.CenterOnVisibleOwner(messageBox);
 
         var result = await messageBox.ShowDialogAsync();
         if (result == Wpf.Ui.Controls.MessageBoxResult.Primary)

--- a/BetterGenshinImpact/ViewModel/Pages/ScriptControlViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/ScriptControlViewModel.cs
@@ -317,6 +317,7 @@ public partial class ScriptControlViewModel : ViewModel
             WindowStartupLocation = WindowStartupLocation.CenterOwner,
         };
         uiMessageBox.SourceInitialized += (s, e) => WindowHelper.TryApplySystemBackdrop(uiMessageBox);
+        WindowHelper.CenterOnVisibleOwner(uiMessageBox);
 
         void OnQuestionButtonOnClick(object sender, RoutedEventArgs args)
         {
@@ -1624,6 +1625,7 @@ public partial class ScriptControlViewModel : ViewModel
             Owner = Application.Current.MainWindow,
             WindowStartupLocation = WindowStartupLocation.CenterOwner,
         };
+        WindowHelper.CenterOnVisibleOwner(uiMessageBox);
         await uiMessageBox.ShowDialogAsync();
         editor.DataContext = null;
     }
@@ -1669,6 +1671,7 @@ public partial class ScriptControlViewModel : ViewModel
                 WindowStartupLocation = WindowStartupLocation.CenterOwner,
             };
             AutoTranslateInterceptor.SetEnableAutoTranslate(uiMessageBox, false);
+            WindowHelper.CenterOnVisibleOwner(uiMessageBox);
             uiMessageBox.ShowDialogAsync();
 
             // 由于 JsScriptSettingsObject 的存在，这里只能手动再次保存配置
@@ -2175,6 +2178,7 @@ public partial class ScriptControlViewModel : ViewModel
             Owner = Application.Current.MainWindow,
             WindowStartupLocation = WindowStartupLocation.CenterOwner,
         };
+        WindowHelper.CenterOnVisibleOwner(uiMessageBox);
 
         var result = await uiMessageBox.ShowDialogAsync();
         if (result == MessageBoxResult.Primary)
@@ -2363,6 +2367,7 @@ public partial class ScriptControlViewModel : ViewModel
             Owner = Application.Current.MainWindow,
             WindowStartupLocation = WindowStartupLocation.CenterOwner,
         };
+        WindowHelper.CenterOnVisibleOwner(uiMessageBox);
 
         var result = await uiMessageBox.ShowDialogAsync();
         if (result == MessageBoxResult.Primary)

--- a/BetterGenshinImpact/ViewModel/Pages/TaskSettingsPageViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/TaskSettingsPageViewModel.cs
@@ -19,6 +19,7 @@ using BetterGenshinImpact.GameTask.GetGridIcons;
 using BetterGenshinImpact.GameTask.Model.GameUI;
 using BetterGenshinImpact.GameTask.UseRedeemCode;
 using BetterGenshinImpact.Helpers;
+using BetterGenshinImpact.Helpers.Ui;
 using BetterGenshinImpact.Service.Interface;
 using BetterGenshinImpact.View.Pages;
 using BetterGenshinImpact.View.Windows;
@@ -284,6 +285,7 @@ public partial class TaskSettingsPageViewModel : ViewModel
             Owner = Application.Current.MainWindow,
             WindowStartupLocation = WindowStartupLocation.CenterOwner,
         };
+        WindowHelper.CenterOnVisibleOwner(messageBox);
 
         var result = await messageBox.ShowDialogAsync();
         var accepted = result == Wpf.Ui.Controls.MessageBoxResult.Primary;


### PR DESCRIPTION
# fix(ui): 最大化时 MessageBox 相对父窗口居中

## 问题

主窗口最大化后，`Wpf.Ui.Controls.MessageBox` 没有相对父窗口居中，而是跟着最大化前的还原尺寸走。还原窗口接近全屏时看起来正常，真正最大化后会偏位。

## 原因

WPF-UI 的 `MessageBox` 在 `Loaded` 里自行计算位置，使用 `Owner.Left` / `Owner.Width`。最大化后这两项仍是还原尺寸。上游 [#1045](https://github.com/lepoco/wpfui/issues/1045) 仍为 open。

普通 `FluentWindow` / `ThemedMessageBox` 使用 WPF 原生 `CenterOwner`，最大化后位置正常，无需修改。

## 方案

新增 `WindowHelper.CenterOnVisibleOwner`：用父窗口 `PointToScreen` 与 `ActualWidth` / `ActualHeight` 居中。对话框尚未 `Loaded` 时会等加载完成后再执行，从而覆盖 WPF-UI 自己的错误定位。

调用处仍保留 `Owner` 与 `WindowStartupLocation.CenterOwner`，避免先被放到屏幕中央。

## 受影响的 UI 路径

| 对话框标题 | UI 路径 |
|---|---|
| 修改JS脚本自定义设置 | 全自动 → 调度器 → 选中 JS 任务 → 右键 → **修改JS脚本自定义配置** |
| 修改通用设置 | 全自动 → 调度器 → 选中任务 → 右键 → **修改通用配置** |
| 日志分析 | 全自动 → 调度器 → **更多功能** → **日志分析** |
| 选择需要执行的配置组 | 全自动 → 调度器 → **连续执行** |
| 选择需要继续执行的进度记录 | 全自动 → 调度器 → **继续执行**（需已有进度记录） |
| 删除确认 | 全自动 → JS 脚本 → 选中脚本 → 右键 → **删除** |
| 删除确认 | 全自动 → 地图追踪 → 选中文件/文件夹 → 右键 → **删除** |
| 风险提示 | 独立任务 → **自动地脉花** → 打开 **领取奖励后扫描掉落物光柱** |
| 脚本订阅 | 剪贴板或协议打开 `bettergi://script?import=...` |

## 部分效果图

| 修复前 | 修复后 |
|---|---|
| <img width="1920" height="1155" alt="1-1" src="https://github.com/user-attachments/assets/86e5be08-2cf0-448a-8072-34d2b8dcc875" /> | <img width="1920" height="1155" alt="1-2" src="https://github.com/user-attachments/assets/8a3fa456-14ae-45de-b562-cd718d05d041" /> |
| <img width="1920" height="1155" alt="2-1" src="https://github.com/user-attachments/assets/7c122cc7-0028-4353-93b2-a59a285cc405" /> | <img width="1920" height="1155" alt="2-2" src="https://github.com/user-attachments/assets/36910c10-0c8a-4e92-a68d-4c69b15290a1" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 优化多个确认、设置和提示对话框的定位方式。
  * 对话框现在会根据当前可见窗口自动居中显示，提升多窗口场景下的使用体验。
  * 当窗口尚未完成加载时，将在显示后自动调整位置，确保对话框稳定出现在合适的位置。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->