### PR TITLE
fix: 等待奖励界面稳定后再进行识别

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoDomain/AutoDomainTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoDomain/AutoDomainTask.cs
@@ -1285,8 +1285,7 @@ public class AutoDomainTask : ISoloTask<Dictionary<string, int>>
         
         Notify.Event(NotificationEvent.DomainReward).Success("自动秘境奖励领取");
 
-        Sleep(1000, _ct);
-        TryRecognizeRewardResult();
+        await TryRecognizeRewardResult();
 
         for (var i = 0; i < 30; i++)
         {
@@ -1344,7 +1343,7 @@ public class AutoDomainTask : ISoloTask<Dictionary<string, int>>
         throw new NormalEndException("未检测到秘境结束，可能是背包物品已满。");
     }
 
-    private void TryRecognizeRewardResult()
+    private async Task TryRecognizeRewardResult()
     {
         if (!_taskParam.RewardRecognitionEnabled)
         {
@@ -1353,6 +1352,12 @@ public class AutoDomainTask : ISoloTask<Dictionary<string, int>>
 
         try
         {
+            if (!await WaitForRewardResultReady())
+            {
+                Logger.LogWarning("自动秘境：奖励结果页未检测到退出按钮，已跳过本轮奖励识别");
+                return;
+            }
+
             // 使用多页识别（自动检测是否需要翻页）
             Logger.LogInformation("自动秘境：开始奖励识别");
             var rewards = RewardResultRecognizer.Instance.RecognizeMultiPage();
@@ -1373,6 +1378,21 @@ public class AutoDomainTask : ISoloTask<Dictionary<string, int>>
         {
             Logger.LogWarning(e, "自动秘境：奖励识别失败，已跳过本轮奖励汇总");
         }
+    }
+
+    private async Task<bool> WaitForRewardResultReady()
+    {
+        for (var i = 0; i < 20; i++)
+        {
+            using var capture = CaptureToRectArea();
+            using var exitRegion = capture.Find(RecognitionAssets.Get("AutoFight", "Exit", capture));
+            if (exitRegion.IsExist())
+            {
+                return true;
+            }
+            await Delay(300, _ct);
+        }
+        return false;
     }
 
     private async Task ExitDomain()


### PR DESCRIPTION
识别前只有一个1s的等待，此时大部分情况下都没有加载出奖励图标来。
此PR改为识别到退出按钮再进行识别，按钮比奖励图标出现的要晚，奖励图标已基本稳定。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化奖励领取流程，等待奖励结果页面准备完成后再进行识别。
  * 在页面未准备就绪时跳过本轮识别，减少识别失败或流程异常。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->