### PR TITLE
fix: 奖励识别优化

### DIFF
--- a/BetterGenshinImpact/BetterGenshinImpact.csproj
+++ b/BetterGenshinImpact/BetterGenshinImpact.csproj
@@ -44,7 +44,7 @@
 
 		<PackageReference Include="BetterGI.VCRuntime" Version="14.44.35208" />
 		<PackageReference Include="BetterGI.Assets.Map" Version="1.0.21" />
-        <PackageReference Include="BetterGI.Assets.Model" Version="1.0.30" />
+        <PackageReference Include="BetterGI.Assets.Model" Version="1.0.31" />
 		<PackageReference Include="BetterGI.Assets.Other" Version="1.0.20" />
 
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />

--- a/BetterGenshinImpact/GameTask/AutoDomain/AutoDomainTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoDomain/AutoDomainTask.cs
@@ -1286,7 +1286,7 @@ public class AutoDomainTask : ISoloTask<Dictionary<string, int>>
         Notify.Event(NotificationEvent.DomainReward).Success("自动秘境奖励领取");
 
         Sleep(1000, _ct);
-        TryRecognizeRewardResult();
+        await TryRecognizeRewardResult();
 
         for (var i = 0; i < 30; i++)
         {
@@ -1344,7 +1344,7 @@ public class AutoDomainTask : ISoloTask<Dictionary<string, int>>
         throw new NormalEndException("未检测到秘境结束，可能是背包物品已满。");
     }
 
-    private void TryRecognizeRewardResult()
+    private async Task TryRecognizeRewardResult()
     {
         if (!_taskParam.RewardRecognitionEnabled)
         {
@@ -1353,6 +1353,12 @@ public class AutoDomainTask : ISoloTask<Dictionary<string, int>>
 
         try
         {
+            if (!await WaitForRewardResultReady())
+            {
+                Logger.LogWarning("自动秘境：奖励结果页未检测到退出按钮，已跳过本轮奖励识别");
+                return;
+            }
+
             // 使用多页识别（自动检测是否需要翻页）
             Logger.LogInformation("自动秘境：开始奖励识别");
             var rewards = RewardResultRecognizer.Instance.RecognizeMultiPage();
@@ -1373,6 +1379,21 @@ public class AutoDomainTask : ISoloTask<Dictionary<string, int>>
         {
             Logger.LogWarning(e, "自动秘境：奖励识别失败，已跳过本轮奖励汇总");
         }
+    }
+
+    private async Task<bool> WaitForRewardResultReady()
+    {
+        for (var i = 0; i < 20; i++)
+        {
+            using var capture = CaptureToRectArea();
+            using var exitRegion = capture.Find(RecognitionAssets.Get("AutoFight", "Exit", capture));
+            if (exitRegion.IsExist())
+            {
+                return true;
+            }
+            await Delay(300, _ct);
+        }
+        return false;
     }
 
     private async Task ExitDomain()

--- a/BetterGenshinImpact/GameTask/AutoDomain/AutoDomainTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoDomain/AutoDomainTask.cs
@@ -1375,7 +1375,7 @@ public class AutoDomainTask : ISoloTask<Dictionary<string, int>>
                 Logger.LogWarning("自动秘境：本轮奖励识别结果为空");
             }
         }
-        catch (Exception e) when (e is not OperationCanceledException)
+        catch (Exception e) when (e is not OperationCanceledException and not NormalEndException)
         {
             Logger.LogWarning(e, "自动秘境：奖励识别失败，已跳过本轮奖励汇总");
         }

--- a/BetterGenshinImpact/GameTask/Common/Reward/RewardResultRecognizer.cs
+++ b/BetterGenshinImpact/GameTask/Common/Reward/RewardResultRecognizer.cs
@@ -12,7 +12,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading;
 
 namespace BetterGenshinImpact.GameTask.Common.Reward;
@@ -387,29 +386,29 @@ public class RewardResultRecognizer
     /// <returns>识别到的数量；失败时返回 -1。</returns>
     private int RecognizeCountByOcr(Mat cardMat, IOcrService ocrService, int cardIdx)
     {
-        int count = -1;
-        string? countOcrText = null;
         try
         {
-            countOcrText = cardMat.GetGridItemIconText(ocrService);
-            string numStr = StringUtils.ConvertFullWidthNumToHalfWidth(countOcrText ?? string.Empty);
-            var digits = Regex.Replace(numStr, @"\D", string.Empty);
-            if (!string.IsNullOrEmpty(digits) && int.TryParse(digits, out var n))
+            using GridItemCountRecognitionResult result =
+                GridItemCountRecognizer.RecognizeCropped(cardMat, ocrService);
+            if (result.Count >= 0)
             {
-                count = n;
+                return result.Count;
             }
+
+            _logger.LogWarning(
+                "奖励识别：卡片 {CardIndex} 数量没有识别出来，OCR 原文：{RawText}，原因：{Reason}，有效连通域：{ComponentCount}，已按 1 个计入。",
+                cardIdx,
+                result.RawText,
+                result.Reason,
+                result.ComponentCount);
         }
         catch (Exception ex)
         {
             _logger.LogDebug(ex, "奖励识别：卡片 {CardIndex} 数量OCR异常，数量保持 -1", cardIdx);
+            _logger.LogWarning("奖励识别：卡片 {CardIndex} 数量识别异常，已按 1 个计入。", cardIdx);
         }
 
-        if (count < 0)
-        {
-            _logger.LogWarning("奖励识别：有一个奖励数量没有识别出来，已按 1 个计入。");
-        }
-
-        return count;
+        return -1;
     }
 
     /// <summary>


### PR DESCRIPTION
秘境的奖励识别前只有一个1s的等待，改为识别到退出按钮再进行识别。


奖励数量的数字1还是有概率识别不到，改为沿用上次pr的背包计数的数量识别方法。


另外更新了识别模型版本号。需要等https://github.com/babalae/bettergi-libraries/pull/21 对应的包发布再合并

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug 修复**
  - 优化自动秘境奖励识别流程，等待奖励结果页面准备完成后再执行识别，减少识别过早导致的遗漏。
  - 改进奖励数量识别及异常处理，识别失败时记录更明确的诊断信息，并按默认数量处理，避免流程中断。
  - 增加结果页面未准备完成时的保护机制，降低奖励汇总错误的发生概率。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->