### PR TITLE
feat(script): 地图追踪JS调用添加执行结果返回值

### DIFF
--- a/BetterGenshinImpact/Core/Script/Dependence/AutoPathingScript.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/AutoPathingScript.cs
@@ -29,9 +29,20 @@ public class AutoPathingScript
     /// <returns>执行结果（是否成功等）</returns>
     public async Task<PathingRunResult> Run(string json)
     {
+        PathingTask task;
         try
         {
-            var task = PathingTask.BuildFromJson(json);
+            task = PathingTask.BuildFromJson(json);
+        }
+        catch (Exception e)
+        {
+            TaskControl.Logger.LogDebug(e, "地图追踪 JSON 解析失败");
+            TaskControl.Logger.LogError("地图追踪 JSON 解析失败: {Msg}", e.Message);
+            return PathingRunResult.Fail($"地图追踪 JSON 解析失败: {e.Message}");
+        }
+
+        try
+        {
             var pathExecutor = new PathExecutor(CancellationContext.Instance.Cts.Token);
             if (_config != null && _config is PathingPartyConfig patyConfig)
             {
@@ -40,19 +51,31 @@ public class AutoPathingScript
 
             await pathExecutor.Pathing(task);
 
-            // 成功判定：完整走完所有路径
-            // 中途放弃（HandledException）时 EndByHandledException 为 true，不能视为成功
+            // 只有真正正常完整走完所有路径才算成功
             if (pathExecutor.SuccessEnd && !pathExecutor.EndByHandledException)
             {
                 return PathingRunResult.Ok();
             }
 
-            return PathingRunResult.Fail("地图追踪未完整走完");
+            // 与 Pathing 使用同一个取消令牌，独立运行时 Pathing 内部会静默吞掉取消异常，这里补判定
+            if (CancellationContext.Instance.Cts.IsCancellationRequested)
+            {
+                TaskControl.Logger.LogInformation("地图追踪被手动取消");
+                return PathingRunResult.Fail("地图追踪被手动取消");
+            }
+
+            // 中途放弃路径（HandledException）
+            if (pathExecutor.EndByHandledException)
+            {
+                return PathingRunResult.Fail("点位无法识别，放弃路线");
+            }
+
+            return PathingRunResult.Fail("此追踪脚本未正常走完！");
         }
-        catch (OperationCanceledException e)
+        catch (OperationCanceledException)
         {
-            TaskControl.Logger.LogInformation("地图追踪被取消: {Msg}", e.Message);
-            return PathingRunResult.Fail($"地图追踪被取消: {e.Message}", PathingRunStatus.Cancelled);
+            TaskControl.Logger.LogInformation("地图追踪被手动取消");
+            return PathingRunResult.Fail("地图追踪被手动取消");
         }
         catch (Exception e)
         {
@@ -69,17 +92,22 @@ public class AutoPathingScript
     /// <returns>执行结果（是否成功等）</returns>
     public async Task<PathingRunResult> RunFile(string path)
     {
-        try
+        var limitedFile = new LimitedFile(_rootPath);
+        if (!limitedFile.IsFile(path))
         {
-            var json = await new LimitedFile(_rootPath).ReadText(path);
-            return await Run(json);
+            TaskControl.Logger.LogError("地图追踪文件不存在: {Path}", path);
+            return PathingRunResult.Fail($"地图追踪文件不存在: {path}");
         }
-        catch (Exception e)
+
+        var json = await limitedFile.ReadText(path);
+        // ReadText 读取失败时返回空字符串，路径 JSON 内容非空，空串视为读取失败
+        if (string.IsNullOrEmpty(json))
         {
-            TaskControl.Logger.LogDebug(e, "读取文件时发生错误");
-            TaskControl.Logger.LogError("读取文件时发生错误: {Msg}", e.Message);
-            return PathingRunResult.Fail($"读取路径文件失败: {e.Message}", PathingRunStatus.FileReadError);
+            TaskControl.Logger.LogError("地图追踪文件读取失败: {Path}", path);
+            return PathingRunResult.Fail($"地图追踪文件读取失败: {path}");
         }
+
+        return await Run(json);
     }
 
     /// <summary>
@@ -89,17 +117,21 @@ public class AutoPathingScript
     /// <returns>执行结果（是否成功等）</returns>
     public async Task<PathingRunResult> RunFileFromUser(string path)
     {
-        try
+        if (!AutoPathingFile.IsFile(path))
         {
-            var json = await AutoPathingFile.ReadText(path);
-            return await Run(json);
+            TaskControl.Logger.LogError("地图追踪文件不存在: {Path}", path);
+            return PathingRunResult.Fail($"地图追踪文件不存在: {path}");
         }
-        catch (Exception e)
+
+        var json = await AutoPathingFile.ReadText(path);
+        // ReadText 读取失败时返回空字符串，路径 JSON 内容非空，空串视为读取失败
+        if (string.IsNullOrEmpty(json))
         {
-            TaskControl.Logger.LogDebug(e, "读取文件时发生错误");
-            TaskControl.Logger.LogError("读取文件时发生错误: {Msg}", e.Message);
-            return PathingRunResult.Fail($"读取路径文件失败: {e.Message}", PathingRunStatus.FileReadError);
+            TaskControl.Logger.LogError("地图追踪文件读取失败: {Path}", path);
+            return PathingRunResult.Fail($"地图追踪文件读取失败: {path}");
         }
+
+        return await Run(json);
     }
 
     /// <summary>

--- a/BetterGenshinImpact/Core/Script/Dependence/AutoPathingScript.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/AutoPathingScript.cs
@@ -40,8 +40,9 @@ public class AutoPathingScript
 
             await pathExecutor.Pathing(task);
 
-            // 与内置"地图追踪"任务的判定保持一致：未完整走完视为失败
-            if (pathExecutor.SuccessEnd)
+            // 成功判定：完整走完所有路径
+            // 中途放弃（HandledException）时 EndByHandledException 为 true，不能视为成功
+            if (pathExecutor.SuccessEnd && !pathExecutor.EndByHandledException)
             {
                 return PathingRunResult.Ok();
             }

--- a/BetterGenshinImpact/Core/Script/Dependence/AutoPathingScript.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/AutoPathingScript.cs
@@ -3,6 +3,7 @@ using BetterGenshinImpact.GameTask.AutoPathing;
 using BetterGenshinImpact.GameTask.AutoPathing.Model;
 using System.Threading.Tasks;
 using BetterGenshinImpact.Core.Config;
+using BetterGenshinImpact.Core.Script.Dependence.Model;
 using BetterGenshinImpact.GameTask.Common;
 using Microsoft.Extensions.Logging;
 
@@ -21,7 +22,12 @@ public class AutoPathingScript
         _autoPathingFile = new LimitedFile(Global.Absolute(@"User\AutoPathing"));
     }
 
-    public async Task Run(string json)
+    /// <summary>
+    /// 通过 JSON 字符串执行地图追踪，返回执行结果
+    /// </summary>
+    /// <param name="json">地图追踪路径的 JSON 内容</param>
+    /// <returns>执行结果（是否成功等）</returns>
+    public async Task<PathingRunResult> Run(string json)
     {
         try
         {
@@ -33,36 +39,66 @@ public class AutoPathingScript
             }
 
             await pathExecutor.Pathing(task);
-        }
-        catch (Exception e)
-        {
-            TaskControl.Logger.LogDebug(e,"执行地图追踪时候发生错误");
-            TaskControl.Logger.LogError("执行地图追踪时候发生错误: {Msg}",e.Message);
-        }
-    }
 
-    public async Task RunFile(string path)
-    {
-        try
+            // 与内置"地图追踪"任务的判定保持一致：未完整走完视为失败
+            if (pathExecutor.SuccessEnd)
+            {
+                return PathingRunResult.Ok();
+            }
+
+            return PathingRunResult.Fail("地图追踪未完整走完");
+        }
+        catch (OperationCanceledException e)
         {
-            var json = await new LimitedFile(_rootPath).ReadText(path);
-            await Run(json);
+            TaskControl.Logger.LogInformation("地图追踪被取消: {Msg}", e.Message);
+            return PathingRunResult.Fail($"地图追踪被取消: {e.Message}", PathingRunStatus.Cancelled);
         }
         catch (Exception e)
         {
-            TaskControl.Logger.LogDebug(e,"读取文件时发生错误");
-            TaskControl.Logger.LogError("读取文件时发生错误: {Msg}",e.Message);
+            TaskControl.Logger.LogDebug(e, "执行地图追踪时候发生错误");
+            TaskControl.Logger.LogError("执行地图追踪时候发生错误: {Msg}", e.Message);
+            return PathingRunResult.Fail($"地图追踪执行失败: {e.Message}");
         }
     }
 
     /// <summary>
-    /// 从已订阅的内容中获取文件
+    /// 通过脚本目录下的路径文件执行地图追踪，返回执行结果
+    /// </summary>
+    /// <param name="path">相对于脚本根目录的路径文件路径</param>
+    /// <returns>执行结果（是否成功等）</returns>
+    public async Task<PathingRunResult> RunFile(string path)
+    {
+        try
+        {
+            var json = await new LimitedFile(_rootPath).ReadText(path);
+            return await Run(json);
+        }
+        catch (Exception e)
+        {
+            TaskControl.Logger.LogDebug(e, "读取文件时发生错误");
+            TaskControl.Logger.LogError("读取文件时发生错误: {Msg}", e.Message);
+            return PathingRunResult.Fail($"读取路径文件失败: {e.Message}", PathingRunStatus.FileReadError);
+        }
+    }
+
+    /// <summary>
+    /// 从已订阅的内容中获取文件并执行地图追踪，返回执行结果
     /// </summary>
     /// <param name="path">在 `\User\AutoPathing` 目录下获取文件</param>
-    public async Task RunFileFromUser(string path)
+    /// <returns>执行结果（是否成功等）</returns>
+    public async Task<PathingRunResult> RunFileFromUser(string path)
     {
-        var json = await AutoPathingFile.ReadText(path);
-        await Run(json);
+        try
+        {
+            var json = await AutoPathingFile.ReadText(path);
+            return await Run(json);
+        }
+        catch (Exception e)
+        {
+            TaskControl.Logger.LogDebug(e, "读取文件时发生错误");
+            TaskControl.Logger.LogError("读取文件时发生错误: {Msg}", e.Message);
+            return PathingRunResult.Fail($"读取路径文件失败: {e.Message}", PathingRunStatus.FileReadError);
+        }
     }
 
     /// <summary>

--- a/BetterGenshinImpact/Core/Script/Dependence/Model/PathingRunResult.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/Model/PathingRunResult.cs
@@ -1,0 +1,73 @@
+namespace BetterGenshinImpact.Core.Script.Dependence.Model;
+
+/// <summary>
+/// 地图追踪执行结果，作为 JS 调用 pathingScript 的返回值
+/// </summary>
+public class PathingRunResult
+{
+    /// <summary>
+    /// 是否成功完成地图追踪
+    /// </summary>
+    public bool Success { get; set; }
+
+    /// <summary>
+    /// 执行结果状态
+    /// </summary>
+    public string Status { get; set; } = PathingRunStatus.Failed;
+
+    /// <summary>
+    /// 结果描述（失败原因等）
+    /// </summary>
+    public string Message { get; set; } = "";
+
+    public static PathingRunResult Ok(string message = "地图追踪执行成功")
+    {
+        return new PathingRunResult
+        {
+            Success = true,
+            Status = PathingRunStatus.Success,
+            Message = message
+        };
+    }
+
+    public static PathingRunResult Fail(string message, string status = PathingRunStatus.Failed)
+    {
+        return new PathingRunResult
+        {
+            Success = false,
+            Status = status,
+            Message = message
+        };
+    }
+}
+
+/// <summary>
+/// 地图追踪执行结果状态常量
+/// </summary>
+public static class PathingRunStatus
+{
+    /// <summary>
+    /// 成功完成
+    /// </summary>
+    public const string Success = "Success";
+
+    /// <summary>
+    /// 执行被取消
+    /// </summary>
+    public const string Cancelled = "Cancelled";
+
+    /// <summary>
+    /// 路径 JSON 解析失败
+    /// </summary>
+    public const string JsonParseError = "JsonParseError";
+
+    /// <summary>
+    /// 路径文件读取失败
+    /// </summary>
+    public const string FileReadError = "FileReadError";
+
+    /// <summary>
+    /// 执行失败
+    /// </summary>
+    public const string Failed = "Failed";
+}

--- a/BetterGenshinImpact/Core/Script/Dependence/Model/PathingRunResult.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/Model/PathingRunResult.cs
@@ -15,6 +15,11 @@ public class PathingRunResult
     /// </summary>
     public string Message { get; set; } = "";
 
+    /// <summary>
+    /// 创建成功结果
+    /// </summary>
+    /// <param name="message">结果描述</param>
+    /// <returns>成功结果对象</returns>
     public static PathingRunResult Ok(string message = "地图追踪执行成功")
     {
         return new PathingRunResult
@@ -24,6 +29,11 @@ public class PathingRunResult
         };
     }
 
+    /// <summary>
+    /// 创建失败结果
+    /// </summary>
+    /// <param name="message">失败原因描述</param>
+    /// <returns>失败结果对象</returns>
     public static PathingRunResult Fail(string message)
     {
         return new PathingRunResult

--- a/BetterGenshinImpact/Core/Script/Dependence/Model/PathingRunResult.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/Model/PathingRunResult.cs
@@ -6,14 +6,9 @@ namespace BetterGenshinImpact.Core.Script.Dependence.Model;
 public class PathingRunResult
 {
     /// <summary>
-    /// 是否成功完成地图追踪
+    /// 是否真正正常完整运行完成（取消、中途放弃、解析/读取失败、异常等均视为失败）
     /// </summary>
     public bool Success { get; set; }
-
-    /// <summary>
-    /// 执行结果状态
-    /// </summary>
-    public string Status { get; set; } = PathingRunStatus.Failed;
 
     /// <summary>
     /// 结果描述（失败原因等）
@@ -25,49 +20,16 @@ public class PathingRunResult
         return new PathingRunResult
         {
             Success = true,
-            Status = PathingRunStatus.Success,
             Message = message
         };
     }
 
-    public static PathingRunResult Fail(string message, string status = PathingRunStatus.Failed)
+    public static PathingRunResult Fail(string message)
     {
         return new PathingRunResult
         {
             Success = false,
-            Status = status,
             Message = message
         };
     }
-}
-
-/// <summary>
-/// 地图追踪执行结果状态常量
-/// </summary>
-public static class PathingRunStatus
-{
-    /// <summary>
-    /// 成功完成
-    /// </summary>
-    public const string Success = "Success";
-
-    /// <summary>
-    /// 执行被取消
-    /// </summary>
-    public const string Cancelled = "Cancelled";
-
-    /// <summary>
-    /// 路径 JSON 解析失败
-    /// </summary>
-    public const string JsonParseError = "JsonParseError";
-
-    /// <summary>
-    /// 路径文件读取失败
-    /// </summary>
-    public const string FileReadError = "FileReadError";
-
-    /// <summary>
-    /// 执行失败
-    /// </summary>
-    public const string Failed = "Failed";
 }

--- a/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
@@ -50,6 +50,8 @@ public partial class PathExecutor
     public int SuccessFight = 0;
     //路径追踪完全走完所有路径结束的标识
     public bool SuccessEnd = false;
+    //是否因 HandledException 中途结束（JS 调用不设置 EndAction 时，即表示中途放弃路径，不能视为成功）
+    public bool EndByHandledException = false;
     private PathingPartyConfig? _partyConfig;
     private CancellationToken ct;
     private PathExecutorSuspend pathExecutorSuspend;
@@ -253,6 +255,7 @@ public partial class PathExecutor
                 catch (HandledException handledException)
                 {
                     SuccessEnd = true;
+                    EndByHandledException = true;
                     break;
                 }
                 catch (NormalEndException normalEndException)


### PR DESCRIPTION
## 背景

JS 调用 `pathingScript.run / runFile / runFileFromUser` 执行地图追踪时没有任何返回值，且 C# 侧把所有异常吞掉只写日志，JS 无法得知地图追踪的运行结果（是否成功、失败原因等）。

这导致现有脚本作者只能各自用旁路手段推断成败（如读取路线 JSON 终点坐标 + `genshin.getPositionFromMap` 距离判定、执行耗时 >10s 判定等），阈值互不统一、可靠性差。

## 改动

- 新增 `PathingRunResult` 结果类型（`Core\Script\Dependence\Model\PathingRunResult.cs`）：
  - `Success`（bool）：是否真正正常完整运行完成
  - `Message`（string）：结果描述（失败原因等）
- `AutoPathingScript` 的三个方法改为返回 `Task<PathingRunResult>`：
  - 只有路径真正正常完整走完才算成功（`SuccessEnd` 且未中途放弃）
  - 用户取消、中途放弃、JSON 解析失败、文件不存在/读取失败、其他异常一律视为失败，原因通过 `Message` 反映
  - 失败文案尽量沿用项目已有日志/异常描述（如 `"此追踪脚本未正常走完！"`、HandledException 的"放弃此路径"场景等）
  - 保持"不向 JS 抛异常"的现有行为，失败通过结果对象反映
- `PathExecutor` 新增 `EndByHandledException` 字段，用于区分"中途放弃路径"与"正常走完"（仅 JS 调用场景使用，内置地图追踪任务判定不受影响）

## 兼容性

- 现有 JS 脚本均为 `await pathingScript.runFile(...)` 且不读取返回值，完全向后兼容
- 引擎已开启 `EnableTaskPromiseConversion`，JS 侧 `const res = await pathingScript.runFile(path)` 可直接拿到结果对象
- 与 ClearScript 大小写不敏感绑定一致，JS 中 `res.success` / `res.Success` 均可访问

## 示例

```js
const res = await pathingScript.runFile("assets/路线.json");
if (res.success) {
    log.info("地图追踪执行成功");
} else {
    log.error(`地图追踪失败: ${res.message}`);
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 地图追踪执行现在会返回明确的成功或失败结果，并提供详细提示。
  - 支持识别取消、解析失败及路线无法识别等情况。

- **问题修复**
  - 改进路径文件存在性检查与读取失败处理。
  - 手动取消或路线中途异常结束时，不再误判为成功。
  - 补充相关日志，提升执行状态反馈的准确性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->