### PR TITLE
fix: 原子保存脚本配置组

### DIFF
--- a/BetterGenshinImpact/Core/Script/Group/ScriptGroup.cs
+++ b/BetterGenshinImpact/Core/Script/Group/ScriptGroup.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.IO;
@@ -62,14 +62,7 @@ public partial class ScriptGroup : ObservableObject
         try
         {
             File.WriteAllText(tempPath, json, Utf8WithoutBom);
-            if (File.Exists(fullPath))
-            {
-                File.Replace(tempPath, fullPath, null);
-            }
-            else
-            {
-                File.Move(tempPath, fullPath);
-            }
+            File.Move(tempPath, fullPath, overwrite: true);
         }
         finally
         {

--- a/BetterGenshinImpact/Core/Script/Group/ScriptGroup.cs
+++ b/BetterGenshinImpact/Core/Script/Group/ScriptGroup.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
+using System.IO;
+using System.Text;
 using BetterGenshinImpact.Service;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Newtonsoft.Json;
@@ -12,6 +14,8 @@ namespace BetterGenshinImpact.Core.Script.Group;
 /// </summary>
 public partial class ScriptGroup : ObservableObject
 {
+    private static readonly Encoding Utf8WithoutBom = new UTF8Encoding(false);
+
     public int Index { get; set; }
 
     [ObservableProperty]
@@ -44,6 +48,33 @@ public partial class ScriptGroup : ObservableObject
     public string ToJson()
     {
         return JsonSerializer.Serialize(this, ConfigService.JsonOptions);
+    }
+
+    public void WriteToFileAtomically(string filePath)
+    {
+        var json = ToJson();
+        var fullPath = Path.GetFullPath(filePath);
+        var directory = Path.GetDirectoryName(fullPath)
+                        ?? throw new ArgumentException("配置组文件路径无效", nameof(filePath));
+        Directory.CreateDirectory(directory);
+
+        var tempPath = Path.Combine(directory, $".{Path.GetFileName(fullPath)}.{Guid.NewGuid():N}.tmp");
+        try
+        {
+            File.WriteAllText(tempPath, json, Utf8WithoutBom);
+            if (File.Exists(fullPath))
+            {
+                File.Replace(tempPath, fullPath, null);
+            }
+            else
+            {
+                File.Move(tempPath, fullPath);
+            }
+        }
+        finally
+        {
+            File.Delete(tempPath);
+        }
     }
 
     public static ScriptGroup FromJson(string json)

--- a/BetterGenshinImpact/Service/ScriptService.cs
+++ b/BetterGenshinImpact/Service/ScriptService.cs
@@ -573,7 +573,7 @@ public partial class ScriptService : IScriptService
             }
 
             var file = Path.Combine(scriptGroupPath, $"{scriptGroup.Name}.json");
-            File.WriteAllText(file, scriptGroup.ToJson());
+            scriptGroup.WriteToFileAtomically(file);
         }
         catch (Exception ex)
         {

--- a/BetterGenshinImpact/ViewModel/Pages/ScriptControlViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/ScriptControlViewModel.cs
@@ -1851,7 +1851,7 @@ public partial class ScriptControlViewModel : ViewModel
             }
 
             var file = Path.Combine(ScriptGroupPath, $"{scriptGroup.Name}.json");
-            File.WriteAllText(file, scriptGroup.ToJson());
+            scriptGroup.WriteToFileAtomically(file);
         }
         catch (Exception e)
         {


### PR DESCRIPTION
## 修改内容
- 先将配置组 JSON 完整写入同目录临时文件
- 写入成功后原子替换目标文件，避免进程中止留下 0 字节配置
- 调度器保存与 JS 执行结束保存统一使用同一入口

## 验证
- 在隔离输出目录完成项目编译验证
- 本地验证已有配置文件可被完整替换并重新反序列化

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 优化脚本组配置保存流程，降低文件写入过程中数据损坏或保存失败的风险。
  * 配置文件现以原子方式写入，确保替换文件时内容完整。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->