### PR TITLE
fix: 修复自动邀约分支选择

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoSkip/AutoSkipTrigger.cs
+++ b/BetterGenshinImpact/GameTask/AutoSkip/AutoSkipTrigger.cs
@@ -393,66 +393,63 @@ public partial class AutoSkipTrigger : ITaskTrigger
                 .. selectedRects.Select(selectedRect => new HangoutOption(selectedRect, true)),
                 .. unselectedRects.Select(unselectedRect => new HangoutOption(unselectedRect, false)),
             ];
-            // 只有一个选项直接点击
-            // if (hangoutOptionList.Count == 1)
-            // {
-            //     hangoutOptionList[0].Click(clickOffset);
-            //     AutoHangoutSkipLog("点击唯一邀约选项");
-            //     return;
-            // }
-
-            hangoutOptionList = hangoutOptionList.Where(hangoutOption => hangoutOption.TextRect != null).ToList();
-            if (hangoutOptionList.Count == 0)
+            var allHangoutOptions = hangoutOptionList;
+            try
             {
-                return;
-            }
+                // 文字区域不存在的识别结果不能参与选择。
+                hangoutOptionList = hangoutOptionList.Where(hangoutOption => hangoutOption.TextRect != null).ToList();
+                if (hangoutOptionList.Count == 0)
+                {
+                    return;
+                }
 
-            // OCR识别选项文字
-            foreach (var hangoutOption in hangoutOptionList)
-            {
-                var text = OcrFactory.Paddle.Ocr(hangoutOption.TextRect!.SrcMat);
-                hangoutOption.OptionTextSrc = StringUtils.RemoveAllEnter(text);
-            }
-
-            // 优先选择分支选项
-            if (!string.IsNullOrEmpty(_config.AutoHangoutEndChoose))
-            {
-                var chooseList = HangoutConfig.Instance.HangoutOptions[_config.AutoHangoutEndChoose];
+                // OCR识别选项文字
                 foreach (var hangoutOption in hangoutOptionList)
                 {
-                    foreach (var str in chooseList)
+                    var text = OcrFactory.Paddle.Ocr(hangoutOption.TextRect!.SrcMat);
+                    hangoutOption.OptionTextSrc = StringUtils.RemoveAllEnter(text);
+                }
+
+                // 目标分支只允许点击当前尚未选择的选项，避免重复点击已选项导致流程偏离。
+                if (!string.IsNullOrEmpty(_config.AutoHangoutEndChoose)
+                    && HangoutConfig.Instance.HangoutOptions.TryGetValue(_config.AutoHangoutEndChoose, out var chooseList))
+                {
+                    var target = FindHangoutTargetOption(hangoutOptionList, chooseList);
+                    if (target != null)
                     {
-                        if (hangoutOption.OptionTextSrc.Contains(str))
-                        {
-                            HangoutOptionClick(hangoutOption);
-                            _logger.LogInformation("邀约分支[{Text}]关键词[{Str}]命中", _config.AutoHangoutEndChoose, str);
-                            AutoHangoutSkipLog(hangoutOption.OptionTextSrc);
-                            VisionContext.Instance().DrawContent.RemoveRect("HangoutSelected");
-                            VisionContext.Instance().DrawContent.RemoveRect("HangoutUnselected");
-                            return;
-                        }
+                        HangoutOptionClick(target);
+                        _logger.LogInformation("邀约分支[{Text}]关键词命中，选择[{Option}]", _config.AutoHangoutEndChoose, target.OptionTextSrc);
+                        AutoHangoutSkipLog(target.OptionTextSrc);
+                        VisionContext.Instance().DrawContent.RemoveRect("HangoutSelected");
+                        VisionContext.Instance().DrawContent.RemoveRect("HangoutUnselected");
+                        return;
                     }
                 }
-            }
 
-            // 没有停留的选项 优先选择未点击的的选项
-            foreach (var hangoutOption in hangoutOptionList)
-            {
-                if (!hangoutOption.IsSelected)
+                // 没有命中目标分支时，优先选择未点击的选项。
+                var unselectedOption = hangoutOptionList.FirstOrDefault(hangoutOption => !hangoutOption.IsSelected);
+                if (unselectedOption != null)
                 {
-                    HangoutOptionClick(hangoutOption);
-                    AutoHangoutSkipLog(hangoutOption.OptionTextSrc);
+                    HangoutOptionClick(unselectedOption);
+                    AutoHangoutSkipLog(unselectedOption.OptionTextSrc);
                     VisionContext.Instance().DrawContent.RemoveRect("HangoutSelected");
                     VisionContext.Instance().DrawContent.RemoveRect("HangoutUnselected");
                     return;
                 }
-            }
 
-            // 没有未点击的选项 选择第一个已点击选项
-            HangoutOptionClick(hangoutOptionList[0]);
-            AutoHangoutSkipLog(hangoutOptionList[0].OptionTextSrc);
-            VisionContext.Instance().DrawContent.RemoveRect("HangoutSelected");
-            VisionContext.Instance().DrawContent.RemoveRect("HangoutUnselected");
+                // 没有未点击的选项时选择第一个已点击选项，推进对话状态。
+                HangoutOptionClick(hangoutOptionList[0]);
+                AutoHangoutSkipLog(hangoutOptionList[0].OptionTextSrc);
+                VisionContext.Instance().DrawContent.RemoveRect("HangoutSelected");
+                VisionContext.Instance().DrawContent.RemoveRect("HangoutUnselected");
+            }
+            finally
+            {
+                foreach (var hangoutOption in allHangoutOptions)
+                {
+                    hangoutOption.Dispose();
+                }
+            }
         }
         else
         {
@@ -475,6 +472,50 @@ public partial class AutoSkipTrigger : ITaskTrigger
                 }
             }
         }
+    }
+
+    private static HangoutOption? FindHangoutTargetOption(
+        IEnumerable<HangoutOption> options,
+        IEnumerable<string> keywords)
+    {
+        var normalizedOptions = options
+            .Where(option => !option.IsSelected)
+            .Select(option => new
+            {
+                Option = option,
+                Text = NormalizeHangoutText(option.OptionTextSrc)
+            })
+            .Where(item => !string.IsNullOrEmpty(item.Text))
+            .ToList();
+
+        return keywords
+            .Select(keyword => new
+            {
+                Keyword = keyword,
+                Text = NormalizeHangoutText(keyword)
+            })
+            .Where(item => !string.IsNullOrEmpty(item.Text))
+            .SelectMany(keyword => normalizedOptions
+                .Where(option => option.Text.Contains(keyword.Text, StringComparison.Ordinal))
+                .Select(option => new
+                {
+                    option.Option,
+                    option.Text,
+                    Keyword = keyword.Text,
+                    IsExact = string.Equals(option.Text, keyword.Text, StringComparison.Ordinal)
+                }))
+            .OrderByDescending(item => item.IsExact)
+            .ThenByDescending(item => item.Keyword.Length)
+            .ThenBy(item => item.Option.IconRect.Top)
+            .Select(item => item.Option)
+            .FirstOrDefault();
+    }
+
+    private static string NormalizeHangoutText(string text)
+    {
+        return new string(text
+            .Where(character => !char.IsWhiteSpace(character) && !char.IsPunctuation(character))
+            .ToArray());
     }
 
     private bool IsOrangeOption(Mat textMat)

--- a/BetterGenshinImpact/GameTask/AutoSkip/AutoSkipTrigger.cs
+++ b/BetterGenshinImpact/GameTask/AutoSkip/AutoSkipTrigger.cs
@@ -410,7 +410,7 @@ public partial class AutoSkipTrigger : ITaskTrigger
                     hangoutOption.OptionTextSrc = StringUtils.RemoveAllEnter(text);
                 }
 
-                // 目标分支只允许点击当前尚未选择的选项，避免重复点击已选项导致流程偏离。
+                // 历史已选状态不影响当前路线，目标分支仍需优先匹配全部选项。
                 if (!string.IsNullOrEmpty(_config.AutoHangoutEndChoose)
                     && HangoutConfig.Instance.HangoutOptions.TryGetValue(_config.AutoHangoutEndChoose, out var chooseList))
                 {
@@ -479,7 +479,6 @@ public partial class AutoSkipTrigger : ITaskTrigger
         IEnumerable<string> keywords)
     {
         var normalizedOptions = options
-            .Where(option => !option.IsSelected)
             .Select(option => new
             {
                 Option = option,

--- a/BetterGenshinImpact/View/Behavior/ComboBoxPopupScrollBehavior.cs
+++ b/BetterGenshinImpact/View/Behavior/ComboBoxPopupScrollBehavior.cs
@@ -1,0 +1,114 @@
+using Microsoft.Xaml.Behaviors;
+using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Threading;
+
+namespace BetterGenshinImpact.View.Behavior;
+
+/// <summary>
+/// Handles mouse-wheel scrolling inside a ComboBox popup, which has a separate visual tree.
+/// </summary>
+public sealed class ComboBoxPopupScrollBehavior : Behavior<ComboBox>
+{
+    private const double ScrollSensitivity = 0.27;
+    private ScrollViewer? _scrollViewer;
+
+    protected override void OnAttached()
+    {
+        base.OnAttached();
+        AssociatedObject.DropDownOpened += OnDropDownOpened;
+        AssociatedObject.DropDownClosed += OnDropDownClosed;
+        AssociatedObject.Unloaded += OnUnloaded;
+    }
+
+    protected override void OnDetaching()
+    {
+        AssociatedObject.DropDownOpened -= OnDropDownOpened;
+        AssociatedObject.DropDownClosed -= OnDropDownClosed;
+        AssociatedObject.Unloaded -= OnUnloaded;
+        DetachScrollViewer();
+        base.OnDetaching();
+    }
+
+    private void OnDropDownOpened(object? sender, EventArgs e)
+    {
+        AssociatedObject.Dispatcher.BeginInvoke(AttachScrollViewer, DispatcherPriority.Loaded);
+    }
+
+    private void OnDropDownClosed(object? sender, EventArgs e)
+    {
+        DetachScrollViewer();
+    }
+
+    private void OnUnloaded(object sender, RoutedEventArgs e)
+    {
+        DetachScrollViewer();
+    }
+
+    private void AttachScrollViewer()
+    {
+        DetachScrollViewer();
+        if (!AssociatedObject.IsDropDownOpen)
+        {
+            return;
+        }
+
+        AssociatedObject.ApplyTemplate();
+        if (AssociatedObject.Template.FindName("PART_Popup", AssociatedObject) is not Popup { Child: { } popupChild })
+        {
+            return;
+        }
+
+        _scrollViewer = FindVisualChild<ScrollViewer>(popupChild);
+        _scrollViewer?.AddHandler(
+            UIElement.PreviewMouseWheelEvent,
+            new MouseWheelEventHandler(OnPreviewMouseWheel),
+            true);
+    }
+
+    private void DetachScrollViewer()
+    {
+        _scrollViewer?.RemoveHandler(
+            UIElement.PreviewMouseWheelEvent,
+            new MouseWheelEventHandler(OnPreviewMouseWheel));
+        _scrollViewer = null;
+    }
+
+    private void OnPreviewMouseWheel(object sender, MouseWheelEventArgs e)
+    {
+        if (sender is not ScrollViewer scrollViewer || scrollViewer.ScrollableHeight <= 0)
+        {
+            return;
+        }
+
+        var targetOffset = Math.Clamp(
+            scrollViewer.VerticalOffset - e.Delta * ScrollSensitivity,
+            0,
+            scrollViewer.ScrollableHeight);
+        scrollViewer.ScrollToVerticalOffset(targetOffset);
+        e.Handled = true;
+    }
+
+    private static T? FindVisualChild<T>(DependencyObject parent) where T : DependencyObject
+    {
+        for (var i = 0; i < VisualTreeHelper.GetChildrenCount(parent); i++)
+        {
+            var child = VisualTreeHelper.GetChild(parent, i);
+            if (child is T result)
+            {
+                return result;
+            }
+
+            if (FindVisualChild<T>(child) is { } descendant)
+            {
+                return descendant;
+            }
+        }
+
+        return null;
+    }
+}

--- a/BetterGenshinImpact/View/MainWindow.xaml.cs
+++ b/BetterGenshinImpact/View/MainWindow.xaml.cs
@@ -120,10 +120,10 @@ public partial class MainWindow : FluentWindow, INavigationWindow
                 return scrollViewer;
             }
 
-            if (current is System.Windows.Controls.ListViewItem listViewItem
-                && ItemsControl.ItemsControlFromItemContainer(listViewItem) is System.Windows.Controls.ListView listView)
+            if ((current is System.Windows.Controls.ListBoxItem or System.Windows.Controls.ComboBoxItem)
+                && ItemsControl.ItemsControlFromItemContainer(current) is ItemsControl itemsControl)
             {
-                var listScrollViewer = FindVisualChild<ScrollViewer>(listView);
+                var listScrollViewer = FindVisualChild<ScrollViewer>(itemsControl);
                 if (listScrollViewer is { ScrollableHeight: > 0 })
                 {
                     return listScrollViewer;

--- a/BetterGenshinImpact/View/MainWindow.xaml.cs
+++ b/BetterGenshinImpact/View/MainWindow.xaml.cs
@@ -120,10 +120,10 @@ public partial class MainWindow : FluentWindow, INavigationWindow
                 return scrollViewer;
             }
 
-            if ((current is System.Windows.Controls.ListBoxItem or System.Windows.Controls.ComboBoxItem)
-                && ItemsControl.ItemsControlFromItemContainer(current) is ItemsControl itemsControl)
+            if (current is System.Windows.Controls.ListViewItem listViewItem
+                && ItemsControl.ItemsControlFromItemContainer(listViewItem) is System.Windows.Controls.ListView listView)
             {
-                var listScrollViewer = FindVisualChild<ScrollViewer>(itemsControl);
+                var listScrollViewer = FindVisualChild<ScrollViewer>(listView);
                 if (listScrollViewer is { ScrollableHeight: > 0 })
                 {
                     return listScrollViewer;

--- a/BetterGenshinImpact/View/Pages/TriggerSettingsPage.xaml
+++ b/BetterGenshinImpact/View/Pages/TriggerSettingsPage.xaml
@@ -3,6 +3,7 @@
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:autoPick="clr-namespace:BetterGenshinImpact.GameTask.AutoPick"
       xmlns:b="http://schemas.microsoft.com/xaml/behaviors"
+      xmlns:behavior="clr-namespace:BetterGenshinImpact.View.Behavior"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:pages="clr-namespace:BetterGenshinImpact.ViewModel.Pages"
@@ -949,7 +950,11 @@
                               ScrollViewer.CanContentScroll="False"
                               ScrollViewer.VerticalScrollBarVisibility="Auto"
                               ItemsSource="{Binding HangoutBranches, Mode=OneWay}"
-                              SelectedItem="{Binding Config.AutoSkipConfig.AutoHangoutEndChoose, Mode=TwoWay}" />
+                              SelectedItem="{Binding Config.AutoSkipConfig.AutoHangoutEndChoose, Mode=TwoWay}">
+                        <b:Interaction.Behaviors>
+                            <behavior:ComboBoxPopupScrollBehavior />
+                        </b:Interaction.Behaviors>
+                    </ComboBox>
                 </Grid>
                 <Grid Margin="16">
                     <Grid.RowDefinitions>

--- a/BetterGenshinImpact/View/Pages/TriggerSettingsPage.xaml
+++ b/BetterGenshinImpact/View/Pages/TriggerSettingsPage.xaml
@@ -945,6 +945,9 @@
                               Grid.RowSpan="2"
                               Grid.Column="1"
                               Margin="0,0,8,0"
+                              MaxDropDownHeight="360"
+                              ScrollViewer.CanContentScroll="False"
+                              ScrollViewer.VerticalScrollBarVisibility="Auto"
                               ItemsSource="{Binding HangoutBranches, Mode=OneWay}"
                               SelectedItem="{Binding Config.AutoSkipConfig.AutoHangoutEndChoose, Mode=TwoWay}" />
                 </Grid>


### PR DESCRIPTION
## 修改内容

- 修复“选择邀约分支”下拉列表无法使用滚轮的问题
- 仅在未选选项中匹配目标分支
- 优先精确匹配，再按关键词长度匹配，降低错误选项命中概率
- 处理缺失分支配置并释放图像识别资源

## 验证

- 更新 main 前已成功执行 Release publish，退出码为 0
- 修改在更新后的 main 上恢复无冲突
- 更新 main 后未重新执行构建

Refs #1474

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **功能优化**
  * 优化自动邀约选项识别与匹配，支持更准确地查找目标选项。
  * 改进文本匹配逻辑，可忽略空格和标点，并根据匹配度进行选择。
  * 未找到目标选项时，将优先选择未点击的选项。
  * 优化邀约分支下拉列表的滚轮操作体验。

* **问题修复**
  * 修复下拉列表滚动及选项处理异常，提升自动邀约流程的稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->