### PR TITLE
修复自动地脉花按星期配置与至冬地域切换

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoLeyLineOutcrop/AutoLeyLineOutcropTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoLeyLineOutcrop/AutoLeyLineOutcropTask.cs
@@ -3,6 +3,7 @@ using BetterGenshinImpact.Core.Recognition.OpenCv;
 using BetterGenshinImpact.Core.Recognition.OCR;
 using BetterGenshinImpact.Core.Config;
 using BetterGenshinImpact.Core.Script;
+using BetterGenshinImpact.Core.Script.Dependence;
 using BetterGenshinImpact.Core.Simulator;
 using BetterGenshinImpact.Core.Simulator.Extensions;
 using BetterGenshinImpact.GameTask.AutoDomain;
@@ -79,6 +80,8 @@ public class AutoLeyLineOutcropTask : ISoloTask
 
     private const int MaxRecheckCount = 3;
     private const int MaxConsecutiveFailures = 5;
+    private const int MaxCountryScrollAttempts = 8;
+    private const int CountryScrollDelayMs = 250;
     private const string OcrFlowOverlayKey = "AutoLeyLineOutcrop.OcrFlow";
     private const string OcrFightOverlayKey = "AutoLeyLineOutcrop.OcrFight";
     private const int OcrOverlayRenderLeadMs = 300;
@@ -2295,15 +2298,30 @@ public class AutoLeyLineOutcropTask : ISoloTask
     private async Task FindAndClickCountry(string country)
     {
         var match = country == "挪德卡莱" ? "挪德卡" : country;
-        using var capture = CaptureToRectArea();
-        var list = capture.FindMulti(_ocrRoThis);
-        var target = list.FirstOrDefault(r => r.Text.Contains(match, StringComparison.Ordinal));
-        if (target == null)
+
+        for (var attempt = 0; attempt <= MaxCountryScrollAttempts; attempt++)
         {
-            throw new Exception($"冒险之证未找到国家: {country}");
+            using var capture = CaptureToRectArea();
+            var list = capture.FindMulti(_ocrRoThis);
+            var target = list.FirstOrDefault(r => r.Text.Contains(match, StringComparison.Ordinal));
+            if (target != null)
+            {
+                target.Click();
+                return;
+            }
+
+            if (attempt == MaxCountryScrollAttempts)
+            {
+                break;
+            }
+
+            GlobalMethod.MoveMouseTo(1300, 800);
+            Simulation.SendInput.Mouse.VerticalScroll(-1);
+            await Delay(CountryScrollDelayMs, _ct);
         }
 
-        target.Click();
+        _logger.LogWarning("冒险之证向下滚动{ScrollAttempts}次后仍未找到国家: {Country}", MaxCountryScrollAttempts, country);
+        throw new Exception($"冒险之证未找到国家: {country}");
     }
 
     private async Task<bool> TryOpenBigMapFromHandbook()

--- a/BetterGenshinImpact/GameTask/AutoLeyLineOutcrop/AutoLeyLineOutcropTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoLeyLineOutcrop/AutoLeyLineOutcropTask.cs
@@ -3,7 +3,6 @@ using BetterGenshinImpact.Core.Recognition.OpenCv;
 using BetterGenshinImpact.Core.Recognition.OCR;
 using BetterGenshinImpact.Core.Config;
 using BetterGenshinImpact.Core.Script;
-using BetterGenshinImpact.Core.Script.Dependence;
 using BetterGenshinImpact.Core.Simulator;
 using BetterGenshinImpact.Core.Simulator.Extensions;
 using BetterGenshinImpact.GameTask.AutoDomain;
@@ -82,6 +81,10 @@ public class AutoLeyLineOutcropTask : ISoloTask
     private const int MaxConsecutiveFailures = 5;
     private const int MaxCountryScrollAttempts = 8;
     private const int CountryScrollDelayMs = 250;
+    private const double CountryListLeftRatio = 0.55;
+    private const double CountryListTopRatio = 0.15;
+    private const double CountryListRightRatio = 0.95;
+    private const double CountryListVisibleBottomRatio = 0.74;
     private const string OcrFlowOverlayKey = "AutoLeyLineOutcrop.OcrFlow";
     private const string OcrFightOverlayKey = "AutoLeyLineOutcrop.OcrFight";
     private const int OcrOverlayRenderLeadMs = 300;
@@ -2303,11 +2306,17 @@ public class AutoLeyLineOutcropTask : ISoloTask
         {
             using var capture = CaptureToRectArea();
             var list = capture.FindMulti(_ocrRoThis);
-            var target = list.FirstOrDefault(r => r.Text.Contains(match, StringComparison.Ordinal));
+            var matchingTargets = list.Where(r => r.Text.Contains(match, StringComparison.Ordinal)).ToList();
+            var target = matchingTargets.FirstOrDefault(r => IsCountryOptionFullyVisible(r, capture));
             if (target != null)
             {
                 target.Click();
                 return;
+            }
+
+            if (matchingTargets.Count > 0)
+            {
+                _logger.LogDebug("国家 {Country} 仅在冒险之证下拉列表裁切区域中被识别，继续向下滚动", country);
             }
 
             if (attempt == MaxCountryScrollAttempts)
@@ -2315,13 +2324,21 @@ public class AutoLeyLineOutcropTask : ISoloTask
                 break;
             }
 
-            GlobalMethod.MoveMouseTo(1300, 800);
+            GameCaptureRegion.GameRegion1080PPosMove(1500, 600);
             Simulation.SendInput.Mouse.VerticalScroll(-1);
             await Delay(CountryScrollDelayMs, _ct);
         }
 
         _logger.LogWarning("冒险之证向下滚动{ScrollAttempts}次后仍未找到国家: {Country}", MaxCountryScrollAttempts, country);
         throw new Exception($"冒险之证未找到国家: {country}");
+    }
+
+    private static bool IsCountryOptionFullyVisible(Region region, ImageRegion capture)
+    {
+        return region.Left >= capture.Width * CountryListLeftRatio
+               && region.Top >= capture.Height * CountryListTopRatio
+               && region.Right <= capture.Width * CountryListRightRatio
+               && region.Bottom <= capture.Height * CountryListVisibleBottomRatio;
     }
 
     private async Task<bool> TryOpenBigMapFromHandbook()

--- a/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml
+++ b/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml
@@ -1623,7 +1623,8 @@
                                               Grid.Column="0"
                                               Grid.ColumnSpan="4"
                                               Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
-                                              Text="仅在勾选的星期执行；类型/国家留空时使用独立任务默认设置。"
+                                              Margin="0,0,0,12"
+                                              Text="仅在勾选的星期执行；若未勾选任何星期，则每天执行。类型/国家留空时使用独立任务默认设置。"
                                               TextWrapping="Wrap" />
 
                                 <ui:TextBlock Grid.Row="2"
@@ -1647,12 +1648,12 @@
                                 <ComboBox Grid.Row="3"
                                           Grid.Column="2"
                                           Margin="0,0,12,8"
-                                          ItemsSource="{Binding Source={x:Static pages:TaskSettingsPageViewModel.LeyLineOutcropTypeList}}"
+                                          ItemsSource="{Binding Source={x:Static pages:TaskSettingsPageViewModel.LeyLineOutcropTypeListWithEmpty}}"
                                           SelectedItem="{Binding SelectedConfig.LeyLineMondayType, Mode=TwoWay}" />
                                 <ComboBox Grid.Row="3"
                                           Grid.Column="3"
                                           Margin="0,0,0,8"
-                                          ItemsSource="{Binding Source={x:Static pages:TaskSettingsPageViewModel.LeyLineOutcropCountryList}}"
+                                          ItemsSource="{Binding Source={x:Static pages:TaskSettingsPageViewModel.LeyLineOutcropCountryListWithEmpty}}"
                                           SelectedItem="{Binding SelectedConfig.LeyLineMondayCountry, Mode=TwoWay}" />
 
                                 <CheckBox Grid.Row="4"
@@ -1663,12 +1664,12 @@
                                 <ComboBox Grid.Row="4"
                                           Grid.Column="2"
                                           Margin="0,0,12,8"
-                                          ItemsSource="{Binding Source={x:Static pages:TaskSettingsPageViewModel.LeyLineOutcropTypeList}}"
+                                          ItemsSource="{Binding Source={x:Static pages:TaskSettingsPageViewModel.LeyLineOutcropTypeListWithEmpty}}"
                                           SelectedItem="{Binding SelectedConfig.LeyLineTuesdayType, Mode=TwoWay}" />
                                 <ComboBox Grid.Row="4"
                                           Grid.Column="3"
                                           Margin="0,0,0,8"
-                                          ItemsSource="{Binding Source={x:Static pages:TaskSettingsPageViewModel.LeyLineOutcropCountryList}}"
+                                          ItemsSource="{Binding Source={x:Static pages:TaskSettingsPageViewModel.LeyLineOutcropCountryListWithEmpty}}"
                                           SelectedItem="{Binding SelectedConfig.LeyLineTuesdayCountry, Mode=TwoWay}" />
 
                                 <CheckBox Grid.Row="5"
@@ -1679,12 +1680,12 @@
                                 <ComboBox Grid.Row="5"
                                           Grid.Column="2"
                                           Margin="0,0,12,8"
-                                          ItemsSource="{Binding Source={x:Static pages:TaskSettingsPageViewModel.LeyLineOutcropTypeList}}"
+                                          ItemsSource="{Binding Source={x:Static pages:TaskSettingsPageViewModel.LeyLineOutcropTypeListWithEmpty}}"
                                           SelectedItem="{Binding SelectedConfig.LeyLineWednesdayType, Mode=TwoWay}" />
                                 <ComboBox Grid.Row="5"
                                           Grid.Column="3"
                                           Margin="0,0,0,8"
-                                          ItemsSource="{Binding Source={x:Static pages:TaskSettingsPageViewModel.LeyLineOutcropCountryList}}"
+                                          ItemsSource="{Binding Source={x:Static pages:TaskSettingsPageViewModel.LeyLineOutcropCountryListWithEmpty}}"
                                           SelectedItem="{Binding SelectedConfig.LeyLineWednesdayCountry, Mode=TwoWay}" />
 
                                 <CheckBox Grid.Row="6"
@@ -1695,12 +1696,12 @@
                                 <ComboBox Grid.Row="6"
                                           Grid.Column="2"
                                           Margin="0,0,12,8"
-                                          ItemsSource="{Binding Source={x:Static pages:TaskSettingsPageViewModel.LeyLineOutcropTypeList}}"
+                                          ItemsSource="{Binding Source={x:Static pages:TaskSettingsPageViewModel.LeyLineOutcropTypeListWithEmpty}}"
                                           SelectedItem="{Binding SelectedConfig.LeyLineThursdayType, Mode=TwoWay}" />
                                 <ComboBox Grid.Row="6"
                                           Grid.Column="3"
                                           Margin="0,0,0,8"
-                                          ItemsSource="{Binding Source={x:Static pages:TaskSettingsPageViewModel.LeyLineOutcropCountryList}}"
+                                          ItemsSource="{Binding Source={x:Static pages:TaskSettingsPageViewModel.LeyLineOutcropCountryListWithEmpty}}"
                                           SelectedItem="{Binding SelectedConfig.LeyLineThursdayCountry, Mode=TwoWay}" />
 
                                 <CheckBox Grid.Row="7"
@@ -1711,12 +1712,12 @@
                                 <ComboBox Grid.Row="7"
                                           Grid.Column="2"
                                           Margin="0,0,12,8"
-                                          ItemsSource="{Binding Source={x:Static pages:TaskSettingsPageViewModel.LeyLineOutcropTypeList}}"
+                                          ItemsSource="{Binding Source={x:Static pages:TaskSettingsPageViewModel.LeyLineOutcropTypeListWithEmpty}}"
                                           SelectedItem="{Binding SelectedConfig.LeyLineFridayType, Mode=TwoWay}" />
                                 <ComboBox Grid.Row="7"
                                           Grid.Column="3"
                                           Margin="0,0,0,8"
-                                          ItemsSource="{Binding Source={x:Static pages:TaskSettingsPageViewModel.LeyLineOutcropCountryList}}"
+                                          ItemsSource="{Binding Source={x:Static pages:TaskSettingsPageViewModel.LeyLineOutcropCountryListWithEmpty}}"
                                           SelectedItem="{Binding SelectedConfig.LeyLineFridayCountry, Mode=TwoWay}" />
 
                                 <CheckBox Grid.Row="8"
@@ -1727,12 +1728,12 @@
                                 <ComboBox Grid.Row="8"
                                           Grid.Column="2"
                                           Margin="0,0,12,8"
-                                          ItemsSource="{Binding Source={x:Static pages:TaskSettingsPageViewModel.LeyLineOutcropTypeList}}"
+                                          ItemsSource="{Binding Source={x:Static pages:TaskSettingsPageViewModel.LeyLineOutcropTypeListWithEmpty}}"
                                           SelectedItem="{Binding SelectedConfig.LeyLineSaturdayType, Mode=TwoWay}" />
                                 <ComboBox Grid.Row="8"
                                           Grid.Column="3"
                                           Margin="0,0,0,8"
-                                          ItemsSource="{Binding Source={x:Static pages:TaskSettingsPageViewModel.LeyLineOutcropCountryList}}"
+                                          ItemsSource="{Binding Source={x:Static pages:TaskSettingsPageViewModel.LeyLineOutcropCountryListWithEmpty}}"
                                           SelectedItem="{Binding SelectedConfig.LeyLineSaturdayCountry, Mode=TwoWay}" />
 
                                 <CheckBox Grid.Row="9"
@@ -1743,11 +1744,11 @@
                                 <ComboBox Grid.Row="9"
                                           Grid.Column="2"
                                           Margin="0,0,12,0"
-                                          ItemsSource="{Binding Source={x:Static pages:TaskSettingsPageViewModel.LeyLineOutcropTypeList}}"
+                                          ItemsSource="{Binding Source={x:Static pages:TaskSettingsPageViewModel.LeyLineOutcropTypeListWithEmpty}}"
                                           SelectedItem="{Binding SelectedConfig.LeyLineSundayType, Mode=TwoWay}" />
                                 <ComboBox Grid.Row="9"
                                           Grid.Column="3"
-                                          ItemsSource="{Binding Source={x:Static pages:TaskSettingsPageViewModel.LeyLineOutcropCountryList}}"
+                                          ItemsSource="{Binding Source={x:Static pages:TaskSettingsPageViewModel.LeyLineOutcropCountryListWithEmpty}}"
                                           SelectedItem="{Binding SelectedConfig.LeyLineSundayCountry, Mode=TwoWay}" />
                             </Grid>
                         </StackPanel>

--- a/BetterGenshinImpact/ViewModel/Pages/TaskSettingsPageViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/TaskSettingsPageViewModel.cs
@@ -145,6 +145,8 @@ public partial class TaskSettingsPageViewModel : ViewModel
     public static List<string> AvatarIndexList = ["", "1", "2", "3", "4"];
     public static List<string> LeyLineOutcropTypeList = ["启示之花", "藏金之花"];
     public static List<string> LeyLineOutcropCountryList = ["蒙德", "璃月", "稻妻", "须弥", "枫丹", "纳塔", "挪德卡莱", "至冬"];
+    public static List<string> LeyLineOutcropTypeListWithEmpty = ["", .. LeyLineOutcropTypeList];
+    public static List<string> LeyLineOutcropCountryListWithEmpty = ["", .. LeyLineOutcropCountryList];
 
     [ObservableProperty]
     private List<string> _autoMusicLevelList = ["传说", "大师", "困难", "普通", "所有"];


### PR DESCRIPTION
## 变更内容

- 为一条龙自动地脉花的星期类型和国家下拉框增加空选项，空值沿用独立任务默认配置
- 补充“未勾选任何星期时每天执行”的界面说明，并调整说明文字底部间距
- 冒险之证未识别到目标国家时，向下滚动并重新 OCR，支持“至冬”等被遮挡选项
- 滚动重试达到上限后记录警告并保留原有异常行为

## 验证

- `dotnet build BetterGenshinImpact/BetterGenshinImpact.csproj -c Debug -p:Platform=x64 -p:RestoreDisableParallel=true -m:1`
- 结果：0 个错误

Fixes #3515

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 优化地脉花国家选择：支持自动滚动查找，并提升列表滚动过程中的识别准确性。
  * 地脉花类型和国家选项新增空选项，方便用户不指定筛选条件。

* **界面改进**
  * 补充运行日期配置说明，明确未选择星期时将按每天执行。
  * 优化相关设置页面的布局与间距。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->