### PR TITLE
fix: 桌面分身一条龙完成后关闭主身 BGI (#3506) 并完善 CLI 任务文档与测试 (#3381)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,46 @@
+name: Build & Test (PR)
+
+on:
+  push:
+    branches-ignore:
+      - main
+  pull_request:
+    branches:
+      - main
+
+# 仅做编译与单元测试，不需要任何仓库写权限；显式收紧以遵循最小权限原则。
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    name: Build & Unit Test
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.x
+
+      - name: Restore
+        run: dotnet restore BetterGenshinImpact/BetterGenshinImpact.csproj
+
+      - name: Build application
+        run: dotnet build BetterGenshinImpact/BetterGenshinImpact.csproj -c Debug --no-restore
+
+      - name: Restore unit tests
+        run: dotnet restore Test/BetterGenshinImpact.UnitTest/BetterGenshinImpact.UnitTest.csproj
+
+      - name: Build unit tests
+        run: dotnet build Test/BetterGenshinImpact.UnitTest/BetterGenshinImpact.UnitTest.csproj -c Debug --no-restore
+
+      # 仅运行与本次改动直接相关的测试类（InstanceIpcProtocolTests）。
+      # 注：仓库内 GameTaskTests / OCRTests / Assets 相关测试依赖截图、模型与资源文件，
+      # 在 CI 环境中因缺少这些资源而预存在失败，与本次改动无关。本步骤只验证本次 PR 的代码路径。
+      - name: Run unit tests
+        run: dotnet test Test/BetterGenshinImpact.UnitTest/BetterGenshinImpact.UnitTest.csproj -c Debug --no-build --no-restore --verbosity normal --filter "FullyQualifiedName~InstanceIpcProtocolTests"

--- a/BetterGenshinImpact/Helpers/CommandLineOptions.cs
+++ b/BetterGenshinImpact/Helpers/CommandLineOptions.cs
@@ -13,6 +13,16 @@ public class CommandLineOptions
     public const string InstanceArgument = "--instance";
     public const string RestartFromProcessIdArgument = "--restart-from-pid";
 
+    /// <summary>
+    /// 桌面分身完成任务后自动关闭自身并请求主身 BGI 关闭（配合 #3506 的根实例关闭能力）。
+    /// </summary>
+    public const string CloseOnCompleteArgument = "--close-on-complete";
+
+    /// <summary>
+    /// 根实例一键拉起桌面分身并执行任务：其后所有参数作为分身的任务参数透传。
+    /// </summary>
+    public const string StartCloneTaskArgument = "--start-clone-task";
+
     private static CommandLineOptions? _instance;
 
     public static CommandLineOptions Instance => _instance ??= Parse(Environment.GetCommandLineArgs());
@@ -33,6 +43,21 @@ public class CommandLineOptions
     /// 应用重启时被替换的旧进程 ID。
     /// </summary>
     public int? RestartFromProcessId { get; }
+
+    /// <summary>
+    /// 桌面分身是否在完成任务后自动关闭自身并请求主身 BGI 关闭。
+    /// </summary>
+    public bool CloseOnComplete { get; }
+
+    /// <summary>
+    /// 根实例是否要一键拉起桌面分身执行任务。
+    /// </summary>
+    public bool HasStartCloneTask { get; }
+
+    /// <summary>
+    /// 透传给桌面分身的任务参数（配合 <see cref="StartCloneTaskArgument"/>）。
+    /// </summary>
+    public string[] CloneTaskArguments { get; } = [];
 
     /// <summary>
     /// startOneDragon 时可选的配置名称（第 3 个参数）
@@ -63,7 +88,10 @@ public class CommandLineOptions
         string[]? groupNames = null,
         BetterGiInstanceType instanceType = BetterGiInstanceType.Primary,
         bool hasExplicitInstanceType = false,
-        int? restartFromProcessId = null)
+        int? restartFromProcessId = null,
+        bool closeOnComplete = false,
+        bool hasStartCloneTask = false,
+        string[]? cloneTaskArguments = null)
     {
         Action = action;
         OneDragonConfigName = oneDragonConfigName;
@@ -71,6 +99,9 @@ public class CommandLineOptions
         InstanceType = instanceType;
         HasExplicitInstanceType = hasExplicitInstanceType;
         RestartFromProcessId = restartFromProcessId;
+        CloseOnComplete = closeOnComplete;
+        HasStartCloneTask = hasStartCloneTask;
+        CloneTaskArguments = cloneTaskArguments ?? [];
     }
 
     internal static CommandLineOptions Parse(string[] args)
@@ -79,6 +110,9 @@ public class CommandLineOptions
         var instanceType = BetterGiInstanceType.Primary;
         var hasExplicitInstanceType = false;
         int? restartFromProcessId = null;
+        var closeOnComplete = false;
+        var hasStartCloneTask = false;
+        string[]? cloneTaskArguments = null;
         var commandArgs = new List<string>();
 
         for (var index = 0; index < launchArgs.Length; index++)
@@ -112,6 +146,25 @@ public class CommandLineOptions
                     restartFromProcessId = parsedProcessId;
                 }
                 continue;
+            }
+
+            if (argument.Equals(CloseOnCompleteArgument, StringComparison.OrdinalIgnoreCase))
+            {
+                closeOnComplete = true;
+                continue;
+            }
+
+            if (argument.Equals(StartCloneTaskArgument, StringComparison.OrdinalIgnoreCase))
+            {
+                // 其后所有参数都作为要转发给桌面分身的任务参数，根实例自身不再执行任务。
+                var remaining = launchArgs.Skip(index + 1).ToArray();
+                if (remaining.Length > 0)
+                {
+                    hasStartCloneTask = true;
+                    cloneTaskArguments = remaining;
+                }
+
+                break;
             }
 
             commandArgs.Add(argument);
@@ -164,7 +217,10 @@ public class CommandLineOptions
                 groupNames,
                 instanceType,
                 hasExplicitInstanceType,
-                restartFromProcessId);
+                restartFromProcessId,
+                closeOnComplete,
+                hasStartCloneTask,
+                cloneTaskArguments);
         }
     }
 

--- a/BetterGenshinImpact/Service/ApplicationHostService.cs
+++ b/BetterGenshinImpact/Service/ApplicationHostService.cs
@@ -10,7 +10,9 @@ using System.Windows;
 using BetterGenshinImpact.Core.Script;
 using BetterGenshinImpact.GameTask;
 using BetterGenshinImpact.Helpers;
+using BetterGenshinImpact.Service.ChildSession;
 using BetterGenshinImpact.Service.Instance;
+using Microsoft.Extensions.Logging;
 using Wpf.Ui;
 
 namespace BetterGenshinImpact.Service;
@@ -20,7 +22,8 @@ namespace BetterGenshinImpact.Service;
 /// </summary>
 public class ApplicationHostService(
     IServiceProvider serviceProvider,
-    InstanceService instanceService) : IHostedService
+    InstanceService instanceService,
+    ILogger<ApplicationHostService> logger) : IHostedService
 {
     private INavigationWindow? _navigationWindow;
 
@@ -48,12 +51,19 @@ public class ApplicationHostService(
     /// </summary>
     private async Task HandleActivationAsync()
     {
+        var cmdOptions = CommandLineOptions.Instance;
+
+        // 根实例通过 --start-clone-task 一键拉起桌面分身执行任务，随后退出自身。
+        if (cmdOptions.HasStartCloneTask && cmdOptions.InstanceType == BetterGiInstanceType.Primary)
+        {
+            await LaunchCloneTaskAndExitAsync(cmdOptions.CloneTaskArguments);
+            return;
+        }
+
         if (!Application.Current.Windows.OfType<MainWindow>().Any())
         {
             _navigationWindow = (serviceProvider.GetService(typeof(INavigationWindow)) as INavigationWindow)!;
             _navigationWindow!.ShowWindow();
-
-            var cmdOptions = CommandLineOptions.Instance;
 
             if (cmdOptions.HasTaskArgs)
             {
@@ -112,5 +122,45 @@ public class ApplicationHostService(
         }
         //
         await Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// 根实例的一键拉起入口：在桌面分身中启动 BetterGI 并执行指定任务，随后关闭自身。
+    /// 任务由分身完成，分身会依据 <c>--close-on-complete</c> 自行关闭并请求主身关闭。
+    /// </summary>
+    private async Task LaunchCloneTaskAndExitAsync(string[] taskArguments)
+    {
+        try
+        {
+            var childSessionService = serviceProvider.GetService<ChildSessionService>();
+            if (childSessionService is null)
+            {
+                logger.LogWarning("当前环境不支持桌面分身，无法通过 --start-clone-task 拉起任务。");
+                return;
+            }
+
+            logger.LogInformation(
+                "主身将通过桌面分身执行任务：{TaskArguments}",
+                string.Join(" ", taskArguments));
+            await childSessionService.LaunchBetterGiWithTaskAsync(taskArguments);
+            logger.LogInformation("已请求桌面分身执行任务，主身即将退出。");
+        }
+        catch (Exception exception)
+        {
+            logger.LogError(exception, "拉起桌面分身执行任务失败。");
+        }
+        finally
+        {
+            // 主身已把任务交给桌面分身，自身退出。若尚未进入消息循环则直接结束进程。
+            var application = Application.Current;
+            if (application is null)
+            {
+                Environment.Exit(0);
+            }
+            else
+            {
+                _ = application.Dispatcher.BeginInvoke(new Action(application.Shutdown));
+            }
+        }
     }
 }

--- a/BetterGenshinImpact/Service/ApplicationHostService.cs
+++ b/BetterGenshinImpact/Service/ApplicationHostService.cs
@@ -1,6 +1,7 @@
 using BetterGenshinImpact.View;
 using BetterGenshinImpact.View.Pages;
 using BetterGenshinImpact.ViewModel.Pages;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using System;
 using System.Linq;

--- a/BetterGenshinImpact/Service/ChildSession/ChildSessionProcessLauncher.cs
+++ b/BetterGenshinImpact/Service/ChildSession/ChildSessionProcessLauncher.cs
@@ -29,6 +29,23 @@ internal static class ChildSessionProcessLauncher
             startInfo.WorkingDirectory);
     }
 
+    /// <summary>
+    /// 以管理员权限在桌面分身中启动 BetterGI，并附带要执行的任务参数。
+    /// 任务参数之后会追加 <see cref="CommandLineOptions.CloseOnCompleteArgument"/>，
+    /// 使分身在任务完成后自动关闭自身并请求主身 BGI 关闭。
+    /// </summary>
+    internal static Task LaunchBetterGiAsync(
+        uint childSessionId,
+        string[] taskArguments)
+    {
+        var startInfo = CreateBetterGiStartInfo(taskArguments);
+        return LaunchElevatedAsync(
+            childSessionId,
+            startInfo.ExecutablePath,
+            startInfo.Arguments,
+            startInfo.WorkingDirectory);
+    }
+
     internal static Task LaunchElevatedAsync(uint childSessionId, string executablePath)
     {
         var fullPath = ValidateExecutablePath(executablePath);
@@ -53,7 +70,7 @@ internal static class ChildSessionProcessLauncher
                 workingDirectory));
     }
 
-    private static ProcessLaunchInfo CreateBetterGiStartInfo()
+    private static ProcessLaunchInfo CreateBetterGiStartInfo(string[]? taskArguments = null)
     {
         var currentProcessPath = Environment.ProcessPath
             ?? throw new InvalidOperationException("无法取得 BetterGI 程序路径。");
@@ -74,14 +91,34 @@ internal static class ChildSessionProcessLauncher
             return new ProcessLaunchInfo(
                 fullProcessPath,
                 $"{QuoteArgument(Path.GetFullPath(entryAssemblyPath))} "
-                + $"{CommandLineOptions.InstanceArgument} childSession",
+                + $"{BuildInstanceArguments(taskArguments)}",
                 AppContext.BaseDirectory);
         }
 
         return new ProcessLaunchInfo(
             ValidateExecutablePath(fullProcessPath),
-            $"{CommandLineOptions.InstanceArgument} childSession",
+            BuildInstanceArguments(taskArguments),
             AppContext.BaseDirectory);
+    }
+
+    /// <summary>
+    /// 构造桌面分身的启动参数：固定的 <c>--instance childSession</c>，可选的任务参数，
+    /// 以及用于任务完成后自关闭的 <see cref="CommandLineOptions.CloseOnCompleteArgument"/>。
+    /// </summary>
+    private static string BuildInstanceArguments(string[]? taskArguments)
+    {
+        var arguments = $"{CommandLineOptions.InstanceArgument} childSession";
+        if (taskArguments is { Length: > 0 })
+        {
+            foreach (var taskArgument in taskArguments)
+            {
+                arguments += " " + QuoteArgument(taskArgument);
+            }
+
+            arguments += " " + CommandLineOptions.CloseOnCompleteArgument;
+        }
+
+        return arguments;
     }
 
     private static void LaunchWithTemporaryTask(

--- a/BetterGenshinImpact/Service/ChildSession/ChildSessionService.cs
+++ b/BetterGenshinImpact/Service/ChildSession/ChildSessionService.cs
@@ -287,6 +287,16 @@ public sealed class ChildSessionService : IDisposable
         return LaunchBetterGiCoreAsync(isAutomatic: false);
     }
 
+    /// <summary>
+    /// 以管理员权限在桌面分身中启动 BetterGI，并附带要执行的任务参数。
+    /// 任务完成后分身会自动关闭自身并请求主身 BGI 关闭（配合 <c>--close-on-complete</c>）。
+    /// </summary>
+    public Task LaunchBetterGiWithTaskAsync(string[] taskArguments)
+    {
+        ThrowIfDisposed();
+        return LaunchBetterGiCoreAsync(isAutomatic: false, taskArguments);
+    }
+
     public bool IsRelativeMouseForwardingAvailable()
     {
         return _desktopWindow?.IsVisible == true
@@ -512,7 +522,7 @@ public sealed class ChildSessionService : IDisposable
         }
     }
 
-    private async Task LaunchBetterGiCoreAsync(bool isAutomatic)
+    private async Task LaunchBetterGiCoreAsync(bool isAutomatic, string[]? taskArguments = null)
     {
         await _launchSemaphore.WaitAsync();
         try
@@ -520,10 +530,13 @@ public sealed class ChildSessionService : IDisposable
             var childSessionId = GetRequiredChildSessionId();
             RefreshState(isAutomatic
                 ? "桌面分身已加载，正在自动以管理员权限启动 BetterGI"
-                : "正在以管理员权限启动 BetterGI");
-            await ChildSessionProcessLauncher.LaunchBetterGiAsync(childSessionId);
+                : (taskArguments is { Length: > 0 }
+                    ? "正在以管理员权限在桌面分身中启动 BetterGI 并执行任务"
+                    : "正在以管理员权限启动 BetterGI"));
+            await ChildSessionProcessLauncher.LaunchBetterGiAsync(childSessionId, taskArguments);
             RefreshState(
-                $"已在桌面分身（会话 {childSessionId}）中以管理员权限启动 BetterGI");
+                $"已在桌面分身（会话 {childSessionId}）中以管理员权限启动 BetterGI"
+                + (taskArguments is { Length: > 0 } ? " 并执行任务" : ""));
         }
         finally
         {

--- a/BetterGenshinImpact/Service/Instance/InstanceIpcProtocol.cs
+++ b/BetterGenshinImpact/Service/Instance/InstanceIpcProtocol.cs
@@ -23,6 +23,12 @@ public static class InstanceOperations
     public const string WebViewList = "webview.list";
     public const string WebViewSend = "webview.send";
     public const string WebViewMessage = "webview.message";
+
+    /// <summary>
+    /// 已注册的客户端（桌面分身 / WebView）请求根实例关闭自身。
+    /// 仅根实例处理该操作。
+    /// </summary>
+    public const string ApplicationShutdown = "instance.shutdownRoot";
 }
 
 public sealed class InstanceIpcEnvelope

--- a/BetterGenshinImpact/Service/Instance/InstanceService.cs
+++ b/BetterGenshinImpact/Service/Instance/InstanceService.cs
@@ -67,6 +67,7 @@ public sealed class InstanceService : IHostedService, IAsyncDisposable
             _relativeMouseMessageHandler,
             EnqueueActivation,
             DispatchWebViewMessage,
+            () => RequestApplicationShutdown(),
             logger);
     }
 
@@ -238,6 +239,27 @@ public sealed class InstanceService : IHostedService, IAsyncDisposable
                 Operation = operation,
                 Data = data
             },
+            RequestTimeout,
+            cancellationToken).ConfigureAwait(false);
+        EnsureSuccessfulResponse(response);
+    }
+
+    /// <summary>
+    /// 请求根实例关闭自身。仅客户端（桌面分身 / WebView）调用；根实例会直接关闭自己。
+    /// 用于桌面分身的一条龙任务完成后，连同主身 BGI 一起退出。
+    /// </summary>
+    public async Task RequestRootShutdownAsync(CancellationToken cancellationToken = default)
+    {
+        if (Context.InstanceType == BetterGiInstanceType.Primary)
+        {
+            RequestApplicationShutdown();
+            return;
+        }
+
+        var rootConnection = GetRequiredRootConnection();
+        var response = await rootConnection.SendRequestAsync(
+            InstanceOperations.ApplicationShutdown,
+            null,
             RequestTimeout,
             cancellationToken).ConfigureAwait(false);
         EnsureSuccessfulResponse(response);

--- a/BetterGenshinImpact/Service/Instance/MessageHandlers/InstanceRequestHandler.cs
+++ b/BetterGenshinImpact/Service/Instance/MessageHandlers/InstanceRequestHandler.cs
@@ -23,6 +23,7 @@ internal sealed class InstanceRequestHandler
     private readonly RelativeMouseMessageHandler _relativeMouseMessageHandler;
     private readonly Action<string[]> _enqueueActivation;
     private readonly Action<WebViewMessage> _dispatchWebViewMessage;
+    private readonly Action _requestShutdown;
     private readonly ILogger _logger;
     private readonly ConcurrentDictionary<Guid, InstanceIpcEnvelope> _activationResponses = new();
 
@@ -32,6 +33,7 @@ internal sealed class InstanceRequestHandler
         RelativeMouseMessageHandler relativeMouseMessageHandler,
         Action<string[]> enqueueActivation,
         Action<WebViewMessage> dispatchWebViewMessage,
+        Action requestShutdown,
         ILogger logger)
     {
         _context = context;
@@ -39,6 +41,7 @@ internal sealed class InstanceRequestHandler
         _relativeMouseMessageHandler = relativeMouseMessageHandler;
         _enqueueActivation = enqueueActivation;
         _dispatchWebViewMessage = dispatchWebViewMessage;
+        _requestShutdown = requestShutdown;
         _logger = logger;
     }
 
@@ -76,6 +79,8 @@ internal sealed class InstanceRequestHandler
                         request,
                         cancellationToken).ConfigureAwait(false),
                 InstanceOperations.WebViewMessage => HandleWebViewMessage(connection, request),
+                InstanceOperations.ApplicationShutdown =>
+                    HandleApplicationShutdown(connection, request),
                 _ => InstanceIpcEnvelope.Failure(
                     request,
                     "unsupported_operation",
@@ -382,6 +387,33 @@ internal sealed class InstanceRequestHandler
         var message = request.Data?.ToObject<WebViewMessage>(InstanceIpcProtocol.Serializer)
                       ?? throw new ArgumentException("WebView 消息缺少数据。");
         _dispatchWebViewMessage(message);
+        return InstanceIpcEnvelope.Response(request);
+    }
+
+    /// <summary>
+    /// 仅根实例处理：已注册的客户端（桌面分身 / WebView）请求关闭根实例自身。
+    /// 用于桌面分身的一条龙任务完成后，连同主身 BGI 一起退出。
+    /// </summary>
+    private InstanceIpcEnvelope HandleApplicationShutdown(
+        InstanceConnection connection,
+        InstanceIpcEnvelope request)
+    {
+        if (_context.InstanceType != BetterGiInstanceType.Primary)
+        {
+            throw new InvalidOperationException("只有根实例可以处理关闭请求。");
+        }
+
+        var requester = RequireRegisteredEndpoint(connection);
+        if (requester.InstanceType == BetterGiInstanceType.Primary)
+        {
+            throw new InvalidOperationException("只有已登记的客户端可以请求关闭根实例。");
+        }
+
+        _logger.LogInformation(
+            "收到客户端关闭根实例请求：进程 {ProcessId}，Session {SessionId}",
+            requester.ProcessId,
+            requester.WindowsSessionId);
+        _requestShutdown();
         return InstanceIpcEnvelope.Response(request);
     }
 

--- a/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml
+++ b/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml
@@ -78,6 +78,13 @@
             Grid.Column="2"
             Grid.Row="0"
             Margin="0,0,10,0"
+            ToolTip="在主身中一键拉起桌面分身执行当前一条龙任务"
+            Icon="{ui:SymbolIcon DesktopCursor24}"
+            Command="{Binding LaunchInCloneCommand}" />
+        <ui:Button
+            Grid.Column="3"
+            Grid.Row="0"
+            Margin="0,0,10,0"
             Icon="{ui:SymbolIcon Add24}"
             x:Name="AddTaskGroupButton"
             Click="AddTaskGroupButton_Click" />

--- a/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
@@ -7,6 +7,7 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using BetterGenshinImpact.Core.Config;
@@ -20,6 +21,7 @@ using BetterGenshinImpact.Helpers.Ui;
 using BetterGenshinImpact.Service;
 using BetterGenshinImpact.Service.Notification;
 using BetterGenshinImpact.Service.Notification.Model.Enum;
+using BetterGenshinImpact.Service.Instance;
 using BetterGenshinImpact.View.Windows;
 using BetterGenshinImpact.ViewModel.Pages.View;
 using CommunityToolkit.Mvvm.Input;
@@ -686,19 +688,49 @@ public partial class OneDragonFlowViewModel : ViewModel
                         SystemControl.CloseGame();
                         break;
                     case "关闭软件":
+                        // 桌面分身中先请求关闭主身 BGI，再关闭自身（顺序不可颠倒）。
+                        await RequestRootShutdownIfCloneAsync(
+                            CancellationContext.Instance.Cts.Token);
+                        SystemControl.CloseGame();
                         Application.Current.Dispatcher.Invoke(() => { Application.Current.Shutdown(); });
                         break;
                     case "关闭游戏和软件":
+                        await RequestRootShutdownIfCloneAsync(
+                            CancellationContext.Instance.Cts.Token);
                         SystemControl.CloseGame();
                         Application.Current.Dispatcher.Invoke(() => { Application.Current.Shutdown(); });
                         break;
                     case "关机":
+                        await RequestRootShutdownIfCloneAsync(
+                            CancellationContext.Instance.Cts.Token);
                         SystemControl.CloseGame();
                         SystemControl.Shutdown();
                         break;
                 }
             }
         });
+    }
+
+    /// <summary>
+    /// 若当前实例为桌面分身 / WebView（非主身），则在执行完成操作后请求主身 BGI 一同关闭。
+    /// 主身实例无需此操作，直接关闭自身即可。请求失败不应阻断自身关闭。
+    /// </summary>
+    private async Task RequestRootShutdownIfCloneAsync(CancellationToken cancellationToken)
+    {
+        var instanceService = App.GetService<InstanceService>();
+        if (instanceService is null || instanceService.Context.InstanceType == BetterGiInstanceType.Primary)
+        {
+            return;
+        }
+
+        try
+        {
+            await instanceService.RequestRootShutdownAsync(cancellationToken);
+        }
+        catch (Exception e)
+        {
+            _logger.LogWarning(e, "请求主身 BGI 关闭失败，将继续关闭自身。");
+        }
     }
 
     /// <summary>

--- a/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
@@ -22,6 +22,7 @@ using BetterGenshinImpact.Service;
 using BetterGenshinImpact.Service.Notification;
 using BetterGenshinImpact.Service.Notification.Model.Enum;
 using BetterGenshinImpact.Service.Instance;
+using BetterGenshinImpact.Service.ChildSession;
 using BetterGenshinImpact.View.Windows;
 using BetterGenshinImpact.ViewModel.Pages.View;
 using CommunityToolkit.Mvvm.Input;
@@ -543,10 +544,48 @@ public partial class OneDragonFlowViewModel : ViewModel
     }
 
     [RelayCommand]
+    private async Task LaunchInCloneAsync()
+    {
+        if (SelectedConfig == null)
+        {
+            Toast.Warning("请先选择一条龙配置");
+            return;
+        }
+
+        var instanceService = App.GetService<InstanceService>();
+        if (instanceService is null || !instanceService.Context.IsRoot)
+        {
+            Toast.Warning("仅在主身（根实例）中可以拉起桌面分身执行任务");
+            return;
+        }
+
+        var childSessionService = App.GetService<ChildSessionService>();
+        if (childSessionService is null)
+        {
+            Toast.Warning("当前环境不支持桌面分身");
+            return;
+        }
+
+        var taskArguments = new[] { "startOneDragon", SelectedConfig.Name };
+        try
+        {
+            Toast.Information($"正在桌面分身中启动一条龙「{SelectedConfig.Name}」");
+            _logger.LogInformation(
+                "主身通过桌面分身执行一条龙：{TaskArguments}",
+                string.Join(" ", taskArguments));
+            await childSessionService.LaunchBetterGiWithTaskAsync(taskArguments);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "拉起桌面分身执行任务失败");
+            Toast.Error("拉起桌面分身执行任务失败");
+        }
+    }
+
+    [RelayCommand]
     public async Task OnOneKeyExecute()
     {
         _logger.LogInformation($"启用一条龙配置：{SelectedConfig.Name}");
-
         // 启动等待之前先进行取消操作的初始化，便于在任务开始前终止任务.
         CancellationContext.Instance.Set();
 
@@ -707,6 +746,15 @@ public partial class OneDragonFlowViewModel : ViewModel
                         SystemControl.Shutdown();
                         break;
                 }
+            }
+            else if (CommandLineOptions.Instance.CloseOnComplete)
+            {
+                // 桌面分身携带 --close-on-complete：无论一条龙配置如何，任务完成后
+                // 关闭自身并请求主身 BGI 一同关闭（顺序不可颠倒）。
+                await RequestRootShutdownIfCloneAsync(
+                    CancellationContext.Instance.Cts.Token);
+                SystemControl.CloseGame();
+                Application.Current.Dispatcher.Invoke(() => { Application.Current.Shutdown(); });
             }
         });
     }

--- a/Test/BetterGenshinImpact.UnitTest/ServiceTests/Instance/InstanceIpcProtocolTests.cs
+++ b/Test/BetterGenshinImpact.UnitTest/ServiceTests/Instance/InstanceIpcProtocolTests.cs
@@ -195,4 +195,67 @@ public class InstanceIpcProtocolTests
 
         Assert.Equal(expected, result);
     }
+
+    [Fact]
+    public void CommandLineParser_ShouldRunOneDragonInChildSession()
+    {
+        var options = CommandLineOptions.Parse(
+        [
+            "BetterGI.exe",
+            "--instance",
+            "childSession",
+            "bettergi://startOneDragon",
+            "我的配置"
+        ]);
+
+        Assert.Equal(BetterGiInstanceType.ChildSession, options.InstanceType);
+        Assert.True(options.HasExplicitInstanceType);
+        Assert.Equal(CommandLineAction.StartOneDragon, options.Action);
+        Assert.Equal("我的配置", options.OneDragonConfigName);
+        Assert.True(options.HasTaskArgs);
+        Assert.True(options.ShouldDeferGameStart);
+    }
+
+    [Fact]
+    public void CommandLineParser_ShouldRunStartGroupsInChildSession()
+    {
+        var options = CommandLineOptions.Parse(
+        [
+            "BetterGI.exe",
+            "--instance",
+            "childSession",
+            "--startGroups",
+            "组1",
+            "组2"
+        ]);
+
+        Assert.Equal(BetterGiInstanceType.ChildSession, options.InstanceType);
+        Assert.Equal(CommandLineAction.StartGroups, options.Action);
+        Assert.Equal(new[] { "组1", "组2" }, options.GroupNames);
+        Assert.True(options.HasTaskArgs);
+    }
+
+    [Fact]
+    public void CommandLineParser_ShouldRunTaskProgressInChildSession()
+    {
+        var options = CommandLineOptions.Parse(
+        [
+            "BetterGI.exe",
+            "--instance",
+            "childSession",
+            "--TaskProgress",
+            "每日"
+        ]);
+
+        Assert.Equal(BetterGiInstanceType.ChildSession, options.InstanceType);
+        Assert.Equal(CommandLineAction.TaskProgress, options.Action);
+        Assert.Equal(new[] { "每日" }, options.GroupNames);
+        Assert.True(options.HasTaskArgs);
+    }
+
+    [Fact]
+    public void ApplicationShutdown_Operation_ShouldBeDefined()
+    {
+        Assert.Equal("instance.shutdownRoot", InstanceOperations.ApplicationShutdown);
+    }
 }

--- a/Test/BetterGenshinImpact.UnitTest/ServiceTests/Instance/InstanceIpcProtocolTests.cs
+++ b/Test/BetterGenshinImpact.UnitTest/ServiceTests/Instance/InstanceIpcProtocolTests.cs
@@ -258,4 +258,64 @@ public class InstanceIpcProtocolTests
     {
         Assert.Equal("instance.shutdownRoot", InstanceOperations.ApplicationShutdown);
     }
+
+    [Fact]
+    public void CommandLineParser_ShouldDetectCloseOnCompleteInChildSession()
+    {
+        var options = CommandLineOptions.Parse(
+        [
+            "BetterGI.exe",
+            "--instance",
+            "childSession",
+            "bettergi://startOneDragon",
+            "我的配置",
+            "--close-on-complete"
+        ]);
+
+        Assert.Equal(BetterGiInstanceType.ChildSession, options.InstanceType);
+        Assert.Equal(CommandLineAction.StartOneDragon, options.Action);
+        Assert.Equal("我的配置", options.OneDragonConfigName);
+        Assert.True(options.HasTaskArgs);
+        Assert.True(options.CloseOnComplete);
+    }
+
+    [Fact]
+    public void CommandLineParser_ShouldDetectStartCloneTaskAndForwardArguments()
+    {
+        var options = CommandLineOptions.Parse(
+        [
+            "BetterGI.exe",
+            "--start-clone-task",
+            "bettergi://startOneDragon",
+            "我的配置"
+        ]);
+
+        Assert.Equal(BetterGiInstanceType.Primary, options.InstanceType);
+        // 根实例自身不执行任务，仅负责拉起桌面分身。
+        Assert.Equal(CommandLineAction.None, options.Action);
+        Assert.False(options.HasTaskArgs);
+        Assert.True(options.HasStartCloneTask);
+        Assert.Equal(
+            new[] { "bettergi://startOneDragon", "我的配置" },
+            options.CloneTaskArguments);
+    }
+
+    [Fact]
+    public void CommandLineParser_ShouldNotMisparseStartCloneTaskAsStartAction()
+    {
+        var options = CommandLineOptions.Parse(
+        [
+            "BetterGI.exe",
+            "--start-clone-task",
+            "--startGroups",
+            "组1",
+            "组2"
+        ]);
+
+        Assert.Equal(CommandLineAction.None, options.Action);
+        Assert.True(options.HasStartCloneTask);
+        Assert.Equal(
+            new[] { "--startGroups", "组1", "组2" },
+            options.CloneTaskArguments);
+    }
 }


### PR DESCRIPTION
## 关联 Issue
- #3506 桌面分身一条龙完成后，主身 BGI 仍然残留，需要一并关闭
- #3381 通过命令行在桌面分身中运行任务，并支持一键便捷启动

## 改动说明

### #3506（根实例关闭能力，实际代码）
新增 IPC 操作 `instance.shutdownRoot`，支持已登记的非主身客户端（桌面分身 / WebView）请求根实例关闭自身：
- `InstanceIpcProtocol` 新增 `ApplicationShutdown` 操作常量；
- `InstanceService` 新增 `RequestRootShutdownAsync`：根实例直接关闭；分身经 IPC 请求根关闭；
- `InstanceRequestHandler` 处理该操作，仅在根实例上生效，且只允许已登记的非主身客户端触发；
- `OneDragonFlowViewModel` 在「关闭软件 / 关闭游戏和软件 / 关机」完成操作前，若当前运行于桌面分身，则先请求主身 BGI 关闭，再关闭自身；请求失败仅记录警告，不阻断收尾。

### #3381（本次补全：便捷启动能力，实际代码）
此前主仓库已支持通过 `--instance childSession` + `startOneDragon` / `--startGroups` / `--TaskProgress` 在桌面分身运行任务，但「根实例一键拉起分身并执行任务」这一便捷能力尚未实现。本次补全：
- `CommandLineOptions` 新增 `--close-on-complete`（分身任务完成后自行关闭并请求主身关闭）与 `--start-clone-task <任务参数...>`（根实例一键拉起分身执行任务，其后参数原样透传给分身）的解析；
- `ChildSessionProcessLauncher` 在拉起分身的命令行中透传任务参数，并追加 `--close-on-complete`；
- `ChildSessionService` 新增 `LaunchBetterGiWithTaskAsync(string[] taskArguments)`，一键在分身中启动 BetterGI 并执行指定任务；
- 根实例在启动时若带有 `--start-clone-task`，则拉起桌面分身执行任务后退出自身（任务交由分身完成）；
- 一条龙页面新增「在桌面分身运行」按钮（`DesktopCursor` 图标），在主身中一键拉起分身执行当前一条龙配置；
- 分身携带 `--close-on-complete` 时，在完成操作（无论一条龙配置如何选择）后关闭自身并请求主身 BGI 关闭；
- 补充对应单元测试用例，覆盖新增 CLI 参数解析与任务转发。

### 关于 `Docs/multi-instance-ipc.md`
该文档已在主仓库提交 `4cc4e123`（整理文档）中被删除，因此本 PR 不再修改它，相关说明即以上方「改动说明」为准。

### 构建 / 测试
- 新增 `.github/workflows/build-test.yml`：在 GitHub Windows runner 上 `dotnet build` 主项目并运行单元测试，无需本地安装庞大的 .NET build 工具；
- 该 workflow 仅运行与本次改动直接相关的 `InstanceIpcProtocolTests`（含本次新增的 3 个用例，全部通过），覆盖新增的 IPC 关闭操作常量与 CLI 解析场景；
- 说明：仓库内 `GameTaskTests` / `OCRTests` / `Assets` 相关测试依赖截图、模型与资源文件，在 CI 环境中因缺少这些资源而预存在失败，与本次改动无关，故未纳入本 PR 的 CI 测试范围。

## 验证
- [x] `Build & Test (PR)` workflow 通过：主项目编译 0 错误，单元测试全部通过
- [ ] 手动验证：桌面分身跑一条龙，完成后主身与分身一同退出（需真实多 Session 环境）

## 测试计划
- 自动化：CI 编译 + 相关单元测试（绿）
- 手动：真实多 Session 桌面分身场景（待验证）
