### PR TITLE
feat(AutoFishing): 支持至冬/挪德卡莱新鱼类（snowfin/starbloom）与新检测模型

### DIFF
--- a/BetterGenshinImpact/BetterGenshinImpact.csproj
+++ b/BetterGenshinImpact/BetterGenshinImpact.csproj
@@ -44,7 +44,7 @@
 
 		<PackageReference Include="BetterGI.VCRuntime" Version="14.44.35208" />
 		<PackageReference Include="BetterGI.Assets.Map" Version="1.0.21" />
-        <PackageReference Include="BetterGI.Assets.Model" Version="1.0.32" />
+        <PackageReference Include="BetterGI.Assets.Model" Version="1.0.33" />
 		<PackageReference Include="BetterGI.Assets.Other" Version="1.0.25" />
 
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />

--- a/BetterGenshinImpact/BetterGenshinImpact.csproj
+++ b/BetterGenshinImpact/BetterGenshinImpact.csproj
@@ -44,7 +44,7 @@
 
 		<PackageReference Include="BetterGI.VCRuntime" Version="14.44.35208" />
 		<PackageReference Include="BetterGI.Assets.Map" Version="1.0.21" />
-        <PackageReference Include="BetterGI.Assets.Model" Version="1.0.31" />
+        <PackageReference Include="BetterGI.Assets.Model" Version="1.0.32" />
 		<PackageReference Include="BetterGI.Assets.Other" Version="1.0.25" />
 
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />

--- a/BetterGenshinImpact/GameTask/AutoFishing/Model/BaitType.cs
+++ b/BetterGenshinImpact/GameTask/AutoFishing/Model/BaitType.cs
@@ -25,5 +25,7 @@ public enum BaitType
     [Description("槲梭饵")]
     BerryBait,
     [Description("清白饵")]
-    RefreshingLakkaBait
+    RefreshingLakkaBait,
+    [Description("闪烁饵")]
+    GlimmeringBait
 }

--- a/BetterGenshinImpact/GameTask/AutoFishing/Model/BigFishType.cs
+++ b/BetterGenshinImpact/GameTask/AutoFishing/Model/BigFishType.cs
@@ -36,7 +36,9 @@ public class BigFishType
     public static readonly BigFishType CrystalEye = new("crystal eye", BaitType.RefreshingLakkaBait, "明眼鱼", 9);
     public static readonly BigFishType AxeheadFish = new ("axehead", BaitType.BerryBait, "巨斧鱼", 9);
 
+    // 雪圆鳍为球形浅层鱼(炮鲀远亲), RodNet 借用炮鲀参数 (NetIndex=5)
     public static readonly BigFishType Snowfin = new("snowfin", BaitType.GlimmeringBait, "雪鳍鱼", 5);
+    // 星花鱼沿用近期新增鱼类的默认 RodNet 参数 (NetIndex=9)
     public static readonly BigFishType Starbloom = new("starbloom", BaitType.GlimmeringBait, "星花鱼", 9);
 
     public static IEnumerable<BigFishType> Values

--- a/BetterGenshinImpact/GameTask/AutoFishing/Model/BigFishType.cs
+++ b/BetterGenshinImpact/GameTask/AutoFishing/Model/BigFishType.cs
@@ -36,6 +36,9 @@ public class BigFishType
     public static readonly BigFishType CrystalEye = new("crystal eye", BaitType.RefreshingLakkaBait, "明眼鱼", 9);
     public static readonly BigFishType AxeheadFish = new ("axehead", BaitType.BerryBait, "巨斧鱼", 9);
 
+    public static readonly BigFishType Snowfin = new("snowfin", BaitType.GlimmeringBait, "雪鳍鱼", 5);
+    public static readonly BigFishType Starbloom = new("starbloom", BaitType.GlimmeringBait, "星花鱼", 9);
+
     public static IEnumerable<BigFishType> Values
     {
         get
@@ -63,6 +66,8 @@ public class BigFishType
             yield return MaulerShark;
             yield return CrystalEye;
             yield return AxeheadFish;
+            yield return Snowfin;
+            yield return Starbloom;
         }
     }
 


### PR DESCRIPTION
## 变更内容

配合新训练的自动钓鱼检测模型（bgi_fish.onnx，新增 snowfin/starbloom 两个大类），更新鱼类枚举：

- `BaitType` 新增 `GlimmeringBait`（闪烁饵）：雪圆鳍类与星花鱼类均使用此饵（已核对游戏内数据与 wiki）
- `BigFishType` 新增：
  - `Snowfin`（雪鳍鱼，含炭灰/奶油/月光雪圆鳍）：球形浅层鱼，RodNet 借用炮鲀参数（NetIndex=5）
  - `Starbloom`（星花鱼，含青仙/虹晶/赤甜星花鱼）：沿用近期新增鱼类的默认参数（NetIndex=9）

## 模型训练说明

- 数据集：旧标注数据 5132 张 + 新标注至冬钓鱼点数据 200 张，合并为 25 类（旧类别索引 0-22 不变，追加 23=snowfin、24=starbloom）
- 对比训练了 YOLOv8n / YOLO11n / YOLO26n（imgsz=1280, epochs=100）：
  - YOLOv8n: val mAP50 0.960, test mAP50 0.973
  - **YOLO11n: val mAP50 0.977, test mAP50 0.973（采用）**
  - YOLO26n: val mAP50 0.962, test mAP50 0.867（小目标召回差，未采用）
- 新模型为 YOLO11n，输出格式与 YoloSharp 6.0.3 完全兼容（[1,29,33600] float32，metadata 完整）
- W8A8 量化实验（PTQ/QAT）：ORT CPU 上 QDQ int8 比 FP32 慢约 3 倍且 PTQ 精度崩塌，故仍交付 FP32

## 模型文件

模型文件不在本仓库中，已上传至：https://github.com/lwh9346/better-genshin-impact/releases/tag/fish-model-20260824
（bgi_fish.onnx, YOLO11n, 11.1MB, sha256: 10f131ba6b24aab053737577a7760b101ddd560a6d7035d1211a0fd4f9fd3861）
替换 `Assets/Model/Fish/bgi_fish.onnx` 即可。

注意：换饵界面的图标分类 prototypes 需包含"闪烁饵"才能正常选择该饵，如缺失请补充。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增“闪烁饵”鱼饵类型。
  * 自动钓鱼新增“雪鳍”和“星花”鱼类支持。
  * 为新增鱼类配置了对应鱼饵及捕捞位置。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->