### PR TITLE
fix:派蒙检测改为调用bv，调整相关配置默认值

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoFight/AutoFightConfig.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/AutoFightConfig.cs
@@ -124,13 +124,13 @@ public partial class AutoFightConfig : ObservableObject
         /// 派蒙辅助检测：按L后当派蒙头像可见时提前跳出战斗结束检测
         /// </summary>
         [ObservableProperty]
-        private bool _paimonEndCheckEnabled = true;
+        private bool _paimonEndCheckEnabled = false;
 
         /// <summary>
-        /// 派蒙辅助检测延时（秒），默认为0.075秒
+        /// 派蒙辅助检测延时（秒），默认为0.2秒
         /// </summary>
         [ObservableProperty]
-        private double _paimonEndCheckDelay = 0.075;
+        private double _paimonEndCheckDelay = 0.2;
 
         /// <summary>
         /// 与"敌人可见时跳过战斗结束检查"互斥：开启旋转寻找敌人时关闭跳过检查，

--- a/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
@@ -14,6 +14,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using static BetterGenshinImpact.GameTask.Common.TaskControl;
+using BetterGenshinImpact.GameTask.Common.BgiVision;
 using BetterGenshinImpact.GameTask.Common.Job;
 using OpenCvSharp;
 using BetterGenshinImpact.Helpers;
@@ -983,11 +984,12 @@ public class AutoFightTask : ISoloTask
 
             if (finishDetectConfig.PaimonEndCheckEnabled)
             {
-                // 派蒙辅助检测：按L后等待PaimonEndCheckDelayMs，检测(32,67)像素是否为派蒙头冠颜色
+                // 派蒙辅助检测：按L后等待PaimonEndCheckDelayMs，检测左上角派蒙头像是否可见
                 await Delay(finishDetectConfig.PaimonEndCheckDelayMs, ct);
                 using var paimonRa = CaptureToRectArea();
-                var paimonPixel = paimonRa.SrcMat.At<Vec3b>(32, 67);
-                var paimonVisible = IsPaimon(paimonPixel.Item2, paimonPixel.Item1, paimonPixel.Item0);
+                // 复用 Bv 的派蒙头像检测：左上四分之一 ROI 内模板匹配 PaimonMenu（派蒙头像），
+                // 命中即视为派蒙可见 → 按L未生效、编队界面未打开、战斗未结束
+                var paimonVisible = Bv.IsInMainUi(paimonRa);
                 if (paimonVisible)
                 {
                     // 派蒙头像可见 → 编队界面未打开（按L未生效），战斗未结束，按X取消后提前跳出战斗结束检查
@@ -1039,14 +1041,6 @@ public class AutoFightTask : ISoloTask
             _lastFightFlagTime = DateTime.Now;
             return false;
         }
-    }
-
-    static bool IsPaimon(int r, int g, int b)
-    {
-        // 派蒙头冠颜色：R高，G中，B低（BGR 143,196,233 转换后 R=233,G=196,B=143，容差±10）
-        return (r >= 223 && r <= 243) &&
-               (g >= 186 && g <= 206) &&
-               (b >= 133 && b <= 153);
     }
 
     static bool IsYellow(int r, int g, int b)


### PR DESCRIPTION
## 改动内容

将战斗结束检测中的派蒙辅助检测从「固定像素坐标点判断」改为「复用 Bv 的派蒙头像区域检测」，并调整相关配置默认值。

### 1. 派蒙检测改为调用 bv
- 原实现：读取硬编码坐标 (32,67) 的像素颜色，用本地 IsPaimon 判断是否为派蒙头冠颜色。
- 新实现：复用 Bv.IsInMainUi（左上四分之一 ROI 内模板匹配 PaimonMenu 派蒙头像模板），自动适配 AssetScale 缩放，更稳健。
- 删除不再使用的 IsPaimon 静态方法。

### 2. 调整配置默认值
- PaimonEndCheckEnabled：默认开启 true → 默认禁用 false
- PaimonEndCheckDelay：默认 0.075 秒 → 0.2 秒

## 修改文件
- BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
- BetterGenshinImpact/GameTask/AutoFight/AutoFightConfig.cs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 优化自动战斗结束检测，提升对战斗结束状态的识别准确性。
  - 默认关闭派蒙辅助战斗结束检测，减少不必要的检测触发。
  - 将检测延时默认值调整为 0.2 秒，增强检测稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->