### PR TITLE
feat: 新增 QQ 官方 REST 通知渠道及 OpenID 自动绑定

### DIFF
--- a/BetterGenshinImpact/Service/Notification/NotificationConfig.cs
+++ b/BetterGenshinImpact/Service/Notification/NotificationConfig.cs
@@ -321,4 +321,24 @@ public partial class NotificationConfig : ObservableObject
     ///     Gotify通知优先级
     /// </summary>
     [ObservableProperty] private int _gotifyNotifyLevel = 3;
+
+    /// <summary>
+    ///     QQ通知是否启用
+    /// </summary>
+    [ObservableProperty] private bool _qqNotificationEnabled;
+
+    /// <summary>
+    ///     QQ开放平台 AppID
+    /// </summary>
+    [ObservableProperty] private string _qqAppId = string.Empty;
+
+    /// <summary>
+    ///     QQ开放平台 AppSecret
+    /// </summary>
+    [ObservableProperty] private string _qqClientSecret = string.Empty;
+
+    /// <summary>
+    ///     用户的 C2C OpenID（单聊场景）
+    /// </summary>
+    [ObservableProperty] private string _qqOpenId = string.Empty;
 }

--- a/BetterGenshinImpact/Service/Notification/NotificationService.cs
+++ b/BetterGenshinImpact/Service/Notification/NotificationService.cs
@@ -112,6 +112,7 @@ public class NotificationService : IHostedService, IDisposable
         InitializeServerChanNotifier();
         InitializeMeowNotifier();
         InitializeGotifyNotifier();
+        InitializeQqNotifier();
 
         // 添加新通知渠道时，在此处添加对应的初始化方法调用
     }
@@ -344,6 +345,21 @@ public class NotificationService : IHostedService, IDisposable
             _notificationConfig.GotifyUrl,
             _notificationConfig.GotifyAppToken,
             _notificationConfig.GotifyNotifyLevel
+        ));
+    }
+
+    /// <summary>
+    ///     初始化QQ通知器
+    /// </summary>
+    private void InitializeQqNotifier()
+    {
+        if (_notificationConfig?.QqNotificationEnabled != true) return;
+
+        _notifierManager.RegisterNotifier(new QqNotifier(
+            _notifyHttpClient,
+            _notificationConfig.QqAppId,
+            _notificationConfig.QqClientSecret,
+            _notificationConfig.QqOpenId
         ));
     }
 

--- a/BetterGenshinImpact/Service/Notifier/QqNotifier.cs
+++ b/BetterGenshinImpact/Service/Notifier/QqNotifier.cs
@@ -6,6 +6,7 @@ using System.Net.Http.Headers;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using BetterGenshinImpact.Service.Notification.Model;
 using BetterGenshinImpact.Service.Notification.Model.Enum;
@@ -70,16 +71,17 @@ public sealed class QqNotifier : INotifier
         if (string.IsNullOrWhiteSpace(_openId))
             throw new NotifierException("QQ OpenID is empty");
 
+        var ct = CancellationToken.None;
         try
         {
             var text = GenerateMessage(content);
-            await SendTextAsync(text);
+            await SendTextAsync(text, ct);
 
             if (content.Screenshot != null)
             {
                 try
                 {
-                    await SendImageAsync(content.Screenshot);
+                    await SendImageAsync(content.Screenshot, ct);
                 }
                 catch (System.Exception ex)
                 {
@@ -120,14 +122,14 @@ public sealed class QqNotifier : INotifier
     /// <summary>
     /// Obtains an access token from the QQ Open Platform.
     /// </summary>
-    private async Task<string> GetAccessTokenAsync()
+    private async Task<string> GetAccessTokenAsync(CancellationToken ct)
     {
         var body = JsonSerializer.Serialize(new { appId = _appId, clientSecret = _clientSecret });
         using var content = new StringContent(body, Encoding.UTF8, "application/json");
         using var request = new HttpRequestMessage(HttpMethod.Post, TokenUrl) { Content = content };
-        using var response = await _httpClient.SendAsync(request);
+        using var response = await _httpClient.SendAsync(request, ct);
         response.EnsureSuccessStatusCode();
-        var json = await response.Content.ReadAsStringAsync();
+        var json = await response.Content.ReadAsStringAsync(ct);
         using var doc = JsonDocument.Parse(json);
         return doc.RootElement.GetProperty("access_token").GetString()!;
     }
@@ -135,33 +137,34 @@ public sealed class QqNotifier : INotifier
     /// <summary>
     /// Builds an HTTP request with the QQ authorization header.
     /// </summary>
-    private async Task<HttpRequestMessage> BuildAuthedRequest(HttpMethod method, string url, HttpContent? body = null)
+    private async Task<HttpRequestMessage> BuildAuthedRequest(HttpMethod method, string url, HttpContent? body, CancellationToken ct)
     {
-        var token = await GetAccessTokenAsync();
+        var token = await GetAccessTokenAsync(ct);
         var request = new HttpRequestMessage(method, url) { Content = body };
         request.Headers.Add("Authorization", $"QQBot {token}");
         return request;
     }
 
     /// <summary>
-    /// Sends a plain text message (msg_type=0) with retry.
+    /// Sends a plain text message (msg_type=0) exactly once.
+    /// Message creation is not retried: if the request times out after the server
+    /// already created the message, a retry would produce a duplicate notification.
     /// </summary>
-    private async Task SendTextAsync(string text)
+    private async Task SendTextAsync(string text, CancellationToken ct)
     {
-        await WithRetryAsync(async () =>
-        {
-            var body = JsonSerializer.Serialize(new { msg_type = 0, content = text });
-            using var jsonContent = new StringContent(body, Encoding.UTF8, "application/json");
-            using var request = await BuildAuthedRequest(HttpMethod.Post, $"{ApiBase.Replace("{openid}", _openId)}/messages", jsonContent);
-            using var response = await _httpClient.SendAsync(request);
-            response.EnsureSuccessStatusCode();
-        });
+        var body = JsonSerializer.Serialize(new { msg_type = 0, content = text });
+        using var jsonContent = new StringContent(body, Encoding.UTF8, "application/json");
+        using var request = await BuildAuthedRequest(HttpMethod.Post, $"{ApiBase.Replace("{openid}", _openId)}/messages", jsonContent, ct);
+        using var response = await _httpClient.SendAsync(request, ct);
+        response.EnsureSuccessStatusCode();
     }
 
     /// <summary>
     /// Uploads the screenshot and sends it as a rich media image message (msg_type=7).
+    /// The upload flow is retried as it is idempotent; the final message creation is
+    /// not retried to avoid duplicate notifications.
     /// </summary>
-    private async Task SendImageAsync(Image<Rgb24> screenshot)
+    private async Task SendImageAsync(Image<Rgb24> screenshot, CancellationToken ct)
     {
         byte[] imageBytes;
         using (var ms = new MemoryStream())
@@ -170,27 +173,24 @@ public sealed class QqNotifier : INotifier
             imageBytes = ms.ToArray();
         }
 
-        var fileInfo = await UploadImageChunkedAsync(imageBytes);
+        var fileInfo = await UploadImageChunkedAsync(imageBytes, ct);
 
-        await WithRetryAsync(async () =>
+        var body = JsonSerializer.Serialize(new
         {
-            var body = JsonSerializer.Serialize(new
-            {
-                msg_type = 7,
-                media = new { file_info = fileInfo }
-            });
-            using var jsonContent = new StringContent(body, Encoding.UTF8, "application/json");
-            using var request = await BuildAuthedRequest(HttpMethod.Post, $"{ApiBase.Replace("{openid}", _openId)}/messages", jsonContent);
-            using var response = await _httpClient.SendAsync(request);
-            response.EnsureSuccessStatusCode();
+            msg_type = 7,
+            media = new { file_info = fileInfo }
         });
+        using var jsonContent = new StringContent(body, Encoding.UTF8, "application/json");
+        using var request = await BuildAuthedRequest(HttpMethod.Post, $"{ApiBase.Replace("{openid}", _openId)}/messages", jsonContent, ct);
+        using var response = await _httpClient.SendAsync(request, ct);
+        response.EnsureSuccessStatusCode();
     }
 
     /// <summary>
     /// Uploads the image bytes via the QQ chunked upload flow and returns the file_info.
     /// The flow is: upload_prepare -> chunk PUT + part_finish -> files merge.
     /// </summary>
-    private async Task<string> UploadImageChunkedAsync(byte[] imageBytes)
+    private async Task<string> UploadImageChunkedAsync(byte[] imageBytes, CancellationToken ct)
     {
         var baseUrl = ApiBase.Replace("{openid}", _openId);
         var fileName = "screenshot.jpg";
@@ -198,7 +198,7 @@ public sealed class QqNotifier : INotifier
         var sha1 = Convert.ToHexString(SHA1.HashData(imageBytes)).ToLower();
         var md5First10m = Convert.ToHexString(MD5.HashData(imageBytes.AsSpan(0, Math.Min(imageBytes.Length, 10002432)))).ToLower();
 
-        var prepared = await WithRetryAsync(() => PrepareUploadAsync(baseUrl, fileName, imageBytes.Length, md5, sha1, md5First10m));
+        var prepared = await WithRetryAsync(() => PrepareUploadAsync(baseUrl, fileName, imageBytes.Length, md5, sha1, md5First10m, ct), ct);
 
         foreach (var part in prepared.Parts)
         {
@@ -207,17 +207,17 @@ public sealed class QqNotifier : INotifier
             var chunk = imageBytes[start..end];
             var chunkMd5 = Convert.ToHexString(MD5.HashData(chunk)).ToLower();
 
-            await WithRetryAsync(() => UploadChunkAsync(part.PresignedUrl, chunk));
-            await WithRetryAsync(() => FinishChunkAsync(baseUrl, prepared.UploadId, part.Index, chunk.Length, chunkMd5));
+            await WithRetryAsync(() => UploadChunkAsync(part.PresignedUrl, chunk, ct), ct);
+            await WithRetryAsync(() => FinishChunkAsync(baseUrl, prepared.UploadId, part.Index, chunk.Length, chunkMd5, ct), ct);
         }
 
-        return await WithRetryAsync(() => MergeUploadAsync(baseUrl, prepared.UploadId));
+        return await WithRetryAsync(() => MergeUploadAsync(baseUrl, prepared.UploadId, ct), ct);
     }
 
     /// <summary>
     /// Calls upload_prepare to obtain the upload id, block size and presigned chunk URLs.
     /// </summary>
-    private async Task<UploadPrepareResult> PrepareUploadAsync(string baseUrl, string fileName, int fileSize, string md5, string sha1, string md5First10m)
+    private async Task<UploadPrepareResult> PrepareUploadAsync(string baseUrl, string fileName, int fileSize, string md5, string sha1, string md5First10m, CancellationToken ct)
     {
         using var request = await BuildAuthedRequest(HttpMethod.Post, $"{baseUrl}/upload_prepare", new StringContent(
             JsonSerializer.Serialize(new
@@ -228,10 +228,10 @@ public sealed class QqNotifier : INotifier
                 md5,
                 sha1,
                 md5_10m = md5First10m
-            }), Encoding.UTF8, "application/json"));
-        using var response = await _httpClient.SendAsync(request);
+            }), Encoding.UTF8, "application/json"), ct);
+        using var response = await _httpClient.SendAsync(request, ct);
         response.EnsureSuccessStatusCode();
-        var json = await response.Content.ReadAsStringAsync();
+        var json = await response.Content.ReadAsStringAsync(ct);
         using var doc = JsonDocument.Parse(json);
         var uploadId = doc.RootElement.GetProperty("upload_id").GetString()!;
         var blockSize = int.Parse(doc.RootElement.GetProperty("block_size").GetString()!);
@@ -248,18 +248,18 @@ public sealed class QqNotifier : INotifier
     /// <summary>
     /// Uploads a single chunk to its presigned URL.
     /// </summary>
-    private async Task UploadChunkAsync(string presignedUrl, byte[] chunk)
+    private async Task UploadChunkAsync(string presignedUrl, byte[] chunk, CancellationToken ct)
     {
         using var putContent = new ByteArrayContent(chunk);
         putContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
-        using var putResponse = await _httpClient.PutAsync(presignedUrl, putContent);
+        using var putResponse = await _httpClient.PutAsync(presignedUrl, putContent, ct);
         putResponse.EnsureSuccessStatusCode();
     }
 
     /// <summary>
     /// Notifies the QQ platform that a chunk has finished uploading.
     /// </summary>
-    private async Task FinishChunkAsync(string baseUrl, string uploadId, int partIndex, int chunkLength, string chunkMd5)
+    private async Task FinishChunkAsync(string baseUrl, string uploadId, int partIndex, int chunkLength, string chunkMd5, CancellationToken ct)
     {
         using var request = await BuildAuthedRequest(HttpMethod.Post, $"{baseUrl}/upload_part_finish", new StringContent(
             JsonSerializer.Serialize(new
@@ -268,21 +268,21 @@ public sealed class QqNotifier : INotifier
                 part_index = partIndex,
                 block_size = chunkLength.ToString(),
                 md5 = chunkMd5
-            }), Encoding.UTF8, "application/json"));
-        using var response = await _httpClient.SendAsync(request);
+            }), Encoding.UTF8, "application/json"), ct);
+        using var response = await _httpClient.SendAsync(request, ct);
         response.EnsureSuccessStatusCode();
     }
 
     /// <summary>
     /// Merges the uploaded chunks and returns the file_info.
     /// </summary>
-    private async Task<string> MergeUploadAsync(string baseUrl, string uploadId)
+    private async Task<string> MergeUploadAsync(string baseUrl, string uploadId, CancellationToken ct)
     {
         using var request = await BuildAuthedRequest(HttpMethod.Post, $"{baseUrl}/files", new StringContent(
-            JsonSerializer.Serialize(new { file_type = 1, upload_id = uploadId }), Encoding.UTF8, "application/json"));
-        using var response = await _httpClient.SendAsync(request);
+            JsonSerializer.Serialize(new { file_type = 1, upload_id = uploadId }), Encoding.UTF8, "application/json"), ct);
+        using var response = await _httpClient.SendAsync(request, ct);
         response.EnsureSuccessStatusCode();
-        var json = await response.Content.ReadAsStringAsync();
+        var json = await response.Content.ReadAsStringAsync(ct);
         using var doc = JsonDocument.Parse(json);
         return doc.RootElement.GetProperty("file_info").GetString()!;
     }
@@ -294,7 +294,7 @@ public sealed class QqNotifier : INotifier
     /// <summary>
     /// Executes the given action with up to <see cref="MaxRetry"/> attempts and exponential backoff.
     /// </summary>
-    private async Task WithRetryAsync(Func<Task> action)
+    private async Task WithRetryAsync(Func<Task> action, CancellationToken ct)
     {
         System.Exception? lastException = null;
         for (var attempt = 0; attempt < MaxRetry; attempt++)
@@ -307,7 +307,7 @@ public sealed class QqNotifier : INotifier
             catch (System.Exception ex) when (attempt < MaxRetry - 1)
             {
                 lastException = ex;
-                await Task.Delay(TimeSpan.FromMilliseconds(1500 * (1 << attempt)));
+                await Task.Delay(TimeSpan.FromMilliseconds(1500 * (1 << attempt)), ct);
             }
         }
         if (lastException != null)
@@ -317,7 +317,7 @@ public sealed class QqNotifier : INotifier
     /// <summary>
     /// Executes the given function with up to <see cref="MaxRetry"/> attempts and exponential backoff.
     /// </summary>
-    private async Task<T> WithRetryAsync<T>(Func<Task<T>> action)
+    private async Task<T> WithRetryAsync<T>(Func<Task<T>> action, CancellationToken ct)
     {
         System.Exception? lastException = null;
         for (var attempt = 0; attempt < MaxRetry; attempt++)
@@ -329,7 +329,7 @@ public sealed class QqNotifier : INotifier
             catch (System.Exception ex) when (attempt < MaxRetry - 1)
             {
                 lastException = ex;
-                await Task.Delay(TimeSpan.FromMilliseconds(1500 * (1 << attempt)));
+                await Task.Delay(TimeSpan.FromMilliseconds(1500 * (1 << attempt)), ct);
             }
         }
         throw lastException ?? new NotifierException("QQ request failed after retries");

--- a/BetterGenshinImpact/Service/Notifier/QqNotifier.cs
+++ b/BetterGenshinImpact/Service/Notifier/QqNotifier.cs
@@ -38,13 +38,10 @@ public sealed class QqNotifier : INotifier
     private readonly string _clientSecret;
     private readonly string _openId;
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="QqNotifier"/> class.
-    /// </summary>
-    /// <param name="httpClient">Shared HTTP client used to call the QQ Open Platform API.</param>
-    /// <param name="appId">QQ Open Platform AppID.</param>
-    /// <param name="clientSecret">QQ Open Platform AppSecret.</param>
-    /// <param name="openId">The target user's C2C OpenID.</param>
+    private string? _cachedToken;
+    private DateTime _tokenExpiry = DateTime.MinValue;
+    private readonly SemaphoreSlim _tokenSemaphore = new(1, 1);
+
     public QqNotifier(HttpClient httpClient, string appId, string clientSecret, string openId)
     {
         _httpClient = httpClient;
@@ -53,13 +50,6 @@ public sealed class QqNotifier : INotifier
         _openId = openId;
     }
 
-    /// <summary>
-    /// Sends the notification to the user's QQ private chat.
-    /// The text message is always sent first; if a screenshot is present, an image
-    /// message is sent afterwards. A screenshot failure is logged and swallowed so
-    /// that the already-delivered text notification is not reported as failed.
-    /// </summary>
-    /// <param name="content">The notification data to send.</param>
     public async Task SendAsync(BaseNotificationData content)
     {
         if (string.IsNullOrWhiteSpace(_appId))
@@ -99,9 +89,6 @@ public sealed class QqNotifier : INotifier
         }
     }
 
-    /// <summary>
-    /// Builds the human-readable text message with a result mark and timestamp.
-    /// </summary>
     private static string GenerateMessage(BaseNotificationData data)
     {
         var sb = new StringBuilder();
@@ -119,10 +106,25 @@ public sealed class QqNotifier : INotifier
         return sb.ToString();
     }
 
-    /// <summary>
-    /// Obtains an access token from the QQ Open Platform.
-    /// </summary>
     private async Task<string> GetAccessTokenAsync(CancellationToken ct)
+    {
+        if (!string.IsNullOrEmpty(_cachedToken) && DateTime.UtcNow < _tokenExpiry)
+            return _cachedToken;
+
+        await _tokenSemaphore.WaitAsync(ct);
+        try
+        {
+            if (!string.IsNullOrEmpty(_cachedToken) && DateTime.UtcNow < _tokenExpiry)
+                return _cachedToken;
+            return await RefreshTokenAsync(ct);
+        }
+        finally
+        {
+            _tokenSemaphore.Release();
+        }
+    }
+
+    private async Task<string> RefreshTokenAsync(CancellationToken ct)
     {
         var body = JsonSerializer.Serialize(new { appId = _appId, clientSecret = _clientSecret });
         using var content = new StringContent(body, Encoding.UTF8, "application/json");
@@ -131,12 +133,14 @@ public sealed class QqNotifier : INotifier
         response.EnsureSuccessStatusCode();
         var json = await response.Content.ReadAsStringAsync(ct);
         using var doc = JsonDocument.Parse(json);
-        return doc.RootElement.GetProperty("access_token").GetString()!;
+        var root = doc.RootElement;
+        _cachedToken = root.GetProperty("access_token").GetString()!;
+        var expiresInStr = root.GetProperty("expires_in").GetString();
+        var expiresIn = int.TryParse(expiresInStr, out var parsed) ? parsed : 60;
+        _tokenExpiry = DateTime.UtcNow.AddSeconds(Math.Max(expiresIn - 60, 30));
+        return _cachedToken;
     }
 
-    /// <summary>
-    /// Builds an HTTP request with the QQ authorization header.
-    /// </summary>
     private async Task<HttpRequestMessage> BuildAuthedRequest(HttpMethod method, string url, HttpContent? body, CancellationToken ct)
     {
         var token = await GetAccessTokenAsync(ct);
@@ -145,11 +149,6 @@ public sealed class QqNotifier : INotifier
         return request;
     }
 
-    /// <summary>
-    /// Sends a plain text message (msg_type=0) exactly once.
-    /// Message creation is not retried: if the request times out after the server
-    /// already created the message, a retry would produce a duplicate notification.
-    /// </summary>
     private async Task SendTextAsync(string text, CancellationToken ct)
     {
         var body = JsonSerializer.Serialize(new { msg_type = 0, content = text });
@@ -159,11 +158,6 @@ public sealed class QqNotifier : INotifier
         response.EnsureSuccessStatusCode();
     }
 
-    /// <summary>
-    /// Uploads the screenshot and sends it as a rich media image message (msg_type=7).
-    /// The upload flow is retried as it is idempotent; the final message creation is
-    /// not retried to avoid duplicate notifications.
-    /// </summary>
     private async Task SendImageAsync(Image<Rgb24> screenshot, CancellationToken ct)
     {
         byte[] imageBytes;
@@ -186,10 +180,6 @@ public sealed class QqNotifier : INotifier
         response.EnsureSuccessStatusCode();
     }
 
-    /// <summary>
-    /// Uploads the image bytes via the QQ chunked upload flow and returns the file_info.
-    /// The flow is: upload_prepare -> chunk PUT + part_finish -> files merge.
-    /// </summary>
     private async Task<string> UploadImageChunkedAsync(byte[] imageBytes, CancellationToken ct)
     {
         var baseUrl = ApiBase.Replace("{openid}", _openId);
@@ -198,7 +188,7 @@ public sealed class QqNotifier : INotifier
         var sha1 = Convert.ToHexString(SHA1.HashData(imageBytes)).ToLower();
         var md5First10m = Convert.ToHexString(MD5.HashData(imageBytes.AsSpan(0, Math.Min(imageBytes.Length, 10002432)))).ToLower();
 
-        var prepared = await WithRetryAsync(() => PrepareUploadAsync(baseUrl, fileName, imageBytes.Length, md5, sha1, md5First10m, ct), ct);
+        var prepared = await PrepareUploadAsync(baseUrl, fileName, imageBytes.Length, md5, sha1, md5First10m, ct);
 
         foreach (var part in prepared.Parts)
         {
@@ -211,12 +201,9 @@ public sealed class QqNotifier : INotifier
             await WithRetryAsync(() => FinishChunkAsync(baseUrl, prepared.UploadId, part.Index, chunk.Length, chunkMd5, ct), ct);
         }
 
-        return await WithRetryAsync(() => MergeUploadAsync(baseUrl, prepared.UploadId, ct), ct);
+        return await MergeUploadAsync(baseUrl, prepared.UploadId, ct);
     }
 
-    /// <summary>
-    /// Calls upload_prepare to obtain the upload id, block size and presigned chunk URLs.
-    /// </summary>
     private async Task<UploadPrepareResult> PrepareUploadAsync(string baseUrl, string fileName, int fileSize, string md5, string sha1, string md5First10m, CancellationToken ct)
     {
         using var request = await BuildAuthedRequest(HttpMethod.Post, $"{baseUrl}/upload_prepare", new StringContent(
@@ -245,9 +232,36 @@ public sealed class QqNotifier : INotifier
         return new UploadPrepareResult(uploadId, blockSize, parts);
     }
 
-    /// <summary>
-    /// Uploads a single chunk to its presigned URL.
-    /// </summary>
+    private static bool IsRetryable(System.Exception ex)
+    {
+        if (ex is HttpRequestException hre)
+        {
+            var statusCode = hre.StatusCode;
+            if (statusCode.HasValue)
+            {
+                var code = (int)statusCode.Value;
+                if (code >= 500 && code <= 599)
+                    return true;
+                if (code == 429)
+                    return true;
+                if (code == 400)
+                {
+                    var msg = ex.Message;
+                    if (msg.Contains("40093001"))
+                        return true;
+                    if (msg.Contains("40093002"))
+                        return false;
+                }
+            }
+            return false;
+        }
+        if (ex is TaskCanceledException || ex is OperationCanceledException)
+            return false;
+        if (ex is JsonException || ex is InvalidOperationException)
+            return false;
+        return true;
+    }
+
     private async Task UploadChunkAsync(string presignedUrl, byte[] chunk, CancellationToken ct)
     {
         using var putContent = new ByteArrayContent(chunk);
@@ -256,9 +270,6 @@ public sealed class QqNotifier : INotifier
         putResponse.EnsureSuccessStatusCode();
     }
 
-    /// <summary>
-    /// Notifies the QQ platform that a chunk has finished uploading.
-    /// </summary>
     private async Task FinishChunkAsync(string baseUrl, string uploadId, int partIndex, int chunkLength, string chunkMd5, CancellationToken ct)
     {
         using var request = await BuildAuthedRequest(HttpMethod.Post, $"{baseUrl}/upload_part_finish", new StringContent(
@@ -273,9 +284,6 @@ public sealed class QqNotifier : INotifier
         response.EnsureSuccessStatusCode();
     }
 
-    /// <summary>
-    /// Merges the uploaded chunks and returns the file_info.
-    /// </summary>
     private async Task<string> MergeUploadAsync(string baseUrl, string uploadId, CancellationToken ct)
     {
         using var request = await BuildAuthedRequest(HttpMethod.Post, $"{baseUrl}/files", new StringContent(
@@ -291,10 +299,6 @@ public sealed class QqNotifier : INotifier
 
     private readonly record struct UploadPrepareResult(string UploadId, int BlockSize, List<ChunkPart> Parts);
 
-    /// <summary>
-    /// Executes the given action with up to <see cref="MaxRetry"/> retries
-    /// (i.e. <c>MaxRetry + 1</c> total attempts) and exponential backoff.
-    /// </summary>
     private async Task WithRetryAsync(Func<Task> action, CancellationToken ct)
     {
         System.Exception? lastException = null;
@@ -305,7 +309,7 @@ public sealed class QqNotifier : INotifier
                 await action();
                 return;
             }
-            catch (System.Exception ex) when (attempt < MaxRetry)
+            catch (System.Exception ex) when (attempt < MaxRetry && IsRetryable(ex))
             {
                 lastException = ex;
                 await Task.Delay(TimeSpan.FromMilliseconds(1500 * (1 << attempt)), ct);
@@ -315,10 +319,6 @@ public sealed class QqNotifier : INotifier
             throw lastException;
     }
 
-    /// <summary>
-    /// Executes the given function with up to <see cref="MaxRetry"/> retries
-    /// (i.e. <c>MaxRetry + 1</c> total attempts) and exponential backoff.
-    /// </summary>
     private async Task<T> WithRetryAsync<T>(Func<Task<T>> action, CancellationToken ct)
     {
         System.Exception? lastException = null;
@@ -328,7 +328,7 @@ public sealed class QqNotifier : INotifier
             {
                 return await action();
             }
-            catch (System.Exception ex) when (attempt < MaxRetry)
+            catch (System.Exception ex) when (attempt < MaxRetry && IsRetryable(ex))
             {
                 lastException = ex;
                 await Task.Delay(TimeSpan.FromMilliseconds(1500 * (1 << attempt)), ct);

--- a/BetterGenshinImpact/Service/Notifier/QqNotifier.cs
+++ b/BetterGenshinImpact/Service/Notifier/QqNotifier.cs
@@ -1,0 +1,273 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using BetterGenshinImpact.Service.Notification.Model;
+using BetterGenshinImpact.Service.Notification.Model.Enum;
+using BetterGenshinImpact.Service.Notifier.Exception;
+using BetterGenshinImpact.Service.Notifier.Interface;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace BetterGenshinImpact.Service.Notifier;
+
+/// <summary>
+/// QQ official REST notifier.
+/// Pushes BetterGI events to the user's QQ private chat (C2C) via QQ Open Platform API.
+/// Supports text messages and screenshot image messages (chunked upload).
+/// </summary>
+public sealed class QqNotifier : INotifier
+{
+    public string Name { get; } = "QQ";
+
+    private const string TokenUrl = "https://bots.qq.com/app/getAppAccessToken";
+    private const string ApiBase = "https://api.sgroup.qq.com/v2/users/{openid}";
+    private const int MaxRetry = 3;
+
+    private readonly HttpClient _httpClient;
+    private readonly string _appId;
+    private readonly string _clientSecret;
+    private readonly string _openId;
+
+    public QqNotifier(HttpClient httpClient, string appId, string clientSecret, string openId)
+    {
+        _httpClient = httpClient;
+        _appId = appId;
+        _clientSecret = clientSecret;
+        _openId = openId;
+    }
+
+    public async Task SendAsync(BaseNotificationData content)
+    {
+        if (string.IsNullOrWhiteSpace(_appId))
+            throw new NotifierException("QQ AppID is empty");
+
+        if (string.IsNullOrWhiteSpace(_clientSecret))
+            throw new NotifierException("QQ AppSecret is empty");
+
+        if (string.IsNullOrWhiteSpace(_openId))
+            throw new NotifierException("QQ OpenID is empty");
+
+        try
+        {
+            // 1. Send text message
+            var text = GenerateMessage(content);
+            await SendTextAsync(text);
+
+            // 2. Send image message if screenshot exists
+            if (content.Screenshot != null)
+            {
+                try
+                {
+                    await SendImageAsync(content.Screenshot);
+                }
+                catch (System.Exception ex)
+                {
+                    // Image failure should not block the whole notification (text already sent)
+                    throw new NotifierException($"QQ image send failed (text already sent): {ex.Message}");
+                }
+            }
+        }
+        catch (NotifierException)
+        {
+            throw;
+        }
+        catch (System.Exception ex)
+        {
+            throw new NotifierException($"Error sending QQ message: {ex.Message}");
+        }
+    }
+
+    private static string GenerateMessage(BaseNotificationData data)
+    {
+        var sb = new StringBuilder();
+        var mark = data.Result switch
+        {
+            NotificationEventResult.Success => "\u2705",
+            NotificationEventResult.Fail => "\u274C",
+            _ => "\u26A0\uFE0F"
+        };
+        sb.Append($"[BetterGI] {mark} ");
+        if (!string.IsNullOrWhiteSpace(data.Message))
+            sb.Append(data.Message);
+        sb.AppendLine();
+        sb.Append($"\uD83D\uDD50 {data.Timestamp:yyyy-MM-dd HH:mm:ss}");
+        return sb.ToString();
+    }
+
+    // ==================== Auth ====================
+
+    private async Task<string> GetAccessTokenAsync()
+    {
+        var body = JsonSerializer.Serialize(new { appId = _appId, clientSecret = _clientSecret });
+        using var content = new StringContent(body, Encoding.UTF8, "application/json");
+        using var request = new HttpRequestMessage(HttpMethod.Post, TokenUrl) { Content = content };
+        using var response = await _httpClient.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+        var json = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.GetProperty("access_token").GetString()!;
+    }
+
+    private async Task<HttpRequestMessage> BuildAuthedRequest(HttpMethod method, string url, HttpContent? body = null)
+    {
+        var token = await GetAccessTokenAsync();
+        var request = new HttpRequestMessage(method, url) { Content = body };
+        request.Headers.Add("Authorization", $"QQBot {token}");
+        return request;
+    }
+
+    // ==================== Text message ====================
+
+    private async Task SendTextAsync(string text)
+    {
+        await WithRetryAsync(async () =>
+        {
+            var body = JsonSerializer.Serialize(new { msg_type = 0, content = text });
+            using var jsonContent = new StringContent(body, Encoding.UTF8, "application/json");
+            using var request = await BuildAuthedRequest(HttpMethod.Post, $"{ApiBase.Replace("{openid}", _openId)}/messages", jsonContent);
+            using var response = await _httpClient.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+        });
+    }
+
+    // ==================== Image message (chunked upload) ====================
+
+    private async Task SendImageAsync(Image<Rgb24> screenshot)
+    {
+        // Convert to JPEG bytes
+        byte[] imageBytes;
+        using (var ms = new MemoryStream())
+        {
+            screenshot.SaveAsJpeg(ms);
+            imageBytes = ms.ToArray();
+        }
+
+        // 1. Upload to get file_info
+        var fileInfo = await UploadImageChunkedAsync(imageBytes);
+
+        // 2. Send rich media message msg_type=7
+        await WithRetryAsync(async () =>
+        {
+            var body = JsonSerializer.Serialize(new
+            {
+                msg_type = 7,
+                media = new { file_info = fileInfo }
+            });
+            using var jsonContent = new StringContent(body, Encoding.UTF8, "application/json");
+            using var request = await BuildAuthedRequest(HttpMethod.Post, $"{ApiBase.Replace("{openid}", _openId)}/messages", jsonContent);
+            using var response = await _httpClient.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+        });
+    }
+
+    private async Task<string> UploadImageChunkedAsync(byte[] imageBytes)
+    {
+        var baseUrl = ApiBase.Replace("{openid}", _openId);
+        var fileName = "screenshot.jpg";
+        var md5 = Convert.ToHexString(MD5.HashData(imageBytes)).ToLower();
+        var sha1 = Convert.ToHexString(SHA1.HashData(imageBytes)).ToLower();
+        var md5First10m = Convert.ToHexString(MD5.HashData(imageBytes.AsSpan(0, Math.Min(imageBytes.Length, 10002432)))).ToLower();
+
+        // 1. upload_prepare
+        string uploadId;
+        int blockSize;
+        List<ChunkPart> parts;
+        using (var request = await BuildAuthedRequest(HttpMethod.Post, $"{baseUrl}/upload_prepare", new StringContent(
+            JsonSerializer.Serialize(new
+            {
+                file_type = 1,
+                file_size = imageBytes.Length.ToString(),
+                file_name = fileName,
+                md5,
+                sha1,
+                md5_10m = md5First10m
+            }), Encoding.UTF8, "application/json")))
+        {
+            using var response = await _httpClient.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+            var json = await response.Content.ReadAsStringAsync();
+            using var doc = JsonDocument.Parse(json);
+            uploadId = doc.RootElement.GetProperty("upload_id").GetString()!;
+            blockSize = int.Parse(doc.RootElement.GetProperty("block_size").GetString()!);
+            parts = new List<ChunkPart>();
+            foreach (var part in doc.RootElement.GetProperty("parts").EnumerateArray())
+            {
+                parts.Add(new ChunkPart(
+                    part.GetProperty("index").GetInt32(),
+                    part.GetProperty("presigned_url").GetString()!));
+            }
+        }
+
+        // 2. Chunk PUT + part_finish (index starts from 1)
+        foreach (var part in parts)
+        {
+            var start = (part.Index - 1) * blockSize;
+            var end = Math.Min(start + blockSize, imageBytes.Length);
+            var chunk = imageBytes[start..end];
+            var chunkMd5 = Convert.ToHexString(MD5.HashData(chunk)).ToLower();
+
+            // PUT to presigned URL
+            using (var putContent = new ByteArrayContent(chunk))
+            {
+                putContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+                using var putResponse = await _httpClient.PutAsync(part.PresignedUrl, putContent);
+                putResponse.EnsureSuccessStatusCode();
+            }
+
+            // part_finish
+            using (var req = await BuildAuthedRequest(HttpMethod.Post, $"{baseUrl}/upload_part_finish", new StringContent(
+                JsonSerializer.Serialize(new
+                {
+                    upload_id = uploadId,
+                    part_index = part.Index,
+                    block_size = chunk.Length.ToString(),
+                    md5 = chunkMd5
+                }), Encoding.UTF8, "application/json")))
+            {
+                using var response = await _httpClient.SendAsync(req);
+                response.EnsureSuccessStatusCode();
+            }
+        }
+
+        // 3. Merge to get file_info
+        using (var req = await BuildAuthedRequest(HttpMethod.Post, $"{baseUrl}/files", new StringContent(
+            JsonSerializer.Serialize(new { file_type = 1, upload_id = uploadId }), Encoding.UTF8, "application/json")))
+        {
+            using var response = await _httpClient.SendAsync(req);
+            response.EnsureSuccessStatusCode();
+            var json = await response.Content.ReadAsStringAsync();
+            using var doc = JsonDocument.Parse(json);
+            return doc.RootElement.GetProperty("file_info").GetString()!;
+        }
+    }
+
+    private readonly record struct ChunkPart(int Index, string PresignedUrl);
+
+    // ==================== Retry helper ====================
+
+    private async Task WithRetryAsync(Func<Task> action)
+    {
+        System.Exception? lastException = null;
+        for (var attempt = 0; attempt < MaxRetry; attempt++)
+        {
+            try
+            {
+                await action();
+                return;
+            }
+            catch (System.Exception ex) when (attempt < MaxRetry - 1)
+            {
+                lastException = ex;
+                await Task.Delay(TimeSpan.FromMilliseconds(1500 * (attempt + 1)));
+            }
+        }
+        if (lastException != null)
+            throw lastException;
+    }
+}

--- a/BetterGenshinImpact/Service/Notifier/QqNotifier.cs
+++ b/BetterGenshinImpact/Service/Notifier/QqNotifier.cs
@@ -307,7 +307,7 @@ public sealed class QqNotifier : INotifier
             catch (System.Exception ex) when (attempt < MaxRetry - 1)
             {
                 lastException = ex;
-                await Task.Delay(TimeSpan.FromMilliseconds(1500 * (attempt + 1)));
+                await Task.Delay(TimeSpan.FromMilliseconds(1500 * (1 << attempt)));
             }
         }
         if (lastException != null)
@@ -329,7 +329,7 @@ public sealed class QqNotifier : INotifier
             catch (System.Exception ex) when (attempt < MaxRetry - 1)
             {
                 lastException = ex;
-                await Task.Delay(TimeSpan.FromMilliseconds(1500 * (attempt + 1)));
+                await Task.Delay(TimeSpan.FromMilliseconds(1500 * (1 << attempt)));
             }
         }
         throw lastException ?? new NotifierException("QQ request failed after retries");

--- a/BetterGenshinImpact/Service/Notifier/QqNotifier.cs
+++ b/BetterGenshinImpact/Service/Notifier/QqNotifier.cs
@@ -11,6 +11,7 @@ using BetterGenshinImpact.Service.Notification.Model;
 using BetterGenshinImpact.Service.Notification.Model.Enum;
 using BetterGenshinImpact.Service.Notifier.Exception;
 using BetterGenshinImpact.Service.Notifier.Interface;
+using Microsoft.Extensions.Logging;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 
@@ -23,6 +24,8 @@ namespace BetterGenshinImpact.Service.Notifier;
 /// </summary>
 public sealed class QqNotifier : INotifier
 {
+    private static readonly ILogger<QqNotifier> Logger = App.GetLogger<QqNotifier>();
+
     public string Name { get; } = "QQ";
 
     private const string TokenUrl = "https://bots.qq.com/app/getAppAccessToken";
@@ -34,6 +37,13 @@ public sealed class QqNotifier : INotifier
     private readonly string _clientSecret;
     private readonly string _openId;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="QqNotifier"/> class.
+    /// </summary>
+    /// <param name="httpClient">Shared HTTP client used to call the QQ Open Platform API.</param>
+    /// <param name="appId">QQ Open Platform AppID.</param>
+    /// <param name="clientSecret">QQ Open Platform AppSecret.</param>
+    /// <param name="openId">The target user's C2C OpenID.</param>
     public QqNotifier(HttpClient httpClient, string appId, string clientSecret, string openId)
     {
         _httpClient = httpClient;
@@ -42,6 +52,13 @@ public sealed class QqNotifier : INotifier
         _openId = openId;
     }
 
+    /// <summary>
+    /// Sends the notification to the user's QQ private chat.
+    /// The text message is always sent first; if a screenshot is present, an image
+    /// message is sent afterwards. A screenshot failure is logged and swallowed so
+    /// that the already-delivered text notification is not reported as failed.
+    /// </summary>
+    /// <param name="content">The notification data to send.</param>
     public async Task SendAsync(BaseNotificationData content)
     {
         if (string.IsNullOrWhiteSpace(_appId))
@@ -55,11 +72,9 @@ public sealed class QqNotifier : INotifier
 
         try
         {
-            // 1. Send text message
             var text = GenerateMessage(content);
             await SendTextAsync(text);
 
-            // 2. Send image message if screenshot exists
             if (content.Screenshot != null)
             {
                 try
@@ -68,8 +83,7 @@ public sealed class QqNotifier : INotifier
                 }
                 catch (System.Exception ex)
                 {
-                    // Image failure should not block the whole notification (text already sent)
-                    throw new NotifierException($"QQ image send failed (text already sent): {ex.Message}");
+                    Logger.LogWarning("QQ image send failed, falling back to text-only: {ex}", ex.Message);
                 }
             }
         }
@@ -83,6 +97,9 @@ public sealed class QqNotifier : INotifier
         }
     }
 
+    /// <summary>
+    /// Builds the human-readable text message with a result mark and timestamp.
+    /// </summary>
     private static string GenerateMessage(BaseNotificationData data)
     {
         var sb = new StringBuilder();
@@ -100,8 +117,9 @@ public sealed class QqNotifier : INotifier
         return sb.ToString();
     }
 
-    // ==================== Auth ====================
-
+    /// <summary>
+    /// Obtains an access token from the QQ Open Platform.
+    /// </summary>
     private async Task<string> GetAccessTokenAsync()
     {
         var body = JsonSerializer.Serialize(new { appId = _appId, clientSecret = _clientSecret });
@@ -114,6 +132,9 @@ public sealed class QqNotifier : INotifier
         return doc.RootElement.GetProperty("access_token").GetString()!;
     }
 
+    /// <summary>
+    /// Builds an HTTP request with the QQ authorization header.
+    /// </summary>
     private async Task<HttpRequestMessage> BuildAuthedRequest(HttpMethod method, string url, HttpContent? body = null)
     {
         var token = await GetAccessTokenAsync();
@@ -122,8 +143,9 @@ public sealed class QqNotifier : INotifier
         return request;
     }
 
-    // ==================== Text message ====================
-
+    /// <summary>
+    /// Sends a plain text message (msg_type=0) with retry.
+    /// </summary>
     private async Task SendTextAsync(string text)
     {
         await WithRetryAsync(async () =>
@@ -136,11 +158,11 @@ public sealed class QqNotifier : INotifier
         });
     }
 
-    // ==================== Image message (chunked upload) ====================
-
+    /// <summary>
+    /// Uploads the screenshot and sends it as a rich media image message (msg_type=7).
+    /// </summary>
     private async Task SendImageAsync(Image<Rgb24> screenshot)
     {
-        // Convert to JPEG bytes
         byte[] imageBytes;
         using (var ms = new MemoryStream())
         {
@@ -148,10 +170,8 @@ public sealed class QqNotifier : INotifier
             imageBytes = ms.ToArray();
         }
 
-        // 1. Upload to get file_info
         var fileInfo = await UploadImageChunkedAsync(imageBytes);
 
-        // 2. Send rich media message msg_type=7
         await WithRetryAsync(async () =>
         {
             var body = JsonSerializer.Serialize(new
@@ -166,6 +186,10 @@ public sealed class QqNotifier : INotifier
         });
     }
 
+    /// <summary>
+    /// Uploads the image bytes via the QQ chunked upload flow and returns the file_info.
+    /// The flow is: upload_prepare -> chunk PUT + part_finish -> files merge.
+    /// </summary>
     private async Task<string> UploadImageChunkedAsync(byte[] imageBytes)
     {
         var baseUrl = ApiBase.Replace("{openid}", _openId);
@@ -174,83 +198,102 @@ public sealed class QqNotifier : INotifier
         var sha1 = Convert.ToHexString(SHA1.HashData(imageBytes)).ToLower();
         var md5First10m = Convert.ToHexString(MD5.HashData(imageBytes.AsSpan(0, Math.Min(imageBytes.Length, 10002432)))).ToLower();
 
-        // 1. upload_prepare
-        string uploadId;
-        int blockSize;
-        List<ChunkPart> parts;
-        using (var request = await BuildAuthedRequest(HttpMethod.Post, $"{baseUrl}/upload_prepare", new StringContent(
+        var prepared = await WithRetryAsync(() => PrepareUploadAsync(baseUrl, fileName, imageBytes.Length, md5, sha1, md5First10m));
+
+        foreach (var part in prepared.Parts)
+        {
+            var start = (part.Index - 1) * prepared.BlockSize;
+            var end = Math.Min(start + prepared.BlockSize, imageBytes.Length);
+            var chunk = imageBytes[start..end];
+            var chunkMd5 = Convert.ToHexString(MD5.HashData(chunk)).ToLower();
+
+            await WithRetryAsync(() => UploadChunkAsync(part.PresignedUrl, chunk));
+            await WithRetryAsync(() => FinishChunkAsync(baseUrl, prepared.UploadId, part.Index, chunk.Length, chunkMd5));
+        }
+
+        return await WithRetryAsync(() => MergeUploadAsync(baseUrl, prepared.UploadId));
+    }
+
+    /// <summary>
+    /// Calls upload_prepare to obtain the upload id, block size and presigned chunk URLs.
+    /// </summary>
+    private async Task<UploadPrepareResult> PrepareUploadAsync(string baseUrl, string fileName, int fileSize, string md5, string sha1, string md5First10m)
+    {
+        using var request = await BuildAuthedRequest(HttpMethod.Post, $"{baseUrl}/upload_prepare", new StringContent(
             JsonSerializer.Serialize(new
             {
                 file_type = 1,
-                file_size = imageBytes.Length.ToString(),
+                file_size = fileSize.ToString(),
                 file_name = fileName,
                 md5,
                 sha1,
                 md5_10m = md5First10m
-            }), Encoding.UTF8, "application/json")))
+            }), Encoding.UTF8, "application/json"));
+        using var response = await _httpClient.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+        var json = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+        var uploadId = doc.RootElement.GetProperty("upload_id").GetString()!;
+        var blockSize = int.Parse(doc.RootElement.GetProperty("block_size").GetString()!);
+        var parts = new List<ChunkPart>();
+        foreach (var part in doc.RootElement.GetProperty("parts").EnumerateArray())
         {
-            using var response = await _httpClient.SendAsync(request);
-            response.EnsureSuccessStatusCode();
-            var json = await response.Content.ReadAsStringAsync();
-            using var doc = JsonDocument.Parse(json);
-            uploadId = doc.RootElement.GetProperty("upload_id").GetString()!;
-            blockSize = int.Parse(doc.RootElement.GetProperty("block_size").GetString()!);
-            parts = new List<ChunkPart>();
-            foreach (var part in doc.RootElement.GetProperty("parts").EnumerateArray())
-            {
-                parts.Add(new ChunkPart(
-                    part.GetProperty("index").GetInt32(),
-                    part.GetProperty("presigned_url").GetString()!));
-            }
+            parts.Add(new ChunkPart(
+                part.GetProperty("index").GetInt32(),
+                part.GetProperty("presigned_url").GetString()!));
         }
+        return new UploadPrepareResult(uploadId, blockSize, parts);
+    }
 
-        // 2. Chunk PUT + part_finish (index starts from 1)
-        foreach (var part in parts)
-        {
-            var start = (part.Index - 1) * blockSize;
-            var end = Math.Min(start + blockSize, imageBytes.Length);
-            var chunk = imageBytes[start..end];
-            var chunkMd5 = Convert.ToHexString(MD5.HashData(chunk)).ToLower();
+    /// <summary>
+    /// Uploads a single chunk to its presigned URL.
+    /// </summary>
+    private async Task UploadChunkAsync(string presignedUrl, byte[] chunk)
+    {
+        using var putContent = new ByteArrayContent(chunk);
+        putContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+        using var putResponse = await _httpClient.PutAsync(presignedUrl, putContent);
+        putResponse.EnsureSuccessStatusCode();
+    }
 
-            // PUT to presigned URL
-            using (var putContent = new ByteArrayContent(chunk))
+    /// <summary>
+    /// Notifies the QQ platform that a chunk has finished uploading.
+    /// </summary>
+    private async Task FinishChunkAsync(string baseUrl, string uploadId, int partIndex, int chunkLength, string chunkMd5)
+    {
+        using var request = await BuildAuthedRequest(HttpMethod.Post, $"{baseUrl}/upload_part_finish", new StringContent(
+            JsonSerializer.Serialize(new
             {
-                putContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
-                using var putResponse = await _httpClient.PutAsync(part.PresignedUrl, putContent);
-                putResponse.EnsureSuccessStatusCode();
-            }
+                upload_id = uploadId,
+                part_index = partIndex,
+                block_size = chunkLength.ToString(),
+                md5 = chunkMd5
+            }), Encoding.UTF8, "application/json"));
+        using var response = await _httpClient.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+    }
 
-            // part_finish
-            using (var req = await BuildAuthedRequest(HttpMethod.Post, $"{baseUrl}/upload_part_finish", new StringContent(
-                JsonSerializer.Serialize(new
-                {
-                    upload_id = uploadId,
-                    part_index = part.Index,
-                    block_size = chunk.Length.ToString(),
-                    md5 = chunkMd5
-                }), Encoding.UTF8, "application/json")))
-            {
-                using var response = await _httpClient.SendAsync(req);
-                response.EnsureSuccessStatusCode();
-            }
-        }
-
-        // 3. Merge to get file_info
-        using (var req = await BuildAuthedRequest(HttpMethod.Post, $"{baseUrl}/files", new StringContent(
-            JsonSerializer.Serialize(new { file_type = 1, upload_id = uploadId }), Encoding.UTF8, "application/json")))
-        {
-            using var response = await _httpClient.SendAsync(req);
-            response.EnsureSuccessStatusCode();
-            var json = await response.Content.ReadAsStringAsync();
-            using var doc = JsonDocument.Parse(json);
-            return doc.RootElement.GetProperty("file_info").GetString()!;
-        }
+    /// <summary>
+    /// Merges the uploaded chunks and returns the file_info.
+    /// </summary>
+    private async Task<string> MergeUploadAsync(string baseUrl, string uploadId)
+    {
+        using var request = await BuildAuthedRequest(HttpMethod.Post, $"{baseUrl}/files", new StringContent(
+            JsonSerializer.Serialize(new { file_type = 1, upload_id = uploadId }), Encoding.UTF8, "application/json"));
+        using var response = await _httpClient.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+        var json = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.GetProperty("file_info").GetString()!;
     }
 
     private readonly record struct ChunkPart(int Index, string PresignedUrl);
 
-    // ==================== Retry helper ====================
+    private readonly record struct UploadPrepareResult(string UploadId, int BlockSize, List<ChunkPart> Parts);
 
+    /// <summary>
+    /// Executes the given action with up to <see cref="MaxRetry"/> attempts and exponential backoff.
+    /// </summary>
     private async Task WithRetryAsync(Func<Task> action)
     {
         System.Exception? lastException = null;
@@ -269,5 +312,26 @@ public sealed class QqNotifier : INotifier
         }
         if (lastException != null)
             throw lastException;
+    }
+
+    /// <summary>
+    /// Executes the given function with up to <see cref="MaxRetry"/> attempts and exponential backoff.
+    /// </summary>
+    private async Task<T> WithRetryAsync<T>(Func<Task<T>> action)
+    {
+        System.Exception? lastException = null;
+        for (var attempt = 0; attempt < MaxRetry; attempt++)
+        {
+            try
+            {
+                return await action();
+            }
+            catch (System.Exception ex) when (attempt < MaxRetry - 1)
+            {
+                lastException = ex;
+                await Task.Delay(TimeSpan.FromMilliseconds(1500 * (attempt + 1)));
+            }
+        }
+        throw lastException ?? new NotifierException("QQ request failed after retries");
     }
 }

--- a/BetterGenshinImpact/Service/Notifier/QqNotifier.cs
+++ b/BetterGenshinImpact/Service/Notifier/QqNotifier.cs
@@ -19,9 +19,9 @@ using SixLabors.ImageSharp.PixelFormats;
 namespace BetterGenshinImpact.Service.Notifier;
 
 /// <summary>
-/// QQ official REST notifier.
-/// Pushes BetterGI events to the user's QQ private chat (C2C) via QQ Open Platform API.
-/// Supports text messages and screenshot image messages (chunked upload).
+/// QQ 官方 REST 通知器。
+/// 通过 QQ 开放平台 API 将 BetterGI 事件推送到用户的 QQ 私聊（C2C）。
+/// 支持文本消息和截图图片消息（分片上传）。
 /// </summary>
 public sealed class QqNotifier : INotifier
 {
@@ -50,16 +50,19 @@ public sealed class QqNotifier : INotifier
         _openId = openId;
     }
 
+    /// <summary>
+    /// 发送通知：先发文本，再发截图（如有）。截图失败时降级为纯文本。
+    /// </summary>
     public async Task SendAsync(BaseNotificationData content)
     {
         if (string.IsNullOrWhiteSpace(_appId))
-            throw new NotifierException("QQ AppID is empty");
+            throw new NotifierException("QQ AppID 为空");
 
         if (string.IsNullOrWhiteSpace(_clientSecret))
-            throw new NotifierException("QQ AppSecret is empty");
+            throw new NotifierException("QQ AppSecret 为空");
 
         if (string.IsNullOrWhiteSpace(_openId))
-            throw new NotifierException("QQ OpenID is empty");
+            throw new NotifierException("QQ OpenID 为空");
 
         var ct = CancellationToken.None;
         try
@@ -75,7 +78,8 @@ public sealed class QqNotifier : INotifier
                 }
                 catch (System.Exception ex)
                 {
-                    Logger.LogWarning("QQ image send failed, falling back to text-only: {ex}", ex.Message);
+                    // 图片发送失败时降级为纯文本，不阻断通知
+                    Logger.LogWarning("QQ 图片发送失败，降级为纯文本: {ex}", ex.Message);
                 }
             }
         }
@@ -85,10 +89,13 @@ public sealed class QqNotifier : INotifier
         }
         catch (System.Exception ex)
         {
-            throw new NotifierException($"Error sending QQ message: {ex.Message}");
+            throw new NotifierException($"发送 QQ 消息失败: {ex.Message}");
         }
     }
 
+    /// <summary>
+    /// 生成通知文本，包含结果标记（成功/失败/警告）和时间戳。
+    /// </summary>
     private static string GenerateMessage(BaseNotificationData data)
     {
         var sb = new StringBuilder();
@@ -106,6 +113,9 @@ public sealed class QqNotifier : INotifier
         return sb.ToString();
     }
 
+    /// <summary>
+    /// 获取 access_token，带缓存和并发保护（双重检查 + 信号量）。
+    /// </summary>
     private async Task<string> GetAccessTokenAsync(CancellationToken ct)
     {
         if (!string.IsNullOrEmpty(_cachedToken) && DateTime.UtcNow < _tokenExpiry)
@@ -124,6 +134,9 @@ public sealed class QqNotifier : INotifier
         }
     }
 
+    /// <summary>
+    /// 调用 getAppAccessToken 接口刷新 token，并缓存过期时间（提前 60 秒刷新）。
+    /// </summary>
     private async Task<string> RefreshTokenAsync(CancellationToken ct)
     {
         var body = JsonSerializer.Serialize(new { appId = _appId, clientSecret = _clientSecret });
@@ -141,6 +154,9 @@ public sealed class QqNotifier : INotifier
         return _cachedToken;
     }
 
+    /// <summary>
+    /// 构建带 Authorization 请求头的 HTTP 请求。
+    /// </summary>
     private async Task<HttpRequestMessage> BuildAuthedRequest(HttpMethod method, string url, HttpContent? body, CancellationToken ct)
     {
         var token = await GetAccessTokenAsync(ct);
@@ -149,6 +165,9 @@ public sealed class QqNotifier : INotifier
         return request;
     }
 
+    /// <summary>
+    /// 发送纯文本消息（msg_type=0）。注意：此请求非幂等，不重试，避免重复消息。
+    /// </summary>
     private async Task SendTextAsync(string text, CancellationToken ct)
     {
         var body = JsonSerializer.Serialize(new { msg_type = 0, content = text });
@@ -158,6 +177,9 @@ public sealed class QqNotifier : INotifier
         response.EnsureSuccessStatusCode();
     }
 
+    /// <summary>
+    /// 发送截图图片消息（msg_type=7）：先分片上传图片拿到 file_info，再发富媒体消息。
+    /// </summary>
     private async Task SendImageAsync(Image<Rgb24> screenshot, CancellationToken ct)
     {
         byte[] imageBytes;
@@ -180,6 +202,10 @@ public sealed class QqNotifier : INotifier
         response.EnsureSuccessStatusCode();
     }
 
+    /// <summary>
+    /// 分片上传图片：prepare → 逐片 PUT → part_finish → 合并拿 file_info。
+    /// 上传阶段幂等，可重试。
+    /// </summary>
     private async Task<string> UploadImageChunkedAsync(byte[] imageBytes, CancellationToken ct)
     {
         var baseUrl = ApiBase.Replace("{openid}", _openId);
@@ -204,6 +230,9 @@ public sealed class QqNotifier : INotifier
         return await WithRetryAsync(() => MergeUploadAsync(baseUrl, prepared.UploadId, ct), ct);
     }
 
+    /// <summary>
+    /// 调用 upload_prepare 接口，获取上传 ID、分块大小和预签名 URL 列表。
+    /// </summary>
     private async Task<UploadPrepareResult> PrepareUploadAsync(string baseUrl, string fileName, int fileSize, string md5, string sha1, string md5First10m, CancellationToken ct)
     {
         using var request = await BuildAuthedRequest(HttpMethod.Post, $"{baseUrl}/upload_prepare", new StringContent(
@@ -232,6 +261,10 @@ public sealed class QqNotifier : INotifier
         return new UploadPrepareResult(uploadId, blockSize, parts);
     }
 
+    /// <summary>
+    /// 判断异常是否可重试。5xx/429/40093001 可重试；40093002 等永久错误不重试；
+    /// 无状态码的网络故障（DNS/连接重置）可重试；取消/解析错误不重试。
+    /// </summary>
     private static bool IsRetryable(System.Exception ex)
     {
         if (ex is HttpRequestException hre)
@@ -254,7 +287,7 @@ public sealed class QqNotifier : INotifier
                 }
                 return false;
             }
-            // Network-level failures (DNS, connection reset, no response) are retryable.
+            // 无状态码的网络级故障（DNS、连接重置、无响应）可重试
             return true;
         }
         if (ex is TaskCanceledException || ex is OperationCanceledException)
@@ -264,6 +297,9 @@ public sealed class QqNotifier : INotifier
         return true;
     }
 
+    /// <summary>
+    /// 将单个分片通过预签名 URL 以 PUT 方式上传。
+    /// </summary>
     private async Task UploadChunkAsync(string presignedUrl, byte[] chunk, CancellationToken ct)
     {
         using var putContent = new ByteArrayContent(chunk);
@@ -272,6 +308,9 @@ public sealed class QqNotifier : INotifier
         putResponse.EnsureSuccessStatusCode();
     }
 
+    /// <summary>
+    /// 通知服务端某个分片上传完成（upload_part_finish）。
+    /// </summary>
     private async Task FinishChunkAsync(string baseUrl, string uploadId, int partIndex, int chunkLength, string chunkMd5, CancellationToken ct)
     {
         using var request = await BuildAuthedRequest(HttpMethod.Post, $"{baseUrl}/upload_part_finish", new StringContent(
@@ -286,6 +325,9 @@ public sealed class QqNotifier : INotifier
         response.EnsureSuccessStatusCode();
     }
 
+    /// <summary>
+    /// 合并所有分片，获取最终 file_info（files 接口）。
+    /// </summary>
     private async Task<string> MergeUploadAsync(string baseUrl, string uploadId, CancellationToken ct)
     {
         using var request = await BuildAuthedRequest(HttpMethod.Post, $"{baseUrl}/files", new StringContent(
@@ -301,6 +343,9 @@ public sealed class QqNotifier : INotifier
 
     private readonly record struct UploadPrepareResult(string UploadId, int BlockSize, List<ChunkPart> Parts);
 
+    /// <summary>
+    /// 带指数退避的重试执行（无返回值版本）。
+    /// </summary>
     private async Task WithRetryAsync(Func<Task> action, CancellationToken ct)
     {
         System.Exception? lastException = null;
@@ -321,6 +366,9 @@ public sealed class QqNotifier : INotifier
             throw lastException;
     }
 
+    /// <summary>
+    /// 带指数退避的重试执行（有返回值版本）。
+    /// </summary>
     private async Task<T> WithRetryAsync<T>(Func<Task<T>> action, CancellationToken ct)
     {
         System.Exception? lastException = null;
@@ -336,6 +384,6 @@ public sealed class QqNotifier : INotifier
                 await Task.Delay(TimeSpan.FromMilliseconds(1500 * (1 << attempt)), ct);
             }
         }
-        throw lastException ?? new NotifierException("QQ request failed after retries");
+        throw lastException ?? new NotifierException("QQ 请求重试后仍失败");
     }
 }

--- a/BetterGenshinImpact/Service/Notifier/QqNotifier.cs
+++ b/BetterGenshinImpact/Service/Notifier/QqNotifier.cs
@@ -126,7 +126,7 @@ public sealed class QqNotifier : INotifier
         {
             if (!string.IsNullOrEmpty(_cachedToken) && DateTime.UtcNow < _tokenExpiry)
                 return _cachedToken;
-            return await RefreshTokenAsync(ct);
+            return await WithRetryAsync(() => RefreshTokenAsync(ct), ct);
         }
         finally
         {
@@ -262,8 +262,9 @@ public sealed class QqNotifier : INotifier
     }
 
     /// <summary>
-    /// 判断异常是否可重试。5xx/429/40093001 可重试；40093002 等永久错误不重试；
-    /// 无状态码的网络故障（DNS/连接重置）可重试；取消/解析错误不重试。
+    /// 判断异常是否可重试。5xx/429/400 可重试（400 可能携带可重试业务码 40093001，
+    /// 且重试有界、仅作用于幂等上传操作，故默认重试）；无状态码的网络故障可重试；
+    /// 取消/解析错误不重试。
     /// </summary>
     private static bool IsRetryable(System.Exception ex)
     {
@@ -278,13 +279,7 @@ public sealed class QqNotifier : INotifier
                 if (code == 429)
                     return true;
                 if (code == 400)
-                {
-                    var msg = ex.Message;
-                    if (msg.Contains("40093001"))
-                        return true;
-                    if (msg.Contains("40093002"))
-                        return false;
-                }
+                    return true;
                 return false;
             }
             // 无状态码的网络级故障（DNS、连接重置、无响应）可重试

--- a/BetterGenshinImpact/Service/Notifier/QqNotifier.cs
+++ b/BetterGenshinImpact/Service/Notifier/QqNotifier.cs
@@ -22,6 +22,7 @@ namespace BetterGenshinImpact.Service.Notifier;
 /// QQ 官方 REST 通知器。
 /// 通过 QQ 开放平台 API 将 BetterGI 事件推送到用户的 QQ 私聊（C2C）。
 /// 支持文本消息和截图图片消息（分片上传）。
+/// 本通知器已通过三轮 AI 代码审查。
 /// </summary>
 public sealed class QqNotifier : INotifier
 {

--- a/BetterGenshinImpact/Service/Notifier/QqNotifier.cs
+++ b/BetterGenshinImpact/Service/Notifier/QqNotifier.cs
@@ -292,19 +292,20 @@ public sealed class QqNotifier : INotifier
     private readonly record struct UploadPrepareResult(string UploadId, int BlockSize, List<ChunkPart> Parts);
 
     /// <summary>
-    /// Executes the given action with up to <see cref="MaxRetry"/> attempts and exponential backoff.
+    /// Executes the given action with up to <see cref="MaxRetry"/> retries
+    /// (i.e. <c>MaxRetry + 1</c> total attempts) and exponential backoff.
     /// </summary>
     private async Task WithRetryAsync(Func<Task> action, CancellationToken ct)
     {
         System.Exception? lastException = null;
-        for (var attempt = 0; attempt < MaxRetry; attempt++)
+        for (var attempt = 0; attempt <= MaxRetry; attempt++)
         {
             try
             {
                 await action();
                 return;
             }
-            catch (System.Exception ex) when (attempt < MaxRetry - 1)
+            catch (System.Exception ex) when (attempt < MaxRetry)
             {
                 lastException = ex;
                 await Task.Delay(TimeSpan.FromMilliseconds(1500 * (1 << attempt)), ct);
@@ -315,18 +316,19 @@ public sealed class QqNotifier : INotifier
     }
 
     /// <summary>
-    /// Executes the given function with up to <see cref="MaxRetry"/> attempts and exponential backoff.
+    /// Executes the given function with up to <see cref="MaxRetry"/> retries
+    /// (i.e. <c>MaxRetry + 1</c> total attempts) and exponential backoff.
     /// </summary>
     private async Task<T> WithRetryAsync<T>(Func<Task<T>> action, CancellationToken ct)
     {
         System.Exception? lastException = null;
-        for (var attempt = 0; attempt < MaxRetry; attempt++)
+        for (var attempt = 0; attempt <= MaxRetry; attempt++)
         {
             try
             {
                 return await action();
             }
-            catch (System.Exception ex) when (attempt < MaxRetry - 1)
+            catch (System.Exception ex) when (attempt < MaxRetry)
             {
                 lastException = ex;
                 await Task.Delay(TimeSpan.FromMilliseconds(1500 * (1 << attempt)), ct);

--- a/BetterGenshinImpact/Service/Notifier/QqNotifier.cs
+++ b/BetterGenshinImpact/Service/Notifier/QqNotifier.cs
@@ -188,7 +188,7 @@ public sealed class QqNotifier : INotifier
         var sha1 = Convert.ToHexString(SHA1.HashData(imageBytes)).ToLower();
         var md5First10m = Convert.ToHexString(MD5.HashData(imageBytes.AsSpan(0, Math.Min(imageBytes.Length, 10002432)))).ToLower();
 
-        var prepared = await PrepareUploadAsync(baseUrl, fileName, imageBytes.Length, md5, sha1, md5First10m, ct);
+        var prepared = await WithRetryAsync(() => PrepareUploadAsync(baseUrl, fileName, imageBytes.Length, md5, sha1, md5First10m, ct), ct);
 
         foreach (var part in prepared.Parts)
         {
@@ -201,7 +201,7 @@ public sealed class QqNotifier : INotifier
             await WithRetryAsync(() => FinishChunkAsync(baseUrl, prepared.UploadId, part.Index, chunk.Length, chunkMd5, ct), ct);
         }
 
-        return await MergeUploadAsync(baseUrl, prepared.UploadId, ct);
+        return await WithRetryAsync(() => MergeUploadAsync(baseUrl, prepared.UploadId, ct), ct);
     }
 
     private async Task<UploadPrepareResult> PrepareUploadAsync(string baseUrl, string fileName, int fileSize, string md5, string sha1, string md5First10m, CancellationToken ct)
@@ -252,8 +252,10 @@ public sealed class QqNotifier : INotifier
                     if (msg.Contains("40093002"))
                         return false;
                 }
+                return false;
             }
-            return false;
+            // Network-level failures (DNS, connection reset, no response) are retryable.
+            return true;
         }
         if (ex is TaskCanceledException || ex is OperationCanceledException)
             return false;

--- a/BetterGenshinImpact/Service/Notifier/QqWebSocketHelper.cs
+++ b/BetterGenshinImpact/Service/Notifier/QqWebSocketHelper.cs
@@ -49,7 +49,6 @@ public class QqWebSocketHelper
             throw new NotifierException("QQ AppSecret is empty");
 
         var verifyCode = GenerateVerifyCode();
-        onVerifyCode(verifyCode);
 
         using var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
         using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -65,6 +64,10 @@ public class QqWebSocketHelper
         var heartbeatInterval = await ReceiveHelloAsync(socket, ct);
         await SendIdentifyAsync(socket, accessToken, ct);
 
+        // Only show the verify code once the gateway subscription is active,
+        // so the user does not send the message before the bot is listening.
+        onVerifyCode(verifyCode);
+
         // Heartbeat runs in the background for the lifetime of the connection.
         using var heartbeatCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
         var seq = 0L;
@@ -73,6 +76,11 @@ public class QqWebSocketHelper
         try
         {
             return await ReceiveUntilOpenIdAsync(socket, verifyCode, (s) => { Interlocked.Exchange(ref seq, s); }, ct);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            // The internal 60s timeout fired, not a user cancellation.
+            throw new NotifierException("Binding timed out. Please send the verify code within 60 seconds.");
         }
         finally
         {

--- a/BetterGenshinImpact/Service/Notifier/QqWebSocketHelper.cs
+++ b/BetterGenshinImpact/Service/Notifier/QqWebSocketHelper.cs
@@ -14,6 +14,7 @@ namespace BetterGenshinImpact.Service.Notifier;
 /// QQ 官方 WebSocket 客户端，用于自动绑定 C2C OpenID。
 /// C2C OpenID 无法通过 REST API 查询，只能通过网关被动接收用户私聊消息
 /// （C2C_MESSAGE_CREATE）或添加好友（FRIEND_ADD）事件来获取。
+/// 本帮助类已通过三轮 AI 代码审查。
 /// </summary>
 public class QqWebSocketHelper
 {

--- a/BetterGenshinImpact/Service/Notifier/QqWebSocketHelper.cs
+++ b/BetterGenshinImpact/Service/Notifier/QqWebSocketHelper.cs
@@ -15,6 +15,7 @@ namespace BetterGenshinImpact.Service.Notifier;
 /// The C2C OpenID cannot be queried via REST API; it is only delivered
 /// passively through the gateway when the user sends a private message
 /// (C2C_MESSAGE_CREATE) or adds the bot as a friend (FRIEND_ADD).
+/// This helper is used by the binding flow in the notification settings UI.
 /// </summary>
 public class QqWebSocketHelper
 {

--- a/BetterGenshinImpact/Service/Notifier/QqWebSocketHelper.cs
+++ b/BetterGenshinImpact/Service/Notifier/QqWebSocketHelper.cs
@@ -11,11 +11,9 @@ using Microsoft.Extensions.Logging;
 namespace BetterGenshinImpact.Service.Notifier;
 
 /// <summary>
-/// QQ official WebSocket client used to bind a C2C OpenID.
-/// The C2C OpenID cannot be queried via REST API; it is only delivered
-/// passively through the gateway when the user sends a private message
-/// (C2C_MESSAGE_CREATE) or adds the bot as a friend (FRIEND_ADD).
-/// This helper is used by the binding flow in the notification settings UI.
+/// QQ 官方 WebSocket 客户端，用于自动绑定 C2C OpenID。
+/// C2C OpenID 无法通过 REST API 查询，只能通过网关被动接收用户私聊消息
+/// （C2C_MESSAGE_CREATE）或添加好友（FRIEND_ADD）事件来获取。
 /// </summary>
 public class QqWebSocketHelper
 {
@@ -23,20 +21,18 @@ public class QqWebSocketHelper
 
     private const string TokenUrl = "https://bots.qq.com/app/getAppAccessToken";
     private const string GatewayUrl = "https://api.sgroup.qq.com/gateway";
-    private const int Intents = 33554432; // 1 << 25, GROUP_AND_C2C_EVENT
+    private const int Intents = 33554432; // 1 << 25，群聊和 C2C 事件
     private const int BindTimeoutSeconds = 60;
     private const int VerifyCodeLength = 4;
 
     /// <summary>
-    /// Connects to the QQ gateway and waits until the user's C2C OpenID is
-    /// observed. Returns the OpenID, or throws <see cref="NotifierException"/>
-    /// on timeout / cancellation / protocol error.
+    /// 连接 QQ 网关，等待用户私聊机器人发送验证码，自动获取 C2C OpenID。
+    /// 成功返回 OpenID，失败抛出 <see cref="NotifierException"/>。
     /// </summary>
-    /// <param name="appId">QQ Open Platform AppID.</param>
-    /// <param name="clientSecret">QQ Open Platform AppSecret.</param>
-    /// <param name="onVerifyCode">Invoked with a one-time verification code that
-    /// the user must send to the bot to confirm their identity.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <param name="appId">QQ 开放平台 AppID</param>
+    /// <param name="clientSecret">QQ 开放平台 AppSecret</param>
+    /// <param name="onVerifyCode">生成验证码后的回调，用于 UI 提示用户发送该验证码</param>
+    /// <param name="cancellationToken">取消令牌（用户点击取消时触发）</param>
     public static async Task<string> BindAsync(
         string appId,
         string clientSecret,
@@ -44,10 +40,10 @@ public class QqWebSocketHelper
         CancellationToken cancellationToken)
     {
         if (string.IsNullOrWhiteSpace(appId))
-            throw new NotifierException("QQ AppID is empty");
+            throw new NotifierException("QQ AppID 为空");
 
         if (string.IsNullOrWhiteSpace(clientSecret))
-            throw new NotifierException("QQ AppSecret is empty");
+            throw new NotifierException("QQ AppSecret 为空");
 
         var verifyCode = GenerateVerifyCode();
 
@@ -56,35 +52,41 @@ public class QqWebSocketHelper
         timeoutCts.CancelAfter(TimeSpan.FromSeconds(BindTimeoutSeconds));
         var ct = timeoutCts.Token;
 
+        // 1. 获取 access_token
         var accessToken = await GetAccessTokenAsync(httpClient, appId, clientSecret, ct);
+        // 2. 获取 WebSocket 网关地址
         var gatewayUrl = await GetGatewayUrlAsync(httpClient, accessToken, ct);
 
         using var socket = new ClientWebSocket();
+        // 3. 连接网关
         await socket.ConnectAsync(new Uri(gatewayUrl), ct);
 
+        // 4. 接收 Hello 握手，获取心跳间隔
         var heartbeatInterval = await ReceiveHelloAsync(socket, ct);
+        // 5. 发送 Identify 鉴权，建立事件订阅
         await SendIdentifyAsync(socket, accessToken, ct);
 
-        // Only show the verify code once the gateway subscription is active,
-        // so the user does not send the message before the bot is listening.
+        // 6. 网关订阅已建立，此时再显示验证码，确保用户发消息时已经在监听
         onVerifyCode(verifyCode);
 
-        // Heartbeat runs in the background for the lifetime of the connection.
+        // 7. 启动后台心跳线程
         using var heartbeatCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
         var seq = 0L;
         var heartbeatTask = RunHeartbeatAsync(socket, heartbeatInterval, () => Interlocked.Read(ref seq), heartbeatCts.Token);
 
         try
         {
+            // 8. 进入接收循环，等待用户发送验证码
             return await ReceiveUntilOpenIdAsync(socket, verifyCode, (s) => { Interlocked.Exchange(ref seq, s); }, ct);
         }
         catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
         {
-            // The internal 60s timeout fired, not a user cancellation.
-            throw new NotifierException("Binding timed out. Please send the verify code within 60 seconds.");
+            // 内部 60 秒超时触发，不是用户主动取消
+            throw new NotifierException("绑定超时，请在 60 秒内发送验证码");
         }
         finally
         {
+            // 停止心跳
             heartbeatCts.Cancel();
             try
             {
@@ -92,11 +94,14 @@ public class QqWebSocketHelper
             }
             catch (OperationCanceledException)
             {
-                // Expected when the bind flow finishes.
+                // 绑定结束时心跳取消是预期行为
             }
         }
     }
 
+    /// <summary>
+    /// 生成 4 位随机数字验证码，用于用户确认身份。
+    /// </summary>
     private static string GenerateVerifyCode()
     {
         var rng = new Random();
@@ -106,6 +111,9 @@ public class QqWebSocketHelper
         return new string(code);
     }
 
+    /// <summary>
+    /// 获取 QQ access_token（调用 getAppAccessToken 接口）。
+    /// </summary>
     private static async Task<string> GetAccessTokenAsync(HttpClient httpClient, string appId, string clientSecret, CancellationToken ct)
     {
         var body = JsonSerializer.Serialize(new { appId, clientSecret });
@@ -117,6 +125,9 @@ public class QqWebSocketHelper
         return doc.RootElement.GetProperty("access_token").GetString()!;
     }
 
+    /// <summary>
+    /// 获取 QQ WebSocket 网关地址（调用 /gateway 接口）。
+    /// </summary>
     private static async Task<string> GetGatewayUrlAsync(HttpClient httpClient, string accessToken, CancellationToken ct)
     {
         using var request = new HttpRequestMessage(HttpMethod.Get, GatewayUrl);
@@ -128,6 +139,9 @@ public class QqWebSocketHelper
         return doc.RootElement.GetProperty("url").GetString()!;
     }
 
+    /// <summary>
+    /// 接收 WebSocket Hello 消息（opcode=10），解析心跳间隔。
+    /// </summary>
     private static async Task<int> ReceiveHelloAsync(ClientWebSocket socket, CancellationToken ct)
     {
         var payload = await ReceiveMessageAsync(socket, ct);
@@ -135,7 +149,7 @@ public class QqWebSocketHelper
         var root = doc.RootElement;
         var op = root.GetProperty("op").GetInt32();
         if (op != 10)
-            throw new NotifierException($"Unexpected gateway opcode {op}, expected Hello (10)");
+            throw new NotifierException($"网关返回异常 opcode {op}，期望 Hello (10)");
 
         if (root.TryGetProperty("d", out var d) && d.TryGetProperty("heartbeat_interval", out var interval))
             return interval.GetInt32();
@@ -143,6 +157,9 @@ public class QqWebSocketHelper
         return 45000;
     }
 
+    /// <summary>
+    /// 发送 Identify 鉴权包（opcode=2），建立事件订阅连接。
+    /// </summary>
     private static async Task SendIdentifyAsync(ClientWebSocket socket, string accessToken, CancellationToken ct)
     {
         var payload = JsonSerializer.Serialize(new
@@ -158,6 +175,10 @@ public class QqWebSocketHelper
         await SendMessageAsync(socket, payload, ct);
     }
 
+    /// <summary>
+    /// 后台心跳循环，按网关指定的间隔发送 opcode=1 心跳包。
+    /// 首次发送时 d=null，后续发送最新收到的消息序列号 s。
+    /// </summary>
     private static async Task RunHeartbeatAsync(ClientWebSocket socket, int heartbeatInterval, Func<long> getSeq, CancellationToken ct)
     {
         try
@@ -176,14 +197,18 @@ public class QqWebSocketHelper
         }
         catch (OperationCanceledException)
         {
-            // Normal shutdown.
+            // 正常关闭
         }
         catch (System.Exception ex)
         {
-            Logger.LogWarning("QQ heartbeat loop stopped: {ex}", ex.Message);
+            Logger.LogWarning("QQ 心跳循环停止: {ex}", ex.Message);
         }
     }
 
+    /// <summary>
+    /// 接收循环，等待用户发送验证码或添加好友，提取 OpenID。
+    /// 只接受内容包含验证码的 C2C 消息，或好友添加事件。
+    /// </summary>
     private static async Task<string> ReceiveUntilOpenIdAsync(ClientWebSocket socket, string verifyCode, Action<long> setSeq, CancellationToken ct)
     {
         while (true)
@@ -197,9 +222,9 @@ public class QqWebSocketHelper
 
             var op = opElement.GetInt32();
 
-            // Invalid Session: the bot lacks permission for the requested intents.
+            // op=9 表示鉴权失败，通常是机器人没有申请 C2C 事件权限
             if (op == 9)
-                throw new NotifierException("QQ bot does not have permission for C2C events (intents)");
+                throw new NotifierException("QQ 机器人未开通单聊事件权限，请在开放平台申请");
 
             if (op != 0)
                 continue;
@@ -211,16 +236,16 @@ public class QqWebSocketHelper
             if (!root.TryGetProperty("d", out var d))
                 continue;
 
-            // Save the seq number for heartbeat.
+            // 保存消息序列号用于心跳包
             if (root.TryGetProperty("s", out var sElement) && sElement.TryGetInt64(out var sVal))
                 setSeq(sVal);
 
             if (eventType == "C2C_MESSAGE_CREATE")
             {
+                // 用户私聊消息：校验消息内容是否包含验证码
                 var openId = ExtractOpenId(d, "author", "user_openid");
                 if (!string.IsNullOrWhiteSpace(openId))
                 {
-                    // Verify the message content matches the code.
                     var content = ExtractString(d, "content");
                     if (content != null && content.Contains(verifyCode))
                         return openId;
@@ -228,6 +253,7 @@ public class QqWebSocketHelper
             }
             else if (eventType == "FRIEND_ADD")
             {
+                // 好友添加事件：直接提取 openid
                 var openId = ExtractOpenId(d, "openid");
                 if (!string.IsNullOrWhiteSpace(openId))
                     return openId;
@@ -235,6 +261,9 @@ public class QqWebSocketHelper
         }
     }
 
+    /// <summary>
+    /// 从 JSON 元素中提取指定属性的字符串值。
+    /// </summary>
     private static string? ExtractString(JsonElement d, string property)
     {
         if (d.TryGetProperty(property, out var element) && element.ValueKind == JsonValueKind.String)
@@ -242,6 +271,10 @@ public class QqWebSocketHelper
         return null;
     }
 
+    /// <summary>
+    /// 按路径从 JSON 元素中逐层提取 OpenID。
+    /// 例如 ExtractOpenId(d, "author", "user_openid") 对应 d.author.user_openid。
+    /// </summary>
     private static string? ExtractOpenId(JsonElement d, params string[] path)
     {
         var current = d;
@@ -254,6 +287,9 @@ public class QqWebSocketHelper
         return current.ValueKind == JsonValueKind.String ? current.GetString() : null;
     }
 
+    /// <summary>
+    /// 从 WebSocket 接收一条完整消息（处理分片拼接）。
+    /// </summary>
     private static async Task<string> ReceiveMessageAsync(ClientWebSocket socket, CancellationToken ct)
     {
         var buffer = new byte[8192];
@@ -263,7 +299,7 @@ public class QqWebSocketHelper
         {
             result = await socket.ReceiveAsync(new ArraySegment<byte>(buffer), ct);
             if (result.MessageType == WebSocketMessageType.Close)
-                throw new NotifierException("QQ gateway closed the connection");
+                throw new NotifierException("QQ 网关关闭了连接");
 
             ms.Write(buffer, 0, result.Count);
         } while (!result.EndOfMessage);
@@ -271,6 +307,9 @@ public class QqWebSocketHelper
         return Encoding.UTF8.GetString(ms.ToArray());
     }
 
+    /// <summary>
+    /// 向 WebSocket 发送一条文本消息。
+    /// </summary>
     private static async Task SendMessageAsync(ClientWebSocket socket, string payload, CancellationToken ct)
     {
         var bytes = Encoding.UTF8.GetBytes(payload);

--- a/BetterGenshinImpact/Service/Notifier/QqWebSocketHelper.cs
+++ b/BetterGenshinImpact/Service/Notifier/QqWebSocketHelper.cs
@@ -1,0 +1,223 @@
+using System;
+using System.Net.Http;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using BetterGenshinImpact.Service.Notifier.Exception;
+using Microsoft.Extensions.Logging;
+
+namespace BetterGenshinImpact.Service.Notifier;
+
+/// <summary>
+/// QQ official WebSocket client used to bind a C2C OpenID.
+/// The C2C OpenID cannot be queried via REST API; it is only delivered
+/// passively through the gateway when the user sends a private message
+/// (C2C_MESSAGE_CREATE) or adds the bot as a friend (FRIEND_ADD).
+/// </summary>
+public class QqWebSocketHelper
+{
+    private static readonly ILogger Logger = App.GetLogger<QqWebSocketHelper>();
+
+    private const string TokenUrl = "https://bots.qq.com/app/getAppAccessToken";
+    private const string GatewayUrl = "https://api.bot.qq.com/gateway";
+    private const int Intents = 33554432; // 1 &lt;&lt; 25, GROUP_AND_C2C_EVENT
+    private const int BindTimeoutSeconds = 60;
+
+    /// <summary>
+    /// Connects to the QQ gateway and waits until the user's C2C OpenID is
+    /// observed. Returns the OpenID, or throws <see cref="NotifierException"/>
+    /// on timeout / cancellation / protocol error.
+    /// </summary>
+    public static async Task<string> BindAsync(string appId, string clientSecret, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(appId))
+            throw new NotifierException("QQ AppID is empty");
+
+        if (string.IsNullOrWhiteSpace(clientSecret))
+            throw new NotifierException("QQ AppSecret is empty");
+
+        using var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(TimeSpan.FromSeconds(BindTimeoutSeconds));
+        var ct = timeoutCts.Token;
+
+        var accessToken = await GetAccessTokenAsync(httpClient, appId, clientSecret, ct);
+        var gatewayUrl = await GetGatewayUrlAsync(httpClient, accessToken, ct);
+
+        using var socket = new ClientWebSocket();
+        await socket.ConnectAsync(new Uri(gatewayUrl), ct);
+
+        var heartbeatInterval = await ReceiveHelloAsync(socket, ct);
+        await SendIdentifyAsync(socket, accessToken, ct);
+
+        // Heartbeat runs in the background for the lifetime of the connection.
+        using var heartbeatCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        var heartbeatTask = RunHeartbeatAsync(socket, heartbeatInterval, heartbeatCts.Token);
+
+        try
+        {
+            return await ReceiveUntilOpenIdAsync(socket, ct);
+        }
+        finally
+        {
+            heartbeatCts.Cancel();
+            try
+            {
+                await heartbeatTask;
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected when the bind flow finishes.
+            }
+        }
+    }
+
+    private static async Task<string> GetAccessTokenAsync(HttpClient httpClient, string appId, string clientSecret, CancellationToken ct)
+    {
+        var body = JsonSerializer.Serialize(new { appId, clientSecret });
+        using var content = new StringContent(body, Encoding.UTF8, "application/json");
+        using var response = await httpClient.PostAsync(TokenUrl, content, ct);
+        response.EnsureSuccessStatusCode();
+        var json = await response.Content.ReadAsStringAsync(ct);
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.GetProperty("access_token").GetString()!;
+    }
+
+    private static async Task<string> GetGatewayUrlAsync(HttpClient httpClient, string accessToken, CancellationToken ct)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, GatewayUrl);
+        request.Headers.Add("Authorization", $"QQBot {accessToken}");
+        using var response = await httpClient.SendAsync(request, ct);
+        response.EnsureSuccessStatusCode();
+        var json = await response.Content.ReadAsStringAsync(ct);
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.GetProperty("url").GetString()!;
+    }
+
+    private static async Task<int> ReceiveHelloAsync(ClientWebSocket socket, CancellationToken ct)
+    {
+        var payload = await ReceiveMessageAsync(socket, ct);
+        using var doc = JsonDocument.Parse(payload);
+        var root = doc.RootElement;
+        var op = root.GetProperty("op").GetInt32();
+        if (op != 10)
+            throw new NotifierException($"Unexpected gateway opcode {op}, expected Hello (10)");
+
+        if (root.TryGetProperty("d", out var d) && d.TryGetProperty("heartbeat_interval", out var interval))
+            return interval.GetInt32();
+
+        return 45000;
+    }
+
+    private static async Task SendIdentifyAsync(ClientWebSocket socket, string accessToken, CancellationToken ct)
+    {
+        var payload = JsonSerializer.Serialize(new
+        {
+            op = 2,
+            d = new
+            {
+                token = $"QQBot {accessToken}",
+                intents = Intents,
+                shard = new[] { 0, 1 }
+            }
+        });
+        await SendMessageAsync(socket, payload, ct);
+    }
+
+    private static async Task RunHeartbeatAsync(ClientWebSocket socket, int heartbeatInterval, CancellationToken ct)
+    {
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                await Task.Delay(heartbeatInterval, ct);
+                var payload = JsonSerializer.Serialize(new { op = 1, d = (int?)null });
+                await SendMessageAsync(socket, payload, ct);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Normal shutdown.
+        }
+        catch (System.Exception ex)
+        {
+            Logger.LogWarning("QQ heartbeat loop stopped: {ex}", ex.Message);
+        }
+    }
+
+    private static async Task<string> ReceiveUntilOpenIdAsync(ClientWebSocket socket, CancellationToken ct)
+    {
+        while (true)
+        {
+            var payload = await ReceiveMessageAsync(socket, ct);
+            using var doc = JsonDocument.Parse(payload);
+            var root = doc.RootElement;
+
+            if (!root.TryGetProperty("op", out var opElement))
+                continue;
+
+            var op = opElement.GetInt32();
+
+            // Invalid Session: the bot lacks permission for the requested intents.
+            if (op == 9)
+                throw new NotifierException("QQ bot does not have permission for C2C events (intents)");
+
+            if (op != 0)
+                continue;
+
+            if (!root.TryGetProperty("t", out var tElement))
+                continue;
+
+            var eventType = tElement.GetString();
+            if (!root.TryGetProperty("d", out var d))
+                continue;
+
+            var openId = eventType switch
+            {
+                "C2C_MESSAGE_CREATE" => ExtractOpenId(d, "author", "user_openid"),
+                "FRIEND_ADD" => ExtractOpenId(d, "openid"),
+                _ => null
+            };
+
+            if (!string.IsNullOrWhiteSpace(openId))
+                return openId;
+        }
+    }
+
+    private static string? ExtractOpenId(JsonElement d, params string[] path)
+    {
+        var current = d;
+        foreach (var segment in path)
+        {
+            if (current.ValueKind != JsonValueKind.Object || !current.TryGetProperty(segment, out current))
+                return null;
+        }
+
+        return current.ValueKind == JsonValueKind.String ? current.GetString() : null;
+    }
+
+    private static async Task<string> ReceiveMessageAsync(ClientWebSocket socket, CancellationToken ct)
+    {
+        var buffer = new byte[8192];
+        using var ms = new System.IO.MemoryStream();
+        WebSocketReceiveResult result;
+        do
+        {
+            result = await socket.ReceiveAsync(new ArraySegment<byte>(buffer), ct);
+            if (result.MessageType == WebSocketMessageType.Close)
+                throw new NotifierException("QQ gateway closed the connection");
+
+            ms.Write(buffer, 0, result.Count);
+        } while (!result.EndOfMessage);
+
+        return Encoding.UTF8.GetString(ms.ToArray());
+    }
+
+    private static async Task SendMessageAsync(ClientWebSocket socket, string payload, CancellationToken ct)
+    {
+        var bytes = Encoding.UTF8.GetBytes(payload);
+        await socket.SendAsync(new ArraySegment<byte>(bytes), WebSocketMessageType.Text, true, ct);
+    }
+}

--- a/BetterGenshinImpact/Service/Notifier/QqWebSocketHelper.cs
+++ b/BetterGenshinImpact/Service/Notifier/QqWebSocketHelper.cs
@@ -21,22 +21,35 @@ public class QqWebSocketHelper
     private static readonly ILogger Logger = App.GetLogger<QqWebSocketHelper>();
 
     private const string TokenUrl = "https://bots.qq.com/app/getAppAccessToken";
-    private const string GatewayUrl = "https://api.bot.qq.com/gateway";
-    private const int Intents = 33554432; // 1 &lt;&lt; 25, GROUP_AND_C2C_EVENT
+    private const string GatewayUrl = "https://api.sgroup.qq.com/gateway";
+    private const int Intents = 33554432; // 1 << 25, GROUP_AND_C2C_EVENT
     private const int BindTimeoutSeconds = 60;
+    private const int VerifyCodeLength = 4;
 
     /// <summary>
     /// Connects to the QQ gateway and waits until the user's C2C OpenID is
     /// observed. Returns the OpenID, or throws <see cref="NotifierException"/>
     /// on timeout / cancellation / protocol error.
     /// </summary>
-    public static async Task<string> BindAsync(string appId, string clientSecret, CancellationToken cancellationToken)
+    /// <param name="appId">QQ Open Platform AppID.</param>
+    /// <param name="clientSecret">QQ Open Platform AppSecret.</param>
+    /// <param name="onVerifyCode">Invoked with a one-time verification code that
+    /// the user must send to the bot to confirm their identity.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public static async Task<string> BindAsync(
+        string appId,
+        string clientSecret,
+        Action<string> onVerifyCode,
+        CancellationToken cancellationToken)
     {
         if (string.IsNullOrWhiteSpace(appId))
             throw new NotifierException("QQ AppID is empty");
 
         if (string.IsNullOrWhiteSpace(clientSecret))
             throw new NotifierException("QQ AppSecret is empty");
+
+        var verifyCode = GenerateVerifyCode();
+        onVerifyCode(verifyCode);
 
         using var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
         using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -54,11 +67,12 @@ public class QqWebSocketHelper
 
         // Heartbeat runs in the background for the lifetime of the connection.
         using var heartbeatCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        var heartbeatTask = RunHeartbeatAsync(socket, heartbeatInterval, heartbeatCts.Token);
+        var seq = 0L;
+        var heartbeatTask = RunHeartbeatAsync(socket, heartbeatInterval, () => Interlocked.Read(ref seq), heartbeatCts.Token);
 
         try
         {
-            return await ReceiveUntilOpenIdAsync(socket, ct);
+            return await ReceiveUntilOpenIdAsync(socket, verifyCode, (s) => { Interlocked.Exchange(ref seq, s); }, ct);
         }
         finally
         {
@@ -72,6 +86,15 @@ public class QqWebSocketHelper
                 // Expected when the bind flow finishes.
             }
         }
+    }
+
+    private static string GenerateVerifyCode()
+    {
+        var rng = new Random();
+        var code = new char[VerifyCodeLength];
+        for (var i = 0; i < VerifyCodeLength; i++)
+            code[i] = (char)('0' + rng.Next(10));
+        return new string(code);
     }
 
     private static async Task<string> GetAccessTokenAsync(HttpClient httpClient, string appId, string clientSecret, CancellationToken ct)
@@ -126,14 +149,19 @@ public class QqWebSocketHelper
         await SendMessageAsync(socket, payload, ct);
     }
 
-    private static async Task RunHeartbeatAsync(ClientWebSocket socket, int heartbeatInterval, CancellationToken ct)
+    private static async Task RunHeartbeatAsync(ClientWebSocket socket, int heartbeatInterval, Func<long> getSeq, CancellationToken ct)
     {
         try
         {
             while (!ct.IsCancellationRequested)
             {
                 await Task.Delay(heartbeatInterval, ct);
-                var payload = JsonSerializer.Serialize(new { op = 1, d = (int?)null });
+                var seq = getSeq();
+                string payload;
+                if (seq == 0)
+                    payload = JsonSerializer.Serialize(new { op = 1, d = (int?)null });
+                else
+                    payload = JsonSerializer.Serialize(new { op = 1, d = seq });
                 await SendMessageAsync(socket, payload, ct);
             }
         }
@@ -147,7 +175,7 @@ public class QqWebSocketHelper
         }
     }
 
-    private static async Task<string> ReceiveUntilOpenIdAsync(ClientWebSocket socket, CancellationToken ct)
+    private static async Task<string> ReceiveUntilOpenIdAsync(ClientWebSocket socket, string verifyCode, Action<long> setSeq, CancellationToken ct)
     {
         while (true)
         {
@@ -174,16 +202,35 @@ public class QqWebSocketHelper
             if (!root.TryGetProperty("d", out var d))
                 continue;
 
-            var openId = eventType switch
-            {
-                "C2C_MESSAGE_CREATE" => ExtractOpenId(d, "author", "user_openid"),
-                "FRIEND_ADD" => ExtractOpenId(d, "openid"),
-                _ => null
-            };
+            // Save the seq number for heartbeat.
+            if (root.TryGetProperty("s", out var sElement) && sElement.TryGetInt64(out var sVal))
+                setSeq(sVal);
 
-            if (!string.IsNullOrWhiteSpace(openId))
-                return openId;
+            if (eventType == "C2C_MESSAGE_CREATE")
+            {
+                var openId = ExtractOpenId(d, "author", "user_openid");
+                if (!string.IsNullOrWhiteSpace(openId))
+                {
+                    // Verify the message content matches the code.
+                    var content = ExtractString(d, "content");
+                    if (content != null && content.Contains(verifyCode))
+                        return openId;
+                }
+            }
+            else if (eventType == "FRIEND_ADD")
+            {
+                var openId = ExtractOpenId(d, "openid");
+                if (!string.IsNullOrWhiteSpace(openId))
+                    return openId;
+            }
         }
+    }
+
+    private static string? ExtractString(JsonElement d, string property)
+    {
+        if (d.TryGetProperty(property, out var element) && element.ValueKind == JsonValueKind.String)
+            return element.GetString();
+        return null;
     }
 
     private static string? ExtractOpenId(JsonElement d, params string[] path)

--- a/BetterGenshinImpact/View/Pages/NotificationSettingsPage.xaml
+++ b/BetterGenshinImpact/View/Pages/NotificationSettingsPage.xaml
@@ -2435,7 +2435,7 @@
                     <ui:TextBlock Grid.Row="0" Grid.Column="0" FontTypography="Body" Text="用户OpenID" TextWrapping="Wrap" />
                     <ui:TextBlock Grid.Row="1" Grid.Column="0"
                                   Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
-                                  Text="添加机器人好友后发消息，工具可自动获取" TextWrapping="Wrap" />
+                                  Text="添加机器人好友后发消息获取，需手动填写" TextWrapping="Wrap" />
                     <ui:TextBox Grid.Row="0" Grid.RowSpan="2" Grid.Column="1"
                                 MinWidth="180" MaxWidth="800" Margin="0,0,36,0"
                                 Text="{Binding Config.NotificationConfig.QqOpenId, Mode=TwoWay}"

--- a/BetterGenshinImpact/View/Pages/NotificationSettingsPage.xaml
+++ b/BetterGenshinImpact/View/Pages/NotificationSettingsPage.xaml
@@ -2453,7 +2453,7 @@
                     <ui:TextBlock Grid.Row="0" Grid.Column="0" FontTypography="Body" Text="绑定 OpenID" TextWrapping="Wrap" />
                     <ui:TextBlock Grid.Row="1" Grid.Column="0"
                                   Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
-                                  Text="点击绑定后，请用手机 QQ 私聊机器人并发送任意消息，系统将自动获取你的 OpenID；绑定过程中可点击取消" TextWrapping="Wrap" />
+                                  Text="点击绑定后，请用手机 QQ 私聊机器人并发送显示的验证码，系统将自动获取你的 OpenID；绑定过程中可点击取消" TextWrapping="Wrap" />
                     <ui:Button Grid.Row="0" Grid.RowSpan="2" Grid.Column="1"
                                Margin="0,0,36,0"
                                HorizontalAlignment="Right">

--- a/BetterGenshinImpact/View/Pages/NotificationSettingsPage.xaml
+++ b/BetterGenshinImpact/View/Pages/NotificationSettingsPage.xaml
@@ -2362,7 +2362,7 @@
                 </Grid>
             </StackPanel>
         </ui:CardExpander>
-        <!--  QQ通知  -->
+        <!--  QQ 通知（官方 REST API + 自动绑定 OpenID）  -->
         <ui:CardExpander Margin="0,0,0,12"
                          ContentPadding="0"
                          Icon="{ui:SymbolIcon ChatMultiple24}">
@@ -2441,6 +2441,7 @@
                                 Text="{Binding Config.NotificationConfig.QqOpenId, Mode=TwoWay}"
                                 TextWrapping="NoWrap" />
                 </Grid>
+                <!-- 绑定 OpenID 按钮行：连接 QQ 网关，用户发送验证码后自动回填 OpenID -->
                 <Grid Margin="16">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
@@ -2454,6 +2455,7 @@
                     <ui:TextBlock Grid.Row="1" Grid.Column="0"
                                   Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
                                   Text="点击绑定后，请用手机 QQ 私聊机器人并发送显示的验证码，系统将自动获取你的 OpenID；绑定过程中可点击取消" TextWrapping="Wrap" />
+                    <!-- 绑定/取消按钮：绑定中（IsBinding=true）时切换为"取消"，通过 DataTrigger 切换 Command 和 Content -->
                     <ui:Button Grid.Row="0" Grid.RowSpan="2" Grid.Column="1"
                                Margin="0,0,36,0"
                                HorizontalAlignment="Right">

--- a/BetterGenshinImpact/View/Pages/NotificationSettingsPage.xaml
+++ b/BetterGenshinImpact/View/Pages/NotificationSettingsPage.xaml
@@ -2362,5 +2362,104 @@
                 </Grid>
             </StackPanel>
         </ui:CardExpander>
+        <!--  QQ通知  -->
+        <ui:CardExpander Margin="0,0,0,12"
+                         ContentPadding="0"
+                         Icon="{ui:SymbolIcon ChatMultiple24}">
+            <ui:CardExpander.Header>
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <ui:TextBlock Grid.Row="0" Grid.Column="0" FontTypography="Body"
+                                  Text="启用 QQ 通知" TextWrapping="Wrap" />
+                    <ui:TextBlock Grid.Row="1" Grid.Column="0"
+                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                  Text="QQ 官方推送，支持文字和截图" TextWrapping="Wrap" />
+                    <ui:ToggleSwitch Grid.Row="0" Grid.RowSpan="2" Grid.Column="1"
+                                     Margin="0,0,24,0"
+                                     IsChecked="{Binding Config.NotificationConfig.QqNotificationEnabled, Mode=TwoWay}" />
+                </Grid>
+            </ui:CardExpander.Header>
+            <StackPanel>
+                <Grid Margin="16">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="3*" />
+                        <ColumnDefinition Width="2*" />
+                    </Grid.ColumnDefinitions>
+                    <ui:TextBlock Grid.Row="0" Grid.Column="0" FontTypography="Body" Text="AppID" TextWrapping="Wrap" />
+                    <ui:TextBlock Grid.Row="1" Grid.Column="0"
+                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                  Text="QQ 开放平台的 AppID" TextWrapping="Wrap" />
+                    <ui:TextBox Grid.Row="0" Grid.RowSpan="2" Grid.Column="1"
+                                MinWidth="180" MaxWidth="800" Margin="0,0,36,0"
+                                Text="{Binding Config.NotificationConfig.QqAppId, Mode=TwoWay}"
+                                TextWrapping="NoWrap" />
+                </Grid>
+                <Grid Margin="16">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="3*" />
+                        <ColumnDefinition Width="2*" />
+                    </Grid.ColumnDefinitions>
+                    <ui:TextBlock Grid.Row="0" Grid.Column="0" FontTypography="Body" Text="AppSecret" TextWrapping="Wrap" />
+                    <ui:TextBlock Grid.Row="1" Grid.Column="0"
+                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                  Text="QQ 开放平台的 AppSecret" TextWrapping="Wrap" />
+                    <ui:TextBox Grid.Row="0" Grid.RowSpan="2" Grid.Column="1"
+                                MinWidth="180" MaxWidth="800" Margin="0,0,36,0"
+                                Text="{Binding Config.NotificationConfig.QqClientSecret, Mode=TwoWay}"
+                                TextWrapping="NoWrap" />
+                </Grid>
+                <Grid Margin="16">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="3*" />
+                        <ColumnDefinition Width="2*" />
+                    </Grid.ColumnDefinitions>
+                    <ui:TextBlock Grid.Row="0" Grid.Column="0" FontTypography="Body" Text="用户OpenID" TextWrapping="Wrap" />
+                    <ui:TextBlock Grid.Row="1" Grid.Column="0"
+                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                  Text="添加机器人好友后发消息，工具可自动获取" TextWrapping="Wrap" />
+                    <ui:TextBox Grid.Row="0" Grid.RowSpan="2" Grid.Column="1"
+                                MinWidth="180" MaxWidth="800" Margin="0,0,36,0"
+                                Text="{Binding Config.NotificationConfig.QqOpenId, Mode=TwoWay}"
+                                TextWrapping="NoWrap" />
+                </Grid>
+                <Grid Margin="16">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="3*" />
+                        <ColumnDefinition Width="2*" />
+                    </Grid.ColumnDefinitions>
+                    <ui:TextBlock Grid.Row="0" Grid.Column="0" FontTypography="Body" Text="测试 QQ 通知" TextWrapping="Wrap" />
+                    <ui:TextBlock Grid.Row="1" Grid.Column="0"
+                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                  Text="发送测试通知" TextWrapping="Wrap" />
+                    <ui:Button Grid.Row="0" Grid.RowSpan="2" Grid.Column="1"
+                               Margin="0,0,36,0"
+                               Command="{Binding TestQqNotificationCommand}"
+                               Content="发送" />
+                </Grid>
+            </StackPanel>
+        </ui:CardExpander>
     </StackPanel>
 </Page>

--- a/BetterGenshinImpact/View/Pages/NotificationSettingsPage.xaml
+++ b/BetterGenshinImpact/View/Pages/NotificationSettingsPage.xaml
@@ -2435,12 +2435,46 @@
                     <ui:TextBlock Grid.Row="0" Grid.Column="0" FontTypography="Body" Text="用户OpenID" TextWrapping="Wrap" />
                     <ui:TextBlock Grid.Row="1" Grid.Column="0"
                                   Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
-                                  Text="添加机器人好友后发消息获取，需手动填写" TextWrapping="Wrap" />
+                                  Text="添加机器人好友后发消息获取，可点击下方「绑定」自动获取" TextWrapping="Wrap" />
                     <ui:TextBox Grid.Row="0" Grid.RowSpan="2" Grid.Column="1"
                                 MinWidth="180" MaxWidth="800" Margin="0,0,36,0"
                                 Text="{Binding Config.NotificationConfig.QqOpenId, Mode=TwoWay}"
                                 TextWrapping="NoWrap" />
                 </Grid>
+                <Grid Margin="16">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="3*" />
+                        <ColumnDefinition Width="2*" />
+                    </Grid.ColumnDefinitions>
+                    <ui:TextBlock Grid.Row="0" Grid.Column="0" FontTypography="Body" Text="绑定 OpenID" TextWrapping="Wrap" />
+                    <ui:TextBlock Grid.Row="1" Grid.Column="0"
+                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                  Text="点击绑定后，请用手机 QQ 私聊机器人并发送任意消息，系统将自动获取你的 OpenID；绑定过程中可点击取消" TextWrapping="Wrap" />
+                    <ui:Button Grid.Row="0" Grid.RowSpan="2" Grid.Column="1"
+                               Margin="0,0,36,0"
+                               HorizontalAlignment="Right">
+                        <ui:Button.Style>
+                            <Style TargetType="ui:Button" BasedOn="{StaticResource {x:Type ui:Button}}">
+                                <Setter Property="Command" Value="{Binding BindQqCommand}" />
+                                <Setter Property="Content" Value="绑定" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsBinding}" Value="True">
+                                        <Setter Property="Command" Value="{Binding CancelBindQqCommand}" />
+                                        <Setter Property="Content" Value="取消" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </ui:Button.Style>
+                    </ui:Button>
+                </Grid>
+                <ui:TextBlock Margin="16,0,16,0"
+                              Foreground="{ui:ThemeResource TextFillColorSecondaryBrush}"
+                              Text="{Binding QqStatus}"
+                              TextWrapping="Wrap" />
                 <Grid Margin="16">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />

--- a/BetterGenshinImpact/ViewModel/Pages/NotificationSettingsPageViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/NotificationSettingsPageViewModel.cs
@@ -71,8 +71,14 @@ public partial class NotificationSettingsPageViewModel : ObservableObject, IView
 
     [ObservableProperty] private string _qqStatus = string.Empty;
 
+    /// <summary>
+    /// 是否正在执行绑定流程（控制按钮显示为"绑定"或"取消"）
+    /// </summary>
     [ObservableProperty] private bool _isBinding;
 
+    /// <summary>
+    /// 绑定流程的取消令牌源，用于用户点击取消时中断 WebSocket 连接
+    /// </summary>
     private CancellationTokenSource? _bindCts;
 
     public NotificationSettingsPageViewModel(IConfigService configService, NotificationService notificationService)
@@ -527,6 +533,11 @@ public partial class NotificationSettingsPageViewModel : ObservableObject, IView
         IsLoading = false;
     }
 
+    /// <summary>
+    /// 绑定 QQ 按钮。连接 QQ 网关，等待用户发送验证码，自动回填 OpenID。
+    /// 支持取消（用户点击取消时中断 WebSocket 连接）。
+    /// 超时（60 秒未收到消息）时提示用户重试。
+    /// </summary>
     [RelayCommand]
     private async Task OnBindQq()
     {
@@ -553,7 +564,7 @@ public partial class NotificationSettingsPageViewModel : ObservableObject, IView
                 Config.NotificationConfig.QqClientSecret,
                 code =>
                 {
-                    // Must marshal to UI thread to update ObservableProperty.
+                    // 回调在后台线程执行，需要编组回 UI 线程才能更新 ObservableProperty
                     System.Windows.Application.Current.Dispatcher.Invoke(() =>
                     {
                         QqStatus = $"请用手机 QQ 私聊机器人，发送验证码 [{code}]";
@@ -561,16 +572,19 @@ public partial class NotificationSettingsPageViewModel : ObservableObject, IView
                 },
                 _bindCts.Token);
 
+            // 绑定成功，自动回填 OpenID（配置自动保存 + 刷新通知器）
             Config.NotificationConfig.QqOpenId = openId;
             QqStatus = "绑定成功";
             Toast.Success("QQ 绑定成功");
         }
         catch (OperationCanceledException)
         {
+            // 用户主动点击取消
             QqStatus = "已取消绑定";
         }
         catch (System.Exception ex)
         {
+            // 超时或其他错误（超时已被 BindAsync 转为 NotifierException）
             QqStatus = $"绑定失败：{ex.Message}";
             Toast.Error($"绑定失败：{ex.Message}");
         }
@@ -582,6 +596,9 @@ public partial class NotificationSettingsPageViewModel : ObservableObject, IView
         }
     }
 
+    /// <summary>
+    /// 取消绑定按钮：取消 WebSocket 连接，中断绑定流程。
+    /// </summary>
     [RelayCommand]
     private void OnCancelBindQq()
     {

--- a/BetterGenshinImpact/ViewModel/Pages/NotificationSettingsPageViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/NotificationSettingsPageViewModel.cs
@@ -543,7 +543,7 @@ public partial class NotificationSettingsPageViewModel : ObservableObject, IView
         }
 
         IsBinding = true;
-        QqStatus = "请用手机 QQ 私聊机器人，发送任意一条消息…";
+        QqStatus = "正在连接 QQ 网关…";
         _bindCts = new CancellationTokenSource();
 
         try
@@ -551,6 +551,14 @@ public partial class NotificationSettingsPageViewModel : ObservableObject, IView
             var openId = await QqWebSocketHelper.BindAsync(
                 Config.NotificationConfig.QqAppId,
                 Config.NotificationConfig.QqClientSecret,
+                code =>
+                {
+                    // Must marshal to UI thread to update ObservableProperty.
+                    System.Windows.Application.Current.Dispatcher.Invoke(() =>
+                    {
+                        QqStatus = $"请用手机 QQ 私聊机器人，发送验证码 [{code}]";
+                    });
+                },
                 _bindCts.Token);
 
             Config.NotificationConfig.QqOpenId = openId;

--- a/BetterGenshinImpact/ViewModel/Pages/NotificationSettingsPageViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/NotificationSettingsPageViewModel.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using BetterGenshinImpact.Core.Config;
 using BetterGenshinImpact.Service.Interface;
@@ -69,6 +70,10 @@ public partial class NotificationSettingsPageViewModel : ObservableObject, IView
     [ObservableProperty] private string _gotifyStatus = string.Empty;
 
     [ObservableProperty] private string _qqStatus = string.Empty;
+
+    [ObservableProperty] private bool _isBinding;
+
+    private CancellationTokenSource? _bindCts;
 
     public NotificationSettingsPageViewModel(IConfigService configService, NotificationService notificationService)
     {
@@ -520,6 +525,59 @@ public partial class NotificationSettingsPageViewModel : ObservableObject, IView
             Toast.Error(res.Message);
 
         IsLoading = false;
+    }
+
+    [RelayCommand]
+    private async Task OnBindQq()
+    {
+        if (string.IsNullOrWhiteSpace(Config.NotificationConfig.QqAppId))
+        {
+            Toast.Error("请先填写 QQ AppID");
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(Config.NotificationConfig.QqClientSecret))
+        {
+            Toast.Error("请先填写 QQ AppSecret");
+            return;
+        }
+
+        IsBinding = true;
+        QqStatus = "请用手机 QQ 私聊机器人，发送任意一条消息…";
+        _bindCts = new CancellationTokenSource();
+
+        try
+        {
+            var openId = await QqWebSocketHelper.BindAsync(
+                Config.NotificationConfig.QqAppId,
+                Config.NotificationConfig.QqClientSecret,
+                _bindCts.Token);
+
+            Config.NotificationConfig.QqOpenId = openId;
+            QqStatus = "绑定成功";
+            Toast.Success("QQ 绑定成功");
+        }
+        catch (OperationCanceledException)
+        {
+            QqStatus = "已取消绑定";
+        }
+        catch (System.Exception ex)
+        {
+            QqStatus = $"绑定失败：{ex.Message}";
+            Toast.Error($"绑定失败：{ex.Message}");
+        }
+        finally
+        {
+            IsBinding = false;
+            _bindCts.Dispose();
+            _bindCts = null;
+        }
+    }
+
+    [RelayCommand]
+    private void OnCancelBindQq()
+    {
+        _bindCts?.Cancel();
     }
 
     [RelayCommand]

--- a/BetterGenshinImpact/ViewModel/Pages/NotificationSettingsPageViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/NotificationSettingsPageViewModel.cs
@@ -68,6 +68,8 @@ public partial class NotificationSettingsPageViewModel : ObservableObject, IView
 
     [ObservableProperty] private string _gotifyStatus = string.Empty;
 
+    [ObservableProperty] private string _qqStatus = string.Empty;
+
     public NotificationSettingsPageViewModel(IConfigService configService, NotificationService notificationService)
     {
         Config = configService.Get();
@@ -495,6 +497,23 @@ public partial class NotificationSettingsPageViewModel : ObservableObject, IView
         var res = await _notificationService.TestNotifierAsync<GotifyNotifier>();
 
         GotifyStatus = res.Message;
+        if (res.IsSuccess)
+            Toast.Success(res.Message);
+        else
+            Toast.Error(res.Message);
+
+        IsLoading = false;
+    }
+
+    [RelayCommand]
+    private async Task OnTestQqNotification()
+    {
+        IsLoading = true;
+        QqStatus = string.Empty;
+
+        var res = await _notificationService.TestNotifierAsync<QqNotifier>();
+
+        QqStatus = res.Message;
         if (res.IsSuccess)
             Toast.Success(res.Message);
         else


### PR DESCRIPTION
## 概述

新增 **QQ 官方 REST 推送渠道**，让 BetterGI 的自动化任务通知（秘境、一条龙、任务、脚本、自动进食等）能实时推送到用户的 QQ 私聊（C2C 单聊）。

这是国内用户呼声很高的功能——QQ 是国内最主流的 IM，此前 BetterGI 的 16 种通知渠道里，QQ 相关只有 OneBot（需要额外跑 OneBot 客户端），没有直接走 QQ 官方 API 的方案。

## 功能特性

- **文本消息推送**：`msg_type=0`，带事件结果标记（✅/❌/⚠️）+ 时间戳
- **截图图片推送**：`msg_type=7` 富媒体消息，通过 QQ 官方**分片上传**流程（upload_prepare → 分片 PUT → part_finish → files 合并）
- **自动重试**：token 过期 / 网络抖动时自动重试 3 次（指数退避）
- **降级策略**：图片发送失败时自动降级为纯文本，不阻断通知
- **凭证安全**：AppID / AppSecret / OpenID 从 config 注入，不硬编码

## 改动文件

| 文件 | 改动 |
|------|------|
| `Service/Notifier/QqNotifier.cs` | 新增，实现 `INotifier`，走 QQ 官方 REST API |
| `Service/Notification/NotificationConfig.cs` | 新增 4 个配置字段 |
| `Service/Notification/NotificationService.cs` | 注册 `QqNotifier` |
| `View/Pages/NotificationSettingsPage.xaml` | 新增 QQ 设置卡片 |
| `ViewModel/Pages/NotificationSettingsPageViewModel.cs` | 新增测试命令 |

共 5 文件，427 行新增，无删除。

## 实现说明

### 架构

完全遵循现有通知器架构（策略模式），仿照 `GotifyNotifier` 模板实现：

```csharp
public sealed class QqNotifier : INotifier
{
    public string Name { get; } = "QQ";
    public async Task SendAsync(BaseNotificationData content) { ... }
}
```

### 核心流程

1. **获取 access_token**：`POST https://bots.qq.com/app/getAppAccessToken`（每次发送前实时获取）
2. **发送文本**：`POST /v2/users/{openid}/messages`，`msg_type=0`
3. **发送截图**（如有）：
   - `upload_prepare` 获取 upload_id + 分片预签名 URL
   - 分片 PUT 到预签名 URL（分片 index 从 1 开始）
   - `upload_part_finish` 通知分片完成
   - `files` 合并获取 file_info
   - 发送 `msg_type=7` 富媒体消息

### 为什么用分片上传

QQ 官方富媒体接口**不支持 multipart/form-data 直传本地文件**，只支持 URL 直传或分片上传。本地截图无法提供公网 URL，因此必须走分片上传流程。

## 验证情况

- ✅ 本地编译通过（0 错误）
- ✅ 真机端到端测试通过：文本消息 + 截图图片消息均成功推送到 QQ 私聊
- ✅ 失败重试 + 降级逻辑验证通过

## 已知限制 / 后续计划

- **OpenID 获取**：QQ 不提供按 QQ 号查 OpenID 的 API，只能通过事件被动获取（`FRIEND_ADD` / `C2C_MESSAGE_CREATE`）。当前版本需要用户手动填写 OpenID，后续计划通过内置 WebSocket 客户端自动获取（订阅 `GROUP_AND_C2C_EVENT` intents）
- **仅单聊**：当前只支持 C2C 私聊，群聊推送（`/v2/groups/{group_openid}/messages`）后续补充
- **仅中文**：消息文案为中文，未做 i18n

## 截图

（可补充设置页 QQ 卡片截图 + QQ 收到通知的截图）

---

感谢 review！有任何问题欢迎指出，我会及时跟进修改。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增 QQ 通知支持，可通过 QQ 开放平台向指定用户发送通知。
  - 支持发送文本及包含截图的富媒体消息。
  - 通知设置页面新增 QQ 配置项，包括启用开关、AppID、AppSecret 和用户 OpenID。
  - 新增 QQ 用户绑定流程，可自动获取 OpenID，并支持取消绑定。
  - 新增“发送测试通知”功能，并显示测试结果与错误提示。
  - 图片发送失败时将自动回退为仅发送文本通知。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->