### PR TITLE
fix: 清理背包数量 OCR 文本首尾空白

### DIFF
--- a/BetterGenshinImpact/GameTask/Model/GameUI/GridItemCountRecognizer.cs
+++ b/BetterGenshinImpact/GameTask/Model/GameUI/GridItemCountRecognizer.cs
@@ -257,7 +257,7 @@ internal static class GridItemCountRecognizer
 
     private static string NormalizeNumberText(string text)
     {
-        return StringUtils.ConvertFullWidthNumToHalfWidth(text ?? string.Empty);
+        return StringUtils.ConvertFullWidthNumToHalfWidth(text ?? string.Empty).Trim();
     }
 
     private static Rect Union(IReadOnlyList<Rect> rects)


### PR DESCRIPTION
## 问题

`CountInventoryItem` 的数量 OCR 可能返回带首尾空白的纯数字文本，例如 `" 500"`。当前 `TryParseStrict` 会把空白视为非数字字符，返回 `PARSE`，导致已正确识别的库存数量被记为 `-2`。

## 修复

在 `NormalizeNumberText` 完成全角数字转换后调用 `Trim()`，再进入现有的严格数字校验。

严格校验仍会拒绝数字中间夹杂的其他字符；本次修改只清理 OCR 常见的首尾空白。

## 影响范围

统一修复所有通过 `GridItemCountRecognizer` 调用 `CountInventoryItem` 的背包数量识别场景。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 改进数字文本识别结果的格式化，自动移除全角数字转换后的首尾空白。
  - 提升界面数字信息显示和后续处理的准确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->