### PR TITLE
feat: 主窗口自定义背景图片与图片编辑功能

### DIFF
--- a/BetterGenshinImpact/Core/Config/CommonConfig.cs
+++ b/BetterGenshinImpact/Core/Config/CommonConfig.cs
@@ -2,6 +2,7 @@ using BetterGenshinImpact.Helpers;
 using CommunityToolkit.Mvvm.ComponentModel;
 using System;
 using System.Collections.Generic;
+using System.Windows.Media;
 using Wpf.Ui.Controls;
 
 namespace BetterGenshinImpact.Core.Config;
@@ -61,6 +62,30 @@ public partial class CommonConfig : ObservableObject
     /// </summary>
     [ObservableProperty]
     private WindowBackdropType _currentBackdropType = WindowBackdropType.Mica;
+
+    /// <summary>
+    /// 是否启用主窗口自定义背景图
+    /// </summary>
+    [ObservableProperty]
+    private bool _mainBackgroundEnabled;
+
+    /// <summary>
+    /// 主窗口自定义背景图路径，空字符串表示未设置
+    /// </summary>
+    [ObservableProperty]
+    private string _mainBackgroundImagePath = string.Empty;
+
+    /// <summary>
+    /// 主窗口背景图不透明度，数值越小背景越淡，文字越清晰
+    /// </summary>
+    [ObservableProperty]
+    private double _mainBackgroundOpacity = 0.35;
+
+    /// <summary>
+    /// 主窗口背景图拉伸模式
+    /// </summary>
+    [ObservableProperty]
+    private Stretch _mainBackgroundStretch = Stretch.UniformToFill;
 
     /// <summary>
     /// 是否是第一次运行

--- a/BetterGenshinImpact/View/MainWindow.xaml
+++ b/BetterGenshinImpact/View/MainWindow.xaml
@@ -53,6 +53,17 @@
             <ColumnDefinition Width="Auto" />
         </Grid.ColumnDefinitions>
 
+        <!-- 自定义背景图层：置于最底层（首个子元素），覆盖标题栏与内容区，不响应鼠标 -->
+        <Image Grid.Row="0"
+               Grid.RowSpan="2"
+               Grid.Column="0"
+               Grid.ColumnSpan="2"
+               IsHitTestVisible="False"
+               Opacity="{Binding Config.CommonConfig.MainBackgroundOpacity, FallbackValue=0.35}"
+               Source="{Binding MainBackgroundSource, TargetNullValue={x:Null}}"
+               Stretch="{Binding Config.CommonConfig.MainBackgroundStretch, FallbackValue=UniformToFill}"
+               Visibility="{Binding IsMainBackgroundVisible, Converter={StaticResource BooleanToVisibilityConverter}}" />
+
         <ui:NavigationView x:Name="RootNavigation"
                            Grid.Column="0"
                            Grid.Row="1"

--- a/BetterGenshinImpact/View/Pages/CommonSettingsPage.xaml
+++ b/BetterGenshinImpact/View/Pages/CommonSettingsPage.xaml
@@ -115,20 +115,17 @@
         </ui:CardControl>
 
 
-        <ui:CardControl Margin="0,0,0,12" Icon="{ui:SymbolIcon Image24}">
-            <ui:CardControl.Header>
+        <ui:CardExpander Margin="0,0,0,12"
+                         ContentPadding="0"
+                         Icon="{ui:SymbolIcon Image24}">
+            <ui:CardExpander.Header>
                 <Grid>
                     <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
-                        <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="*" />
-                        <ColumnDefinition Width="Auto" />
-                        <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
                     <ui:TextBlock Grid.Row="0"
@@ -139,61 +136,127 @@
                     <ui:TextBlock Grid.Row="1"
                                   Grid.Column="0"
                                   Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
-                                  Text="为软件主窗口设置一张自定义背景图片，透明度可调"
+                                  Text="使用本地图片装饰软件主窗口，可调整透明度和填充方式"
                                   TextWrapping="Wrap" />
                     <ui:ToggleSwitch Grid.Row="0"
                                      Grid.RowSpan="2"
                                      Grid.Column="1"
-                                     Margin="0,0,12,0"
+                                     Margin="0,0,24,0"
                                      IsChecked="{Binding Config.CommonConfig.MainBackgroundEnabled, Mode=TwoWay}" />
-                    <ui:Button Grid.Row="0"
-                               Grid.RowSpan="2"
-                               Grid.Column="2"
-                               Margin="0,0,12,0"
-                               Command="{Binding SelectMainBackgroundImageCommand}"
-                               Content="选择图片" />
-                    <ui:Button Grid.Row="0"
-                               Grid.RowSpan="2"
-                               Grid.Column="3"
-                               Margin="0,0,36,0"
-                               Command="{Binding ClearMainBackgroundImageCommand}"
-                               Content="清除" />
-                    <ui:TextBlock Grid.Row="2"
+                </Grid>
+            </ui:CardExpander.Header>
+            <StackPanel>
+                <Separator Margin="-18,0" BorderThickness="0,1,0,0" />
+                <Grid Margin="16">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <ui:TextBlock Grid.Row="0"
                                   Grid.Column="0"
-                                  Grid.ColumnSpan="4"
-                                  Margin="0,8,36,4"
+                                  FontTypography="Body"
+                                  Text="背景图片"
+                                  TextWrapping="Wrap" />
+                    <ui:TextBlock Grid.Row="1"
+                                  Grid.Column="0"
                                   Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
-                                  Text="{Binding Config.CommonConfig.MainBackgroundImagePath, Mode=OneWay, FallbackValue='未设置背景图片'}"
-                                  TextTrimming="CharacterEllipsis"
-                                  ToolTip="{Binding Config.CommonConfig.MainBackgroundImagePath, Mode=OneWay}" />
-                    <TextBlock Grid.Row="3"
-                               Grid.Column="0"
-                               VerticalAlignment="Center"
-                               FontSize="12"
-                               Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
-                               Text="背景不透明度" />
-                    <Slider Grid.Row="3"
-                            Grid.Column="1"
-                            Grid.ColumnSpan="2"
-                            Width="240"
-                            Margin="0,4,12,0"
-                            VerticalAlignment="Center"
-                            Maximum="1"
-                            Minimum="0.05"
-                            IsSnapToTickEnabled="True"
-                            TickFrequency="0.05"
-                            Value="{Binding Config.CommonConfig.MainBackgroundOpacity, Mode=TwoWay}" />
-                    <TextBlock Grid.Row="4"
-                               Grid.Column="0"
-                               Margin="0,4,0,0"
-                               VerticalAlignment="Center"
-                               FontSize="12"
-                               Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
-                               Text="拉伸方式" />
-                    <ComboBox Grid.Row="4"
+                                  Text="支持常见图像格式，选择后可裁剪或旋转"
+                                  TextWrapping="Wrap" />
+                    <StackPanel Grid.Row="0"
+                                Grid.RowSpan="2"
+                                Grid.Column="1"
+                                Margin="16,0,36,0"
+                                VerticalAlignment="Center"
+                                Orientation="Horizontal">
+                        <ui:Button Margin="0,0,8,0"
+                                   Appearance="Primary"
+                                   Command="{Binding SelectMainBackgroundImageCommand}"
+                                   Content="选择图片"
+                                   Icon="{ui:SymbolIcon FolderOpen24}" />
+                        <ui:Button Command="{Binding ClearMainBackgroundImageCommand}"
+                                   Content="清除"
+                                   Icon="{ui:SymbolIcon Delete24}" />
+                    </StackPanel>
+                    <ui:TextBox Grid.Row="2"
+                                Grid.Column="0"
+                                Grid.ColumnSpan="2"
+                                Margin="0,12,36,0"
+                                IsReadOnly="True"
+                                PlaceholderText="尚未选择背景图片"
+                                Text="{Binding Config.CommonConfig.MainBackgroundImagePath, Mode=OneWay}"
+                                ToolTip="{Binding Config.CommonConfig.MainBackgroundImagePath, Mode=OneWay}" />
+                </Grid>
+                <Separator Margin="-18,0" BorderThickness="0,1,0,0" />
+                <Grid Margin="16">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <ui:TextBlock Grid.Row="0"
+                                  Grid.Column="0"
+                                  FontTypography="Body"
+                                  Text="背景不透明度"
+                                  TextWrapping="Wrap" />
+                    <ui:TextBlock Grid.Row="1"
+                                  Grid.Column="0"
+                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                  Text="数值越低，背景越淡，界面文字越清晰"
+                                  TextWrapping="Wrap" />
+                    <StackPanel Grid.Row="0"
+                                Grid.RowSpan="2"
+                                Grid.Column="1"
+                                Margin="16,0,36,0"
+                                VerticalAlignment="Center"
+                                Orientation="Horizontal">
+                        <Slider Width="180"
+                                VerticalAlignment="Center"
+                                IsSnapToTickEnabled="True"
+                                Maximum="1"
+                                Minimum="0.05"
+                                TickFrequency="0.05"
+                                Value="{Binding Config.CommonConfig.MainBackgroundOpacity, Mode=TwoWay}" />
+                        <TextBlock MinWidth="44"
+                                   Margin="12,0,0,0"
+                                   VerticalAlignment="Center"
+                                   FontFamily="Cascadia Mono, Consolas, Courier New, monospace"
+                                   FontSize="14"
+                                   Text="{Binding Config.CommonConfig.MainBackgroundOpacity, StringFormat={}{0:P0}}" />
+                    </StackPanel>
+                </Grid>
+                <Separator Margin="-18,0" BorderThickness="0,1,0,0" />
+                <Grid Margin="16">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <ui:TextBlock Grid.Row="0"
+                                  Grid.Column="0"
+                                  FontTypography="Body"
+                                  Text="图片填充方式"
+                                  TextWrapping="Wrap" />
+                    <ui:TextBlock Grid.Row="1"
+                                  Grid.Column="0"
+                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                  Text="控制图片在主窗口中的缩放和裁切方式"
+                                  TextWrapping="Wrap" />
+                    <ComboBox Grid.Row="0"
+                              Grid.RowSpan="2"
                               Grid.Column="1"
-                              Width="120"
-                              Margin="0,4,12,0"
+                              MinWidth="120"
+                              Margin="16,0,36,0"
                               VerticalAlignment="Center"
                               SelectedValue="{Binding Config.CommonConfig.MainBackgroundStretch, Mode=TwoWay}"
                               SelectedValuePath="Tag">
@@ -205,8 +268,8 @@
                         <ComboBoxItem Content="原始尺寸" Tag="{x:Static media:Stretch.None}" />
                     </ComboBox>
                 </Grid>
-            </ui:CardControl.Header>
-        </ui:CardControl>
+            </StackPanel>
+        </ui:CardExpander>
 
         <ui:CardExpander Margin="0,0,0,12"
                          ContentPadding="0"

--- a/BetterGenshinImpact/View/Pages/CommonSettingsPage.xaml
+++ b/BetterGenshinImpact/View/Pages/CommonSettingsPage.xaml
@@ -114,6 +114,97 @@
         </ui:CardControl>
 
 
+        <ui:CardControl Margin="0,0,0,12" Icon="{ui:SymbolIcon Image24}">
+            <ui:CardControl.Header>
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <ui:TextBlock Grid.Row="0"
+                                  Grid.Column="0"
+                                  FontTypography="Body"
+                                  Text="主窗口自定义背景"
+                                  TextWrapping="Wrap" />
+                    <ui:TextBlock Grid.Row="1"
+                                  Grid.Column="0"
+                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                  Text="为软件主窗口设置一张自定义背景图片，透明度可调"
+                                  TextWrapping="Wrap" />
+                    <ui:ToggleSwitch Grid.Row="0"
+                                     Grid.RowSpan="2"
+                                     Grid.Column="1"
+                                     Margin="0,0,12,0"
+                                     IsChecked="{Binding Config.CommonConfig.MainBackgroundEnabled, Mode=TwoWay}" />
+                    <ui:Button Grid.Row="0"
+                               Grid.RowSpan="2"
+                               Grid.Column="2"
+                               Margin="0,0,12,0"
+                               Command="{Binding SelectMainBackgroundImageCommand}"
+                               Content="选择图片" />
+                    <ui:Button Grid.Row="0"
+                               Grid.RowSpan="2"
+                               Grid.Column="3"
+                               Margin="0,0,36,0"
+                               Command="{Binding ClearMainBackgroundImageCommand}"
+                               Content="清除" />
+                    <ui:TextBlock Grid.Row="2"
+                                  Grid.Column="0"
+                                  Grid.ColumnSpan="4"
+                                  Margin="0,8,36,4"
+                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                  Text="{Binding Config.CommonConfig.MainBackgroundImagePath, Mode=OneWay, FallbackValue='未设置背景图片'}"
+                                  TextTrimming="CharacterEllipsis"
+                                  ToolTip="{Binding Config.CommonConfig.MainBackgroundImagePath, Mode=OneWay}" />
+                    <TextBlock Grid.Row="3"
+                               Grid.Column="0"
+                               VerticalAlignment="Center"
+                               FontSize="12"
+                               Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                               Text="背景不透明度" />
+                    <Slider Grid.Row="3"
+                            Grid.Column="1"
+                            Grid.ColumnSpan="2"
+                            Width="240"
+                            Margin="0,4,12,0"
+                            VerticalAlignment="Center"
+                            Maximum="1"
+                            Minimum="0.05"
+                            IsSnapToTickEnabled="True"
+                            TickFrequency="0.05"
+                            Value="{Binding Config.CommonConfig.MainBackgroundOpacity, Mode=TwoWay}" />
+                    <TextBlock Grid.Row="4"
+                               Grid.Column="0"
+                               Margin="0,4,0,0"
+                               VerticalAlignment="Center"
+                               FontSize="12"
+                               Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                               Text="拉伸方式" />
+                    <ComboBox Grid.Row="4"
+                              Grid.Column="1"
+                              Width="120"
+                              Margin="0,4,12,0"
+                              VerticalAlignment="Center"
+                              SelectedValue="{Binding Config.CommonConfig.MainBackgroundStretch, Mode=TwoWay}"
+                              SelectedValuePath="Tag">
+                        <ComboBoxItem Content="填充" Tag="Fill" />
+                        <ComboBoxItem Content="等比填充" Tag="UniformToFill" />
+                        <ComboBoxItem Content="等比适应" Tag="Uniform" />
+                        <ComboBoxItem Content="原始尺寸" Tag="None" />
+                    </ComboBox>
+                </Grid>
+            </ui:CardControl.Header>
+        </ui:CardControl>
+
         <ui:CardExpander Margin="0,0,0,12"
                          ContentPadding="0"
                          Icon="{ui:SymbolIcon SquareHintSparkles24}">

--- a/BetterGenshinImpact/View/Pages/CommonSettingsPage.xaml
+++ b/BetterGenshinImpact/View/Pages/CommonSettingsPage.xaml
@@ -7,6 +7,7 @@
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
       xmlns:pages="clr-namespace:BetterGenshinImpact.ViewModel.Pages"
       xmlns:config="clr-namespace:BetterGenshinImpact.Core.Config"
+      xmlns:media="clr-namespace:System.Windows.Media;assembly=PresentationCore"
       xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
       Title="CommonSettingsPage"
       d:DataContext="{d:DesignInstance Type=pages:CommonSettingsPageViewModel}"
@@ -196,10 +197,12 @@
                               VerticalAlignment="Center"
                               SelectedValue="{Binding Config.CommonConfig.MainBackgroundStretch, Mode=TwoWay}"
                               SelectedValuePath="Tag">
-                        <ComboBoxItem Content="填充" Tag="Fill" />
-                        <ComboBoxItem Content="等比填充" Tag="UniformToFill" />
-                        <ComboBoxItem Content="等比适应" Tag="Uniform" />
-                        <ComboBoxItem Content="原始尺寸" Tag="None" />
+                        <!-- Tag 必须是 Stretch 枚举值本身（而非字符串），SelectedValue 按对象相等匹配，
+                             与上方 CrosshairType 选择器写法保持一致，否则配置无法回显 -->
+                        <ComboBoxItem Content="填充" Tag="{x:Static media:Stretch.Fill}" />
+                        <ComboBoxItem Content="等比填充" Tag="{x:Static media:Stretch.UniformToFill}" />
+                        <ComboBoxItem Content="等比适应" Tag="{x:Static media:Stretch.Uniform}" />
+                        <ComboBoxItem Content="原始尺寸" Tag="{x:Static media:Stretch.None}" />
                     </ComboBox>
                 </Grid>
             </ui:CardControl.Header>

--- a/BetterGenshinImpact/View/Windows/ImageEditWindow.xaml
+++ b/BetterGenshinImpact/View/Windows/ImageEditWindow.xaml
@@ -1,0 +1,118 @@
+<ui:FluentWindow x:Class="BetterGenshinImpact.View.Windows.ImageEditWindow"
+                 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                 xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml"
+                 Title="编辑背景图片"
+                 Width="920"
+                 Height="680"
+                 MinWidth="640"
+                 MinHeight="480"
+                 Background="#202020"
+                 ExtendsContentIntoTitleBar="True"
+                 FontFamily="{DynamicResource TextThemeFontFamily}"
+                 WindowBackdropType="Auto"
+                 WindowStartupLocation="CenterOwner"
+                 mc:Ignorable="d">
+    <!--
+      背景图片编辑对话框：
+      - 左右旋转 90°（TransformedBitmap 实现）
+      - 鼠标拖拽绘制/移动/边缘缩放裁剪框（CroppedBitmap 实现）
+      - 三种退出路径：保存并使用（编辑后副本）/ 使用原图 / 取消
+    -->
+    <Grid>
+        <ui:Grid Margin="0,48,0,0" RowDefinitions="Auto,*,Auto">
+            <!-- 工具栏 -->
+            <StackPanel Grid.Row="0"
+                        Margin="16,4,16,8"
+                        HorizontalAlignment="Left"
+                        Orientation="Horizontal">
+                <ui:Button MinWidth="96"
+                           Margin="0,0,8,0"
+                           Click="RotateLeft_Click"
+                           Content="&#8634; 左转 90°"
+                           ToolTip="逆时针旋转 90 度" />
+                <ui:Button MinWidth="96"
+                           Margin="0,0,8,0"
+                           Click="RotateRight_Click"
+                           Content="&#8635; 右转 90°"
+                           ToolTip="顺时针旋转 90 度" />
+                <ui:Button MinWidth="96"
+                           Margin="0,0,16,0"
+                           Click="ResetCrop_Click"
+                           Content="&#9633; 重置裁剪"
+                           ToolTip="清除裁剪区域，保留整张图片" />
+                <ui:TextBlock Name="InfoText"
+                              Margin="8,0,0,0"
+                              VerticalAlignment="Center"
+                              FontSize="12"
+                              Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                              Text="在图片上拖拽可框选裁剪区域；拖动框内移动、贴边缩放" />
+            </StackPanel>
+
+            <!-- 图片预览 + 裁剪框覆盖层 -->
+            <Border Grid.Row="1"
+                    Margin="16,0,16,8"
+                    Background="#141414"
+                    BorderBrush="#3A3A3A"
+                    BorderThickness="1"
+                    ClipToBounds="True">
+                <Grid>
+                    <Image Name="PreviewImage"
+                           HorizontalAlignment="Stretch"
+                           VerticalAlignment="Stretch"
+                           Stretch="Uniform" />
+                    <!-- 透明 Canvas 负责捕获鼠标事件并绘制裁剪矩形 -->
+                    <Canvas Name="CropCanvas"
+                            Background="Transparent"
+                            MouseLeftButtonDown="CropCanvas_MouseLeftButtonDown"
+                            MouseLeftButtonUp="CropCanvas_MouseLeftButtonUp"
+                            MouseMove="CropCanvas_MouseMove"
+                            SizeChanged="CropCanvas_SizeChanged">
+                        <Rectangle Name="CropRect"
+                                   Canvas.Left="0"
+                                   Canvas.Top="0"
+                                   Fill="#224FC3F7"
+                                   IsHitTestVisible="False"
+                                   Stroke="#4FC3F7"
+                                   StrokeDashArray="4 2"
+                                   StrokeThickness="1.5"
+                                   Visibility="Collapsed" />
+                    </Canvas>
+                </Grid>
+            </Border>
+
+            <!-- 底部操作区 -->
+            <Grid Grid.Row="2" Margin="16,0,16,16">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <ui:Button Grid.Column="0"
+                           Width="88"
+                           Click="CancelButton_Click"
+                           Content="取消" />
+                <ui:Button Grid.Column="2"
+                           Margin="0,0,8,0"
+                           Width="110"
+                           Click="UseOriginalButton_Click"
+                           Content="使用原图"
+                           ToolTip="不做任何修改，直接使用选择的图片" />
+                <ui:Button Grid.Column="2"
+                           Margin="0,0,130,0"
+                           Width="120"
+                           Appearance="Primary"
+                           Click="SaveButton_Click"
+                           Content="保存并使用"
+                           ToolTip="应用旋转与裁剪，另存为副本后使用" />
+            </Grid>
+        </ui:Grid>
+        <ui:TitleBar Title="编辑背景图片">
+            <ui:TitleBar.Icon>
+                <ui:ImageIcon Source="pack://application:,,,/Resources/Images/logo.png" />
+            </ui:TitleBar.Icon>
+        </ui:TitleBar>
+    </Grid>
+</ui:FluentWindow>

--- a/BetterGenshinImpact/View/Windows/ImageEditWindow.xaml.cs
+++ b/BetterGenshinImpact/View/Windows/ImageEditWindow.xaml.cs
@@ -1,0 +1,428 @@
+using BetterGenshinImpact.Helpers.Ui;
+using System;
+using System.IO;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+
+namespace BetterGenshinImpact.View.Windows;
+
+/// <summary>
+/// 背景图片编辑对话框：支持 90° 步进旋转与鼠标拖拽裁剪。
+/// 旋转通过 TransformedBitmap 重建位图实现；裁剪框坐标始终以"当前编辑位图的像素坐标"存储，
+/// 避免窗口缩放 / 旋转后坐标错位，保存时直接映射为 Int32Rect 交给 CroppedBitmap。
+/// </summary>
+public partial class ImageEditWindow
+{
+    private readonly string _sourcePath;
+    private BitmapSource _originalImage = null!;
+    private BitmapSource _editImage = null!; // 含旋转效果的当前编辑状态
+    private int _rotation; // 0 / 90 / 180 / 270，已应用到 _editImage
+
+    // 裁剪区域（编辑位图像素坐标），Empty 表示不裁剪
+    private Rect _cropPx = Rect.Empty;
+
+    // 拖拽状态
+    private Point _dragStartPx; // 按下时的像素坐标
+    private Rect _dragOrigPx; // 按下时的裁剪框
+    private DragMode _mode;
+
+    private enum DragMode
+    {
+        None,
+        Create, // 新建选区
+        Move, // 移动选区
+        Resize // 边缘缩放（同时记录激活的边）
+    }
+
+    private enum ResizeEdge
+    {
+        None = 0,
+        Left = 1,
+        Top = 2,
+        Right = 4,
+        Bottom = 8
+    }
+
+    private ResizeEdge _activeEdges;
+
+    /// <summary>编辑结果：最终应写入配置的图片路径；null 表示取消。</summary>
+    public string? ResultImagePath { get; private set; }
+
+    public ImageEditWindow(string imagePath)
+    {
+        _sourcePath = imagePath;
+        InitializeComponent();
+        SourceInitialized += (s, e) => WindowHelper.TryApplySystemBackdrop(this);
+        Loaded += (_, _) => LoadImage();
+    }
+
+    private void LoadImage()
+    {
+        try
+        {
+            var bmp = new BitmapImage();
+            bmp.BeginInit();
+            bmp.CacheOption = BitmapCacheOption.OnLoad; // 立即载入内存，源文件不被锁定，可随时覆盖保存
+            bmp.UriSource = new Uri(_sourcePath);
+            bmp.EndInit();
+            bmp.Freeze();
+            _originalImage = bmp;
+        }
+        catch (Exception e)
+        {
+            ThemedMessageBox.Show($"图片加载失败：{e.Message}", "错误", MessageBoxButton.OK, ThemedMessageBox.MessageBoxIcon.Error);
+            DialogResult = false;
+            return;
+        }
+
+        _editImage = _originalImage;
+        PreviewImage.Source = _editImage;
+        UpdateInfoText();
+    }
+
+    private void UpdateInfoText()
+    {
+        var text = $"{_editImage.PixelWidth} × {_editImage.PixelHeight} px";
+        if (!_cropPx.IsEmpty)
+        {
+            text += $" ｜ 裁剪区域 {(int)_cropPx.Width} × {(int)_cropPx.Height} px";
+        }
+
+        InfoText.Text = text;
+    }
+
+    #region 坐标映射（画布显示坐标 <-> 位图像素坐标）
+
+    /// <summary>Uniform 拉伸下，显示坐标 = 偏移 + 像素 × 缩放。</summary>
+    private (double scale, double offX, double offY) GetViewMapping()
+    {
+        var iw = (double)_editImage.PixelWidth;
+        var ih = (double)_editImage.PixelHeight;
+        var cw = CropCanvas.ActualWidth;
+        var ch = CropCanvas.ActualHeight;
+        if (iw <= 0 || ih <= 0 || cw <= 0 || ch <= 0)
+        {
+            return (1, 0, 0);
+        }
+
+        var s = Math.Min(cw / iw, ch / ih);
+        return (s, (cw - iw * s) / 2, (ch - ih * s) / 2);
+    }
+
+    private Point DisplayToPixel(Point p)
+    {
+        var (s, ox, oy) = GetViewMapping();
+        return new Point((p.X - ox) / s, (p.Y - oy) / s);
+    }
+
+    private Point PixelToDisplay(Point p)
+    {
+        var (s, ox, oy) = GetViewMapping();
+        return new Point(p.X * s + ox, p.Y * s + oy);
+    }
+
+    /// <summary>把像素裁剪框换算为画布上的 Rectangle 位置尺寸。</summary>
+    private void UpdateCropVisual()
+    {
+        if (_cropPx.IsEmpty)
+        {
+            CropRect.Visibility = Visibility.Collapsed;
+        }
+        else
+        {
+            var tl = PixelToDisplay(new Point(_cropPx.X, _cropPx.Y));
+            var br = PixelToDisplay(new Point(_cropPx.X + _cropPx.Width, _cropPx.Y + _cropPx.Height));
+            Canvas.SetLeft(CropRect, Math.Min(tl.X, br.X));
+            Canvas.SetTop(CropRect, Math.Min(tl.Y, br.Y));
+            CropRect.Width = Math.Abs(br.X - tl.X);
+            CropRect.Height = Math.Abs(br.Y - tl.Y);
+            CropRect.Visibility = CropRect.Width > 4 && CropRect.Height > 4
+                ? Visibility.Visible
+                : Visibility.Collapsed;
+        }
+    }
+
+    #endregion
+
+    #region 裁剪框鼠标交互
+
+    private void CropCanvas_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+    {
+        if (_originalImage is not { }) return;
+
+        var mouse = e.GetPosition(CropCanvas);
+        var px = DisplayToPixel(mouse);
+
+        if (_cropPx.IsEmpty)
+        {
+            _mode = DragMode.Create;
+            _dragStartPx = px;
+            _cropPx = new Rect(px, px);
+        }
+        else
+        {
+            _activeEdges = HitTestEdges(px);
+            if (_activeEdges != ResizeEdge.None)
+            {
+                _mode = DragMode.Resize;
+            }
+            else if (RectContains(_cropPx, px))
+            {
+                _mode = DragMode.Move;
+            }
+            else
+            {
+                // 点击框外：重新开一个选区
+                _mode = DragMode.Create;
+                _dragStartPx = px;
+                _cropPx = new Rect(px, px);
+            }
+
+            _dragOrigPx = _cropPx;
+        }
+
+        _dragStartPx = px;
+        CropCanvas.CaptureMouse();
+        UpdateCropVisual();
+        e.Handled = true;
+    }
+
+    private void CropCanvas_MouseMove(object sender, MouseEventArgs e)
+    {
+        if (_mode == DragMode.None || e.LeftButton != MouseButtonState.Pressed)
+        {
+            return;
+        }
+
+        var px = DisplayToPixel(e.GetPosition(CropCanvas));
+        var imgW = (double)_editImage.PixelWidth;
+        var imgH = (double)_editImage.PixelHeight;
+
+        switch (_mode)
+        {
+            case DragMode.Create:
+            {
+                var x1 = Math.Clamp(Math.Min(_dragStartPx.X, px.X), 0, imgW);
+                var y1 = Math.Clamp(Math.Min(_dragStartPx.Y, px.Y), 0, imgH);
+                var x2 = Math.Clamp(Math.Max(_dragStartPx.X, px.X), 0, imgW);
+                var y2 = Math.Clamp(Math.Max(_dragStartPx.Y, px.Y), 0, imgH);
+                _cropPx = new Rect(x1, y1, x2 - x1, y2 - y1);
+                break;
+            }
+            case DragMode.Move:
+            {
+                var dx = px.X - _dragStartPx.X;
+                var dy = px.Y - _dragStartPx.Y;
+                var nx = Math.Clamp(_dragOrigPx.X + dx, 0, imgW - _dragOrigPx.Width);
+                var ny = Math.Clamp(_dragOrigPx.Y + dy, 0, imgH - _dragOrigPx.Height);
+                _cropPx = new Rect(nx, ny, _dragOrigPx.Width, _dragOrigPx.Height);
+                break;
+            }
+            case DragMode.Resize:
+            {
+                var r = _dragOrigPx;
+                var left = r.X;
+                var top = r.Y;
+                var right = r.X + r.Width;
+                var bottom = r.Y + r.Height;
+                if (_activeEdges.HasFlag(ResizeEdge.Left)) left = Math.Clamp(px.X, 0, right - MinPx);
+                if (_activeEdges.HasFlag(ResizeEdge.Top)) top = Math.Clamp(px.Y, 0, bottom - MinPx);
+                if (_activeEdges.HasFlag(ResizeEdge.Right)) right = Math.Clamp(px.X, left + MinPx, imgW);
+                if (_activeEdges.HasFlag(ResizeEdge.Bottom)) bottom = Math.Clamp(px.Y, top + MinPx, imgH);
+                _cropPx = new Rect(left, top, right - left, bottom - top);
+                break;
+            }
+        }
+
+        UpdateCropVisual();
+        UpdateInfoText();
+        e.Handled = true;
+    }
+
+    private void CropCanvas_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+    {
+        if (_mode == DragMode.None)
+        {
+            return;
+        }
+
+        CropCanvas.ReleaseMouseCapture();
+        // 选区太小视为误触，直接清除
+        if (!_cropPx.IsEmpty && (_cropPx.Width < MinPx || _cropPx.Height < MinPx))
+        {
+            _cropPx = Rect.Empty;
+        }
+
+        _mode = DragMode.None;
+        _activeEdges = ResizeEdge.None;
+        UpdateCropVisual();
+        UpdateInfoText();
+        e.Handled = true;
+    }
+
+    private void CropCanvas_SizeChanged(object sender, SizeChangedEventArgs e)
+    {
+        UpdateCropVisual(); // 窗口缩放后按新映射比例重绘裁剪框
+    }
+
+    /// <summary>最小选区（像素），防止拖出 1px 的废框。</summary>
+    private const double MinPx = 8;
+
+    /// <summary>判断点是否命中裁剪框的某条边（容差按显示像素换算为图像像素）。</summary>
+    private ResizeEdge HitTestEdges(Point px)
+    {
+        if (_cropPx.IsEmpty) return ResizeEdge.None;
+
+        var (s, _, _) = GetViewMapping();
+        var tol = Math.Max(4 / s, MinPx / 2); // 4 显示像素的命中容差
+        var r = _cropPx;
+        var edges = ResizeEdge.None;
+        if (Math.Abs(px.X - r.X) <= tol && px.Y >= r.Y - tol && px.Y <= r.Y + r.Height + tol) edges |= ResizeEdge.Left;
+        if (Math.Abs(px.X - (r.X + r.Width)) <= tol && px.Y >= r.Y - tol && px.Y <= r.Y + r.Height + tol) edges |= ResizeEdge.Right;
+        if (Math.Abs(px.Y - r.Y) <= tol && px.X >= r.X - tol && px.X <= r.X + r.Width + tol) edges |= ResizeEdge.Top;
+        if (Math.Abs(px.Y - (r.Y + r.Height)) <= tol && px.X >= r.X - tol && px.X <= r.X + r.Width + tol) edges |= ResizeEdge.Bottom;
+        return edges;
+    }
+
+    private static bool RectContains(Rect r, Point p)
+    {
+        return p.X >= r.X && p.X <= r.X + r.Width && p.Y >= r.Y && p.Y <= r.Y + r.Height;
+    }
+
+    #endregion
+
+    #region 工具栏按钮
+
+    private void RotateLeft_Click(object sender, RoutedEventArgs e) => Rotate(-90);
+
+    private void RotateRight_Click(object sender, RoutedEventArgs e) => Rotate(90);
+
+    private void Rotate(int delta)
+    {
+        if (_originalImage is not { }) return;
+
+        _rotation = ((_rotation + delta) % 360 + 360) % 360;
+        if (_rotation == 0)
+        {
+            _editImage = _originalImage;
+        }
+        else
+        {
+            var tb = new TransformedBitmap(_originalImage, new RotateTransform(_rotation));
+            tb.Freeze();
+            _editImage = tb;
+        }
+
+        PreviewImage.Source = _editImage;
+        _cropPx = Rect.Empty; // 旋转后区域含义变化，重置裁剪更直观
+        UpdateCropVisual();
+        UpdateInfoText();
+    }
+
+    private void ResetCrop_Click(object sender, RoutedEventArgs e)
+    {
+        _cropPx = Rect.Empty;
+        UpdateCropVisual();
+        UpdateInfoText();
+    }
+
+    #endregion
+
+    #region 底部操作按钮
+
+    private void UseOriginalButton_Click(object sender, RoutedEventArgs e)
+    {
+        ResultImagePath = _sourcePath;
+        DialogResult = true;
+    }
+
+    private void CancelButton_Click(object sender, RoutedEventArgs e)
+    {
+        DialogResult = false;
+    }
+
+    private void SaveButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (_originalImage is not { }) return;
+
+        BitmapSource final;
+        if (!_cropPx.IsEmpty && _cropPx.Width >= MinPx && _cropPx.Height >= MinPx)
+        {
+            var rc = new Int32Rect(
+                (int)Math.Floor(_cropPx.X),
+                (int)Math.Floor(_cropPx.Y),
+                (int)Math.Ceiling(_cropPx.Width),
+                (int)Math.Ceiling(_cropPx.Height));
+            // 越界保护
+            rc = new Int32Rect(
+                Math.Clamp(rc.X, 0, _editImage.PixelWidth - 1),
+                Math.Clamp(rc.Y, 0, _editImage.PixelHeight - 1),
+                Math.Min(rc.Width, _editImage.PixelWidth - rc.X),
+                Math.Min(rc.Height, _editImage.PixelHeight - rc.Y));
+            var cb = new CroppedBitmap(_editImage, rc);
+            cb.Freeze();
+            final = cb;
+        }
+        else
+        {
+            final = _editImage;
+        }
+
+        var saved = TrySave(final);
+        if (saved == null)
+        {
+            ThemedMessageBox.Show("编辑结果保存失败，请检查磁盘权限或换一张图片重试。", "错误", MessageBoxButton.OK, ThemedMessageBox.MessageBoxIcon.Error);
+            return;
+        }
+
+        ResultImagePath = saved;
+        DialogResult = true;
+    }
+
+    /// <summary>
+    /// 保存策略：优先存到源文件同目录（用户可见、方便管理）；
+    /// 目录不可写时降级到临时目录。始终另存副本，绝不覆盖用户原图。
+    /// </summary>
+    private string? TrySave(BitmapSource image)
+    {
+        try
+        {
+            var dir = Path.GetDirectoryName(_sourcePath);
+            var baseName = Path.GetFileNameWithoutExtension(_sourcePath);
+            if (!string.IsNullOrEmpty(dir))
+            {
+                var path = Path.Combine(dir, $"{baseName}_bg_edited.png");
+                Encode(image, path);
+                return path;
+            }
+        }
+        catch
+        {
+            // 源目录不可写，走降级路径
+        }
+
+        try
+        {
+            var fallback = Path.Combine(Path.GetTempPath(), $"{Path.GetFileNameWithoutExtension(_sourcePath)}_bg_edited.png");
+            Encode(image, fallback);
+            return fallback;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static void Encode(BitmapSource image, string path)
+    {
+        var encoder = new PngBitmapEncoder();
+        encoder.Frames.Add(BitmapFrame.Create(image));
+        using var fs = new FileStream(path, FileMode.Create, FileAccess.Write);
+        encoder.Save(fs);
+    }
+
+    #endregion
+}

--- a/BetterGenshinImpact/View/Windows/ImageEditWindow.xaml.cs
+++ b/BetterGenshinImpact/View/Windows/ImageEditWindow.xaml.cs
@@ -1,3 +1,4 @@
+using BetterGenshinImpact.Core.Config;
 using BetterGenshinImpact.Helpers.Ui;
 using System;
 using System.IO;
@@ -384,29 +385,36 @@ public partial class ImageEditWindow
 
     /// <summary>
     /// 保存策略：优先存到源文件同目录（用户可见、方便管理）；
-    /// 目录不可写时降级到临时目录。始终另存副本，绝不覆盖用户原图。
+    /// 目录不可写时降级到程序 User\Background 目录（持久化，不会被系统临时清理删除）。
+    /// 文件名带时间戳：重复编辑同一图片时输出路径必然变化，
+    /// 从而保证配置 PropertyChanged 事件触发、主窗口重新加载新结果。
+    /// 始终另存副本，绝不覆盖用户原图。
     /// </summary>
     private string? TrySave(BitmapSource image)
     {
-        try
+        var dir = Path.GetDirectoryName(_sourcePath);
+        var baseName = Path.GetFileNameWithoutExtension(_sourcePath);
+        var fileName = $"{baseName}_bg_{DateTime.Now:yyyyMMddHHmmssfff}.png";
+
+        if (!string.IsNullOrEmpty(dir))
         {
-            var dir = Path.GetDirectoryName(_sourcePath);
-            var baseName = Path.GetFileNameWithoutExtension(_sourcePath);
-            if (!string.IsNullOrEmpty(dir))
+            try
             {
-                var path = Path.Combine(dir, $"{baseName}_bg_edited.png");
+                var path = Path.Combine(dir, fileName);
                 Encode(image, path);
                 return path;
             }
-        }
-        catch
-        {
-            // 源目录不可写，走降级路径
+            catch
+            {
+                // 源目录不可写，走降级路径
+            }
         }
 
         try
         {
-            var fallback = Path.Combine(Path.GetTempPath(), $"{Path.GetFileNameWithoutExtension(_sourcePath)}_bg_edited.png");
+            var fallbackDir = Global.Absolute("User\\Background");
+            Directory.CreateDirectory(fallbackDir);
+            var fallback = Path.Combine(fallbackDir, fileName);
             Encode(image, fallback);
             return fallback;
         }

--- a/BetterGenshinImpact/View/Windows/ImageEditWindow.xaml.cs
+++ b/BetterGenshinImpact/View/Windows/ImageEditWindow.xaml.cs
@@ -70,7 +70,7 @@ public partial class ImageEditWindow
             bmp.UriSource = new Uri(_sourcePath);
             bmp.EndInit();
             bmp.Freeze();
-            _originalImage = bmp;
+            _originalImage = NormalizeDpi(bmp);
         }
         catch (Exception e)
         {
@@ -82,6 +82,29 @@ public partial class ImageEditWindow
         _editImage = _originalImage;
         PreviewImage.Source = _editImage;
         UpdateInfoText();
+    }
+
+    /// <summary>
+    /// 将位图规范化为 96 DPI（像素数据不变，仅重写 DPI 元数据）。
+    /// WPF 的 Image 控件按设备无关尺寸（PixelWidth × 96 / DpiX）布局，
+    /// 若不规范化，非等轴 DPI 图片（如部分扫描件）的显示纵横比会与像素纵横比不一致，
+    /// 导致裁剪框与底图错位、保存结果与用户框选区域不符。
+    /// 规范化后 DIP 尺寸 == 像素尺寸，画布坐标映射逻辑保持简单正确。
+    /// </summary>
+    private static BitmapSource NormalizeDpi(BitmapSource source)
+    {
+        if (Math.Abs(source.DpiX - 96) < 0.5 && Math.Abs(source.DpiY - 96) < 0.5)
+        {
+            return source;
+        }
+
+        var format = source.Format;
+        var stride = (source.PixelWidth * format.BitsPerPixel + 7) / 8;
+        var buffer = new byte[stride * source.PixelHeight];
+        source.CopyPixels(buffer, stride, 0);
+        var normalized = BitmapSource.Create(source.PixelWidth, source.PixelHeight, 96, 96, format, source.Palette, buffer, stride);
+        normalized.Freeze();
+        return normalized;
     }
 
     private void UpdateInfoText()

--- a/BetterGenshinImpact/ViewModel/MainWindowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/MainWindowViewModel.cs
@@ -31,6 +31,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Media;
+using System.Windows.Media.Imaging;
 using BetterGenshinImpact.Helpers.Http;
 using BetterGenshinImpact.Service.ChildSession;
 using BetterGenshinImpact.Service.Instance;
@@ -73,6 +74,16 @@ public partial class MainWindowViewModel : ObservableObject, IViewModel
 
     [ObservableProperty] private bool _isRedeemCodeInfoBarOpen;
 
+    /// <summary>
+    /// 主窗口自定义背景图源，null 表示未加载或加载失败
+    /// </summary>
+    [ObservableProperty] private ImageSource? _mainBackgroundSource;
+
+    /// <summary>
+    /// 主窗口自定义背景图是否可见（开关开启且图片加载成功）
+    /// </summary>
+    [ObservableProperty] private bool _isMainBackgroundVisible;
+
     partial void OnIsRedeemCodeInfoBarOpenChanged(bool value)
     {
         if (!value)
@@ -98,6 +109,51 @@ public partial class MainWindowViewModel : ObservableObject, IViewModel
         _childSessionService = childSessionService;
         Config = _configService.Get();
         _logger = App.GetLogger<MainWindowViewModel>();
+        // 订阅通用配置变更：设置页修改背景图路径或开关后，主窗口背景实时刷新
+        Config.CommonConfig.PropertyChanged += OnCommonConfigPropertyChanged;
+        LoadMainBackground();
+    }
+
+    private void OnCommonConfigPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        // 仅在背景图相关配置变化时重新加载，避免无关配置变更触发图片 IO
+        if (e.PropertyName is nameof(CommonConfig.MainBackgroundImagePath)
+            or nameof(CommonConfig.MainBackgroundEnabled))
+        {
+            LoadMainBackground();
+        }
+    }
+
+    /// <summary>
+    /// 加载主窗口自定义背景图。
+    /// 使用 CacheOption.OnLoad 立即读入内存，不锁定图片文件，方便用户随时替换或删除图片。
+    /// 加载失败（文件被删/格式损坏）时静默降级为隐藏背景，不弹窗打断用户。
+    /// </summary>
+    private void LoadMainBackground()
+    {
+        ImageSource? source = null;
+        var path = Config.CommonConfig.MainBackgroundImagePath;
+        if (Config.CommonConfig.MainBackgroundEnabled && !string.IsNullOrWhiteSpace(path) && File.Exists(path))
+        {
+            try
+            {
+                var bitmap = new BitmapImage();
+                bitmap.BeginInit();
+                bitmap.CacheOption = BitmapCacheOption.OnLoad;
+                bitmap.CreateOptions = BitmapCreateOptions.IgnoreImageCache;
+                bitmap.UriSource = new Uri(path, UriKind.Absolute);
+                bitmap.EndInit();
+                bitmap.Freeze();
+                source = bitmap;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning($"加载主窗口背景图失败：{path}，{ex.Message}");
+            }
+        }
+
+        MainBackgroundSource = source;
+        IsMainBackgroundVisible = source != null;
     }
 
     [RelayCommand]

--- a/BetterGenshinImpact/ViewModel/MainWindowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/MainWindowViewModel.cs
@@ -142,6 +142,11 @@ public partial class MainWindowViewModel : ObservableObject, IViewModel
                 bitmap.CacheOption = BitmapCacheOption.OnLoad;
                 bitmap.CreateOptions = BitmapCreateOptions.IgnoreImageCache;
                 bitmap.UriSource = new Uri(path, UriKind.Absolute);
+                // 以虚拟屏幕（多显示器总范围）宽度为解码上限：
+                // 背景最多铺满屏幕，超过该宽度再高的分辨率也无处可显示，
+                // 限制解码尺寸可避免超大照片同步解码卡 UI 并占用数百 MB 内存；
+                // DecodePixelWidth 不会放大小图（小于该宽度的图片按原始尺寸解码）
+                bitmap.DecodePixelWidth = (int)SystemParameters.VirtualScreenWidth;
                 bitmap.EndInit();
                 bitmap.Freeze();
                 source = bitmap;

--- a/BetterGenshinImpact/ViewModel/Pages/CommonSettingsPageViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/CommonSettingsPageViewModel.cs
@@ -534,7 +534,8 @@ public partial class CommonSettingsPageViewModel : ViewModel
     {
         var dialog = new OpenFileDialog
         {
-            Filter = "图片文件|*.png;*.jpg;*.jpeg;*.bmp;*.gif;*.webp",
+            // 注意：不声明 *.webp —— WPF BitmapImage 原生不支持 WebP 解码，声明了会导致用户选中后加载失败
+            Filter = "图片文件|*.png;*.jpg;*.jpeg;*.bmp;*.gif",
             Title = "选择主窗口背景图片"
         };
         if (dialog.ShowDialog() == true)

--- a/BetterGenshinImpact/ViewModel/Pages/CommonSettingsPageViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/CommonSettingsPageViewModel.cs
@@ -528,6 +528,37 @@ public partial class CommonSettingsPageViewModel : ViewModel
             Config.MaskWindowConfig.CrosshairImagePath = dialog.FileName;
         }
     }
+
+    [RelayCommand]
+    private void SelectMainBackgroundImage()
+    {
+        var dialog = new OpenFileDialog
+        {
+            Filter = "图片文件|*.png;*.jpg;*.jpeg;*.bmp;*.gif;*.webp",
+            Title = "选择主窗口背景图片"
+        };
+        if (dialog.ShowDialog() == true)
+        {
+            // 选图后弹出编辑器：可旋转/裁剪后保存副本使用，也可直接使用原图
+            var editor = new ImageEditWindow(dialog.FileName)
+            {
+                Owner = System.Windows.Application.Current.MainWindow
+            };
+            if (editor.ShowDialog() == true && !string.IsNullOrEmpty(editor.ResultImagePath))
+            {
+                // 主窗口 ViewModel 通过订阅配置变更事件实时刷新背景
+                Config.CommonConfig.MainBackgroundImagePath = editor.ResultImagePath;
+                Config.CommonConfig.MainBackgroundEnabled = true;
+            }
+        }
+    }
+
+    [RelayCommand]
+    private void ClearMainBackgroundImage()
+    {
+        Config.CommonConfig.MainBackgroundImagePath = string.Empty;
+        Config.CommonConfig.MainBackgroundEnabled = false;
+    }
 }
 
 // 只服务于设置页：把遮罩显示开关、样式配置和辅助入口组织成折叠分组。


### PR DESCRIPTION
## 功能说明

为软件新增「主窗口自定义背景」功能，并附带一个轻量级图片编辑对话框。

### 主窗口自定义背景
- 设置页（通用设置）新增「主窗口自定义背景」配置卡片
- 支持启用开关、选择/清除背景图片
- 透明度可调（0.05 - 1.0，步进 0.05）
- 四种拉伸模式：填充 / 等比填充 / 等比适应 / 原始尺寸
- 背景图层置于窗口最底层且不响应鼠标（`IsHitTestVisible=False`），不影响任何交互操作

### 图片编辑对话框（选择图片时）
- 左右旋转 90°
- 鼠标拖拽调整裁剪框：新建 / 移动 / 边缘缩放三种交互模式
- 确认后另存 PNG 副本作为背景，不修改用户原图

## 实现细节

- `CommonConfig` 新增 4 个配置项（开关/路径/透明度/拉伸模式），随现有配置体系自动持久化
- `MainWindowViewModel` 订阅 `CommonConfig.PropertyChanged`，设置页修改后主窗口实时刷新，无需重启软件
- 背景图使用 `BitmapImage.CacheOption.OnLoad` 加载并 `Freeze()`，不锁定图片文件，运行期间可随时替换或删除图片
- 图片加载失败（文件被删/格式损坏）时静默降级为隐藏背景并记录日志，不弹窗打断用户

## 改动范围

| 文件 | 改动 |
|---|---|
| `Core/Config/CommonConfig.cs` | +25 行，新增背景配置字段 |
| `View/MainWindow.xaml` | +11 行，背景图层控件 |
| `ViewModel/MainWindowViewModel.cs` | +56 行，背景加载与实时刷新 |
| `View/Pages/CommonSettingsPage.xaml` | +91 行，设置卡片 UI |
| `ViewModel/Pages/CommonSettingsPageViewModel.cs` | +31 行，选图/清除命令 |
| `View/Windows/ImageEditWindow.xaml` | 新增 118 行 |
| `View/Windows/ImageEditWindow.xaml.cs` | 新增 428 行 |

## 测试

- [x] Release x64 编译通过（.NET 8）
- [x] 选图 → 编辑（旋转/裁剪）→ 应用背景全流程可用
- [x] 透明度滑条、拉伸模式切换实时生效
- [x] 清除背景后恢复默认外观
- [x] 背景图文件在软件运行期间可被替换/删除


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 支持为主窗口设置自定义背景图片。
  - 可调整背景透明度和填充方式，并随时启用、清除或更换背景。
  - 新增图片编辑功能，支持旋转、裁剪、预览及保存使用。
  - 支持自动适配图片显示，加载失败时会自动隐藏背景，提升使用稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->