### PR TITLE
fix(map): guard KnnMatch against empty query descriptors

### DIFF
--- a/BetterGenshinImpact/Core/Recognition/OpenCv/FeatureMatch/Feature2DExtensions.cs
+++ b/BetterGenshinImpact/Core/Recognition/OpenCv/FeatureMatch/Feature2DExtensions.cs
@@ -146,6 +146,12 @@ public static class Feature2DExtensions
         feature2D.DetectAndCompute(queryMat, queryMatMask, out var queryKeyPoints, queryDescriptors);
 #pragma warning restore CS8604 // 引用类型参数可能为 null。
         speedTimer.Record("模板生成KeyPoint");
+        if (queryKeyPoints.Length == 0 || queryDescriptors.Empty())
+        {
+            // 查询图未检测到任何特征点时，空描述子会让 knnMatch 抛出 OpenCVException（type=0），直接按匹配失败处理
+            return new Point2f();
+        }
+
         var matches = GetMatcher(matcherType).KnnMatch(queryDescriptors, trainDescriptors, k: 2);
         speedTimer.Record("FlannMatch");
 
@@ -249,6 +255,12 @@ public static class Feature2DExtensions
         feature2D.DetectAndCompute(queryMat, queryMatMask, out var queryKeyPoints, queryDescriptors);
 #pragma warning restore CS8604 // 引用类型参数可能为 null。
         speedTimer.Record("模板生成KeyPoint");
+        if (queryKeyPoints.Length == 0 || queryDescriptors.Empty())
+        {
+            // 查询图未检测到任何特征点时，空描述子会让 knnMatch 抛出 OpenCVException（type=0），直接按匹配失败处理
+            return [];
+        }
+
         var matches = GetMatcher(matcherType).KnnMatch(queryDescriptors, trainDescriptors, k: 2);
         speedTimer.Record("FlannMatch");
 


### PR DESCRIPTION
## 问题

当 `DetectAndCompute` 在查询图上检测不到任何特征点时（例如大地图 UI 打开/切换过程中截到的退化帧），空的描述子 Mat 会让 `DescriptorMatcher.knnMatch` 抛出：

```
OpenCvSharp.OpenCVException: > type=0
   at OpenCvSharp.Internal.NativeMethods.features2d_DescriptorMatcher_knnMatch1(...)
   at BetterGenshinImpact.Core.Recognition.OpenCv.FeatureMatch.Feature2DExtensions.KnnMatchCorners(...)
   at BetterGenshinImpact.GameTask.MapMask.MapMaskTrigger.ProcessBigMapCompute(...)
```

`MapMaskTrigger` 的 worker 循环把异常记录在 Debug 级别后继续，结果是地图遮罩静默停止更新，用户看不到任何报错（实测单次会话里连续抛出 160+ 次）。

## 修复

在 `KnnMatch` / `KnnMatchCorners` 中，`DetectAndCompute` 之后检查 `queryKeyPoints.Length == 0 || queryDescriptors.Empty()`，为空时按普通匹配失败处理（返回 `new Point2f()` / `[]`），与现有 `goodMatches.Count < 7` 的失败路径行为一致。

`KnnMatchLocal` 已经对训练侧的空描述子做了同样的防护（返回 `default`），本 PR 把查询侧补齐。

## 验证

- 1600x900 意大利语客户端实测：修复后地图遮罩定位正常，日志中不再出现上述异常。
- `dotnet build -c Release` 通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 改进图像特征匹配在输入图像无特征或描述子为空时的处理。
  - 未检测到有效特征时返回安全的默认结果，避免匹配过程发生异常。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->