### PR TITLE
fix(mask): 性能指标遮罩按勾选门控采样

### DIFF
--- a/BetterGenshinImpact/Service/OverlayMetricsService.cs
+++ b/BetterGenshinImpact/Service/OverlayMetricsService.cs
@@ -78,6 +78,14 @@ public sealed class OverlayMetricsService : IDisposable
         TryPublish();
     }
 
+    public void ClearGameFps()
+    {
+        lock (_locker)
+        {
+            _gameFps = null;
+        }
+    }
+
     public void RecordSkippedTick()
     {
         lock (_locker)
@@ -209,8 +217,16 @@ public sealed class OverlayMetricsService : IDisposable
         AddMetric(items, config, OverlayMetricItem.GpuUsage, _gpuUsage, value => $"{value:0}%");
         AddMetric(items, config, OverlayMetricItem.CpuUsage, _cpuUsage, value => $"{value:0}%");
         AddMetric(items, config, OverlayMetricItem.MemoryUsage, _memoryUsage, value => $"{value:0}%");
-        AddMetric(items, config, OverlayMetricItem.BgiMemoryUsage, GetBgiMemoryMb(), value => FormatMemory(value));
-        AddMetric(items, config, OverlayMetricItem.BgiCpuUsage, GetBgiCpuPercent(), value => $"{value:F1}%");
+        // BGI 自身占用是进程级查询，与硬件指标一致：仅在对应指标启用时才执行采样，避免空转。
+        if (config.IsOverlayMetricEnabled(OverlayMetricItem.BgiMemoryUsage))
+        {
+            AddMetric(items, config, OverlayMetricItem.BgiMemoryUsage, GetBgiMemoryMb(), value => FormatMemory(value));
+        }
+
+        if (config.IsOverlayMetricEnabled(OverlayMetricItem.BgiCpuUsage))
+        {
+            AddMetric(items, config, OverlayMetricItem.BgiCpuUsage, GetBgiCpuPercent(), value => $"{value:F1}%");
+        }
 
         return items.Count == 0 ? OverlayMetricsSnapshot.Empty : new OverlayMetricsSnapshot(items);
     }

--- a/BetterGenshinImpact/Service/OverlayMetricsService.cs
+++ b/BetterGenshinImpact/Service/OverlayMetricsService.cs
@@ -80,6 +80,7 @@ public sealed class OverlayMetricsService : IDisposable
 
     public void ClearGameFps()
     {
+        // 仅清缓存值不主动发布：调用方停止帧率采样后会 Refresh(force) 统一发布，避免双发。
         lock (_locker)
         {
             _gameFps = null;
@@ -217,16 +218,8 @@ public sealed class OverlayMetricsService : IDisposable
         AddMetric(items, config, OverlayMetricItem.GpuUsage, _gpuUsage, value => $"{value:0}%");
         AddMetric(items, config, OverlayMetricItem.CpuUsage, _cpuUsage, value => $"{value:0}%");
         AddMetric(items, config, OverlayMetricItem.MemoryUsage, _memoryUsage, value => $"{value:0}%");
-        // BGI 自身占用是进程级查询，与硬件指标一致：仅在对应指标启用时才执行采样，避免空转。
-        if (config.IsOverlayMetricEnabled(OverlayMetricItem.BgiMemoryUsage))
-        {
-            AddMetric(items, config, OverlayMetricItem.BgiMemoryUsage, GetBgiMemoryMb(), value => FormatMemory(value));
-        }
-
-        if (config.IsOverlayMetricEnabled(OverlayMetricItem.BgiCpuUsage))
-        {
-            AddMetric(items, config, OverlayMetricItem.BgiCpuUsage, GetBgiCpuPercent(), value => $"{value:F1}%");
-        }
+        AddMetric(items, config, OverlayMetricItem.BgiMemoryUsage, GetBgiMemoryMb, FormatMemory);
+        AddMetric(items, config, OverlayMetricItem.BgiCpuUsage, GetBgiCpuPercent, value => $"{value:F1}%");
 
         return items.Count == 0 ? OverlayMetricsSnapshot.Empty : new OverlayMetricsSnapshot(items);
     }
@@ -240,6 +233,17 @@ public sealed class OverlayMetricsService : IDisposable
         }
 
         items.Add(new OverlayMetricDisplayItem(OverlayMetricItemDefaults.GetDisplayName(item), formatter(value.Value)));
+    }
+
+    // 进程级查询等昂贵采样必须走本惰性重载：未勾选对应指标时不执行取值，与硬件指标的门控语义保持一致。
+    private static void AddMetric(List<OverlayMetricDisplayItem> items, MaskWindowConfig config, OverlayMetricItem item, Func<double?> valueProvider, Func<double, string> formatter)
+    {
+        if (!config.IsOverlayMetricEnabled(item))
+        {
+            return;
+        }
+
+        AddMetric(items, config, item, valueProvider(), formatter);
     }
 
     private void RecordPeakProcessingCost(double processingCostMs, DateTime now)

--- a/BetterGenshinImpact/ViewModel/MaskWindowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/MaskWindowViewModel.cs
@@ -150,6 +150,7 @@ namespace BetterGenshinImpact.ViewModel
         private bool _isRestoringMapMaskState;
         private bool _metricsSubscribed;
         private bool _fpsStarted;
+        private CancellationTokenSource? _fpsCts;
 
         public MaskWindowViewModel()
         {
@@ -434,24 +435,72 @@ namespace BetterGenshinImpact.ViewModel
             }
 
             if (Config?.MaskWindowConfig.ShowOverlayMetrics == true
-                && Config.MaskWindowConfig.IsOverlayMetricEnabled(OverlayMetricItem.GameFps) == true
-                && !_fpsStarted)
+                && Config.MaskWindowConfig.IsOverlayMetricEnabled(OverlayMetricItem.GameFps) == true)
             {
-                // FPS 由 PresentMon 长任务持续采样，只有用户勾选游戏帧率时才启动一次，避免无意义后台采样。
-                _fpsStarted = true;
-                nint targetHWnd = TaskContext.Instance().GameHandle;
-                _ = User32.GetWindowThreadProcessId(targetHWnd, out var pid);
-                Task.Run(async () =>
-                {
-                    await FpsInspector.StartForeverAsync(new FpsRequest(pid), result =>
-                    {
-                        Fps = $"{result.Fps:0}";
-                        _overlayMetricsService?.UpdateGameFps(result.Fps);
-                    });
-                });
+                StartGameFpsSampling();
+            }
+            else
+            {
+                StopGameFpsSampling();
             }
 
             _overlayMetricsService?.Refresh();
+        }
+
+        private void StartGameFpsSampling()
+        {
+            if (_fpsStarted)
+            {
+                return;
+            }
+
+            // FPS 由 PresentMon 长任务持续采样，只有用户勾选游戏帧率时才启动一次，避免无意义后台采样。
+            _fpsStarted = true;
+            nint targetHWnd = TaskContext.Instance().GameHandle;
+            _ = User32.GetWindowThreadProcessId(targetHWnd, out var pid);
+            _fpsCts = new CancellationTokenSource();
+            var token = _fpsCts.Token;
+            Task.Run(async () =>
+            {
+                try
+                {
+                    await FpsInspector.StartForeverAsync(new FpsRequest(pid), result =>
+                    {
+                        if (token.IsCancellationRequested)
+                        {
+                            return;
+                        }
+
+                        Fps = $"{result.Fps:0}";
+                        _overlayMetricsService?.UpdateGameFps(result.Fps);
+                    }, token);
+                }
+                catch (OperationCanceledException)
+                {
+                    // 用户取消勾选游戏帧率指标后正常退出采样循环
+                }
+            });
+        }
+
+        private void StopGameFpsSampling()
+        {
+            if (!_fpsStarted)
+            {
+                return;
+            }
+
+            _fpsStarted = false;
+            var cts = _fpsCts;
+            _fpsCts = null;
+            if (cts != null)
+            {
+                cts.Cancel();
+                cts.Dispose();
+            }
+
+            Fps = "0";
+            // 立即清掉服务端缓存的帧率值，避免遮罩残留最后一次读数
+            _overlayMetricsService?.ClearGameFps();
         }
 
         private void OverlayMetricsServiceOnMetricsUpdated(object? sender, OverlayMetricsSnapshot snapshot)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **功能改进**
  * 优化游戏 FPS 指标的采样管理：启用时自动采集，禁用时停止采集并清除旧数据。
  * FPS 显示在停止采样后会及时重置，避免展示过期数值。
* **性能优化**
  * 仅在启用相关指标时查询内存和 CPU 数据，减少不必要的系统资源占用。
  * 改进指标数据更新流程，提升覆盖层指标显示的稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->