### PR TITLE
feat(onedragon): 增加一条龙结束后的汇总通知

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoFight/Assets/Recognition.json
+++ b/BetterGenshinImpact/GameTask/AutoFight/Assets/Recognition.json
@@ -1,5 +1,11 @@
 {
   "objects": {
+    "CondensedResinTopIcon": {
+      "type": "TemplateMatch",
+      "template": "condensed_resin_top_icon.png",
+      "threshold": 0.8,
+      "draw": false
+    },
     "OneP": {
       "type": "TemplateMatch",
       "template": "1p.png",

--- a/BetterGenshinImpact/GameTask/Common/Job/CheckRewardsTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/CheckRewardsTask.cs
@@ -126,12 +126,22 @@ public class CheckRewardsTask
             await new TpTask(ct).OpenBigMapUi();
             await Delay(300, ct);
             using var capture = CaptureToRectArea();
-            var resin = ResinRecognition.RecognizeInBigMapTopBar(capture, out var iconRect);
+            var resin = ResinRecognition.RecognizeInBigMapTopBar(capture);
             if (resin != null)
             {
-                resinOk = true;
-                resinText = $"原粹树脂 {resin.Value.Current}/{resin.Value.Max}";
-                resinStrip = capture.DeriveCrop(BuildResinStripRect(iconRect, assetScale)).SrcMat.Clone();
+                var result = resin.Value;
+                resinOk = result.Condensed.HasValue;
+                var condensedText = result.Condensed is int condensed
+                    ? $"浓缩树脂 {condensed}"
+                    : "浓缩树脂识别失败";
+                resinText = $"原粹树脂 {result.Current}/{result.Max}；{condensedText}";
+                using var resinStripRegion = capture.DeriveCrop(BuildResinStripRect(
+                    result.OriginalIconRect, result.CondensedIconRect, assetScale));
+                resinStrip = resinStripRegion.SrcMat.Clone();
+                if (!result.Condensed.HasValue)
+                {
+                    Logger.LogWarning("汇总通知：大地图浓缩树脂识别失败");
+                }
             }
             else
             {
@@ -233,14 +243,22 @@ public class CheckRewardsTask
     }
 
     /// <summary>
-    /// 以树脂图标为锚点向左覆盖"原粹树脂"标签、向右覆盖数字区域，构造截图条矩形。
+    /// 以两种树脂图标为锚点，构造覆盖浓缩树脂与原粹树脂的截图条矩形。
     /// </summary>
-    private static Rect BuildResinStripRect(Rect iconRect, double assetScale)
+    private static Rect BuildResinStripRect(Rect originalIconRect, Rect? condensedIconRect, double assetScale)
     {
-        var left = Math.Max(0, iconRect.Left - (int)(160 * assetScale));
-        var top = Math.Max(0, iconRect.Top - (int)(15 * assetScale));
-        var right = iconRect.Right + (int)(150 * assetScale);
-        var bottom = iconRect.Bottom + (int)(15 * assetScale);
+        var left = condensedIconRect is Rect condensed
+            ? Math.Max(0, condensed.Left - (int)(25 * assetScale))
+            : Math.Max(0, originalIconRect.Left - (int)(200 * assetScale));
+        var topIcon = condensedIconRect is Rect topCondensed
+            ? Math.Min(originalIconRect.Top, topCondensed.Top)
+            : originalIconRect.Top;
+        var bottomIcon = condensedIconRect is Rect bottomCondensed
+            ? Math.Max(originalIconRect.Bottom, bottomCondensed.Bottom)
+            : originalIconRect.Bottom;
+        var top = Math.Max(0, topIcon - (int)(15 * assetScale));
+        var right = originalIconRect.Right + (int)(150 * assetScale);
+        var bottom = bottomIcon + (int)(15 * assetScale);
         return new Rect(left, top, right - left, bottom - top);
     }
 

--- a/BetterGenshinImpact/GameTask/Common/Job/CheckRewardsTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/CheckRewardsTask.cs
@@ -134,9 +134,17 @@ public class CheckRewardsTask
                 var condensedText = result.Condensed is int condensed
                     ? $"浓缩树脂 {condensed}"
                     : "浓缩树脂识别失败";
-                resinText = $"原粹树脂 {result.Current}/{result.Max}；{condensedText}";
+                resinText = $"{condensedText}；原粹树脂 {result.Current}/{result.Max}";
+                using var mapCloseButton = capture.Find(RecognitionAssets.Get(
+                    "QuickTeleport", "MapCloseButton", capture));
+                if (mapCloseButton.IsEmpty())
+                {
+                    Logger.LogWarning("汇总通知：大地图关闭按钮识别失败，树脂截图使用默认右边界");
+                }
+
                 using var resinStripRegion = capture.DeriveCrop(BuildResinStripRect(
-                    result.OriginalIconRect, result.CondensedIconRect, assetScale));
+                    result.OriginalIconRect, result.CondensedIconRect,
+                    mapCloseButton.IsEmpty() ? null : mapCloseButton.Left, assetScale));
                 resinStrip = resinStripRegion.SrcMat.Clone();
                 if (!result.Condensed.HasValue)
                 {
@@ -191,8 +199,8 @@ public class CheckRewardsTask
 
                 using var handbookCapture = CaptureToRectArea();
                 commissionStrip = handbookCapture.DeriveCrop(new Rect(
-                    (int)(10 * assetScale), (int)(100 * assetScale),
-                    (int)(400 * assetScale), (int)(850 * assetScale))).SrcMat.Clone();
+                    (int)(366 * assetScale), (int)(161 * assetScale),
+                    (int)(1260 * assetScale), (int)(749 * assetScale))).SrcMat.Clone();
             }
         }
         catch (Exception e)
@@ -245,7 +253,8 @@ public class CheckRewardsTask
     /// <summary>
     /// 以两种树脂图标为锚点，构造覆盖浓缩树脂与原粹树脂的截图条矩形。
     /// </summary>
-    private static Rect BuildResinStripRect(Rect originalIconRect, Rect? condensedIconRect, double assetScale)
+    private static Rect BuildResinStripRect(
+        Rect originalIconRect, Rect? condensedIconRect, int? mapCloseButtonLeft, double assetScale)
     {
         var left = condensedIconRect is Rect condensed
             ? Math.Max(0, condensed.Left - (int)(25 * assetScale))
@@ -257,7 +266,9 @@ public class CheckRewardsTask
             ? Math.Max(originalIconRect.Bottom, bottomCondensed.Bottom)
             : originalIconRect.Bottom;
         var top = Math.Max(0, topIcon - (int)(15 * assetScale));
-        var right = originalIconRect.Right + (int)(150 * assetScale);
+        var right = mapCloseButtonLeft is int closeButtonLeft
+            ? closeButtonLeft - (int)(10 * assetScale)
+            : originalIconRect.Right + (int)(165 * assetScale);
         var bottom = bottomIcon + (int)(15 * assetScale);
         return new Rect(left, top, right - left, bottom - top);
     }

--- a/BetterGenshinImpact/GameTask/Common/Job/CheckRewardsTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/CheckRewardsTask.cs
@@ -117,141 +117,144 @@ public class CheckRewardsTask
     private async Task StartSummaryAsync(CancellationToken ct)
     {
         var assetScale = TaskContext.Instance().SystemInfo.AssetScale;
-
-        // 体力：打开大地图识别顶栏原粹树脂并截取图标+数字条
-        var resinOk = false;
-        var resinText = "体力识别失败";
         Mat? resinStrip = null;
-        try
-        {
-            await new TpTask(ct).OpenBigMapUi();
-            await Delay(300, ct);
-            using var capture = CaptureToRectArea();
-            var resin = ResinRecognition.RecognizeInBigMapTopBar(capture);
-            if (resin != null)
-            {
-                var result = resin.Value;
-                // 浓缩树脂为零时游戏顶栏不显示图标（图标缺失即视为 0）；
-                // 只有图标已匹配但数量 OCR 失败才算识别失败
-                resinOk = result.Condensed.HasValue || result.CondensedIconRect == null;
-                var condensedText = result.Condensed is int condensed
-                    ? $"浓缩树脂 {condensed}"
-                    : result.CondensedIconRect == null
-                        ? "浓缩树脂 0"
-                        : "浓缩树脂识别失败";
-                resinText = $"{condensedText}；原粹树脂 {result.Current}/{result.Max}";
-                using var mapCloseButton = capture.Find(RecognitionAssets.Get(
-                    "QuickTeleport", "MapCloseButton", capture));
-                if (mapCloseButton.IsEmpty())
-                {
-                    Logger.LogWarning("汇总通知：大地图关闭按钮识别失败，树脂截图使用默认右边界");
-                }
-
-                using var resinStripRegion = capture.DeriveCrop(BuildResinStripRect(
-                    result.OriginalIconRect, result.CondensedIconRect,
-                    mapCloseButton.IsEmpty() ? null : mapCloseButton.Left, assetScale));
-                resinStrip = resinStripRegion.SrcMat.Clone();
-                if (!result.Condensed.HasValue && result.CondensedIconRect != null)
-                {
-                    Logger.LogWarning("汇总通知：大地图浓缩树脂数量 OCR 失败");
-                }
-            }
-            else
-            {
-                Logger.LogWarning("汇总通知：大地图原粹树脂识别失败");
-            }
-        }
-        catch (Exception e) when (e is not NormalEndException and not OperationCanceledException)
-        {
-            Logger.LogDebug(e, "汇总通知：读取体力异常");
-            Logger.LogWarning("汇总通知：读取体力失败: {Msg}", e.Message);
-        }
-        finally
-        {
-            await SafeReturnMainUiAsync(ct);
-        }
-
-        // 委托：打开冒险之证委托页识别奖励领取状态并截取左侧页签+奖励区域
-        bool? commissionClaimed = null;
-        var commissionText = "委托状态识别失败";
         Mat? commissionStrip = null;
         try
         {
-            await new ReturnMainUiTask().Start(ct);
-            await Delay(200, ct);
-
-            var opened = await NewRetry.WaitForElementAppear(
-                GetConfirmRa(true, "每日委托奖励"),
-                () =>
-                {
-                    Simulation.SendInput.SimulateAction(GIActions.OpenAdventurerHandbook);
-                    using var screen = CaptureToRectArea();
-                    var ra = screen.FindMulti(GetConfirmRa())
-                        .FirstOrDefault(btn => btn.Text == "委托");
-                    ra?.Click();
-                }, ct, 4, 1000);
-
-            if (!opened)
+            // 体力：打开大地图识别顶栏原粹树脂并截取图标+数字条
+            var resinOk = false;
+            var resinText = "体力识别失败";
+            try
             {
-                Logger.LogWarning("汇总通知：打开冒险之证委托页失败");
+                await new TpTask(ct).OpenBigMapUi();
+                await Delay(300, ct);
+                using var capture = CaptureToRectArea();
+                var resin = ResinRecognition.RecognizeInBigMapTopBar(capture);
+                if (resin != null)
+                {
+                    var result = resin.Value;
+                    // 浓缩树脂为零时游戏顶栏不显示图标（图标缺失即视为 0）；
+                    // 只有图标已匹配但数量 OCR 失败才算识别失败
+                    resinOk = result.Condensed.HasValue || result.CondensedIconRect == null;
+                    var condensedText = result.Condensed is int condensed
+                        ? $"浓缩树脂 {condensed}"
+                        : result.CondensedIconRect == null
+                            ? "浓缩树脂 0"
+                            : "浓缩树脂识别失败";
+                    resinText = $"{condensedText}；原粹树脂 {result.Current}/{result.Max}";
+                    using var mapCloseButton = capture.Find(RecognitionAssets.Get(
+                        "QuickTeleport", "MapCloseButton", capture));
+                    if (mapCloseButton.IsEmpty())
+                    {
+                        Logger.LogWarning("汇总通知：大地图关闭按钮识别失败，树脂截图使用默认右边界");
+                    }
+
+                    using var resinStripRegion = capture.DeriveCrop(BuildResinStripRect(
+                        result.OriginalIconRect, result.CondensedIconRect,
+                        mapCloseButton.IsEmpty() ? null : mapCloseButton.Left, assetScale));
+                    resinStrip = resinStripRegion.SrcMat.Clone();
+                    if (!result.Condensed.HasValue && result.CondensedIconRect != null)
+                    {
+                        Logger.LogWarning("汇总通知：大地图浓缩树脂数量 OCR 失败");
+                    }
+                }
+                else
+                {
+                    Logger.LogWarning("汇总通知：大地图原粹树脂识别失败");
+                }
+            }
+            catch (Exception e) when (e is not NormalEndException and not OperationCanceledException)
+            {
+                Logger.LogDebug(e, "汇总通知：读取体力异常");
+                Logger.LogWarning("汇总通知：读取体力失败: {Msg}", e.Message);
+            }
+            finally
+            {
+                await SafeReturnMainUiAsync(ct);
+            }
+
+            // 委托：打开冒险之证委托页识别奖励领取状态并截取左侧页签+奖励区域
+            bool? commissionClaimed = null;
+            var commissionText = "委托状态识别失败";
+            try
+            {
+                await new ReturnMainUiTask().Start(ct);
+                await Delay(200, ct);
+
+                var opened = await NewRetry.WaitForElementAppear(
+                    GetConfirmRa(true, "每日委托奖励"),
+                    () =>
+                    {
+                        Simulation.SendInput.SimulateAction(GIActions.OpenAdventurerHandbook);
+                        using var screen = CaptureToRectArea();
+                        var ra = screen.FindMulti(GetConfirmRa())
+                            .FirstOrDefault(btn => btn.Text == "委托");
+                        ra?.Click();
+                    }, ct, 4, 1000);
+
+                if (!opened)
+                {
+                    Logger.LogWarning("汇总通知：打开冒险之证委托页失败");
+                }
+                else
+                {
+                    commissionClaimed = await NewRetry.WaitForElementAppear(
+                        GetConfirmRa(true, _dailyRewardsClaimedLocalizedString), null,
+                        ct, 4, 500);
+                    commissionText = commissionClaimed == true ? "每日委托奖励：已领取" : "每日委托奖励：未领取";
+
+                    using var handbookCapture = CaptureToRectArea();
+                    using var commissionStripRegion = handbookCapture.DeriveCrop(new Rect(
+                        (int)(366 * assetScale), (int)(161 * assetScale),
+                        (int)(1260 * assetScale), (int)(749 * assetScale)));
+                    commissionStrip = commissionStripRegion.SrcMat.Clone();
+                }
+            }
+            catch (Exception e) when (e is not NormalEndException and not OperationCanceledException)
+            {
+                Logger.LogDebug(e, "汇总通知：读取委托状态异常");
+                Logger.LogWarning("汇总通知：读取委托状态失败: {Msg}", e.Message);
+            }
+            finally
+            {
+                await SafeReturnMainUiAsync(ct);
+            }
+
+            // 拼接两块截图：上下排列、等宽白底补齐、中间灰色分隔线
+            Image<Rgb24>? stitched = null;
+            try
+            {
+                stitched = StitchStrips(resinStrip, commissionStrip);
+            }
+            catch (Exception e)
+            {
+                Logger.LogDebug(e, "汇总通知：拼接截图异常");
+                Logger.LogWarning("汇总通知：拼接截图失败: {Msg}", e.Message);
+            }
+
+            var message = $"{resinText}；{commissionText}";
+            Logger.LogInformation("一条龙结束汇总：{Msg}", message);
+
+            var data = Notify.Event(NotificationEvent.DailyReward);
+            data.Screenshot = stitched;
+            if (!resinOk || commissionClaimed == null)
+            {
+                data.Result = NotificationEventResult.PartialSuccess;
+                data.Send(message);
+            }
+            else if (commissionClaimed == true)
+            {
+                data.Success(message);
             }
             else
             {
-                commissionClaimed = await NewRetry.WaitForElementAppear(
-                    GetConfirmRa(true, _dailyRewardsClaimedLocalizedString), null,
-                    ct, 4, 500);
-                commissionText = commissionClaimed == true ? "每日委托奖励：已领取" : "每日委托奖励：未领取";
-
-                using var handbookCapture = CaptureToRectArea();
-                commissionStrip = handbookCapture.DeriveCrop(new Rect(
-                    (int)(366 * assetScale), (int)(161 * assetScale),
-                    (int)(1260 * assetScale), (int)(749 * assetScale))).SrcMat.Clone();
+                data.Fail(message);
             }
-        }
-        catch (Exception e) when (e is not NormalEndException and not OperationCanceledException)
-        {
-            Logger.LogDebug(e, "汇总通知：读取委托状态异常");
-            Logger.LogWarning("汇总通知：读取委托状态失败: {Msg}", e.Message);
-        }
-        finally
-        {
-            await SafeReturnMainUiAsync(ct);
-        }
-
-        // 拼接两块截图：上下排列、等宽白底补齐、中间灰色分隔线
-        Image<Rgb24>? stitched = null;
-        try
-        {
-            stitched = StitchStrips(resinStrip, commissionStrip);
-        }
-        catch (Exception e)
-        {
-            Logger.LogDebug(e, "汇总通知：拼接截图异常");
-            Logger.LogWarning("汇总通知：拼接截图失败: {Msg}", e.Message);
         }
         finally
         {
             resinStrip?.Dispose();
             commissionStrip?.Dispose();
-        }
-
-        var message = $"{resinText}；{commissionText}";
-        Logger.LogInformation("一条龙结束汇总：{Msg}", message);
-
-        var data = Notify.Event(NotificationEvent.DailyReward);
-        data.Screenshot = stitched;
-        if (!resinOk || commissionClaimed == null)
-        {
-            data.Result = NotificationEventResult.PartialSuccess;
-            data.Send(message);
-        }
-        else if (commissionClaimed == true)
-        {
-            data.Success(message);
-        }
-        else
-        {
-            data.Fail(message);
         }
     }
 

--- a/BetterGenshinImpact/GameTask/Common/Job/CheckRewardsTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/CheckRewardsTask.cs
@@ -7,11 +7,16 @@ using System.Threading.Tasks;
 using BetterGenshinImpact.Core.Recognition;
 using BetterGenshinImpact.Core.Simulator;
 using BetterGenshinImpact.Core.Simulator.Extensions;
+using BetterGenshinImpact.GameTask.AutoTrackPath;
+using BetterGenshinImpact.GameTask.Model.Area;
 using BetterGenshinImpact.Helpers;
 using BetterGenshinImpact.Service.Notification;
 using BetterGenshinImpact.Service.Notification.Model.Enum;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
+using OpenCvSharp;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
 using static BetterGenshinImpact.GameTask.Common.TaskControl;
 
 
@@ -38,7 +43,7 @@ public class CheckRewardsTask
     }
 
     public string Name => "检查奖励并通知的任务";
-    
+
     private static RecognitionObject GetConfirmRa(bool isOcrMatch = false,params string[] targetText)
     {
         using var screenArea = CaptureToRectArea();
@@ -46,8 +51,8 @@ public class CheckRewardsTask
         var y = (int)(screenArea.Height * 0.1);
         var width = (int)(screenArea.Width * 0.3);
         var height = (int)(screenArea.Height * 0.7);
-        
-        return isOcrMatch ? RecognitionObject.OcrMatch(x, y, width, height, targetText) : 
+
+        return isOcrMatch ? RecognitionObject.OcrMatch(x, y, width, height, targetText) :
             RecognitionObject.Ocr(x, y, width, height);
     }
 
@@ -55,40 +60,234 @@ public class CheckRewardsTask
     {
         try
         {
-            await new ReturnMainUiTask().Start(ct);
-            
-            _ = await NewRetry.WaitForElementAppear(
-                GetConfirmRa(true,_dailyCommissionRewardsString),
-                ()=>
-                {
-                    Simulation.SendInput.SimulateAction(GIActions.OpenAdventurerHandbook);
-                    using var screen = CaptureToRectArea();
-                    var ra = screen.FindMulti(GetConfirmRa())
-                        .FirstOrDefault(btn => Regex.IsMatch(btn.Text.Trim(), $"^(?:{_commissionsButtonString})$", RegexOptions.IgnoreCase));
-                        ra?.Click();
-                },ct,4,1000);
-            
-            // OCR识别每日是否完成
-            var done = await NewRetry.WaitForElementAppear(
-                GetConfirmRa(true,_dailyRewardsClaimedLocalizedString),null,
-                ct,4,500);
-            if (done)
+            if (TaskContext.Instance().Config.NotificationConfig.DragonEndSummaryEnabled)
             {
-                Logger.LogInformation("检查每日奖励结果：{Msg}", "今日奖励已领取");
-                Notify.Event(NotificationEvent.DailyReward).Success("检查每日奖励：已领取");
+                await StartSummaryAsync(ct);
             }
             else
             {
-                Logger.LogWarning("检查每日奖励结果：{Msg}，请手动检查！", "未领取");
-                Notify.Event(NotificationEvent.DailyReward).Error("检查到每日奖励未领取，请手动查看！");
+                await StartOriginalAsync(ct);
             }
-            await Delay(200, ct);
-            await new ReturnMainUiTask().Start(ct);
         }
         catch (Exception e)
         {
             Logger.LogDebug(e, "检查奖励并通知的任务异常");
             Logger.LogError("检查奖励并通知的任务异常: {Msg}", e.Message);
+        }
+    }
+
+    private async Task StartOriginalAsync(CancellationToken ct)
+    {
+        await new ReturnMainUiTask().Start(ct);
+
+        _ = await NewRetry.WaitForElementAppear(
+            GetConfirmRa(true,_dailyCommissionRewardsString),
+            ()=>
+            {
+                Simulation.SendInput.SimulateAction(GIActions.OpenAdventurerHandbook);
+                using var screen = CaptureToRectArea();
+                var ra = screen.FindMulti(GetConfirmRa())
+                    .FirstOrDefault(btn => Regex.IsMatch(btn.Text.Trim(), $"^(?:{_commissionsButtonString})$", RegexOptions.IgnoreCase));
+                    ra?.Click();
+            },ct,4,1000);
+
+        // OCR识别每日是否完成
+        var done = await NewRetry.WaitForElementAppear(
+            GetConfirmRa(true,_dailyRewardsClaimedLocalizedString),null,
+            ct,4,500);
+        if (done)
+        {
+            Logger.LogInformation("检查每日奖励结果：{Msg}", "今日奖励已领取");
+            Notify.Event(NotificationEvent.DailyReward).Success("检查每日奖励：已领取");
+        }
+        else
+        {
+            Logger.LogWarning("检查每日奖励结果：{Msg}，请手动检查！", "未领取");
+            Notify.Event(NotificationEvent.DailyReward).Error("检查到每日奖励未领取，请手动查看！");
+        }
+        await Delay(200, ct);
+        await new ReturnMainUiTask().Start(ct);
+    }
+
+    /// <summary>
+    /// 一条龙结束汇总：打开大地图识别原粹树脂、打开冒险之证识别委托奖励领取状态，
+    /// 两块截图上下拼接后随通知发送。任何一步失败只降级文本内容，不中断流程。
+    /// </summary>
+    private async Task StartSummaryAsync(CancellationToken ct)
+    {
+        var assetScale = TaskContext.Instance().SystemInfo.AssetScale;
+
+        // 体力：打开大地图识别顶栏原粹树脂并截取图标+数字条
+        var resinOk = false;
+        var resinText = "体力识别失败";
+        Mat? resinStrip = null;
+        try
+        {
+            await new TpTask(ct).OpenBigMapUi();
+            using var capture = CaptureToRectArea();
+            var resin = ResinRecognition.RecognizeInBigMapTopBar(capture, out var iconRect);
+            if (resin != null)
+            {
+                resinOk = true;
+                resinText = $"原粹树脂 {resin.Value.Current}/{resin.Value.Max}";
+                resinStrip = capture.DeriveCrop(BuildResinStripRect(iconRect, assetScale)).SrcMat.Clone();
+            }
+            else
+            {
+                Logger.LogWarning("汇总通知：大地图原粹树脂识别失败");
+            }
+        }
+        catch (Exception e)
+        {
+            Logger.LogDebug(e, "汇总通知：读取体力异常");
+            Logger.LogWarning("汇总通知：读取体力失败: {Msg}", e.Message);
+        }
+        finally
+        {
+            await SafeReturnMainUiAsync(ct);
+        }
+
+        // 委托：打开冒险之证委托页识别奖励领取状态并截取左侧页签+奖励区域
+        bool? commissionClaimed = null;
+        var commissionText = "委托状态识别失败";
+        Mat? commissionStrip = null;
+        try
+        {
+            await new ReturnMainUiTask().Start(ct);
+            await Delay(200, ct);
+
+            var opened = await NewRetry.WaitForElementAppear(
+                GetConfirmRa(true, "每日委托奖励"),
+                () =>
+                {
+                    Simulation.SendInput.SimulateAction(GIActions.OpenAdventurerHandbook);
+                    using var screen = CaptureToRectArea();
+                    var ra = screen.FindMulti(GetConfirmRa())
+                        .FirstOrDefault(btn => btn.Text == "委托");
+                    ra?.Click();
+                }, ct, 4, 1000);
+
+            if (!opened)
+            {
+                Logger.LogWarning("汇总通知：打开冒险之证委托页失败");
+            }
+            else
+            {
+                commissionClaimed = await NewRetry.WaitForElementAppear(
+                    GetConfirmRa(true, _dailyRewardsClaimedLocalizedString), null,
+                    ct, 4, 500);
+                commissionText = commissionClaimed == true ? "每日委托奖励：已领取" : "每日委托奖励：未领取";
+
+                using var handbookCapture = CaptureToRectArea();
+                commissionStrip = handbookCapture.DeriveCrop(new Rect(
+                    (int)(10 * assetScale), (int)(100 * assetScale),
+                    (int)(400 * assetScale), (int)(850 * assetScale))).SrcMat.Clone();
+            }
+        }
+        catch (Exception e)
+        {
+            Logger.LogDebug(e, "汇总通知：读取委托状态异常");
+            Logger.LogWarning("汇总通知：读取委托状态失败: {Msg}", e.Message);
+        }
+        finally
+        {
+            await SafeReturnMainUiAsync(ct);
+        }
+
+        // 拼接两块截图：上下排列、等宽白底补齐、中间灰色分隔线
+        Image<Rgb24>? stitched = null;
+        try
+        {
+            stitched = StitchStrips(resinStrip, commissionStrip);
+        }
+        catch (Exception e)
+        {
+            Logger.LogDebug(e, "汇总通知：拼接截图异常");
+            Logger.LogWarning("汇总通知：拼接截图失败: {Msg}", e.Message);
+        }
+        finally
+        {
+            resinStrip?.Dispose();
+            commissionStrip?.Dispose();
+        }
+
+        var message = $"{resinText}；{commissionText}";
+        Logger.LogInformation("一条龙结束汇总：{Msg}", message);
+
+        var data = Notify.Event(NotificationEvent.DailyReward);
+        data.Screenshot = stitched;
+        if (!resinOk || commissionClaimed == null)
+        {
+            data.Result = NotificationEventResult.PartialSuccess;
+            data.Send(message);
+        }
+        else if (commissionClaimed == true)
+        {
+            data.Success(message);
+        }
+        else
+        {
+            data.Fail(message);
+        }
+    }
+
+    /// <summary>
+    /// 以树脂图标为锚点向左覆盖"原粹树脂"标签、向右覆盖数字区域，构造截图条矩形。
+    /// </summary>
+    private static Rect BuildResinStripRect(Rect iconRect, double assetScale)
+    {
+        var left = Math.Max(0, iconRect.Left - (int)(160 * assetScale));
+        var top = Math.Max(0, iconRect.Top - (int)(15 * assetScale));
+        var right = iconRect.Right + (int)(150 * assetScale);
+        var bottom = iconRect.Bottom + (int)(15 * assetScale);
+        return new Rect(left, top, right - left, bottom - top);
+    }
+
+    /// <summary>
+    /// 上下拼接两块截图，等宽白底补齐并在中间画灰色分隔线；只有一块时直接返回该块。
+    /// </summary>
+    private static Image<Rgb24>? StitchStrips(Mat? top, Mat? bottom)
+    {
+        if (top == null && bottom == null)
+        {
+            return null;
+        }
+
+        if (top == null || bottom == null)
+        {
+            using var single = (top ?? bottom)!.Clone();
+            using var singleRegion = new ImageRegion(single, 0, 0);
+            return singleRegion.CacheImage.Clone();
+        }
+
+        var width = Math.Max(top.Width, bottom.Width);
+        using var paddedTop = PadWhiteToWidth(top, width);
+        using var paddedBottom = PadWhiteToWidth(bottom, width);
+        Cv2.Line(paddedTop, 0, paddedTop.Rows - 1, paddedTop.Cols - 1, paddedTop.Rows - 1, new Scalar(128, 128, 128), 2);
+        using var result = new Mat();
+        Cv2.VConcat(paddedTop, paddedBottom, result);
+        using var resultRegion = new ImageRegion(result, 0, 0);
+        return resultRegion.CacheImage.Clone();
+    }
+
+    private static Mat PadWhiteToWidth(Mat src, int width)
+    {
+        var left = (width - src.Width) / 2;
+        var right = width - src.Width - left;
+        var padded = new Mat();
+        Cv2.CopyMakeBorder(src, padded, 0, 0, left, right, BorderTypes.Constant, Scalar.White);
+        return padded;
+    }
+
+    private static async Task SafeReturnMainUiAsync(CancellationToken ct)
+    {
+        try
+        {
+            await new ReturnMainUiTask().Start(ct);
+        }
+        catch (Exception e)
+        {
+            Logger.LogDebug(e, "汇总通知：回到主界面失败");
         }
     }
 }

--- a/BetterGenshinImpact/GameTask/Common/Job/CheckRewardsTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/CheckRewardsTask.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using BetterGenshinImpact.Core.Recognition;
 using BetterGenshinImpact.Core.Simulator;
 using BetterGenshinImpact.Core.Simulator.Extensions;
+using BetterGenshinImpact.GameTask.AutoGeniusInvokation.Exception;
 using BetterGenshinImpact.GameTask.AutoTrackPath;
 using BetterGenshinImpact.GameTask.Model.Area;
 using BetterGenshinImpact.Helpers;
@@ -44,13 +45,13 @@ public class CheckRewardsTask
 
     public string Name => "检查奖励并通知的任务";
 
-    private static RecognitionObject GetConfirmRa(bool isOcrMatch = false,params string[] targetText)
+    private static RecognitionObject GetConfirmRa(bool isOcrMatch = false, params string[] targetText)
     {
-        using var screenArea = CaptureToRectArea();
-        var x = (int)(screenArea.Width * 0.1);
-        var y = (int)(screenArea.Height * 0.1);
-        var width = (int)(screenArea.Width * 0.3);
-        var height = (int)(screenArea.Height * 0.7);
+        var captureRect = TaskContext.Instance().SystemInfo.ScaleMax1080PCaptureRect;
+        var x = (int)(captureRect.Width * 0.1);
+        var y = (int)(captureRect.Height * 0.1);
+        var width = (int)(captureRect.Width * 0.3);
+        var height = (int)(captureRect.Height * 0.7);
 
         return isOcrMatch ? RecognitionObject.OcrMatch(x, y, width, height, targetText) :
             RecognitionObject.Ocr(x, y, width, height);
@@ -69,7 +70,7 @@ public class CheckRewardsTask
                 await StartOriginalAsync(ct);
             }
         }
-        catch (Exception e)
+        catch (Exception e) when (e is not NormalEndException and not OperationCanceledException)
         {
             Logger.LogDebug(e, "检查奖励并通知的任务异常");
             Logger.LogError("检查奖励并通知的任务异常: {Msg}", e.Message);
@@ -130,10 +131,14 @@ public class CheckRewardsTask
             if (resin != null)
             {
                 var result = resin.Value;
-                resinOk = result.Condensed.HasValue;
+                // 浓缩树脂为零时游戏顶栏不显示图标（图标缺失即视为 0）；
+                // 只有图标已匹配但数量 OCR 失败才算识别失败
+                resinOk = result.Condensed.HasValue || result.CondensedIconRect == null;
                 var condensedText = result.Condensed is int condensed
                     ? $"浓缩树脂 {condensed}"
-                    : "浓缩树脂识别失败";
+                    : result.CondensedIconRect == null
+                        ? "浓缩树脂 0"
+                        : "浓缩树脂识别失败";
                 resinText = $"{condensedText}；原粹树脂 {result.Current}/{result.Max}";
                 using var mapCloseButton = capture.Find(RecognitionAssets.Get(
                     "QuickTeleport", "MapCloseButton", capture));
@@ -146,9 +151,9 @@ public class CheckRewardsTask
                     result.OriginalIconRect, result.CondensedIconRect,
                     mapCloseButton.IsEmpty() ? null : mapCloseButton.Left, assetScale));
                 resinStrip = resinStripRegion.SrcMat.Clone();
-                if (!result.Condensed.HasValue)
+                if (!result.Condensed.HasValue && result.CondensedIconRect != null)
                 {
-                    Logger.LogWarning("汇总通知：大地图浓缩树脂识别失败");
+                    Logger.LogWarning("汇总通知：大地图浓缩树脂数量 OCR 失败");
                 }
             }
             else
@@ -156,7 +161,7 @@ public class CheckRewardsTask
                 Logger.LogWarning("汇总通知：大地图原粹树脂识别失败");
             }
         }
-        catch (Exception e)
+        catch (Exception e) when (e is not NormalEndException and not OperationCanceledException)
         {
             Logger.LogDebug(e, "汇总通知：读取体力异常");
             Logger.LogWarning("汇总通知：读取体力失败: {Msg}", e.Message);
@@ -203,7 +208,7 @@ public class CheckRewardsTask
                     (int)(1260 * assetScale), (int)(749 * assetScale))).SrcMat.Clone();
             }
         }
-        catch (Exception e)
+        catch (Exception e) when (e is not NormalEndException and not OperationCanceledException)
         {
             Logger.LogDebug(e, "汇总通知：读取委托状态异常");
             Logger.LogWarning("汇总通知：读取委托状态失败: {Msg}", e.Message);
@@ -315,7 +320,7 @@ public class CheckRewardsTask
         {
             await new ReturnMainUiTask().Start(ct);
         }
-        catch (Exception e)
+        catch (Exception e) when (e is not NormalEndException and not OperationCanceledException)
         {
             Logger.LogDebug(e, "汇总通知：回到主界面失败");
         }

--- a/BetterGenshinImpact/GameTask/Common/Job/CheckRewardsTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/CheckRewardsTask.cs
@@ -182,13 +182,13 @@ public class CheckRewardsTask
                 await Delay(200, ct);
 
                 var opened = await NewRetry.WaitForElementAppear(
-                    GetConfirmRa(true, "每日委托奖励"),
+                    GetConfirmRa(true, _dailyCommissionRewardsString),
                     () =>
                     {
                         Simulation.SendInput.SimulateAction(GIActions.OpenAdventurerHandbook);
                         using var screen = CaptureToRectArea();
                         var ra = screen.FindMulti(GetConfirmRa())
-                            .FirstOrDefault(btn => btn.Text == "委托");
+                            .FirstOrDefault(btn => Regex.IsMatch(btn.Text.Trim(), $"^(?:{_commissionsButtonString})$", RegexOptions.IgnoreCase));
                         ra?.Click();
                     }, ct, 4, 1000);
 

--- a/BetterGenshinImpact/GameTask/Common/Job/CheckRewardsTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/CheckRewardsTask.cs
@@ -124,6 +124,7 @@ public class CheckRewardsTask
         try
         {
             await new TpTask(ct).OpenBigMapUi();
+            await Delay(300, ct);
             using var capture = CaptureToRectArea();
             var resin = ResinRecognition.RecognizeInBigMapTopBar(capture, out var iconRect);
             if (resin != null)

--- a/BetterGenshinImpact/GameTask/Common/ResinRecognition.cs
+++ b/BetterGenshinImpact/GameTask/Common/ResinRecognition.cs
@@ -1,10 +1,14 @@
 using System;
 using System.Globalization;
+using System.IO;
 using System.Text.RegularExpressions;
+using BetterGenshinImpact.Core.Config;
 using BetterGenshinImpact.Core.Recognition;
 using BetterGenshinImpact.Core.Recognition.OCR;
+using BetterGenshinImpact.Core.Recognition.OpenCv;
 using BetterGenshinImpact.GameTask.Model.Area;
 using BetterGenshinImpact.Helpers;
+using Microsoft.Extensions.Logging;
 using OpenCvSharp;
 
 namespace BetterGenshinImpact.GameTask.Common;
@@ -24,6 +28,9 @@ public static class ResinRecognition
     public static (int Current, int Max)? RecognizeInBigMapTopBar(ImageRegion capture, out Rect resinIconRect)
     {
         var assetScale = TaskContext.Instance().SystemInfo.AssetScale;
+        var debugPrefix = DateTime.Now.ToString("yyyyMMdd_HHmmss_ffff", CultureInfo.InvariantCulture);
+        SaveDebugImage(capture.SrcMat, $"{debugPrefix}_full.png");
+
         using var iconSearchRegion = capture.DeriveCrop(new Rect(
             (int)(1200 * assetScale), (int)(25 * assetScale),
             (int)(580 * assetScale), (int)(50 * assetScale)));
@@ -43,10 +50,20 @@ public static class ResinRecognition
 
         var countRect = new Rect(
             resinIconRect.Right + (int)(25 * assetScale),
-            (int)(37 * assetScale),
-            (int)(120 * assetScale),
-            (int)(24 * assetScale));
+            (int)(33 * assetScale),
+            (int)(105 * assetScale),
+            (int)(25 * assetScale));
         using var countRegion = capture.DeriveCrop(countRect);
+        SaveDebugImage(countRegion.SrcMat, $"{debugPrefix}_count-raw.png");
+
+        // 根据树脂数字实测 RGB 颜色生成暖灰色文字掩膜，仅用于调试，不参与当前识别流程。
+        // 样本：(236,229,216)、(227,222,216)、(191,191,184)。HSV 范围留出抗锯齿和亮度变化余量。
+        using var textColorMask = OpenCvCommonHelper.InRangeHsv(
+            countRegion.SrcMat,
+            new Scalar(8, 0, 175),
+            new Scalar(38, 40, 255));
+        SaveDebugImage(textColorMask, $"{debugPrefix}_count-text-color-mask.png");
+
         var countText = OcrFactory.Paddle.OcrWithoutDetector(countRegion.SrcMat);
 
         // 顶栏文本为 "当前/上限"，上限固定为三位数(200)；斜杠可能被 OCR 认成 7 或 1，
@@ -65,5 +82,23 @@ public static class ResinRecognition
         }
 
         return (current, max);
+    }
+
+    private static void SaveDebugImage(Mat image, string fileName)
+    {
+        try
+        {
+            var directory = Global.Absolute(@"log\ResinRecognition");
+            Directory.CreateDirectory(directory);
+            var path = Path.Combine(directory, fileName);
+            if (!Cv2.ImWrite(path, image))
+            {
+                TaskControl.Logger.LogWarning("树脂识别调试截图保存失败: {Path}", path);
+            }
+        }
+        catch (Exception e)
+        {
+            TaskControl.Logger.LogDebug(e, "树脂识别调试截图保存异常: {FileName}", fileName);
+        }
     }
 }

--- a/BetterGenshinImpact/GameTask/Common/ResinRecognition.cs
+++ b/BetterGenshinImpact/GameTask/Common/ResinRecognition.cs
@@ -78,7 +78,7 @@ public static class ResinRecognition
         // 因此不校验 current <= max。
         var match = Regex.Match(
             StringUtils.ConvertFullWidthNumToHalfWidth(countText),
-            @"(\d{1,3})\s*[/17]\s*(2\d{2})");
+            @"(\d{1,3})\s*[/17]\s*(200)");
         if (!match.Success)
         {
             return null;

--- a/BetterGenshinImpact/GameTask/Common/ResinRecognition.cs
+++ b/BetterGenshinImpact/GameTask/Common/ResinRecognition.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Globalization;
+using System.Text.RegularExpressions;
+using BetterGenshinImpact.Core.Recognition;
+using BetterGenshinImpact.Core.Recognition.OCR;
+using BetterGenshinImpact.GameTask.Model.Area;
+using BetterGenshinImpact.Helpers;
+using OpenCvSharp;
+
+namespace BetterGenshinImpact.GameTask.Common;
+
+/// <summary>
+/// 大地图顶栏原粹树脂识别。图标模板匹配与 OCR 区域参考 AutoBossTask 的实现。
+/// </summary>
+public static class ResinRecognition
+{
+    /// <summary>
+    /// 在大地图界面顶栏识别原粹树脂当前值与上限。
+    /// 不点击图标，直接解析顶栏 "当前/上限" 文本。
+    /// </summary>
+    /// <param name="capture">大地图界面的截图区域</param>
+    /// <param name="resinIconRect">输出：树脂图标在截图中的矩形（绝对坐标），可用于裁剪截图条；识别失败时为 default</param>
+    /// <returns>(当前值, 上限)；识别失败返回 null</returns>
+    public static (int Current, int Max)? RecognizeInBigMapTopBar(ImageRegion capture, out Rect resinIconRect)
+    {
+        var assetScale = TaskContext.Instance().SystemInfo.AssetScale;
+        using var iconSearchRegion = capture.DeriveCrop(new Rect(
+            (int)(1200 * assetScale), (int)(25 * assetScale),
+            (int)(580 * assetScale), (int)(50 * assetScale)));
+        var captureRect = TaskContext.Instance().SystemInfo.ScaleMax1080PCaptureRect;
+        var iconRa = iconSearchRegion.Find(RecognitionAssets.Get("AutoBoss", "OriginalResinTopIcon", captureRect.Width, captureRect.Height));
+        if (iconRa.IsEmpty())
+        {
+            resinIconRect = default;
+            return null;
+        }
+
+        resinIconRect = new Rect(
+            iconSearchRegion.X + iconRa.Left,
+            iconSearchRegion.Y + iconRa.Top,
+            iconRa.Width,
+            iconRa.Height);
+
+        var countRect = new Rect(
+            resinIconRect.Right + (int)(25 * assetScale),
+            (int)(37 * assetScale),
+            (int)(120 * assetScale),
+            (int)(24 * assetScale));
+        using var countRegion = capture.DeriveCrop(countRect);
+        var countText = OcrFactory.Paddle.OcrWithoutDetector(countRegion.SrcMat);
+
+        // 顶栏文本为 "当前/上限"，上限固定为三位数(200)；斜杠可能被 OCR 认成 7 或 1，
+        // 因此删除全部非数字后按"后三位为上限、其余为当前值"切分
+        var digits = Regex.Replace(StringUtils.ConvertFullWidthNumToHalfWidth(countText), @"\D", "");
+        if (digits.Length < 4)
+        {
+            return null;
+        }
+
+        if (!int.TryParse(digits[..^3], NumberStyles.None, CultureInfo.InvariantCulture, out var current)
+            || !int.TryParse(digits[^3..], NumberStyles.None, CultureInfo.InvariantCulture, out var max)
+            || current < 0 || max <= 0 || current > max)
+        {
+            return null;
+        }
+
+        return (current, max);
+    }
+}

--- a/BetterGenshinImpact/GameTask/Common/ResinRecognition.cs
+++ b/BetterGenshinImpact/GameTask/Common/ResinRecognition.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Globalization;
-using System.IO;
 using System.Text.RegularExpressions;
-using BetterGenshinImpact.Core.Config;
 using BetterGenshinImpact.Core.Recognition;
 using BetterGenshinImpact.Core.Recognition.OCR;
 using BetterGenshinImpact.GameTask.Model.Area;
@@ -42,8 +40,6 @@ public static class ResinRecognition
     public static ResinRecognitionResult? RecognizeInBigMapTopBar(ImageRegion capture)
     {
         var assetScale = TaskContext.Instance().SystemInfo.AssetScale;
-        var debugPrefix = DateTime.Now.ToString("yyyyMMdd_HHmmss_ffff", CultureInfo.InvariantCulture);
-        SaveDebugImage(capture.SrcMat, $"{debugPrefix}_full.png");
 
         using var iconSearchRegion = capture.DeriveCrop(new Rect(
             (int)(1200 * assetScale), (int)(25 * assetScale),
@@ -61,7 +57,7 @@ public static class ResinRecognition
             iconRa.Width,
             iconRa.Height);
         var (condensedResin, condensedIconRect) = RecognizeCondensedResin(
-            capture, resinIconRect, assetScale, debugPrefix);
+            capture, resinIconRect, assetScale);
 
         var countRect = new Rect(
             resinIconRect.Right + (int)(25 * assetScale),
@@ -69,13 +65,11 @@ public static class ResinRecognition
             (int)(105 * assetScale),
             (int)(25 * assetScale));
         using var countRegion = capture.DeriveCrop(countRect);
-        SaveDebugImage(countRegion.SrcMat, $"{debugPrefix}_count-raw.png");
 
         using var threshold = countRegion.CacheGreyMat.Threshold(
             TextThreshold, 255, ThresholdTypes.Binary);
         using var inverted = new Mat();
         Cv2.BitwiseNot(threshold, inverted);
-        SaveDebugImage(inverted, $"{debugPrefix}_count-threshold-inverted.png");
 
         var countText = OcrFactory.Paddle.OcrWithoutDetector(inverted);
 
@@ -101,8 +95,7 @@ public static class ResinRecognition
     private static (int? Count, Rect? IconRect) RecognizeCondensedResin(
         ImageRegion capture,
         Rect originalResinIconRect,
-        double assetScale,
-        string debugPrefix)
+        double assetScale)
     {
         // 复用秘境树脂识别中的相对关系：浓缩树脂图标位于原粹树脂图标左侧约 90～180 像素。
         var desiredLeft = originalResinIconRect.Left - (int)(180 * assetScale);
@@ -118,7 +111,6 @@ public static class ResinRecognition
 
         using var searchRegion = capture.DeriveCrop(new Rect(
             searchLeft, searchTop, searchRight - searchLeft, searchBottom - searchTop));
-        SaveDebugImage(searchRegion.SrcMat, $"{debugPrefix}_condensed-search.png");
 
         var captureRect = TaskContext.Instance().SystemInfo.ScaleMax1080PCaptureRect;
         var iconRa = searchRegion.Find(RecognitionAssets.Get(
@@ -134,10 +126,6 @@ public static class ResinRecognition
             searchRegion.Y + iconRa.Top,
             iconRa.Width,
             iconRa.Height);
-        using (var iconRegion = capture.DeriveCrop(iconRect))
-        {
-            SaveDebugImage(iconRegion.SrcMat, $"{debugPrefix}_condensed-icon.png");
-        }
 
         var countLeft = iconRect.Right + (int)(20 * assetScale);
         var countRight = Math.Min(capture.Width, countLeft + (int)(30 * assetScale));
@@ -149,13 +137,11 @@ public static class ResinRecognition
 
         using var countRegion = capture.DeriveCrop(new Rect(
             countLeft, iconRect.Top, countRight - countLeft, countBottom - iconRect.Top));
-        SaveDebugImage(countRegion.SrcMat, $"{debugPrefix}_condensed-count-raw.png");
 
         using var threshold = countRegion.CacheGreyMat.Threshold(
             TextThreshold, 255, ThresholdTypes.Binary);
         using var inverted = new Mat();
         Cv2.BitwiseNot(threshold, inverted);
-        SaveDebugImage(inverted, $"{debugPrefix}_condensed-count-threshold-inverted.png");
 
         var countText = OcrFactory.Paddle.OcrWithoutDetector(inverted);
         var digits = Regex.Replace(StringUtils.ConvertFullWidthNumToHalfWidth(countText), @"\D", "");
@@ -168,23 +154,5 @@ public static class ResinRecognition
 
         TaskControl.Logger.LogDebug("浓缩树脂数量 OCR：{Text} -> {Count}", countText, count);
         return (count, iconRect);
-    }
-
-    private static void SaveDebugImage(Mat image, string fileName)
-    {
-        try
-        {
-            var directory = Global.Absolute(@"log\ResinRecognition");
-            Directory.CreateDirectory(directory);
-            var path = Path.Combine(directory, fileName);
-            if (!Cv2.ImWrite(path, image))
-            {
-                TaskControl.Logger.LogWarning("树脂识别调试截图保存失败: {Path}", path);
-            }
-        }
-        catch (Exception e)
-        {
-            TaskControl.Logger.LogDebug(e, "树脂识别调试截图保存异常: {FileName}", fileName);
-        }
     }
 }

--- a/BetterGenshinImpact/GameTask/Common/ResinRecognition.cs
+++ b/BetterGenshinImpact/GameTask/Common/ResinRecognition.cs
@@ -5,7 +5,6 @@ using System.Text.RegularExpressions;
 using BetterGenshinImpact.Core.Config;
 using BetterGenshinImpact.Core.Recognition;
 using BetterGenshinImpact.Core.Recognition.OCR;
-using BetterGenshinImpact.Core.Recognition.OpenCv;
 using BetterGenshinImpact.GameTask.Model.Area;
 using BetterGenshinImpact.Helpers;
 using Microsoft.Extensions.Logging;
@@ -14,18 +13,33 @@ using OpenCvSharp;
 namespace BetterGenshinImpact.GameTask.Common;
 
 /// <summary>
-/// 大地图顶栏原粹树脂识别。图标模板匹配与 OCR 区域参考 AutoBossTask 的实现。
+/// 大地图顶栏树脂识别结果。
+/// </summary>
+/// <param name="Current">当前原粹树脂数量</param>
+/// <param name="Max">原粹树脂上限</param>
+/// <param name="Condensed">浓缩树脂数量；图标或数量识别失败时为空</param>
+/// <param name="OriginalIconRect">原粹树脂图标矩形</param>
+/// <param name="CondensedIconRect">浓缩树脂图标矩形；图标未匹配时为空</param>
+public readonly record struct ResinRecognitionResult(
+    int Current,
+    int Max,
+    int? Condensed,
+    Rect OriginalIconRect,
+    Rect? CondensedIconRect);
+
+/// <summary>
+/// 大地图顶栏原粹树脂与浓缩树脂识别。
 /// </summary>
 public static class ResinRecognition
 {
+    private const int TextThreshold = 180;
+
     /// <summary>
-    /// 在大地图界面顶栏识别原粹树脂当前值与上限。
-    /// 不点击图标，直接解析顶栏 "当前/上限" 文本。
+    /// 在大地图界面顶栏识别原粹树脂当前值与上限，并以原粹树脂图标为锚点识别左侧的浓缩树脂数量。
     /// </summary>
     /// <param name="capture">大地图界面的截图区域</param>
-    /// <param name="resinIconRect">输出：树脂图标在截图中的矩形（绝对坐标），可用于裁剪截图条；识别失败时为 default</param>
-    /// <returns>(当前值, 上限)；识别失败返回 null</returns>
-    public static (int Current, int Max)? RecognizeInBigMapTopBar(ImageRegion capture, out Rect resinIconRect)
+    /// <returns>树脂识别结果；原粹树脂识别失败时返回 null</returns>
+    public static ResinRecognitionResult? RecognizeInBigMapTopBar(ImageRegion capture)
     {
         var assetScale = TaskContext.Instance().SystemInfo.AssetScale;
         var debugPrefix = DateTime.Now.ToString("yyyyMMdd_HHmmss_ffff", CultureInfo.InvariantCulture);
@@ -38,15 +52,16 @@ public static class ResinRecognition
         var iconRa = iconSearchRegion.Find(RecognitionAssets.Get("AutoBoss", "OriginalResinTopIcon", captureRect.Width, captureRect.Height));
         if (iconRa.IsEmpty())
         {
-            resinIconRect = default;
             return null;
         }
 
-        resinIconRect = new Rect(
+        var resinIconRect = new Rect(
             iconSearchRegion.X + iconRa.Left,
             iconSearchRegion.Y + iconRa.Top,
             iconRa.Width,
             iconRa.Height);
+        var (condensedResin, condensedIconRect) = RecognizeCondensedResin(
+            capture, resinIconRect, assetScale, debugPrefix);
 
         var countRect = new Rect(
             resinIconRect.Right + (int)(25 * assetScale),
@@ -56,15 +71,13 @@ public static class ResinRecognition
         using var countRegion = capture.DeriveCrop(countRect);
         SaveDebugImage(countRegion.SrcMat, $"{debugPrefix}_count-raw.png");
 
-        // 根据树脂数字实测 RGB 颜色生成暖灰色文字掩膜，仅用于调试，不参与当前识别流程。
-        // 样本：(236,229,216)、(227,222,216)、(191,191,184)。HSV 范围留出抗锯齿和亮度变化余量。
-        using var textColorMask = OpenCvCommonHelper.InRangeHsv(
-            countRegion.SrcMat,
-            new Scalar(8, 0, 175),
-            new Scalar(38, 40, 255));
-        SaveDebugImage(textColorMask, $"{debugPrefix}_count-text-color-mask.png");
+        using var threshold = countRegion.CacheGreyMat.Threshold(
+            TextThreshold, 255, ThresholdTypes.Binary);
+        using var inverted = new Mat();
+        Cv2.BitwiseNot(threshold, inverted);
+        SaveDebugImage(inverted, $"{debugPrefix}_count-threshold-inverted.png");
 
-        var countText = OcrFactory.Paddle.OcrWithoutDetector(countRegion.SrcMat);
+        var countText = OcrFactory.Paddle.OcrWithoutDetector(inverted);
 
         // 顶栏文本为 "当前/上限"，上限固定为三位数(200)；斜杠可能被 OCR 认成 7 或 1，
         // 因此删除全部非数字后按"后三位为上限、其余为当前值"切分
@@ -81,7 +94,80 @@ public static class ResinRecognition
             return null;
         }
 
-        return (current, max);
+        return new ResinRecognitionResult(
+            current, max, condensedResin, resinIconRect, condensedIconRect);
+    }
+
+    private static (int? Count, Rect? IconRect) RecognizeCondensedResin(
+        ImageRegion capture,
+        Rect originalResinIconRect,
+        double assetScale,
+        string debugPrefix)
+    {
+        // 复用秘境树脂识别中的相对关系：浓缩树脂图标位于原粹树脂图标左侧约 90～180 像素。
+        var desiredLeft = originalResinIconRect.Left - (int)(180 * assetScale);
+        var desiredTop = originalResinIconRect.Top - (int)(15 * assetScale);
+        var searchLeft = Math.Max(0, desiredLeft);
+        var searchTop = Math.Max(0, desiredTop);
+        var searchRight = Math.Min(capture.Width, originalResinIconRect.Left - (int)(90 * assetScale));
+        var searchBottom = Math.Min(capture.Height, desiredTop + (int)(50 * assetScale));
+        if (searchRight <= searchLeft || searchBottom <= searchTop)
+        {
+            return (null, null);
+        }
+
+        using var searchRegion = capture.DeriveCrop(new Rect(
+            searchLeft, searchTop, searchRight - searchLeft, searchBottom - searchTop));
+        SaveDebugImage(searchRegion.SrcMat, $"{debugPrefix}_condensed-search.png");
+
+        var captureRect = TaskContext.Instance().SystemInfo.ScaleMax1080PCaptureRect;
+        var iconRa = searchRegion.Find(RecognitionAssets.Get(
+            "AutoFight", "CondensedResinTopIcon", captureRect.Width, captureRect.Height));
+        if (iconRa.IsEmpty())
+        {
+            TaskControl.Logger.LogDebug("大地图顶栏未匹配到浓缩树脂图标");
+            return (null, null);
+        }
+
+        var iconRect = new Rect(
+            searchRegion.X + iconRa.Left,
+            searchRegion.Y + iconRa.Top,
+            iconRa.Width,
+            iconRa.Height);
+        using (var iconRegion = capture.DeriveCrop(iconRect))
+        {
+            SaveDebugImage(iconRegion.SrcMat, $"{debugPrefix}_condensed-icon.png");
+        }
+
+        var countLeft = iconRect.Right + (int)(20 * assetScale);
+        var countRight = Math.Min(capture.Width, countLeft + (int)(30 * assetScale));
+        var countBottom = Math.Min(capture.Height, iconRect.Bottom);
+        if (countRight <= countLeft || countBottom <= iconRect.Top)
+        {
+            return (null, iconRect);
+        }
+
+        using var countRegion = capture.DeriveCrop(new Rect(
+            countLeft, iconRect.Top, countRight - countLeft, countBottom - iconRect.Top));
+        SaveDebugImage(countRegion.SrcMat, $"{debugPrefix}_condensed-count-raw.png");
+
+        using var threshold = countRegion.CacheGreyMat.Threshold(
+            TextThreshold, 255, ThresholdTypes.Binary);
+        using var inverted = new Mat();
+        Cv2.BitwiseNot(threshold, inverted);
+        SaveDebugImage(inverted, $"{debugPrefix}_condensed-count-threshold-inverted.png");
+
+        var countText = OcrFactory.Paddle.OcrWithoutDetector(inverted);
+        var digits = Regex.Replace(StringUtils.ConvertFullWidthNumToHalfWidth(countText), @"\D", "");
+        if (!int.TryParse(digits, NumberStyles.None, CultureInfo.InvariantCulture, out var count)
+            || count is < 0 or > 5)
+        {
+            TaskControl.Logger.LogDebug("浓缩树脂数量 OCR 失败：{Text}", countText);
+            return (null, iconRect);
+        }
+
+        TaskControl.Logger.LogDebug("浓缩树脂数量 OCR：{Text} -> {Count}", countText, count);
+        return (count, iconRect);
     }
 
     private static void SaveDebugImage(Mat image, string fileName)

--- a/BetterGenshinImpact/GameTask/Common/ResinRecognition.cs
+++ b/BetterGenshinImpact/GameTask/Common/ResinRecognition.cs
@@ -73,17 +73,19 @@ public static class ResinRecognition
 
         var countText = OcrFactory.Paddle.OcrWithoutDetector(inverted);
 
-        // 顶栏文本为 "当前/上限"，上限固定为三位数(200)；斜杠可能被 OCR 认成 7 或 1，
-        // 因此删除全部非数字后按"后三位为上限、其余为当前值"切分
-        var digits = Regex.Replace(StringUtils.ConvertFullWidthNumToHalfWidth(countText), @"\D", "");
-        if (digits.Length < 4)
+        // 顶栏文本为 "当前/上限"，上限固定为三位数(200)；斜杠可能被 OCR 认成 1 或 7，
+        // 因此把 /、1、7 都作为分隔符处理。原粹树脂可在使用补充道具后暂时超过上限，
+        // 因此不校验 current <= max。
+        var match = Regex.Match(
+            StringUtils.ConvertFullWidthNumToHalfWidth(countText),
+            @"(\d{1,3})\s*[/17]\s*(2\d{2})");
+        if (!match.Success)
         {
             return null;
         }
 
-        if (!int.TryParse(digits[..^3], NumberStyles.None, CultureInfo.InvariantCulture, out var current)
-            || !int.TryParse(digits[^3..], NumberStyles.None, CultureInfo.InvariantCulture, out var max)
-            || current < 0 || max <= 0 || current > max)
+        if (!int.TryParse(match.Groups[1].Value, NumberStyles.None, CultureInfo.InvariantCulture, out var current)
+            || !int.TryParse(match.Groups[2].Value, NumberStyles.None, CultureInfo.InvariantCulture, out var max))
         {
             return null;
         }

--- a/BetterGenshinImpact/Service/Notification/NotificationConfig.cs
+++ b/BetterGenshinImpact/Service/Notification/NotificationConfig.cs
@@ -107,6 +107,11 @@ public partial class NotificationConfig : ObservableObject
     /// </summary>
     [ObservableProperty] private string _dingdingWebhookUrl = string.Empty;
 
+    /// <summary>
+    ///     一条龙结束后发送汇总通知（体力+委托奖励，附拼接截图）
+    /// </summary>
+    [ObservableProperty] private bool _dragonEndSummaryEnabled = false;
+
     // Email 通知配置
     [ObservableProperty] private bool _emailNotificationEnabled;
 

--- a/BetterGenshinImpact/Service/Notification/NotificationService.cs
+++ b/BetterGenshinImpact/Service/Notification/NotificationService.cs
@@ -533,12 +533,17 @@ public class NotificationService : IHostedService, IDisposable
     {
         if (notificationData == null) throw new ArgumentNullException(nameof(notificationData));
 
-        if (!ShouldSendNotification(notificationData.Event)) return;
+        if (!ShouldSendNotification(notificationData.Event))
+        {
+            // 订阅关闭时同样需要释放调用方传入的截图，避免长期泄漏
+            notificationData.Screenshot?.Dispose();
+            notificationData.Screenshot = null;
+            return;
+        }
 
-        Image<Rgb24>? ownedScreenshot = null;
         try
         {
-            ownedScreenshot = AddScreenshotIfNeeded(notificationData);
+            AddScreenshotIfNeeded(notificationData);
             await _notifierManager.SendNotificationToAllAsync(notificationData);
         }
         catch (Exception ex)
@@ -547,15 +552,9 @@ public class NotificationService : IHostedService, IDisposable
         }
         finally
         {
-            if (ownedScreenshot != null)
-            {
-                if (ReferenceEquals(notificationData.Screenshot, ownedScreenshot))
-                {
-                    notificationData.Screenshot = null;
-                }
-
-                ownedScreenshot.Dispose();
-            }
+            // 无论截图由调用方传入还是此处补充，发送完成后统一释放并清空引用
+            notificationData.Screenshot?.Dispose();
+            notificationData.Screenshot = null;
         }
     }
 
@@ -572,11 +571,11 @@ public class NotificationService : IHostedService, IDisposable
     /// <summary>
     ///     如果需要，为通知添加截图
     /// </summary>
-    private Image<Rgb24>? AddScreenshotIfNeeded(BaseNotificationData notificationData)
+    private void AddScreenshotIfNeeded(BaseNotificationData notificationData)
     {
         if (_notificationConfig?.IncludeScreenShot != true || notificationData.Screenshot != null)
         {
-            return null;
+            return;
         }
 
         try
@@ -585,17 +584,13 @@ public class NotificationService : IHostedService, IDisposable
             if (mat != null)
             {
                 using var imageRegion = new ImageRegion(mat, 0, 0);
-                var screenshot = imageRegion.CacheImage.Clone();
-                notificationData.Screenshot = screenshot;
-                return screenshot;
+                notificationData.Screenshot = imageRegion.CacheImage.Clone();
             }
         }
         catch (Exception ex)
         {
             TaskControl.Logger.LogDebug(ex, "补充通知截图失败");
         }
-
-        return null;
     }
 
     /// <summary>

--- a/BetterGenshinImpact/View/Pages/NotificationSettingsPage.xaml
+++ b/BetterGenshinImpact/View/Pages/NotificationSettingsPage.xaml
@@ -90,6 +90,31 @@
                     <ui:TextBlock Grid.Row="0"
                                   Grid.Column="0"
                                   FontTypography="Body"
+                                  Text="一条龙结束发送汇总通知"
+                                  TextWrapping="Wrap" />
+                    <ui:TextBlock Grid.Row="1"
+                                  Grid.Column="0"
+                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                  Text="结束时打开地图与冒险之证，推送体力与每日委托奖励汇总及截图"
+                                  TextWrapping="Wrap" />
+                    <ui:ToggleSwitch Grid.Row="0"
+                                     Grid.RowSpan="2"
+                                     Grid.Column="1"
+                                     Margin="0,0,36,0"
+                                     IsChecked="{Binding Config.NotificationConfig.DragonEndSummaryEnabled, Mode=TwoWay}" />
+                </Grid>
+                <Grid Margin="16">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <ui:TextBlock Grid.Row="0"
+                                  Grid.Column="0"
+                                  FontTypography="Body"
                                   Text="{i18n:T 是否允许 JS 通知}"
                                   TextWrapping="Wrap" />
                     <ui:TextBlock Grid.Row="1"


### PR DESCRIPTION
相关: #3155
只增加了该issue里面提到的“将委托完成情况，体力情况关键性信息文字+截图一起发送”，没有做合并通知。
增加的设置项:
<img width="456" height="309" alt="image" src="https://github.com/user-attachments/assets/12d20be7-af70-43d9-85b2-2782de9c84b3" />
现在的效果/关闭该选项的效果:
<img width="380" height="40" alt="image" src="https://github.com/user-attachments/assets/2b2c587c-daef-4145-991a-8936ec20a0fb" />
关闭该选项 同时打开 通知中包含截图的效果:
<img width="549" height="340" alt="image" src="https://github.com/user-attachments/assets/025640cf-8c6c-4096-a6cd-c9b1ea1c250a" />
打开该选项的效果:
<img width="546" height="380" alt="image" src="https://github.com/user-attachments/assets/18567783-12e3-4292-995b-273d34d0a905" />
树脂部分截图的左右边界都通过模板匹配来确认。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增识别大地图顶部原粹树脂与浓缩树脂数量的能力。
  * 可在一条龙结束时发送包含体力、每日委托奖励及截图的汇总通知。
  * 新增通知设置项，可开启或关闭一条龙结束汇总通知，默认关闭。

* **改进**
  * 汇总生成失败时自动降级为文本或部分结果，提升通知可靠性。
  * 优化通知截图资源管理，减少无效截图占用。
  * 提升树脂数量识别的准确性与异常处理能力。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->