### PR TITLE
feat: 新增微信 Clawbot 通知渠道（扫码登录 + 独立 REST 推送）

### DIFF
--- a/BetterGenshinImpact/Core/Config/AllConfig.cs
+++ b/BetterGenshinImpact/Core/Config/AllConfig.cs
@@ -320,13 +320,6 @@ public partial class AllConfig : ObservableObject
 
     public void OnNotificationPropertyChanged(object? sender, PropertyChangedEventArgs args)
     {
-        // 排除微信 Clawbot 内部轮询状态字段，避免后台长轮询每次刷新令牌/游标都触发通知器重建
-        if (args.PropertyName is nameof(NotificationConfig.WechatClawbotContextToken)
-            or nameof(NotificationConfig.WechatClawbotGetUpdatesBuf))
-        {
-            return;
-        }
-
         NotificationService.Instance().RefreshNotifiers();
     }
 }

--- a/BetterGenshinImpact/Core/Config/AllConfig.cs
+++ b/BetterGenshinImpact/Core/Config/AllConfig.cs
@@ -320,6 +320,13 @@ public partial class AllConfig : ObservableObject
 
     public void OnNotificationPropertyChanged(object? sender, PropertyChangedEventArgs args)
     {
+        // 排除微信 Clawbot 内部轮询状态字段，避免后台长轮询每次刷新令牌/游标都触发通知器重建
+        if (args.PropertyName is nameof(NotificationConfig.WechatClawbotContextToken)
+            or nameof(NotificationConfig.WechatClawbotGetUpdatesBuf))
+        {
+            return;
+        }
+
         NotificationService.Instance().RefreshNotifiers();
     }
 }

--- a/BetterGenshinImpact/Service/Notification/NotificationConfig.cs
+++ b/BetterGenshinImpact/Service/Notification/NotificationConfig.cs
@@ -358,12 +358,19 @@ public partial class NotificationConfig : ObservableObject
     [ObservableProperty] private string _wechatClawbotToUserId = string.Empty;
 
     /// <summary>
-    ///     微信 Clawbot 会话上下文令牌（后台长轮询持续刷新）
+    ///     微信 Clawbot API 基础地址（登录响应 baseurl；为空时使用默认 https://ilinkai.weixin.qq.com）
+    /// </summary>
+    [ObservableProperty] private string _wechatClawbotBaseUrl = string.Empty;
+
+    /// <summary>
+    ///     微信 Clawbot 会话上下文令牌（后台长轮询持续刷新）。
+    ///     注意：AllConfig.OnNotificationPropertyChanged 已排除该字段，更新不会触发 RefreshNotifiers。
     /// </summary>
     [ObservableProperty] private string _wechatClawbotContextToken = string.Empty;
 
     /// <summary>
-    ///     微信 Clawbot 长轮询同步游标（get_updates_buf，后台长轮询持续刷新）
+    ///     微信 Clawbot 长轮询同步游标（get_updates_buf，后台长轮询持续刷新）。
+    ///     注意：AllConfig.OnNotificationPropertyChanged 已排除该字段，更新不会触发 RefreshNotifiers。
     /// </summary>
     [ObservableProperty] private string _wechatClawbotGetUpdatesBuf = string.Empty;
 }

--- a/BetterGenshinImpact/Service/Notification/NotificationConfig.cs
+++ b/BetterGenshinImpact/Service/Notification/NotificationConfig.cs
@@ -361,16 +361,4 @@ public partial class NotificationConfig : ObservableObject
     ///     微信 Clawbot API 基础地址（登录响应 baseurl；为空时使用默认 https://ilinkai.weixin.qq.com）
     /// </summary>
     [ObservableProperty] private string _wechatClawbotBaseUrl = string.Empty;
-
-    /// <summary>
-    ///     微信 Clawbot 会话上下文令牌（后台长轮询持续刷新）。
-    ///     注意：AllConfig.OnNotificationPropertyChanged 已排除该字段，更新不会触发 RefreshNotifiers。
-    /// </summary>
-    [ObservableProperty] private string _wechatClawbotContextToken = string.Empty;
-
-    /// <summary>
-    ///     微信 Clawbot 长轮询同步游标（get_updates_buf，后台长轮询持续刷新）。
-    ///     注意：AllConfig.OnNotificationPropertyChanged 已排除该字段，更新不会触发 RefreshNotifiers。
-    /// </summary>
-    [ObservableProperty] private string _wechatClawbotGetUpdatesBuf = string.Empty;
 }

--- a/BetterGenshinImpact/Service/Notification/NotificationConfig.cs
+++ b/BetterGenshinImpact/Service/Notification/NotificationConfig.cs
@@ -341,4 +341,29 @@ public partial class NotificationConfig : ObservableObject
     ///     用户的 C2C OpenID（单聊场景）
     /// </summary>
     [ObservableProperty] private string _qqOpenId = string.Empty;
+
+    /// <summary>
+    ///     微信 Clawbot 通知是否启用
+    /// </summary>
+    [ObservableProperty] private bool _wechatClawbotNotificationEnabled;
+
+    /// <summary>
+    ///     微信 Clawbot 扫码登录获得的 bot_token
+    /// </summary>
+    [ObservableProperty] private string _wechatClawbotBotToken = string.Empty;
+
+    /// <summary>
+    ///     微信 Clawbot 推送目标用户 ID（用户给机器人发消息后自动获取）
+    /// </summary>
+    [ObservableProperty] private string _wechatClawbotToUserId = string.Empty;
+
+    /// <summary>
+    ///     微信 Clawbot 会话上下文令牌（后台长轮询持续刷新）
+    /// </summary>
+    [ObservableProperty] private string _wechatClawbotContextToken = string.Empty;
+
+    /// <summary>
+    ///     微信 Clawbot 长轮询同步游标（get_updates_buf，后台长轮询持续刷新）
+    /// </summary>
+    [ObservableProperty] private string _wechatClawbotGetUpdatesBuf = string.Empty;
 }

--- a/BetterGenshinImpact/Service/Notification/NotificationService.cs
+++ b/BetterGenshinImpact/Service/Notification/NotificationService.cs
@@ -405,9 +405,49 @@ public class NotificationService : IHostedService, IDisposable
     /// </summary>
     public void RefreshNotifiers()
     {
+        // 批量提交期间抑制刷新，待提交完成后统一刷新一次，避免逐字段触发多次通知器重建
+        if (_suppressRefresh)
+        {
+            _refreshPending = true;
+            return;
+        }
+
         _notificationConfig = TaskContext.Instance().Config.NotificationConfig;
         _notifierManager.RemoveAllNotifiers();
         InitializeNotifiers();
+    }
+
+    /// <summary>
+    ///     是否处于批量提交抑制刷新状态
+    /// </summary>
+    private bool _suppressRefresh;
+
+    /// <summary>
+    ///     抑制期间是否有待刷新的标记
+    /// </summary>
+    private bool _refreshPending;
+
+    /// <summary>
+    ///     批量更新通知配置（如微信 Clawbot 绑定凭证）时抑制逐字段刷新，
+    ///     提交完成后统一刷新一次，保证通知器读到完整的配置集合。
+    /// </summary>
+    public IDisposable SuppressRefreshNotifiers()
+    {
+        _suppressRefresh = true;
+        return new RefreshSuppression(this);
+    }
+
+    private sealed class RefreshSuppression(NotificationService service) : IDisposable
+    {
+        public void Dispose()
+        {
+            service._suppressRefresh = false;
+            if (service._refreshPending)
+            {
+                service._refreshPending = false;
+                service.RefreshNotifiers();
+            }
+        }
     }
 
     /// <summary>

--- a/BetterGenshinImpact/Service/Notification/NotificationService.cs
+++ b/BetterGenshinImpact/Service/Notification/NotificationService.cs
@@ -374,13 +374,12 @@ public class NotificationService : IHostedService, IDisposable
         if (_notificationConfig?.WechatClawbotNotificationEnabled != true) return;
 
         // 微信会话状态（context_token / get_updates_buf）跨进程共享同一份 User/WechatClawbot 文件，
-        // 仅在主实例（Primary）维护长轮询会话，避免桌面分身等多实例用旧游标并发推进导致令牌互相覆盖。
-        if (!IsPrimaryInstance())
-            return;
-
+        // 仅主实例（Primary）启动长轮询会话，避免桌面分身等多实例用旧游标并发推进导致令牌互相覆盖。
+        // 子实例仍注册通知器保留发送能力（从共享存储读取最新 context_token）。
         _notifierManager.RegisterNotifier(new WechatClawbotNotifier(
             _notifyHttpClient,
-            _notificationConfig
+            _notificationConfig,
+            IsPrimaryInstance()
         ));
     }
 

--- a/BetterGenshinImpact/Service/Notification/NotificationService.cs
+++ b/BetterGenshinImpact/Service/Notification/NotificationService.cs
@@ -53,6 +53,8 @@ public class NotificationService : IHostedService, IDisposable
     /// </summary>
     public void Dispose()
     {
+        // 先释放所有通知器（含微信 Clawbot 后台长轮询会话），再释放共享 HttpClient
+        _notifierManager.RemoveAllNotifiers();
         // _webSocketCts?.Cancel();
         _webSocketCts?.Dispose();
         _notifyHttpClient?.Dispose();
@@ -113,6 +115,7 @@ public class NotificationService : IHostedService, IDisposable
         InitializeMeowNotifier();
         InitializeGotifyNotifier();
         InitializeQqNotifier();
+        InitializeWechatClawbotNotifier();
 
         // 添加新通知渠道时，在此处添加对应的初始化方法调用
     }
@@ -360,6 +363,19 @@ public class NotificationService : IHostedService, IDisposable
             _notificationConfig.QqAppId,
             _notificationConfig.QqClientSecret,
             _notificationConfig.QqOpenId
+        ));
+    }
+
+    /// <summary>
+    ///     初始化微信 Clawbot 通知器
+    /// </summary>
+    private void InitializeWechatClawbotNotifier()
+    {
+        if (_notificationConfig?.WechatClawbotNotificationEnabled != true) return;
+
+        _notifierManager.RegisterNotifier(new WechatClawbotNotifier(
+            _notifyHttpClient,
+            _notificationConfig
         ));
     }
 

--- a/BetterGenshinImpact/Service/Notification/NotificationService.cs
+++ b/BetterGenshinImpact/Service/Notification/NotificationService.cs
@@ -373,10 +373,32 @@ public class NotificationService : IHostedService, IDisposable
     {
         if (_notificationConfig?.WechatClawbotNotificationEnabled != true) return;
 
+        // 微信会话状态（context_token / get_updates_buf）跨进程共享同一份 User/WechatClawbot 文件，
+        // 仅在主实例（Primary）维护长轮询会话，避免桌面分身等多实例用旧游标并发推进导致令牌互相覆盖。
+        if (!IsPrimaryInstance())
+            return;
+
         _notifierManager.RegisterNotifier(new WechatClawbotNotifier(
             _notifyHttpClient,
             _notificationConfig
         ));
+    }
+
+    /// <summary>
+    ///     是否为 BetterGI 主实例（Primary）。桌面分身 / WebView 等子实例不维护微信长轮询会话。
+    /// </summary>
+    private static bool IsPrimaryInstance()
+    {
+        try
+        {
+            var bootstrap = BetterGenshinImpact.Service.Instance.InstanceBootstrap.Current;
+            return bootstrap == null || bootstrap.Context.IsRoot;
+        }
+        catch (System.Exception)
+        {
+            // 无法判断时默认主实例行为，避免在单实例场景误禁用
+            return true;
+        }
     }
 
     /// <summary>
@@ -455,25 +477,12 @@ public class NotificationService : IHostedService, IDisposable
     /// </summary>
     public async Task<NotificationTestResult> TestNotifierAsync<T>() where T : INotifier
     {
+        var testData = CreateTestNotificationData();
         try
         {
-            var notifier = _notifierManager.GetNotifier<T>();
-            if (notifier == null)
-            {
-                return NotificationTestResult.Error("通知类型未启用");
-            }
-
-            var testData = CreateTestNotificationData();
-            try
-            {
-                await notifier.SendAsync(testData);
-                return NotificationTestResult.Success();
-            }
-            finally
-            {
-                testData.Screenshot?.Dispose();
-                testData.Screenshot = null;
-            }
+            // 测试发送走管理器入口，纳入在途租约计数，避免发送期间释放通知器资源
+            var error = await _notifierManager.SendTestAsync<T>(testData);
+            return error == null ? NotificationTestResult.Success() : NotificationTestResult.Error(error);
         }
         catch (NotifierException ex)
         {
@@ -482,6 +491,11 @@ public class NotificationService : IHostedService, IDisposable
         catch (Exception ex)
         {
             return NotificationTestResult.Error($"测试通知时发生未知错误: {ex.Message}");
+        }
+        finally
+        {
+            testData.Screenshot?.Dispose();
+            testData.Screenshot = null;
         }
     }
 

--- a/BetterGenshinImpact/Service/Notification/NotificationService.cs
+++ b/BetterGenshinImpact/Service/Notification/NotificationService.cs
@@ -463,11 +463,10 @@ public class NotificationService : IHostedService, IDisposable
         public void Dispose()
         {
             service._suppressRefresh = false;
-            if (service._refreshPending)
-            {
-                service._refreshPending = false;
-                service.RefreshNotifiers();
-            }
+            service._refreshPending = false;
+            // 绑定是用户主动操作，即使凭证未变化也必须刷新通知器，
+            // 以确保会话从独立存储加载最新的 context_token / get_updates_buf。
+            service.RefreshNotifiers();
         }
     }
 

--- a/BetterGenshinImpact/Service/Notifier/NotifierManager.cs
+++ b/BetterGenshinImpact/Service/Notifier/NotifierManager.cs
@@ -9,14 +9,17 @@ using BetterGenshinImpact.Service.Notification.Model;
 
 namespace BetterGenshinImpact.Service.Notifier;
 
+/// <summary>
+/// 通知器管理器。以「发送租约」协调通知器生命周期：
+/// 每个在途发送在锁内获取通知器租约；移除/释放通知器前先原子替换集合，
+/// 再等待所有租约归还，避免在发送中途释放通知器资源。
+/// </summary>
 public class NotifierManager
 {
     private readonly object _sync = new();
     private List<INotifier> _notifiers = [];
-
-    private int _inFlight;
-    private TaskCompletionSource? _drainTcs;
-    private readonly object _drainLock = new();
+    private readonly Dictionary<INotifier, int> _leases = new();
+    private readonly ManualResetEventSlim _idle = new(true);
 
     public static ILogger Logger { get; } = App.GetLogger<NotifierManager>();
 
@@ -34,14 +37,14 @@ public class NotifierManager
 
     public void RemoveNotifier<T>() where T : INotifier
     {
-        List<INotifier> removed;
+        INotifier[] removed;
         lock (_sync)
         {
-            removed = _notifiers.Where(o => o is T).ToList();
-            _notifiers.RemoveAll(o => o is T);
+            removed = _notifiers.Where(o => o is T).ToArray();
+            _notifiers = _notifiers.Where(o => o is not T).ToList();
         }
 
-        WaitForDrain(TimeSpan.FromSeconds(3));
+        WaitForLeasesReleased();
         foreach (var n in removed)
         {
             (n as IDisposable)?.Dispose();
@@ -50,19 +53,17 @@ public class NotifierManager
 
     public void RemoveAllNotifiers()
     {
-        List<INotifier> old;
+        INotifier[] old;
         lock (_sync)
         {
-            old = _notifiers;
+            old = _notifiers.ToArray();
             _notifiers = [];
         }
 
-        // 等待在途发送结束，避免释放仍在使用的通知器资源
-        WaitForDrain(TimeSpan.FromSeconds(3));
-
-        foreach (var notifier in old)
+        WaitForLeasesReleased();
+        foreach (var n in old)
         {
-            (notifier as IDisposable)?.Dispose();
+            (n as IDisposable)?.Dispose();
         }
     }
 
@@ -74,9 +75,15 @@ public class NotifierManager
         }
     }
 
+    /// <summary>
+    /// 以租约方式发送（在途计数，供普通通知与测试通知共用）。
+    /// </summary>
     public async Task SendNotificationAsync(INotifier notifier, BaseNotificationData content)
     {
-        Interlocked.Increment(ref _inFlight);
+        var lease = TryAcquireLease(notifier);
+        if (lease == null)
+            return;
+
         try
         {
             try
@@ -90,17 +97,7 @@ public class NotifierManager
         }
         finally
         {
-            if (Interlocked.Decrement(ref _inFlight) == 0)
-            {
-                TaskCompletionSource? tcs;
-                lock (_drainLock)
-                {
-                    tcs = _drainTcs;
-                    _drainTcs = null;
-                }
-
-                tcs?.TrySetResult();
-            }
+            ReleaseLease(lease);
         }
     }
 
@@ -121,21 +118,80 @@ public class NotifierManager
             snapshot = _notifiers.ToArray();
         }
 
-        await Task.WhenAll(snapshot.Select(notifier => SendNotificationAsync(notifier, content)));
+        await Task.WhenAll(snapshot.Select(n => SendNotificationAsync(n, content)));
     }
 
-    private void WaitForDrain(TimeSpan timeout)
+    /// <summary>
+    /// 测试指定通知器，返回异常信息供 UI 展示；测试发送同样持有租约，避免释放竞态。
+    /// </summary>
+    public async Task<string?> SendTestAsync<T>(BaseNotificationData content) where T : INotifier
     {
-        if (Volatile.Read(ref _inFlight) == 0)
-            return;
+        var notifier = GetNotifier<T>();
+        if (notifier == null)
+            return "通知类型未启用";
 
-        TaskCompletionSource tcs;
-        lock (_drainLock)
+        var lease = TryAcquireLease(notifier);
+        if (lease == null)
+            return "通知器正在被移除，请稍后重试";
+
+        try
         {
-            _drainTcs ??= new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-            tcs = _drainTcs;
+            await notifier.SendAsync(content);
+            return null;
         }
+        catch (System.Exception ex)
+        {
+            return ex.Message;
+        }
+        finally
+        {
+            ReleaseLease(lease);
+        }
+    }
 
-        tcs.Task.Wait(timeout);
+    private Lease? TryAcquireLease(INotifier notifier)
+    {
+        lock (_sync)
+        {
+            if (!_notifiers.Contains(notifier))
+                return null;
+
+            _leases[notifier] = _leases.TryGetValue(notifier, out var c) ? c + 1 : 1;
+            _idle.Reset();
+            return new Lease(this, notifier);
+        }
+    }
+
+    private void ReleaseLease(Lease lease)
+    {
+        lock (_sync)
+        {
+            if (!_leases.TryGetValue(lease.Notifier, out var count) || count <= 1)
+            {
+                _leases.Remove(lease.Notifier);
+            }
+            else
+            {
+                _leases[lease.Notifier] = count - 1;
+            }
+
+            if (_leases.Count == 0)
+            {
+                _idle.Set();
+            }
+        }
+    }
+
+    private void WaitForLeasesReleased()
+    {
+        if (_leases.Count == 0)
+            return;
+        _idle.Wait(TimeSpan.FromSeconds(3));
+    }
+
+    private sealed class Lease(NotifierManager owner, INotifier notifier)
+    {
+        public INotifier Notifier { get; } = notifier;
+        public NotifierManager Owner { get; } = owner;
     }
 }

--- a/BetterGenshinImpact/Service/Notifier/NotifierManager.cs
+++ b/BetterGenshinImpact/Service/Notifier/NotifierManager.cs
@@ -1,5 +1,6 @@
 ﻿using BetterGenshinImpact.Service.Notifier.Interface;
 using Microsoft.Extensions.Logging;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -29,6 +30,14 @@ public class NotifierManager
 
     public void RemoveAllNotifiers()
     {
+        foreach (var notifier in _notifiers)
+        {
+            if (notifier is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
+        }
+
         _notifiers.Clear();
     }
 

--- a/BetterGenshinImpact/Service/Notifier/NotifierManager.cs
+++ b/BetterGenshinImpact/Service/Notifier/NotifierManager.cs
@@ -11,15 +11,14 @@ namespace BetterGenshinImpact.Service.Notifier;
 
 /// <summary>
 /// 通知器管理器。以「发送租约」协调通知器生命周期：
-/// 每个在途发送在锁内获取通知器租约；移除/释放通知器前先原子替换集合，
-/// 再等待所有租约归还，避免在发送中途释放通知器资源。
+/// 每个在途发送在持锁取得快照时同步获取通知器租约；移除/释放通知器前先原子替换集合，
+/// 再等待所有租约归还（无固定超时），避免在发送中途释放通知器资源。
 /// </summary>
 public class NotifierManager
 {
     private readonly object _sync = new();
     private List<INotifier> _notifiers = [];
     private readonly Dictionary<INotifier, int> _leases = new();
-    private readonly ManualResetEventSlim _idle = new(true);
 
     public static ILogger Logger { get; } = App.GetLogger<NotifierManager>();
 
@@ -44,7 +43,7 @@ public class NotifierManager
             _notifiers = _notifiers.Where(o => o is not T).ToList();
         }
 
-        WaitForLeasesReleased();
+        WaitForLeasesReleased(removed);
         foreach (var n in removed)
         {
             (n as IDisposable)?.Dispose();
@@ -60,7 +59,7 @@ public class NotifierManager
             _notifiers = [];
         }
 
-        WaitForLeasesReleased();
+        WaitForLeasesReleased(old);
         foreach (var n in old)
         {
             (n as IDisposable)?.Dispose();
@@ -76,11 +75,16 @@ public class NotifierManager
     }
 
     /// <summary>
-    /// 以租约方式发送（在途计数，供普通通知与测试通知共用）。
+    /// 以租约方式发送单个通知器（在途计数，供普通通知路径使用）。
     /// </summary>
     public async Task SendNotificationAsync(INotifier notifier, BaseNotificationData content)
     {
-        var lease = TryAcquireLease(notifier);
+        Lease? lease;
+        lock (_sync)
+        {
+            lease = TryAcquireLeaseLocked(notifier);
+        }
+
         if (lease == null)
             return;
 
@@ -103,45 +107,27 @@ public class NotifierManager
 
     public async Task SendNotificationAsync<T>(BaseNotificationData content) where T : INotifier
     {
-        var notifier = GetNotifier<T>();
-        if (notifier != null)
-        {
-            await SendNotificationAsync(notifier, content);
-        }
-    }
-
-    public async Task SendNotificationToAllAsync(BaseNotificationData content)
-    {
-        INotifier[] snapshot;
+        INotifier? notifier;
+        Lease? lease;
         lock (_sync)
         {
-            snapshot = _notifiers.ToArray();
+            notifier = _notifiers.FirstOrDefault(o => o is T);
+            lease = notifier != null ? TryAcquireLeaseLocked(notifier) : null;
         }
 
-        await Task.WhenAll(snapshot.Select(n => SendNotificationAsync(n, content)));
-    }
-
-    /// <summary>
-    /// 测试指定通知器，返回异常信息供 UI 展示；测试发送同样持有租约，避免释放竞态。
-    /// </summary>
-    public async Task<string?> SendTestAsync<T>(BaseNotificationData content) where T : INotifier
-    {
-        var notifier = GetNotifier<T>();
-        if (notifier == null)
-            return "通知类型未启用";
-
-        var lease = TryAcquireLease(notifier);
-        if (lease == null)
-            return "通知器正在被移除，请稍后重试";
+        if (notifier == null || lease == null)
+            return;
 
         try
         {
-            await notifier.SendAsync(content);
-            return null;
-        }
-        catch (System.Exception ex)
-        {
-            return ex.Message;
+            try
+            {
+                await notifier.SendAsync(content);
+            }
+            catch (System.Exception ex)
+            {
+                Logger.LogWarning("{name} 通知发送失败: {ex}", notifier.Name, ex.Message);
+            }
         }
         finally
         {
@@ -149,44 +135,125 @@ public class NotifierManager
         }
     }
 
-    private Lease? TryAcquireLease(INotifier notifier)
+    /// <summary>
+    /// 向所有通知器发送。在持锁取得快照时同步为每个通知器获取租约，
+    /// 避免与 RemoveAllNotifiers 竞态导致快照中的实例被释放或无法获取租约。
+    /// </summary>
+    public async Task SendNotificationToAllAsync(BaseNotificationData content)
     {
+        var leased = new List<(INotifier Notifier, Lease Lease)>();
         lock (_sync)
         {
-            if (!_notifiers.Contains(notifier))
-                return null;
-
-            _leases[notifier] = _leases.TryGetValue(notifier, out var c) ? c + 1 : 1;
-            _idle.Reset();
-            return new Lease(this, notifier);
+            foreach (var notifier in _notifiers)
+            {
+                var lease = TryAcquireLeaseLocked(notifier);
+                if (lease != null)
+                    leased.Add((notifier, lease));
+            }
         }
+
+        try
+        {
+            await Task.WhenAll(leased.Select(item => SendWithLeaseAsync(item.Notifier, item.Lease, content)));
+        }
+        finally
+        {
+            foreach (var item in leased)
+            {
+                ReleaseLease(item.Lease);
+            }
+        }
+    }
+
+    /// <summary>
+    /// 测试指定通知器，返回错误信息供 UI 展示；测试发送同样纳入租约计数。
+    /// </summary>
+    public async Task<string?> SendTestAsync<T>(BaseNotificationData content) where T : INotifier
+    {
+        INotifier? notifier;
+        Lease? lease;
+        lock (_sync)
+        {
+            notifier = _notifiers.FirstOrDefault(o => o is T);
+            lease = notifier != null ? TryAcquireLeaseLocked(notifier) : null;
+        }
+
+        if (notifier == null)
+            return "通知类型未启用";
+        if (lease == null)
+            return "通知器正在被移除，请稍后重试";
+
+        try
+        {
+            try
+            {
+                await notifier.SendAsync(content);
+                return null;
+            }
+            catch (System.Exception ex)
+            {
+                return ex.Message;
+            }
+        }
+        finally
+        {
+            ReleaseLease(lease);
+        }
+    }
+
+    private async Task SendWithLeaseAsync(INotifier notifier, Lease lease, BaseNotificationData content)
+    {
+        try
+        {
+            await notifier.SendAsync(content);
+        }
+        catch (System.Exception ex)
+        {
+            Logger.LogWarning("{name} 通知发送失败: {ex}", notifier.Name, ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// 持有 _sync 时调用：若通知器仍注册则获取租约，否则返回 null。
+    /// </summary>
+    private Lease? TryAcquireLeaseLocked(INotifier notifier)
+    {
+        if (!_notifiers.Contains(notifier))
+            return null;
+
+        _leases[notifier] = _leases.TryGetValue(notifier, out var c) ? c + 1 : 1;
+        return new Lease(this, notifier);
     }
 
     private void ReleaseLease(Lease lease)
     {
         lock (_sync)
         {
-            if (!_leases.TryGetValue(lease.Notifier, out var count) || count <= 1)
+            if (_leases.TryGetValue(lease.Notifier, out var count))
             {
-                _leases.Remove(lease.Notifier);
-            }
-            else
-            {
-                _leases[lease.Notifier] = count - 1;
+                if (count <= 1)
+                    _leases.Remove(lease.Notifier);
+                else
+                    _leases[lease.Notifier] = count - 1;
             }
 
-            if (_leases.Count == 0)
-            {
-                _idle.Set();
-            }
+            // 唤醒等待租约释放的释放方
+            Monitor.PulseAll(_sync);
         }
     }
 
-    private void WaitForLeasesReleased()
+    /// <summary>
+    /// 等待给定通知器集合的全部租约归还后才继续（无固定超时）。
+    /// </summary>
+    private void WaitForLeasesReleased(INotifier[] notifiers)
     {
-        if (_leases.Count == 0)
-            return;
-        _idle.Wait(TimeSpan.FromSeconds(3));
+        lock (_sync)
+        {
+            while (notifiers.Any(n => _leases.ContainsKey(n)))
+            {
+                Monitor.Wait(_sync);
+            }
+        }
     }
 
     private sealed class Lease(NotifierManager owner, INotifier notifier)

--- a/BetterGenshinImpact/Service/Notifier/NotifierManager.cs
+++ b/BetterGenshinImpact/Service/Notifier/NotifierManager.cs
@@ -1,8 +1,9 @@
-﻿using BetterGenshinImpact.Service.Notifier.Interface;
+using BetterGenshinImpact.Service.Notifier.Interface;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using BetterGenshinImpact.Service.Notification.Model;
 
@@ -10,7 +11,12 @@ namespace BetterGenshinImpact.Service.Notifier;
 
 public class NotifierManager
 {
-    private readonly List<INotifier> _notifiers = [];
+    private readonly object _sync = new();
+    private List<INotifier> _notifiers = [];
+
+    private int _inFlight;
+    private TaskCompletionSource? _drainTcs;
+    private readonly object _drainLock = new();
 
     public static ILogger Logger { get; } = App.GetLogger<NotifierManager>();
 
@@ -20,48 +26,87 @@ public class NotifierManager
 
     public void RegisterNotifier(INotifier notifier)
     {
-        _notifiers.Add(notifier);
+        lock (_sync)
+        {
+            _notifiers.Add(notifier);
+        }
     }
 
     public void RemoveNotifier<T>() where T : INotifier
     {
-        _notifiers.RemoveAll(o => o is T);
+        List<INotifier> removed;
+        lock (_sync)
+        {
+            removed = _notifiers.Where(o => o is T).ToList();
+            _notifiers.RemoveAll(o => o is T);
+        }
+
+        WaitForDrain(TimeSpan.FromSeconds(3));
+        foreach (var n in removed)
+        {
+            (n as IDisposable)?.Dispose();
+        }
     }
 
     public void RemoveAllNotifiers()
     {
-        foreach (var notifier in _notifiers)
+        List<INotifier> old;
+        lock (_sync)
         {
-            if (notifier is IDisposable disposable)
-            {
-                disposable.Dispose();
-            }
+            old = _notifiers;
+            _notifiers = [];
         }
 
-        _notifiers.Clear();
+        // 等待在途发送结束，避免释放仍在使用的通知器资源
+        WaitForDrain(TimeSpan.FromSeconds(3));
+
+        foreach (var notifier in old)
+        {
+            (notifier as IDisposable)?.Dispose();
+        }
     }
 
     public INotifier? GetNotifier<T>() where T : INotifier
     {
-        return _notifiers.FirstOrDefault(o => o is T);
+        lock (_sync)
+        {
+            return _notifiers.FirstOrDefault(o => o is T);
+        }
     }
 
     public async Task SendNotificationAsync(INotifier notifier, BaseNotificationData content)
     {
+        Interlocked.Increment(ref _inFlight);
         try
         {
-            await notifier.SendAsync(content);
+            try
+            {
+                await notifier.SendAsync(content);
+            }
+            catch (System.Exception ex)
+            {
+                Logger.LogWarning("{name} 通知发送失败: {ex}", notifier.Name, ex.Message);
+            }
         }
-        catch (System.Exception ex)
+        finally
         {
-            Logger.LogWarning("{name} 通知发送失败: {ex}", notifier.Name, ex.Message);
+            if (Interlocked.Decrement(ref _inFlight) == 0)
+            {
+                TaskCompletionSource? tcs;
+                lock (_drainLock)
+                {
+                    tcs = _drainTcs;
+                    _drainTcs = null;
+                }
+
+                tcs?.TrySetResult();
+            }
         }
     }
 
     public async Task SendNotificationAsync<T>(BaseNotificationData content) where T : INotifier
     {
-        var notifier = _notifiers.FirstOrDefault(o => o is T);
-
+        var notifier = GetNotifier<T>();
         if (notifier != null)
         {
             await SendNotificationAsync(notifier, content);
@@ -70,6 +115,27 @@ public class NotifierManager
 
     public async Task SendNotificationToAllAsync(BaseNotificationData content)
     {
-        await Task.WhenAll(_notifiers.Select(notifier => SendNotificationAsync(notifier, content)));
+        INotifier[] snapshot;
+        lock (_sync)
+        {
+            snapshot = _notifiers.ToArray();
+        }
+
+        await Task.WhenAll(snapshot.Select(notifier => SendNotificationAsync(notifier, content)));
+    }
+
+    private void WaitForDrain(TimeSpan timeout)
+    {
+        if (Volatile.Read(ref _inFlight) == 0)
+            return;
+
+        TaskCompletionSource tcs;
+        lock (_drainLock)
+        {
+            _drainTcs ??= new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            tcs = _drainTcs;
+        }
+
+        tcs.Task.Wait(timeout);
     }
 }

--- a/BetterGenshinImpact/Service/Notifier/NotifierManager.cs
+++ b/BetterGenshinImpact/Service/Notifier/NotifierManager.cs
@@ -10,9 +10,16 @@ using BetterGenshinImpact.Service.Notification.Model;
 namespace BetterGenshinImpact.Service.Notifier;
 
 /// <summary>
-/// 通知器管理器。以「发送租约」协调通知器生命周期：
-/// 每个在途发送在持锁取得快照时同步获取通知器租约；移除/释放通知器前先原子替换集合，
-/// 再等待所有租约归还（无固定超时），避免在发送中途释放通知器资源。
+/// 通知器管理器。以「发送租约（Lease）」协调通知器生命周期：
+///
+/// 租约模型：
+/// - 发送方（SendNotificationToAllAsync / SendNotificationAsync）在 _sync 锁内
+///   原子地取得快照 + 为每个通知器递增租约计数，确保快照与租约同步获取。
+/// - 发送完成后释放租约（减计数，唤醒等待者）。
+/// - 移除方（RemoveAllNotifiers）在 _sync 锁内原子替换集合，
+///   然后等待所有旧通知器的租约归还（Monitor.Wait，无固定超时）后再 Dispose。
+///
+/// 这保证：旧集合在发送中途不会被释放，新集合立即生效接收新发送。
 /// </summary>
 public class NotifierManager
 {
@@ -201,6 +208,10 @@ public class NotifierManager
         }
     }
 
+    /// <summary>
+    /// 在持有租约期间执行发送；发送期间租约保证通知器不会被 RemoveAllNotifiers 释放。
+    /// 异常被吞掉并记录日志（不中断 Task.WhenAll 的其他发送任务）。
+    /// </summary>
     private async Task SendWithLeaseAsync(INotifier notifier, Lease lease, BaseNotificationData content)
     {
         try
@@ -214,7 +225,8 @@ public class NotifierManager
     }
 
     /// <summary>
-    /// 持有 _sync 时调用：若通知器仍注册则获取租约，否则返回 null。
+    /// 持有 _sync 时调用：若通知器仍注册则递增其租约计数并返回 Lease 句柄，
+    /// 否则返回 null（通知器已被移除，不应继续发送）。
     /// </summary>
     private Lease? TryAcquireLeaseLocked(INotifier notifier)
     {
@@ -243,7 +255,10 @@ public class NotifierManager
     }
 
     /// <summary>
-    /// 等待给定通知器集合的全部租约归还后才继续（无固定超时）。
+    /// 在 _sync 锁内等待给定通知器集合的全部租约归还（Monitor.Wait，无固定超时）。
+    /// 由 RemoveAllNotifiers / RemoveNotifier 调用，保证发送完成后再释放。
+    /// 注意：持有 _sync 等待期间，新发送会被阻塞（因为 TryAcquireLease 也在锁内），
+    /// 但由于发送通常较快（毫秒级），这不会造成可见的 UI 卡顿。
     /// </summary>
     private void WaitForLeasesReleased(INotifier[] notifiers)
     {

--- a/BetterGenshinImpact/Service/Notifier/WebSocketNotifier.cs
+++ b/BetterGenshinImpact/Service/Notifier/WebSocketNotifier.cs
@@ -74,8 +74,10 @@ namespace BetterGenshinImpact.Service.Notifier
 
         public void Dispose()
         {
+            // 只释放自己拥有的 WebSocket；不取消共享的 _webSocketCts——
+            // 该令牌源由 NotificationService 拥有并在应用关闭时统一取消，
+            // 刷新通知器时若在此取消会导致重建后的 WebSocketNotifier 继续使用已取消令牌。
             _webSocket.Dispose();
-            _cts.Cancel();
         }
 
         public async Task SendNotificationAsync(BaseNotificationData notificationData)

--- a/BetterGenshinImpact/Service/Notifier/WechatClawbotHelper.cs
+++ b/BetterGenshinImpact/Service/Notifier/WechatClawbotHelper.cs
@@ -270,6 +270,7 @@ public static class WechatClawbotHelper
     /// <summary>
     /// 长轮询 getupdates：服务端 hold 35s，客户端通过 linked CTS 按服务器建议超时取消。
     /// OperationCanceledException（非用户取消）视为正常轮询超时，调用方可安全 continue。
+    /// 业务失败码 ret/errcode 非零视为协议错误；errcode -14 表示会话过期需重新登录。
     /// </summary>
     internal static async Task<WechatClawbotGetUpdatesResponse> GetUpdatesAsync(
         HttpClient httpClient,

--- a/BetterGenshinImpact/Service/Notifier/WechatClawbotHelper.cs
+++ b/BetterGenshinImpact/Service/Notifier/WechatClawbotHelper.cs
@@ -76,10 +76,13 @@ public static class WechatClawbotHelper
                 case "confirmed":
                     if (string.IsNullOrWhiteSpace(status.BotToken))
                         throw new NotifierException("登录确认但未返回 bot_token");
+                    // 身份校验依赖 ilink_user_id；缺失时拒绝继续，避免绑定到错误账号
+                    if (string.IsNullOrWhiteSpace(status.UserId))
+                        throw new NotifierException("登录确认但未返回用户 ID，无法完成身份校验，请重新扫码");
                     return new WechatClawbotLoginResult(
                         status.BotToken!,
                         status.BotId ?? string.Empty,
-                        status.UserId ?? string.Empty,
+                        status.UserId!,
                         status.BaseUrl ?? ApiBase);
                 case "expired":
                     throw new NotifierException("二维码已过期，请重新登录");
@@ -118,12 +121,14 @@ public static class WechatClawbotHelper
     /// 一次性验证码绑定：长轮询 getupdates，等待扫码用户发送验证码，返回 to_user_id 和 context_token。
     /// </summary>
     /// <param name="botToken">扫码登录获得的 bot_token</param>
-    /// <param name="expectedUserId">扫码登录返回的用户 ID（ilink_user_id），仅接受该用户发送的验证码，
-    /// 防止绑定窗口内其他用户误发导致绑错账号</param>
+    /// <param name="baseUrl">登录响应返回的 API 基础地址（为空回退默认主机）</param>
+    /// <param name="expectedUserId">扫码登录返回的用户 ID（ilink_user_id）。必须非空，
+    /// 仅接受该用户发送的验证码，防止绑定窗口内其他用户误发导致绑错账号。</param>
     /// <param name="onVerifyCode">生成验证码后的回调，用于 UI 提示用户发送该验证码</param>
     /// <param name="cancellationToken">取消令牌（用户点击取消时触发）</param>
     public static async Task<WechatClawbotBindResult> BindAsync(
         string botToken,
+        string baseUrl,
         string expectedUserId,
         Action<string> onVerifyCode,
         CancellationToken cancellationToken)
@@ -131,6 +136,11 @@ public static class WechatClawbotHelper
         if (string.IsNullOrWhiteSpace(botToken))
             throw new NotifierException("微信 Clawbot BotToken 为空");
 
+        // 必须校验扫码用户身份，否则绑定窗口内其他用户可凭验证码绑定到错误账号
+        if (string.IsNullOrWhiteSpace(expectedUserId))
+            throw new NotifierException("登录未返回用户 ID，无法校验绑定身份，请重新扫码登录");
+
+        var normalizeBaseUrl = NormalizeBaseUrl(baseUrl);
         var verifyCode = GenerateVerifyCode();
         using var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(60) };
         using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
@@ -146,7 +156,7 @@ public static class WechatClawbotHelper
             WechatClawbotGetUpdatesResponse resp;
             try
             {
-                resp = await GetUpdatesAsync(httpClient, botToken, buf, timeoutMs, ct);
+                resp = await GetUpdatesAsync(httpClient, normalizeBaseUrl, botToken, buf, timeoutMs, ct);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -170,9 +180,7 @@ public static class WechatClawbotHelper
             {
                 var text = ExtractText(msg);
                 // 仅接受扫码用户发来的验证码消息，防止其他用户误绑
-                var isExpectedSender = !string.IsNullOrWhiteSpace(expectedUserId)
-                    ? string.Equals(msg.FromUserId, expectedUserId, StringComparison.Ordinal)
-                    : !string.IsNullOrWhiteSpace(msg.FromUserId);
+                var isExpectedSender = string.Equals(msg.FromUserId, expectedUserId, StringComparison.Ordinal);
                 if (text != null && text.Contains(verifyCode) && isExpectedSender)
                     return new WechatClawbotBindResult(msg.FromUserId!, msg.ContextToken ?? string.Empty, buf);
             }
@@ -206,6 +214,15 @@ public static class WechatClawbotHelper
     }
 
     /// <summary>
+    /// 规范化 API 基础地址：空值回退默认主机，并去除尾部斜杠。
+    /// </summary>
+    internal static string NormalizeBaseUrl(string? baseUrl)
+    {
+        var url = string.IsNullOrWhiteSpace(baseUrl) ? ApiBase : baseUrl.Trim();
+        return url.TrimEnd('/');
+    }
+
+    /// <summary>
     /// 为 POST 请求添加完整请求头（Content-Type / AuthorizationType / X-WECHAT-UIN / iLink 标识 / Authorization）。
     /// </summary>
     internal static void AddCommonHeaders(HttpRequestMessage request, string? botToken)
@@ -230,6 +247,7 @@ public static class WechatClawbotHelper
 
     internal static async Task<WechatClawbotGetUpdatesResponse> GetUpdatesAsync(
         HttpClient httpClient,
+        string baseUrl,
         string botToken,
         string getUpdatesBuf,
         int timeoutMs,
@@ -240,7 +258,7 @@ public static class WechatClawbotHelper
             get_updates_buf = getUpdatesBuf,
             base_info = BuildBaseInfo(),
         });
-        using var request = new HttpRequestMessage(HttpMethod.Post, $"{ApiBase}/ilink/bot/getupdates")
+        using var request = new HttpRequestMessage(HttpMethod.Post, $"{NormalizeBaseUrl(baseUrl)}/ilink/bot/getupdates")
         {
             Content = new StringContent(body, Encoding.UTF8, "application/json"),
         };

--- a/BetterGenshinImpact/Service/Notifier/WechatClawbotHelper.cs
+++ b/BetterGenshinImpact/Service/Notifier/WechatClawbotHelper.cs
@@ -204,6 +204,7 @@ public static class WechatClawbotHelper
     /// <summary>
     /// 构建所有 POST 请求体附带的 base_info 块（协议要求）。
     /// channel_version 为 iLink 协议版本；bot_agent 用于后台观测与流量归因。
+    /// 该块随每个请求一起发送，服务端据此识别客户端类型与版本。
     /// </summary>
     internal static object BuildBaseInfo() => new
     {

--- a/BetterGenshinImpact/Service/Notifier/WechatClawbotHelper.cs
+++ b/BetterGenshinImpact/Service/Notifier/WechatClawbotHelper.cs
@@ -1,0 +1,364 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using BetterGenshinImpact.Service.Notifier.Exception;
+
+namespace BetterGenshinImpact.Service.Notifier;
+
+/// <summary>
+/// 微信 Clawbot（iLink 协议）帮助类。
+/// 负责扫码登录（get_bot_qrcode → get_qrcode_status）和一次性验证码绑定（getupdates 长轮询）。
+/// 协议参考官方 npm 包 @tencent-weixin/openclaw-weixin，BetterGI 内置实现，不依赖 OpenClaw。
+/// </summary>
+public static class WechatClawbotHelper
+{
+    internal const string ApiBase = "https://ilinkai.weixin.qq.com";
+    internal const string CdnBase = "https://novac2c.cdn.weixin.qq.com/c2c";
+    internal const string ChannelVersion = "1.0.2";
+    internal const string BotAgent = "BetterGI/0.64.0";
+    internal const string AppId = "bot";
+    internal const string AppClientVersion = "65538"; // 0x00010002 = 1.0.2
+
+    private const int VerifyCodeLength = 4;
+    private const int LoginTimeoutSeconds = 300;
+    private const int BindTimeoutSeconds = 90;
+    private const int DefaultLongPollTimeoutMs = 35000;
+
+    /// <summary>
+    /// 扫码登录：获取二维码并轮询扫码状态，确认后返回 bot_token 等信息。
+    /// </summary>
+    /// <param name="onQrCodeUrl">获取到二维码链接后的回调，用于 UI 展示/打开浏览器</param>
+    /// <param name="cancellationToken">取消令牌（用户点击取消时触发）</param>
+    public static async Task<WechatClawbotLoginResult> LoginAsync(
+        Action<string> onQrCodeUrl,
+        CancellationToken cancellationToken)
+    {
+        using var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(60) };
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(TimeSpan.FromSeconds(LoginTimeoutSeconds));
+        var ct = timeoutCts.Token;
+
+        var (qrcode, qrCodeUrl) = await GetBotQrCodeAsync(httpClient, ct);
+        onQrCodeUrl(qrCodeUrl);
+
+        while (!ct.IsCancellationRequested)
+        {
+            WechatClawbotQrStatus status;
+            try
+            {
+                status = await GetQrCodeStatusAsync(httpClient, qrcode, ct);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (OperationCanceledException)
+            {
+                // 长轮询超时，视为 wait 继续
+                continue;
+            }
+
+            switch (status.Status)
+            {
+                case "confirmed":
+                    if (string.IsNullOrWhiteSpace(status.BotToken))
+                        throw new NotifierException("登录确认但未返回 bot_token");
+                    return new WechatClawbotLoginResult(
+                        status.BotToken!,
+                        status.BotId ?? string.Empty,
+                        status.UserId ?? string.Empty,
+                        status.BaseUrl ?? ApiBase);
+                case "expired":
+                    throw new NotifierException("二维码已过期，请重新登录");
+                case "need_verifycode":
+                case "verify_code_blocked":
+                    throw new NotifierException("登录需要手机验证码，当前版本暂不支持，请稍后重试");
+                case "binded_redirect":
+                    throw new NotifierException("该机器人已绑定过其他实例，请重新扫码");
+                case "wait":
+                case "scaned":
+                case "scaned_but_redirect":
+                default:
+                    break;
+            }
+
+            await Task.Delay(1000, ct);
+        }
+
+        throw new NotifierException("登录超时，请重试");
+    }
+
+    /// <summary>
+    /// 一次性验证码绑定：长轮询 getupdates，等待用户发送验证码，返回 to_user_id 和 context_token。
+    /// </summary>
+    /// <param name="botToken">扫码登录获得的 bot_token</param>
+    /// <param name="onVerifyCode">生成验证码后的回调，用于 UI 提示用户发送该验证码</param>
+    /// <param name="cancellationToken">取消令牌（用户点击取消时触发）</param>
+    public static async Task<WechatClawbotBindResult> BindAsync(
+        string botToken,
+        Action<string> onVerifyCode,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(botToken))
+            throw new NotifierException("微信 Clawbot BotToken 为空");
+
+        var verifyCode = GenerateVerifyCode();
+        using var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(60) };
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(TimeSpan.FromSeconds(BindTimeoutSeconds));
+        var ct = timeoutCts.Token;
+
+        onVerifyCode(verifyCode);
+
+        var buf = string.Empty;
+        var timeoutMs = DefaultLongPollTimeoutMs;
+        while (!ct.IsCancellationRequested)
+        {
+            WechatClawbotGetUpdatesResponse resp;
+            try
+            {
+                resp = await GetUpdatesAsync(httpClient, botToken, buf, timeoutMs, ct);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (OperationCanceledException)
+            {
+                // 长轮询超时，继续
+                continue;
+            }
+
+            if (resp.Ret != 0 || resp.ErrCode != 0)
+                throw new NotifierException($"getupdates 失败：ret={resp.Ret} errcode={resp.ErrCode} errmsg={resp.ErrMsg}");
+
+            if (!string.IsNullOrWhiteSpace(resp.GetUpdatesBuf))
+                buf = resp.GetUpdatesBuf;
+            if (resp.LongPollingTimeoutMs is > 0)
+                timeoutMs = resp.LongPollingTimeoutMs.Value;
+
+            foreach (var msg in resp.Msgs ?? [])
+            {
+                var text = ExtractText(msg);
+                if (text != null && text.Contains(verifyCode) && !string.IsNullOrWhiteSpace(msg.FromUserId))
+                    return new WechatClawbotBindResult(msg.FromUserId!, msg.ContextToken ?? string.Empty, buf);
+            }
+        }
+
+        throw new NotifierException("绑定超时，请重试");
+    }
+
+    internal static object BuildBaseInfo() => new
+    {
+        channel_version = ChannelVersion,
+        bot_agent = BotAgent,
+    };
+
+    /// <summary>
+    /// X-WECHAT-UIN 请求头：随机 uint32（大端）→ 十进制字符串 → base64，每次请求随机生成防重放。
+    /// </summary>
+    internal static string RandomWechatUin()
+    {
+        Span<byte> bytes = stackalloc byte[4];
+        RandomNumberGenerator.Fill(bytes);
+        var value = System.Buffers.Binary.BinaryPrimitives.ReadUInt32BigEndian(bytes);
+        return Convert.ToBase64String(Encoding.UTF8.GetBytes(value.ToString()));
+    }
+
+    internal static string GenerateClientId()
+    {
+        Span<byte> bytes = stackalloc byte[16];
+        RandomNumberGenerator.Fill(bytes);
+        return "openclaw-weixin-" + Convert.ToHexString(bytes).ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// 为 POST 请求添加完整请求头（Content-Type / AuthorizationType / X-WECHAT-UIN / iLink 标识 / Authorization）。
+    /// </summary>
+    internal static void AddCommonHeaders(HttpRequestMessage request, string? botToken)
+    {
+        request.Headers.TryAddWithoutValidation("AuthorizationType", "ilink_bot_token");
+        request.Headers.TryAddWithoutValidation("X-WECHAT-UIN", RandomWechatUin());
+        request.Headers.TryAddWithoutValidation("iLink-App-Id", AppId);
+        request.Headers.TryAddWithoutValidation("iLink-App-ClientVersion", AppClientVersion);
+        if (!string.IsNullOrWhiteSpace(botToken))
+            request.Headers.TryAddWithoutValidation("Authorization", $"Bearer {botToken}");
+    }
+
+    /// <summary>
+    /// 为 GET 请求添加请求头。官方实现中 get_qrcode_status 只携带 iLink 标识头，
+    /// 额外携带 X-WECHAT-UIN / AuthorizationType 会导致服务端立即返回 wait 且二维码快速过期。
+    /// </summary>
+    internal static void AddGetHeaders(HttpRequestMessage request)
+    {
+        request.Headers.TryAddWithoutValidation("iLink-App-Id", AppId);
+        request.Headers.TryAddWithoutValidation("iLink-App-ClientVersion", AppClientVersion);
+    }
+
+    internal static async Task<WechatClawbotGetUpdatesResponse> GetUpdatesAsync(
+        HttpClient httpClient,
+        string botToken,
+        string getUpdatesBuf,
+        int timeoutMs,
+        CancellationToken ct)
+    {
+        var body = JsonSerializer.Serialize(new
+        {
+            get_updates_buf = getUpdatesBuf,
+            base_info = BuildBaseInfo(),
+        });
+        using var request = new HttpRequestMessage(HttpMethod.Post, $"{ApiBase}/ilink/bot/getupdates")
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json"),
+        };
+        AddCommonHeaders(request, botToken);
+
+        // 长轮询超时：服务端 hold 约 35s，客户端按服务端建议值取消本次请求，
+        // 调用方将 OperationCanceledException（非用户取消）视为正常超时并继续轮询。
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeoutCts.CancelAfter(timeoutMs);
+        using var response = await httpClient.SendAsync(request, timeoutCts.Token);
+        var text = await response.Content.ReadAsStringAsync(timeoutCts.Token);
+        if (!response.IsSuccessStatusCode)
+            throw new NotifierException($"getupdates HTTP {(int)response.StatusCode}: {text}");
+        return JsonSerializer.Deserialize<WechatClawbotGetUpdatesResponse>(text)
+               ?? throw new NotifierException("getupdates 响应解析失败");
+    }
+
+    internal static string? ExtractText(WechatClawbotMessage msg)
+    {
+        if (msg.ItemList == null)
+            return null;
+        foreach (var item in msg.ItemList)
+        {
+            if (item.Type == 1 && item.TextItem?.Text != null)
+                return item.TextItem.Text;
+        }
+        return null;
+    }
+
+    private static string GenerateVerifyCode()
+    {
+        Span<byte> bytes = stackalloc byte[VerifyCodeLength];
+        RandomNumberGenerator.Fill(bytes);
+        var code = new char[VerifyCodeLength];
+        for (var i = 0; i < VerifyCodeLength; i++)
+            code[i] = (char)('0' + bytes[i] % 10);
+        return new string(code);
+    }
+
+    private static async Task<(string Qrcode, string QrCodeUrl)> GetBotQrCodeAsync(HttpClient httpClient, CancellationToken ct)
+    {
+        var body = JsonSerializer.Serialize(new { local_token_list = Array.Empty<string>() });
+        using var request = new HttpRequestMessage(HttpMethod.Post, $"{ApiBase}/ilink/bot/get_bot_qrcode?bot_type=3")
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json"),
+        };
+        AddCommonHeaders(request, null);
+        using var response = await httpClient.SendAsync(request, ct);
+        var text = await response.Content.ReadAsStringAsync(ct);
+        if (!response.IsSuccessStatusCode)
+            throw new NotifierException($"获取登录二维码失败 HTTP {(int)response.StatusCode}: {text}");
+        using var doc = JsonDocument.Parse(text);
+        var root = doc.RootElement;
+        var qrcode = root.TryGetProperty("qrcode", out var q) ? q.GetString() : null;
+        if (string.IsNullOrWhiteSpace(qrcode))
+            throw new NotifierException("获取登录二维码失败：响应缺少 qrcode");
+        var url = root.TryGetProperty("qrcode_img_content", out var u) ? u.GetString() : null;
+        if (string.IsNullOrWhiteSpace(url))
+            url = $"https://liteapp.weixin.qq.com/q/{qrcode}?bot_type=3";
+        return (qrcode!, url!);
+    }
+
+    private static async Task<WechatClawbotQrStatus> GetQrCodeStatusAsync(HttpClient httpClient, string qrcode, CancellationToken ct)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"{ApiBase}/ilink/bot/get_qrcode_status?qrcode={Uri.EscapeDataString(qrcode)}");
+        AddGetHeaders(request);
+        using var response = await httpClient.SendAsync(request, ct);
+        var text = await response.Content.ReadAsStringAsync(ct);
+        if (!response.IsSuccessStatusCode)
+            throw new NotifierException($"查询扫码状态失败 HTTP {(int)response.StatusCode}: {text}");
+        using var doc = JsonDocument.Parse(text);
+        var root = doc.RootElement;
+        return new WechatClawbotQrStatus(
+            root.TryGetProperty("status", out var s) ? s.GetString() ?? "wait" : "wait",
+            root.TryGetProperty("bot_token", out var bt) ? bt.GetString() : null,
+            root.TryGetProperty("ilink_bot_id", out var bid) ? bid.GetString() : null,
+            root.TryGetProperty("ilink_user_id", out var uid) ? uid.GetString() : null,
+            root.TryGetProperty("baseurl", out var bu) ? bu.GetString() : null,
+            root.TryGetProperty("redirect_host", out var rh) ? rh.GetString() : null);
+    }
+}
+
+public sealed class WechatClawbotLoginResult
+{
+    public string BotToken { get; }
+    public string BotId { get; }
+    public string UserId { get; }
+    public string BaseUrl { get; }
+
+    public WechatClawbotLoginResult(string botToken, string botId, string userId, string baseUrl)
+    {
+        BotToken = botToken;
+        BotId = botId;
+        UserId = userId;
+        BaseUrl = baseUrl;
+    }
+}
+
+public sealed class WechatClawbotBindResult
+{
+    public string ToUserId { get; }
+    public string ContextToken { get; }
+    public string GetUpdatesBuf { get; }
+
+    public WechatClawbotBindResult(string toUserId, string contextToken, string getUpdatesBuf)
+    {
+        ToUserId = toUserId;
+        ContextToken = contextToken;
+        GetUpdatesBuf = getUpdatesBuf;
+    }
+}
+
+internal sealed record WechatClawbotQrStatus(
+    string Status,
+    string? BotToken,
+    string? BotId,
+    string? UserId,
+    string? BaseUrl,
+    string? RedirectHost);
+
+internal sealed class WechatClawbotGetUpdatesResponse
+{
+    [JsonPropertyName("ret")] public int Ret { get; set; }
+    [JsonPropertyName("errcode")] public int ErrCode { get; set; }
+    [JsonPropertyName("errmsg")] public string? ErrMsg { get; set; }
+    [JsonPropertyName("msgs")] public List<WechatClawbotMessage>? Msgs { get; set; }
+    [JsonPropertyName("get_updates_buf")] public string? GetUpdatesBuf { get; set; }
+    [JsonPropertyName("longpolling_timeout_ms")] public int? LongPollingTimeoutMs { get; set; }
+}
+
+internal sealed class WechatClawbotMessage
+{
+    [JsonPropertyName("from_user_id")] public string? FromUserId { get; set; }
+    [JsonPropertyName("to_user_id")] public string? ToUserId { get; set; }
+    [JsonPropertyName("context_token")] public string? ContextToken { get; set; }
+    [JsonPropertyName("item_list")] public List<WechatClawbotMessageItem>? ItemList { get; set; }
+}
+
+internal sealed class WechatClawbotMessageItem
+{
+    [JsonPropertyName("type")] public int Type { get; set; }
+    [JsonPropertyName("text_item")] public WechatClawbotTextItem? TextItem { get; set; }
+}
+
+internal sealed class WechatClawbotTextItem
+{
+    [JsonPropertyName("text")] public string? Text { get; set; }
+}

--- a/BetterGenshinImpact/Service/Notifier/WechatClawbotHelper.cs
+++ b/BetterGenshinImpact/Service/Notifier/WechatClawbotHelper.cs
@@ -12,9 +12,14 @@ using BetterGenshinImpact.Service.Notifier.Exception;
 namespace BetterGenshinImpact.Service.Notifier;
 
 /// <summary>
-/// 微信 Clawbot（iLink 协议）帮助类。
-/// 负责扫码登录（get_bot_qrcode → get_qrcode_status）和一次性验证码绑定（getupdates 长轮询）。
-/// 协议参考官方 npm 包 @tencent-weixin/openclaw-weixin，BetterGI 内置实现，不依赖 OpenClaw。
+/// 微信 Clawbot（iLink 协议）帮助类，BetterGI 内置实现，不依赖 OpenClaw。
+///
+/// 完整流程：
+/// 1. 登录（get_bot_qrcode → 轮询 get_qrcode_status）→ 获取 bot_token、base_url、用户 ID
+/// 2. 绑定（长轮询 getupdates → 用户发送一次性验证码 → 捕获 to_user_id + context_token）
+/// 3. 发送（sendmessage）+ 图片上传（getuploadurl → AES-128-ECB 加密 → CDN POST → sendmessage）
+///
+/// 协议参考官方 npm 包 @tencent-weixin/openclaw-weixin（v2.4.6），请求头格式见 AddCommonHeaders。
 /// </summary>
 public static class WechatClawbotHelper
 {
@@ -31,7 +36,10 @@ public static class WechatClawbotHelper
     private const int DefaultLongPollTimeoutMs = 35000;
 
     /// <summary>
-    /// 扫码登录：获取二维码并轮询扫码状态，确认后返回 bot_token 等信息。
+    /// 扫码登录：获取二维码并轮询扫码状态，确认后返回 bot_token、base_url、用户 ID 等。
+    ///
+    /// 流程：POST get_bot_qrcode → GET get_qrcode_status（长轮询 ~30s/次）→ confirmed。
+    /// 整体超时 300 秒。confirmed 时必须返回 ilink_user_id（扫码用户身份），否则拒绝继续。
     /// </summary>
     /// <param name="onQrCodeUrl">获取到二维码链接后的回调，用于 UI 展示/打开浏览器</param>
     /// <param name="cancellationToken">取消令牌（用户点击取消时触发）</param>
@@ -119,6 +127,7 @@ public static class WechatClawbotHelper
 
     /// <summary>
     /// 一次性验证码绑定：长轮询 getupdates，等待扫码用户发送验证码，返回 to_user_id 和 context_token。
+    /// 绑定窗口内仅接受 expectedUserId 发送的消息（安全校验），防止其他用户误绑。
     /// </summary>
     /// <param name="botToken">扫码登录获得的 bot_token</param>
     /// <param name="baseUrl">登录响应返回的 API 基础地址（为空回退默认主机）</param>
@@ -189,6 +198,10 @@ public static class WechatClawbotHelper
         throw new NotifierException("绑定超时，请重试");
     }
 
+    /// <summary>
+    /// 构建所有 POST 请求体附带的 base_info 块（协议要求）。
+    /// channel_version 为 iLink 协议版本；bot_agent 用于后台观测与流量归因。
+    /// </summary>
     internal static object BuildBaseInfo() => new
     {
         channel_version = ChannelVersion,
@@ -196,7 +209,8 @@ public static class WechatClawbotHelper
     };
 
     /// <summary>
-    /// X-WECHAT-UIN 请求头：随机 uint32（大端）→ 十进制字符串 → base64，每次请求随机生成防重放。
+    /// X-WECHAT-UIN 请求头：随机 uint32（大端序）→ 十进制字符串 → base64 编码。
+    /// 每次请求随机生成，防止请求重放攻击（服务端以 UIN + 时间戳去重）。
     /// </summary>
     internal static string RandomWechatUin()
     {
@@ -206,6 +220,10 @@ public static class WechatClawbotHelper
         return Convert.ToBase64String(Encoding.UTF8.GetBytes(value.ToString()));
     }
 
+    /// <summary>
+    /// 生成唯一消息客户端 ID（openclaw-weixin- + 32 位随机 hex）。
+    /// 用于 sendmessage 的 client_id 字段，服务端可借此区分不同发送方。
+    /// </summary>
     internal static string GenerateClientId()
     {
         Span<byte> bytes = stackalloc byte[16];
@@ -214,7 +232,8 @@ public static class WechatClawbotHelper
     }
 
     /// <summary>
-    /// 规范化 API 基础地址：空值回退默认主机，并去除尾部斜杠。
+    /// 规范化 API 基础地址：空值回退默认主机（ilinkai.weixin.qq.com），并去除尾部斜杠。
+    /// 微信 ClawBot 协议的 host 可能因 IDC 重定向而变化，base_url 由登录响应提供。
     /// </summary>
     internal static string NormalizeBaseUrl(string? baseUrl)
     {
@@ -245,6 +264,10 @@ public static class WechatClawbotHelper
         request.Headers.TryAddWithoutValidation("iLink-App-ClientVersion", AppClientVersion);
     }
 
+    /// <summary>
+    /// 长轮询 getupdates：服务端 hold 35s，客户端通过 linked CTS 按服务器建议超时取消。
+    /// OperationCanceledException（非用户取消）视为正常轮询超时，调用方可安全 continue。
+    /// </summary>
     internal static async Task<WechatClawbotGetUpdatesResponse> GetUpdatesAsync(
         HttpClient httpClient,
         string baseUrl,

--- a/BetterGenshinImpact/Service/Notifier/WechatClawbotHelper.cs
+++ b/BetterGenshinImpact/Service/Notifier/WechatClawbotHelper.cs
@@ -56,11 +56,18 @@ public static class WechatClawbotHelper
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
+                // 用户主动取消
                 throw;
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                // 内部登录超时（timeoutCts 触发），转成明确错误而不是“已取消”
+                throw new NotifierException("登录超时，请重试");
             }
             catch (OperationCanceledException)
             {
-                // 长轮询超时，视为 wait 继续
+                // 单次长轮询超时，视为 wait 继续；退避 1 秒再查，避免空转
+                await Task.Delay(1000, CancellationToken.None);
                 continue;
             }
 
@@ -88,20 +95,36 @@ public static class WechatClawbotHelper
                     break;
             }
 
-            await Task.Delay(1000, ct);
+            try
+            {
+                await Task.Delay(1000, ct);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // 用户取消
+                throw;
+            }
+            catch (OperationCanceledException)
+            {
+                // 登录超时（timeoutCts 在轮询间隔内触发）→ 转明确错误
+                throw new NotifierException("登录超时，请重试");
+            }
         }
 
         throw new NotifierException("登录超时，请重试");
     }
 
     /// <summary>
-    /// 一次性验证码绑定：长轮询 getupdates，等待用户发送验证码，返回 to_user_id 和 context_token。
+    /// 一次性验证码绑定：长轮询 getupdates，等待扫码用户发送验证码，返回 to_user_id 和 context_token。
     /// </summary>
     /// <param name="botToken">扫码登录获得的 bot_token</param>
+    /// <param name="expectedUserId">扫码登录返回的用户 ID（ilink_user_id），仅接受该用户发送的验证码，
+    /// 防止绑定窗口内其他用户误发导致绑错账号</param>
     /// <param name="onVerifyCode">生成验证码后的回调，用于 UI 提示用户发送该验证码</param>
     /// <param name="cancellationToken">取消令牌（用户点击取消时触发）</param>
     public static async Task<WechatClawbotBindResult> BindAsync(
         string botToken,
+        string expectedUserId,
         Action<string> onVerifyCode,
         CancellationToken cancellationToken)
     {
@@ -146,7 +169,11 @@ public static class WechatClawbotHelper
             foreach (var msg in resp.Msgs ?? [])
             {
                 var text = ExtractText(msg);
-                if (text != null && text.Contains(verifyCode) && !string.IsNullOrWhiteSpace(msg.FromUserId))
+                // 仅接受扫码用户发来的验证码消息，防止其他用户误绑
+                var isExpectedSender = !string.IsNullOrWhiteSpace(expectedUserId)
+                    ? string.Equals(msg.FromUserId, expectedUserId, StringComparison.Ordinal)
+                    : !string.IsNullOrWhiteSpace(msg.FromUserId);
+                if (text != null && text.Contains(verifyCode) && isExpectedSender)
                     return new WechatClawbotBindResult(msg.FromUserId!, msg.ContextToken ?? string.Empty, buf);
             }
         }

--- a/BetterGenshinImpact/Service/Notifier/WechatClawbotHelper.cs
+++ b/BetterGenshinImpact/Service/Notifier/WechatClawbotHelper.cs
@@ -188,10 +188,13 @@ public static class WechatClawbotHelper
             foreach (var msg in resp.Msgs ?? [])
             {
                 var text = ExtractText(msg);
-                // 仅接受扫码用户发来的验证码消息，防止其他用户误绑
+                // 仅接受扫码用户发来的验证码消息，且必须携带 context_token，防止其他用户误绑
                 var isExpectedSender = string.Equals(msg.FromUserId, expectedUserId, StringComparison.Ordinal);
-                if (text != null && text.Contains(verifyCode) && isExpectedSender)
-                    return new WechatClawbotBindResult(msg.FromUserId!, msg.ContextToken ?? string.Empty, buf);
+                if (text != null && text.Contains(verifyCode) && isExpectedSender
+                    && !string.IsNullOrWhiteSpace(msg.ContextToken))
+                {
+                    return new WechatClawbotBindResult(msg.FromUserId!, msg.ContextToken!, buf);
+                }
             }
         }
 

--- a/BetterGenshinImpact/Service/Notifier/WechatClawbotNotifier.cs
+++ b/BetterGenshinImpact/Service/Notifier/WechatClawbotNotifier.cs
@@ -364,6 +364,10 @@ public sealed class WechatClawbotNotifier : INotifier, IDisposable
             return false;
         if (ex is JsonException || ex is InvalidOperationException)
             return false;
+        // NotifierException 为业务错误（如 getuploadurl 缺少上传地址、CDN 响应缺少 x-encrypted-param），
+        // 属于确定性失败，不应重试，避免重复上传截图并累计退避延迟。
+        if (ex is NotifierException)
+            return false;
         return true;
     }
 

--- a/BetterGenshinImpact/Service/Notifier/WechatClawbotNotifier.cs
+++ b/BetterGenshinImpact/Service/Notifier/WechatClawbotNotifier.cs
@@ -40,22 +40,28 @@ public sealed class WechatClawbotNotifier : INotifier, IDisposable
     private readonly WechatClawbotSession _session;
     private readonly CancellationTokenSource _cts = new();
 
+    /// <summary>
+    /// 构造微信通知器，固定构造时的凭证快照（bot_token、user_id、base_url），
+    /// 发送期间即使配置被重新绑定变更，旧实例也不会混用新旧凭证。
+    /// </summary>
+    /// <param name="httpClient">共享的 HttpClient 实例（30s 超时）</param>
+    /// <param name="config">通知配置（读取绑定凭证，运行期不再读取）</param>
+    /// <param name="startSession">仅主实例启动长轮询会话；子实例（桌面分身等）保留发送能力但不推游标。</param>
     public WechatClawbotNotifier(HttpClient httpClient, NotificationConfig config, bool startSession = true)
     {
         _httpClient = httpClient;
-        // 固定构造时的凭证快照：发送期间即使配置被重新绑定变更，旧实例也不会混用新旧凭证
         _botToken = config.WechatClawbotBotToken;
         _toUserId = config.WechatClawbotToUserId;
         _baseUrl = WechatClawbotHelper.NormalizeBaseUrl(config.WechatClawbotBaseUrl);
         _session = new WechatClawbotSession(_botToken, _baseUrl, _toUserId);
-        // 子实例（桌面分身等）保留微信发送能力，但只有主实例启动长轮询会话，
-        // 避免多个进程用旧游标并发推进、互相覆盖 context_token / get_updates_buf。
         if (startSession)
             _ = _session.StartAsync();
     }
 
     /// <summary>
-    /// 发送通知：先发文本，再发截图（如有）。截图失败时降级为纯文本，不阻断主流程。
+    /// 发送通知：先发文本，再发截图（如有）。
+    /// 截图上传链路：JPEG 编码 → getuploadurl 获取预签名 → AES-128-ECB 加密 → CDN POST 上传 → sendmessage。
+    /// 图片发送失败时自动降级为纯文本（文本已成功），不阻断主流程。
     /// </summary>
     public async Task SendAsync(BaseNotificationData content)
     {
@@ -224,8 +230,11 @@ public sealed class WechatClawbotNotifier : INotifier, IDisposable
     }
 
     /// <summary>
-    /// 上传图片到微信 CDN：getuploadurl → AES-128-ECB 加密 → POST 上传。
-    /// 上传阶段幂等，可重试。
+    /// 上传图片到微信 CDN（幂等操作，全链路重试）：
+    /// 1. 计算明文 MD5、PKCS7 填充后密文大小、随机 filekey/aeskey
+    /// 2. POST getuploadurl → 获取 upload_full_url 或 upload_param
+    /// 3. AES-128-ECB 加密明文 → POST 密文到 CDN → 获取 x-encrypted-param
+    /// 4. 返回 downloadParam 供 sendmessage 的 image_item.media 引用
     /// </summary>
     private async Task<WechatClawbotUploadedImage> UploadImageAsync(byte[] imageBytes, CancellationToken ct)
     {
@@ -329,8 +338,13 @@ public sealed class WechatClawbotNotifier : INotifier, IDisposable
     private static int AesEcbPaddedSize(int plaintextSize) => ((plaintextSize + 16) / 16) * 16;
 
     /// <summary>
-    /// 判断异常是否可重试。5xx/429/400 可重试（有界重试仅作用于幂等上传操作）；
-    /// 无状态码的网络故障可重试；取消/解析错误不重试。
+    /// 判断异常是否可重试。分类策略：
+    /// - WechatClawbotHttpException：仅 5xx/429/400 可重试（401/403/404 客户端错误不重试）
+    /// - HttpRequestException（无状态码）：网络故障可重试
+    /// - OperationCanceledException：用户取消不可重试（超时已在调用方处理）
+    /// - JsonException/InvalidOperationException：数据错误不重试
+    /// - NotifierException：业务错误不重试
+    /// 注意：仅用于幂等操作（getuploadurl、CDN 上传），非幂等的 sendmessage 不走此路径。
     /// </summary>
     private static bool IsRetryable(System.Exception ex)
     {

--- a/BetterGenshinImpact/Service/Notifier/WechatClawbotNotifier.cs
+++ b/BetterGenshinImpact/Service/Notifier/WechatClawbotNotifier.cs
@@ -10,7 +10,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using BetterGenshinImpact.Service.Notification;
 using BetterGenshinImpact.Service.Notification.Model;
-using BetterGenshinImpact.Service.Notification.Model.Enum;
 using BetterGenshinImpact.Service.Notifier.Exception;
 using BetterGenshinImpact.Service.Notifier.Interface;
 using Microsoft.Extensions.Logging;
@@ -108,22 +107,16 @@ public sealed class WechatClawbotNotifier : INotifier, IDisposable
     }
 
     /// <summary>
-    /// 生成通知文本，包含结果标记（成功/失败/警告）和时间戳。
+    /// 生成通知文本。简洁排版：时间放开头，推送内容在第二行，
+    /// 去掉 [BetterGI] 前缀和 emoji 状态符号，使消息列表更紧凑、信息层级更清晰。
     /// </summary>
     private static string GenerateMessage(BaseNotificationData data)
     {
         var sb = new StringBuilder();
-        var mark = data.Result switch
-        {
-            NotificationEventResult.Success => "\u2705",
-            NotificationEventResult.Fail => "\u274C",
-            _ => "\u26A0\uFE0F"
-        };
-        sb.Append($"[BetterGI] {mark} ");
+        sb.Append($"[{data.Timestamp:yyyy-MM-dd HH:mm:ss}]");
+        sb.AppendLine();
         if (!string.IsNullOrWhiteSpace(data.Message))
             sb.Append(data.Message);
-        sb.AppendLine();
-        sb.Append($"\uD83D\uDD50 {data.Timestamp:yyyy-MM-dd HH:mm:ss}");
         return sb.ToString();
     }
 

--- a/BetterGenshinImpact/Service/Notifier/WechatClawbotNotifier.cs
+++ b/BetterGenshinImpact/Service/Notifier/WechatClawbotNotifier.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using BetterGenshinImpact.Service.Notification;
 using BetterGenshinImpact.Service.Notification.Model;
+using BetterGenshinImpact.Service.Notification.Model.Enum;
 using BetterGenshinImpact.Service.Notifier.Exception;
 using BetterGenshinImpact.Service.Notifier.Interface;
 using Microsoft.Extensions.Logging;
@@ -107,16 +108,22 @@ public sealed class WechatClawbotNotifier : INotifier, IDisposable
     }
 
     /// <summary>
-    /// 生成通知文本。简洁排版：时间放开头，推送内容在第二行，
-    /// 去掉 [BetterGI] 前缀和 emoji 状态符号，使消息列表更紧凑、信息层级更清晰。
+    /// 生成通知文本，包含结果标记（成功/失败/警告）和时间戳。
     /// </summary>
     private static string GenerateMessage(BaseNotificationData data)
     {
         var sb = new StringBuilder();
-        sb.Append($"[{data.Timestamp:yyyy-MM-dd HH:mm:ss}]");
-        sb.AppendLine();
+        var mark = data.Result switch
+        {
+            NotificationEventResult.Success => "\u2705",
+            NotificationEventResult.Fail => "\u274C",
+            _ => "\u26A0\uFE0F"
+        };
+        sb.Append($"[BetterGI] {mark} ");
         if (!string.IsNullOrWhiteSpace(data.Message))
             sb.Append(data.Message);
+        sb.AppendLine();
+        sb.Append($"\uD83D\uDD50 {data.Timestamp:yyyy-MM-dd HH:mm:ss}");
         return sb.ToString();
     }
 

--- a/BetterGenshinImpact/Service/Notifier/WechatClawbotNotifier.cs
+++ b/BetterGenshinImpact/Service/Notifier/WechatClawbotNotifier.cs
@@ -42,11 +42,7 @@ public sealed class WechatClawbotNotifier : INotifier, IDisposable
     {
         _httpClient = httpClient;
         _config = config;
-        _session = new WechatClawbotSession(
-            config.WechatClawbotBotToken,
-            config.WechatClawbotToUserId,
-            config.WechatClawbotContextToken,
-            config.WechatClawbotGetUpdatesBuf);
+        _session = new WechatClawbotSession(config);
         _session.Start();
     }
 
@@ -196,7 +192,8 @@ public sealed class WechatClawbotNotifier : INotifier, IDisposable
     /// </summary>
     private async Task SendMessageAsync(string body, CancellationToken ct)
     {
-        using var request = new HttpRequestMessage(HttpMethod.Post, $"{WechatClawbotHelper.ApiBase}/ilink/bot/sendmessage")
+        var baseUrl = WechatClawbotHelper.NormalizeBaseUrl(_config.WechatClawbotBaseUrl);
+        using var request = new HttpRequestMessage(HttpMethod.Post, $"{baseUrl}/ilink/bot/sendmessage")
         {
             Content = new StringContent(body, Encoding.UTF8, "application/json"),
         };
@@ -252,7 +249,8 @@ public sealed class WechatClawbotNotifier : INotifier, IDisposable
             aeskey = Convert.ToHexString(aeskey).ToLowerInvariant(),
             base_info = WechatClawbotHelper.BuildBaseInfo(),
         });
-        using var request = new HttpRequestMessage(HttpMethod.Post, $"{WechatClawbotHelper.ApiBase}/ilink/bot/getuploadurl")
+        var baseUrl = WechatClawbotHelper.NormalizeBaseUrl(_config.WechatClawbotBaseUrl);
+        using var request = new HttpRequestMessage(HttpMethod.Post, $"{baseUrl}/ilink/bot/getuploadurl")
         {
             Content = new StringContent(body, Encoding.UTF8, "application/json"),
         };

--- a/BetterGenshinImpact/Service/Notifier/WechatClawbotNotifier.cs
+++ b/BetterGenshinImpact/Service/Notifier/WechatClawbotNotifier.cs
@@ -42,7 +42,11 @@ public sealed class WechatClawbotNotifier : INotifier, IDisposable
     {
         _httpClient = httpClient;
         _config = config;
-        _session = new WechatClawbotSession(config);
+        _session = new WechatClawbotSession(
+            config.WechatClawbotBotToken,
+            config.WechatClawbotToUserId,
+            config.WechatClawbotContextToken,
+            config.WechatClawbotGetUpdatesBuf);
         _session.Start();
     }
 
@@ -256,7 +260,7 @@ public sealed class WechatClawbotNotifier : INotifier, IDisposable
         using var response = await _httpClient.SendAsync(request, ct);
         var text = await response.Content.ReadAsStringAsync(ct);
         if (!response.IsSuccessStatusCode)
-            throw new NotifierException($"getuploadurl HTTP {(int)response.StatusCode}: {text}");
+            throw new WechatClawbotHttpException((int)response.StatusCode, $"getuploadurl HTTP {(int)response.StatusCode}: {text}");
 
         using var doc = JsonDocument.Parse(text);
         var root = doc.RootElement;
@@ -287,7 +291,7 @@ public sealed class WechatClawbotNotifier : INotifier, IDisposable
         if (!response.IsSuccessStatusCode)
         {
             var errText = await response.Content.ReadAsStringAsync(ct);
-            throw new NotifierException($"CDN 上传失败 HTTP {(int)response.StatusCode}: {errText}");
+            throw new WechatClawbotHttpException((int)response.StatusCode, $"CDN 上传失败 HTTP {(int)response.StatusCode}: {errText}");
         }
 
         var downloadParam = response.Headers.TryGetValues("x-encrypted-param", out var values)
@@ -322,6 +326,8 @@ public sealed class WechatClawbotNotifier : INotifier, IDisposable
     /// </summary>
     private static bool IsRetryable(System.Exception ex)
     {
+        if (ex is WechatClawbotHttpException whe)
+            return (whe.StatusCode >= 500 && whe.StatusCode <= 599) || whe.StatusCode == 429 || whe.StatusCode == 400;
         if (ex is HttpRequestException hre)
         {
             var statusCode = hre.StatusCode;
@@ -363,4 +369,12 @@ public sealed class WechatClawbotNotifier : INotifier, IDisposable
     private sealed record WechatClawbotUploadUrl(string? UploadParam, string? UploadFullUrl);
 
     private sealed record WechatClawbotUploadedImage(string DownloadParam, byte[] AesKey, int CiphertextSize);
+
+    /// <summary>
+    /// 携带 HTTP 状态码的通知异常，供重试判定使用（避免把 401/403/404 等客户端错误当成可重试）。
+    /// </summary>
+    private sealed class WechatClawbotHttpException(int statusCode, string message) : NotifierException(message)
+    {
+        public int StatusCode { get; } = statusCode;
+    }
 }

--- a/BetterGenshinImpact/Service/Notifier/WechatClawbotNotifier.cs
+++ b/BetterGenshinImpact/Service/Notifier/WechatClawbotNotifier.cs
@@ -1,0 +1,366 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using BetterGenshinImpact.Service.Notification;
+using BetterGenshinImpact.Service.Notification.Model;
+using BetterGenshinImpact.Service.Notification.Model.Enum;
+using BetterGenshinImpact.Service.Notifier.Exception;
+using BetterGenshinImpact.Service.Notifier.Interface;
+using Microsoft.Extensions.Logging;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace BetterGenshinImpact.Service.Notifier;
+
+/// <summary>
+/// 微信 Clawbot 通知器。
+/// 通过微信 iLink 协议（ilinkai.weixin.qq.com）将 BetterGI 事件推送到用户微信。
+/// 支持文本消息和截图图片消息（CDN AES-128-ECB 加密上传）。
+/// 内置实现，不依赖 OpenClaw；扫码登录后由后台长轮询维持 context_token。
+/// </summary>
+public sealed class WechatClawbotNotifier : INotifier, IDisposable
+{
+    private static readonly ILogger<WechatClawbotNotifier> Logger = App.GetLogger<WechatClawbotNotifier>();
+
+    public string Name { get; } = "微信 Clawbot";
+
+    private const int MaxRetry = 3;
+
+    private readonly HttpClient _httpClient;
+    private readonly NotificationConfig _config;
+    private readonly WechatClawbotSession _session;
+    private readonly CancellationTokenSource _cts = new();
+
+    public WechatClawbotNotifier(HttpClient httpClient, NotificationConfig config)
+    {
+        _httpClient = httpClient;
+        _config = config;
+        _session = new WechatClawbotSession(config);
+        _session.Start();
+    }
+
+    /// <summary>
+    /// 发送通知：先发文本，再发截图（如有）。截图失败时降级为纯文本，不阻断主流程。
+    /// </summary>
+    public async Task SendAsync(BaseNotificationData content)
+    {
+        if (string.IsNullOrWhiteSpace(_config.WechatClawbotBotToken))
+            throw new NotifierException("微信 Clawbot BotToken 为空，请先扫码登录");
+
+        if (string.IsNullOrWhiteSpace(_config.WechatClawbotToUserId))
+            throw new NotifierException("微信 Clawbot 未绑定用户，请先完成绑定");
+
+        var ct = _cts.Token;
+        try
+        {
+            var text = GenerateMessage(content);
+            await SendTextAsync(text, ct);
+
+            if (content.Screenshot != null)
+            {
+                try
+                {
+                    await SendImageAsync(content.Screenshot, ct);
+                }
+                catch (System.Exception ex)
+                {
+                    // 图片发送失败时降级为纯文本，不阻断通知
+                    Logger.LogWarning("微信 Clawbot 图片发送失败，降级为纯文本: {Ex}", ex.Message);
+                }
+            }
+        }
+        catch (NotifierException)
+        {
+            throw;
+        }
+        catch (System.Exception ex)
+        {
+            throw new NotifierException($"发送微信 Clawbot 消息失败: {ex.Message}");
+        }
+    }
+
+    public void Dispose()
+    {
+        _cts.Cancel();
+        _session.Dispose();
+        _cts.Dispose();
+    }
+
+    /// <summary>
+    /// 生成通知文本，包含结果标记（成功/失败/警告）和时间戳。
+    /// </summary>
+    private static string GenerateMessage(BaseNotificationData data)
+    {
+        var sb = new StringBuilder();
+        var mark = data.Result switch
+        {
+            NotificationEventResult.Success => "\u2705",
+            NotificationEventResult.Fail => "\u274C",
+            _ => "\u26A0\uFE0F"
+        };
+        sb.Append($"[BetterGI] {mark} ");
+        if (!string.IsNullOrWhiteSpace(data.Message))
+            sb.Append(data.Message);
+        sb.AppendLine();
+        sb.Append($"\uD83D\uDD50 {data.Timestamp:yyyy-MM-dd HH:mm:ss}");
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// 发送纯文本消息。注意：此请求非幂等，不重试，避免重复消息。
+    /// </summary>
+    private async Task SendTextAsync(string text, CancellationToken ct)
+    {
+        var contextToken = await _session.GetContextTokenAsync(ct);
+        var body = JsonSerializer.Serialize(new
+        {
+            msg = new
+            {
+                from_user_id = string.Empty,
+                to_user_id = _config.WechatClawbotToUserId,
+                client_id = WechatClawbotHelper.GenerateClientId(),
+                message_type = 2,
+                message_state = 2,
+                context_token = contextToken,
+                item_list = new[]
+                {
+                    new { type = 1, text_item = new { text } }
+                }
+            },
+            base_info = WechatClawbotHelper.BuildBaseInfo(),
+        });
+        await SendMessageAsync(body, ct);
+    }
+
+    /// <summary>
+    /// 发送截图图片消息：先上传图片拿到 CDN 引用，再发图片消息。
+    /// </summary>
+    private async Task SendImageAsync(Image<Rgb24> screenshot, CancellationToken ct)
+    {
+        byte[] imageBytes;
+        using (var ms = new MemoryStream())
+        {
+            screenshot.SaveAsJpeg(ms);
+            imageBytes = ms.ToArray();
+        }
+
+        var uploaded = await UploadImageAsync(imageBytes, ct);
+        var contextToken = await _session.GetContextTokenAsync(ct);
+
+        var body = JsonSerializer.Serialize(new
+        {
+            msg = new
+            {
+                from_user_id = string.Empty,
+                to_user_id = _config.WechatClawbotToUserId,
+                client_id = WechatClawbotHelper.GenerateClientId(),
+                message_type = 2,
+                message_state = 2,
+                context_token = contextToken,
+                item_list = new[]
+                {
+                    new
+                    {
+                        type = 2,
+                        image_item = new
+                        {
+                            media = new
+                            {
+                                encrypt_query_param = uploaded.DownloadParam,
+                                aes_key = Convert.ToBase64String(uploaded.AesKey),
+                                encrypt_type = 1,
+                            },
+                            mid_size = uploaded.CiphertextSize,
+                        }
+                    }
+                }
+            },
+            base_info = WechatClawbotHelper.BuildBaseInfo(),
+        });
+        await SendMessageAsync(body, ct);
+    }
+
+    /// <summary>
+    /// 调用 sendmessage 接口。非幂等，不重试；读取响应体检查业务返回码。
+    /// </summary>
+    private async Task SendMessageAsync(string body, CancellationToken ct)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, $"{WechatClawbotHelper.ApiBase}/ilink/bot/sendmessage")
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json"),
+        };
+        WechatClawbotHelper.AddCommonHeaders(request, _config.WechatClawbotBotToken);
+        using var response = await _httpClient.SendAsync(request, ct);
+        var text = await response.Content.ReadAsStringAsync(ct);
+        if (!response.IsSuccessStatusCode)
+            throw new NotifierException($"sendmessage HTTP {(int)response.StatusCode}: {text}");
+
+        using var doc = JsonDocument.Parse(text);
+        var root = doc.RootElement;
+        var ret = root.TryGetProperty("ret", out var retElement) ? retElement.GetInt32() : 0;
+        if (ret != 0)
+        {
+            var errmsg = root.TryGetProperty("errmsg", out var errElement) ? errElement.GetString() : null;
+            throw new NotifierException($"sendmessage 返回错误 ret={ret} errmsg={errmsg}");
+        }
+    }
+
+    /// <summary>
+    /// 上传图片到微信 CDN：getuploadurl → AES-128-ECB 加密 → POST 上传。
+    /// 上传阶段幂等，可重试。
+    /// </summary>
+    private async Task<WechatClawbotUploadedImage> UploadImageAsync(byte[] imageBytes, CancellationToken ct)
+    {
+        var rawsize = imageBytes.Length;
+        var rawfilemd5 = Convert.ToHexString(MD5.HashData(imageBytes)).ToLowerInvariant();
+        var filesize = AesEcbPaddedSize(rawsize);
+        var filekey = Convert.ToHexString(RandomNumberGenerator.GetBytes(16)).ToLowerInvariant();
+        var aeskey = RandomNumberGenerator.GetBytes(16);
+
+        var uploadUrl = await WithRetryAsync(() => GetUploadUrlAsync(filekey, rawsize, rawfilemd5, filesize, aeskey, ct), ct);
+        var downloadParam = await WithRetryAsync(() => UploadToCdnAsync(uploadUrl, filekey, imageBytes, aeskey, ct), ct);
+
+        return new WechatClawbotUploadedImage(downloadParam, aeskey, filesize);
+    }
+
+    /// <summary>
+    /// 调用 getuploadurl 接口获取 CDN 上传地址。
+    /// </summary>
+    private async Task<WechatClawbotUploadUrl> GetUploadUrlAsync(
+        string filekey, int rawsize, string rawfilemd5, int filesize, byte[] aeskey, CancellationToken ct)
+    {
+        var body = JsonSerializer.Serialize(new
+        {
+            filekey,
+            media_type = 1,
+            to_user_id = _config.WechatClawbotToUserId,
+            rawsize,
+            rawfilemd5,
+            filesize,
+            no_need_thumb = true,
+            aeskey = Convert.ToHexString(aeskey).ToLowerInvariant(),
+            base_info = WechatClawbotHelper.BuildBaseInfo(),
+        });
+        using var request = new HttpRequestMessage(HttpMethod.Post, $"{WechatClawbotHelper.ApiBase}/ilink/bot/getuploadurl")
+        {
+            Content = new StringContent(body, Encoding.UTF8, "application/json"),
+        };
+        WechatClawbotHelper.AddCommonHeaders(request, _config.WechatClawbotBotToken);
+        using var response = await _httpClient.SendAsync(request, ct);
+        var text = await response.Content.ReadAsStringAsync(ct);
+        if (!response.IsSuccessStatusCode)
+            throw new NotifierException($"getuploadurl HTTP {(int)response.StatusCode}: {text}");
+
+        using var doc = JsonDocument.Parse(text);
+        var root = doc.RootElement;
+        var uploadParam = root.TryGetProperty("upload_param", out var up) ? up.GetString() : null;
+        var uploadFullUrl = root.TryGetProperty("upload_full_url", out var ufu) ? ufu.GetString() : null;
+        if (string.IsNullOrWhiteSpace(uploadParam) && string.IsNullOrWhiteSpace(uploadFullUrl))
+            throw new NotifierException("getuploadurl 未返回上传地址");
+        return new WechatClawbotUploadUrl(uploadParam, uploadFullUrl);
+    }
+
+    /// <summary>
+    /// 将图片 AES-128-ECB 加密后 POST 到 CDN，返回下载加密参数（x-encrypted-param）。
+    /// </summary>
+    private async Task<string> UploadToCdnAsync(
+        WechatClawbotUploadUrl uploadUrl, string filekey, byte[] imageBytes, byte[] aeskey, CancellationToken ct)
+    {
+        var ciphertext = AesEcbEncrypt(imageBytes, aeskey);
+        var cdnUrl = !string.IsNullOrWhiteSpace(uploadUrl.UploadFullUrl)
+            ? uploadUrl.UploadFullUrl!
+            : $"{WechatClawbotHelper.CdnBase}/upload?encrypted_query_param={Uri.EscapeDataString(uploadUrl.UploadParam!)}&filekey={Uri.EscapeDataString(filekey)}";
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, cdnUrl)
+        {
+            Content = new ByteArrayContent(ciphertext),
+        };
+        request.Content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+        using var response = await _httpClient.SendAsync(request, ct);
+        if (!response.IsSuccessStatusCode)
+        {
+            var errText = await response.Content.ReadAsStringAsync(ct);
+            throw new NotifierException($"CDN 上传失败 HTTP {(int)response.StatusCode}: {errText}");
+        }
+
+        var downloadParam = response.Headers.TryGetValues("x-encrypted-param", out var values)
+            ? string.Join(string.Empty, values)
+            : null;
+        if (string.IsNullOrWhiteSpace(downloadParam))
+            throw new NotifierException("CDN 上传响应缺少 x-encrypted-param");
+        return downloadParam!;
+    }
+
+    /// <summary>
+    /// AES-128-ECB 加密（PKCS7 填充）。
+    /// </summary>
+    private static byte[] AesEcbEncrypt(byte[] plaintext, byte[] key)
+    {
+        using var aes = Aes.Create();
+        aes.Key = key;
+        aes.Mode = CipherMode.ECB;
+        aes.Padding = PaddingMode.PKCS7;
+        using var encryptor = aes.CreateEncryptor();
+        return encryptor.TransformFinalBlock(plaintext, 0, plaintext.Length);
+    }
+
+    /// <summary>
+    /// 计算 AES-128-ECB（PKCS7）加密后的密文大小。
+    /// </summary>
+    private static int AesEcbPaddedSize(int plaintextSize) => ((plaintextSize + 16) / 16) * 16;
+
+    /// <summary>
+    /// 判断异常是否可重试。5xx/429/400 可重试（有界重试仅作用于幂等上传操作）；
+    /// 无状态码的网络故障可重试；取消/解析错误不重试。
+    /// </summary>
+    private static bool IsRetryable(System.Exception ex)
+    {
+        if (ex is HttpRequestException hre)
+        {
+            var statusCode = hre.StatusCode;
+            if (statusCode.HasValue)
+            {
+                var code = (int)statusCode.Value;
+                return (code >= 500 && code <= 599) || code == 429 || code == 400;
+            }
+            return true;
+        }
+        if (ex is TaskCanceledException || ex is OperationCanceledException)
+            return false;
+        if (ex is JsonException || ex is InvalidOperationException)
+            return false;
+        return true;
+    }
+
+    /// <summary>
+    /// 带指数退避的重试执行（有返回值版本）。
+    /// </summary>
+    private async Task<T> WithRetryAsync<T>(Func<Task<T>> action, CancellationToken ct)
+    {
+        System.Exception? lastException = null;
+        for (var attempt = 0; attempt <= MaxRetry; attempt++)
+        {
+            try
+            {
+                return await action();
+            }
+            catch (System.Exception ex) when (attempt < MaxRetry && IsRetryable(ex))
+            {
+                lastException = ex;
+                await Task.Delay(TimeSpan.FromMilliseconds(1500 * (1 << attempt)), ct);
+            }
+        }
+        throw lastException ?? new NotifierException("微信 Clawbot 请求重试后仍失败");
+    }
+
+    private sealed record WechatClawbotUploadUrl(string? UploadParam, string? UploadFullUrl);
+
+    private sealed record WechatClawbotUploadedImage(string DownloadParam, byte[] AesKey, int CiphertextSize);
+}

--- a/BetterGenshinImpact/Service/Notifier/WechatClawbotNotifier.cs
+++ b/BetterGenshinImpact/Service/Notifier/WechatClawbotNotifier.cs
@@ -42,8 +42,11 @@ public sealed class WechatClawbotNotifier : INotifier, IDisposable
     {
         _httpClient = httpClient;
         _config = config;
-        _session = new WechatClawbotSession(config);
-        _session.Start();
+        _session = new WechatClawbotSession(
+            config.WechatClawbotBotToken,
+            config.WechatClawbotBaseUrl,
+            config.WechatClawbotToUserId);
+        _ = _session.StartAsync();
     }
 
     /// <summary>
@@ -206,10 +209,12 @@ public sealed class WechatClawbotNotifier : INotifier, IDisposable
         using var doc = JsonDocument.Parse(text);
         var root = doc.RootElement;
         var ret = root.TryGetProperty("ret", out var retElement) ? retElement.GetInt32() : 0;
-        if (ret != 0)
+        var errcode = root.TryGetProperty("errcode", out var errcodeElement) ? errcodeElement.GetInt32() : 0;
+        // 与 getupdates 一致，ret / errcode 任一非零均视为业务失败
+        if (ret != 0 || errcode != 0)
         {
             var errmsg = root.TryGetProperty("errmsg", out var errElement) ? errElement.GetString() : null;
-            throw new NotifierException($"sendmessage 返回错误 ret={ret} errmsg={errmsg}");
+            throw new NotifierException($"sendmessage 返回错误 ret={ret} errcode={errcode} errmsg={errmsg}");
         }
     }
 

--- a/BetterGenshinImpact/Service/Notifier/WechatClawbotNotifier.cs
+++ b/BetterGenshinImpact/Service/Notifier/WechatClawbotNotifier.cs
@@ -34,19 +34,24 @@ public sealed class WechatClawbotNotifier : INotifier, IDisposable
     private const int MaxRetry = 3;
 
     private readonly HttpClient _httpClient;
-    private readonly NotificationConfig _config;
+    private readonly string _botToken;
+    private readonly string _toUserId;
+    private readonly string _baseUrl;
     private readonly WechatClawbotSession _session;
     private readonly CancellationTokenSource _cts = new();
 
-    public WechatClawbotNotifier(HttpClient httpClient, NotificationConfig config)
+    public WechatClawbotNotifier(HttpClient httpClient, NotificationConfig config, bool startSession = true)
     {
         _httpClient = httpClient;
-        _config = config;
-        _session = new WechatClawbotSession(
-            config.WechatClawbotBotToken,
-            config.WechatClawbotBaseUrl,
-            config.WechatClawbotToUserId);
-        _ = _session.StartAsync();
+        // 固定构造时的凭证快照：发送期间即使配置被重新绑定变更，旧实例也不会混用新旧凭证
+        _botToken = config.WechatClawbotBotToken;
+        _toUserId = config.WechatClawbotToUserId;
+        _baseUrl = WechatClawbotHelper.NormalizeBaseUrl(config.WechatClawbotBaseUrl);
+        _session = new WechatClawbotSession(_botToken, _baseUrl, _toUserId);
+        // 子实例（桌面分身等）保留微信发送能力，但只有主实例启动长轮询会话，
+        // 避免多个进程用旧游标并发推进、互相覆盖 context_token / get_updates_buf。
+        if (startSession)
+            _ = _session.StartAsync();
     }
 
     /// <summary>
@@ -54,10 +59,10 @@ public sealed class WechatClawbotNotifier : INotifier, IDisposable
     /// </summary>
     public async Task SendAsync(BaseNotificationData content)
     {
-        if (string.IsNullOrWhiteSpace(_config.WechatClawbotBotToken))
+        if (string.IsNullOrWhiteSpace(_botToken))
             throw new NotifierException("微信 Clawbot BotToken 为空，请先扫码登录");
 
-        if (string.IsNullOrWhiteSpace(_config.WechatClawbotToUserId))
+        if (string.IsNullOrWhiteSpace(_toUserId))
             throw new NotifierException("微信 Clawbot 未绑定用户，请先完成绑定");
 
         var ct = _cts.Token;
@@ -127,7 +132,7 @@ public sealed class WechatClawbotNotifier : INotifier, IDisposable
             msg = new
             {
                 from_user_id = string.Empty,
-                to_user_id = _config.WechatClawbotToUserId,
+                to_user_id = _toUserId,
                 client_id = WechatClawbotHelper.GenerateClientId(),
                 message_type = 2,
                 message_state = 2,
@@ -162,7 +167,7 @@ public sealed class WechatClawbotNotifier : INotifier, IDisposable
             msg = new
             {
                 from_user_id = string.Empty,
-                to_user_id = _config.WechatClawbotToUserId,
+                to_user_id = _toUserId,
                 client_id = WechatClawbotHelper.GenerateClientId(),
                 message_type = 2,
                 message_state = 2,
@@ -195,12 +200,12 @@ public sealed class WechatClawbotNotifier : INotifier, IDisposable
     /// </summary>
     private async Task SendMessageAsync(string body, CancellationToken ct)
     {
-        var baseUrl = WechatClawbotHelper.NormalizeBaseUrl(_config.WechatClawbotBaseUrl);
+        var baseUrl = _baseUrl;
         using var request = new HttpRequestMessage(HttpMethod.Post, $"{baseUrl}/ilink/bot/sendmessage")
         {
             Content = new StringContent(body, Encoding.UTF8, "application/json"),
         };
-        WechatClawbotHelper.AddCommonHeaders(request, _config.WechatClawbotBotToken);
+        WechatClawbotHelper.AddCommonHeaders(request, _botToken);
         using var response = await _httpClient.SendAsync(request, ct);
         var text = await response.Content.ReadAsStringAsync(ct);
         if (!response.IsSuccessStatusCode)
@@ -246,7 +251,7 @@ public sealed class WechatClawbotNotifier : INotifier, IDisposable
         {
             filekey,
             media_type = 1,
-            to_user_id = _config.WechatClawbotToUserId,
+            to_user_id = _toUserId,
             rawsize,
             rawfilemd5,
             filesize,
@@ -254,12 +259,12 @@ public sealed class WechatClawbotNotifier : INotifier, IDisposable
             aeskey = Convert.ToHexString(aeskey).ToLowerInvariant(),
             base_info = WechatClawbotHelper.BuildBaseInfo(),
         });
-        var baseUrl = WechatClawbotHelper.NormalizeBaseUrl(_config.WechatClawbotBaseUrl);
+        var baseUrl = _baseUrl;
         using var request = new HttpRequestMessage(HttpMethod.Post, $"{baseUrl}/ilink/bot/getuploadurl")
         {
             Content = new StringContent(body, Encoding.UTF8, "application/json"),
         };
-        WechatClawbotHelper.AddCommonHeaders(request, _config.WechatClawbotBotToken);
+        WechatClawbotHelper.AddCommonHeaders(request, _botToken);
         using var response = await _httpClient.SendAsync(request, ct);
         var text = await response.Content.ReadAsStringAsync(ct);
         if (!response.IsSuccessStatusCode)

--- a/BetterGenshinImpact/Service/Notifier/WechatClawbotSession.cs
+++ b/BetterGenshinImpact/Service/Notifier/WechatClawbotSession.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using BetterGenshinImpact.Service.Notification;
+using Microsoft.Extensions.Logging;
+
+namespace BetterGenshinImpact.Service.Notifier;
+
+/// <summary>
+/// 微信 Clawbot 会话维持器。
+/// 后台长轮询 getupdates，持续刷新 context_token（会过期）和 get_updates_buf（同步游标），
+/// 并回写配置以便重启后从上次游标继续。类似 QQ 渠道的 WebSocket 心跳，但 iLink 协议用 HTTP 长轮询实现。
+/// </summary>
+public sealed class WechatClawbotSession : IDisposable
+{
+    private static readonly ILogger<WechatClawbotSession> Logger = App.GetLogger<WechatClawbotSession>();
+
+    private const int DefaultLongPollTimeoutMs = 35000;
+    private const int MaxConsecutiveFailures = 3;
+    private const int BackoffDelayMs = 30000;
+    private const int RetryDelayMs = 2000;
+
+    private readonly string _botToken;
+    private readonly string _toUserId;
+    private readonly NotificationConfig _config;
+    private readonly HttpClient _httpClient;
+    private readonly CancellationTokenSource _cts = new();
+    private readonly SemaphoreSlim _tokenSemaphore = new(1, 1);
+
+    private string _contextToken;
+    private string _getUpdatesBuf;
+    private Task? _loopTask;
+    private bool _disposed;
+
+    public WechatClawbotSession(NotificationConfig config)
+    {
+        _config = config;
+        _botToken = config.WechatClawbotBotToken;
+        _toUserId = config.WechatClawbotToUserId;
+        _contextToken = config.WechatClawbotContextToken;
+        _getUpdatesBuf = config.WechatClawbotGetUpdatesBuf;
+        // 长轮询专用 HttpClient：超时需大于服务端 hold 时间（35s），不能复用 30s 的共享客户端
+        _httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(60) };
+    }
+
+    /// <summary>
+    /// 启动后台长轮询循环（幂等，重复调用不会重复启动）。
+    /// </summary>
+    public void Start()
+    {
+        if (_loopTask != null)
+            return;
+        if (string.IsNullOrWhiteSpace(_botToken) || string.IsNullOrWhiteSpace(_toUserId))
+            return;
+        _loopTask = Task.Run(() => RunLoopAsync(_cts.Token));
+    }
+
+    /// <summary>
+    /// 获取当前缓存的 context_token（线程安全）。
+    /// </summary>
+    public async Task<string> GetContextTokenAsync(CancellationToken ct)
+    {
+        await _tokenSemaphore.WaitAsync(ct);
+        try
+        {
+            return _contextToken;
+        }
+        finally
+        {
+            _tokenSemaphore.Release();
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+        _disposed = true;
+        _cts.Cancel();
+        _cts.Dispose();
+        _tokenSemaphore.Dispose();
+        _httpClient.Dispose();
+    }
+
+    private async Task RunLoopAsync(CancellationToken ct)
+    {
+        var timeoutMs = DefaultLongPollTimeoutMs;
+        var consecutiveFailures = 0;
+
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                var resp = await WechatClawbotHelper.GetUpdatesAsync(_httpClient, _botToken, _getUpdatesBuf, timeoutMs, ct);
+
+                if (resp.Ret != 0 || resp.ErrCode != 0)
+                {
+                    consecutiveFailures++;
+                    Logger.LogWarning("微信 Clawbot getupdates 失败：ret={Ret} errcode={ErrCode} errmsg={ErrMsg}（{Count}/{Max}）",
+                        resp.Ret, resp.ErrCode, resp.ErrMsg, consecutiveFailures, MaxConsecutiveFailures);
+                    if (consecutiveFailures >= MaxConsecutiveFailures)
+                    {
+                        consecutiveFailures = 0;
+                        await DelayAsync(BackoffDelayMs, ct);
+                    }
+                    else
+                    {
+                        await DelayAsync(RetryDelayMs, ct);
+                    }
+                    continue;
+                }
+
+                consecutiveFailures = 0;
+                if (!string.IsNullOrWhiteSpace(resp.GetUpdatesBuf))
+                {
+                    _getUpdatesBuf = resp.GetUpdatesBuf;
+                    _config.WechatClawbotGetUpdatesBuf = resp.GetUpdatesBuf;
+                }
+
+                if (resp.LongPollingTimeoutMs is > 0)
+                    timeoutMs = resp.LongPollingTimeoutMs.Value;
+
+                foreach (var msg in resp.Msgs ?? [])
+                {
+                    if (string.Equals(msg.FromUserId, _toUserId, StringComparison.Ordinal) &&
+                        !string.IsNullOrWhiteSpace(msg.ContextToken))
+                    {
+                        await _tokenSemaphore.WaitAsync(ct);
+                        try
+                        {
+                            _contextToken = msg.ContextToken!;
+                        }
+                        finally
+                        {
+                            _tokenSemaphore.Release();
+                        }
+
+                        _config.WechatClawbotContextToken = msg.ContextToken!;
+                    }
+                }
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (OperationCanceledException)
+            {
+                // 长轮询超时，继续
+            }
+            catch (System.Exception ex)
+            {
+                consecutiveFailures++;
+                Logger.LogWarning("微信 Clawbot 长轮询异常（{Count}/{Max}）：{Ex}",
+                    consecutiveFailures, MaxConsecutiveFailures, ex.Message);
+                if (consecutiveFailures >= MaxConsecutiveFailures)
+                {
+                    consecutiveFailures = 0;
+                    await DelayAsync(BackoffDelayMs, ct);
+                }
+                else
+                {
+                    await DelayAsync(RetryDelayMs, ct);
+                }
+            }
+        }
+    }
+
+    private static async Task DelayAsync(int ms, CancellationToken ct)
+    {
+        try
+        {
+            await Task.Delay(ms, ct);
+        }
+        catch (OperationCanceledException)
+        {
+            // 正常关闭
+        }
+    }
+}

--- a/BetterGenshinImpact/Service/Notifier/WechatClawbotSession.cs
+++ b/BetterGenshinImpact/Service/Notifier/WechatClawbotSession.cs
@@ -106,7 +106,7 @@ public sealed class WechatClawbotSession : IDisposable
     }
 
     /// <summary>
-    /// 停止会话。取消令牌，并等待初始化与长轮询任务退出后再释放依赖资源，
+    /// 停止会话。取消令牌，并等待初始化任务与其启动的长轮询任务完整退出后再释放依赖资源，
     /// 避免旧循环仍在访问已释放的信号量/HttpClient。
     /// </summary>
     public void Dispose()
@@ -115,6 +115,8 @@ public sealed class WechatClawbotSession : IDisposable
             return;
         _disposed = true;
         _cts.Cancel();
+
+        // 先等初始化任务完成（它负责启动 _loopTask，但不等 _loopTask 结束）
         try
         {
             _initTask?.GetAwaiter().GetResult();
@@ -125,7 +127,21 @@ public sealed class WechatClawbotSession : IDisposable
         }
         catch (System.Exception ex)
         {
-            Logger.LogWarning("微信 Clawbot 会话停止异常: {Ex}", ex.Message);
+            Logger.LogWarning("微信 Clawbot 会话初始化停止异常: {Ex}", ex.Message);
+        }
+
+        // 再等长轮询循环完整退出，避免其仍访问已释放的信号量/HttpClient
+        try
+        {
+            _loopTask?.GetAwaiter().GetResult();
+        }
+        catch (OperationCanceledException)
+        {
+            // 取消导致的退出是预期行为
+        }
+        catch (System.Exception ex)
+        {
+            Logger.LogWarning("微信 Clawbot 长轮询停止异常: {Ex}", ex.Message);
         }
 
         _cts.Dispose();

--- a/BetterGenshinImpact/Service/Notifier/WechatClawbotSession.cs
+++ b/BetterGenshinImpact/Service/Notifier/WechatClawbotSession.cs
@@ -9,9 +9,9 @@ namespace BetterGenshinImpact.Service.Notifier;
 
 /// <summary>
 /// 微信 Clawbot 会话维持器。
-/// 后台长轮询 getupdates，持续刷新 context_token（会过期）和 get_updates_buf（同步游标），
-/// 并回写 NotificationConfig 以便重启/重建后继续。这两个字段已被 AllConfig 排除，
-/// 更新不会触发通知器刷新，因此不会自我销毁。
+/// 后台长轮询 getupdates，持续刷新 context_token（会过期）和 get_updates_buf（同步游标）。
+/// 轮询状态通过 WechatClawbotSessionStore 独立持久化（User/WechatClawbot/），
+/// 不写入 NotificationConfig，避免触发全局配置保存与通知器刷新。
 /// 类似 QQ 渠道的 WebSocket 心跳，但 iLink 协议用 HTTP 长轮询实现。
 /// </summary>
 public sealed class WechatClawbotSession : IDisposable
@@ -25,7 +25,7 @@ public sealed class WechatClawbotSession : IDisposable
 
     private readonly string _botToken;
     private readonly string _baseUrl;
-    private readonly NotificationConfig _config;
+    private readonly string _toUserId;
     private readonly HttpClient _httpClient;
     private readonly CancellationTokenSource _cts = new();
     private readonly SemaphoreSlim _tokenSemaphore = new(1, 1);
@@ -35,26 +35,32 @@ public sealed class WechatClawbotSession : IDisposable
     private Task? _loopTask;
     private bool _disposed;
 
-    public WechatClawbotSession(NotificationConfig config)
+    public WechatClawbotSession(string botToken, string baseUrl, string toUserId)
     {
-        _config = config;
-        _botToken = config.WechatClawbotBotToken;
-        _baseUrl = WechatClawbotHelper.NormalizeBaseUrl(config.WechatClawbotBaseUrl);
-        _contextToken = config.WechatClawbotContextToken;
-        _getUpdatesBuf = config.WechatClawbotGetUpdatesBuf;
+        _botToken = botToken;
+        _baseUrl = WechatClawbotHelper.NormalizeBaseUrl(baseUrl);
+        _toUserId = toUserId;
+        _contextToken = string.Empty;
+        _getUpdatesBuf = string.Empty;
         // 长轮询专用 HttpClient：超时需大于服务端 hold 时间（35s），不能复用 30s 的共享客户端
         _httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(60) };
     }
 
     /// <summary>
-    /// 启动后台长轮询循环（幂等，重复调用不会重复启动）。
+    /// 异步启动：先恢复上次的会话状态，再启动后台长轮询循环（幂等）。
     /// </summary>
-    public void Start()
+    public async Task StartAsync()
     {
         if (_loopTask != null)
             return;
-        if (string.IsNullOrWhiteSpace(_botToken) || string.IsNullOrWhiteSpace(_config.WechatClawbotToUserId))
+        if (string.IsNullOrWhiteSpace(_botToken) || string.IsNullOrWhiteSpace(_toUserId))
             return;
+
+        // 从独立存储恢复上次会话状态
+        var (token, buf) = await WechatClawbotSessionStore.LoadAsync(_botToken);
+        _contextToken = token;
+        _getUpdatesBuf = buf;
+
         _loopTask = Task.Run(() => RunLoopAsync(_cts.Token));
     }
 
@@ -74,12 +80,24 @@ public sealed class WechatClawbotSession : IDisposable
         }
     }
 
+    /// <summary>
+    /// 停止会话。取消长轮询令牌，并等待后台任务退出后再释放依赖资源，
+    /// 避免旧循环仍在访问已释放的信号量/HttpClient。
+    /// </summary>
     public void Dispose()
     {
         if (_disposed)
             return;
         _disposed = true;
         _cts.Cancel();
+        try
+        {
+            _loopTask?.GetAwaiter().GetResult();
+        }
+        catch (OperationCanceledException)
+        {
+            // 取消导致的退出是预期行为
+        }
         _cts.Dispose();
         _tokenSemaphore.Dispose();
         _httpClient.Dispose();
@@ -115,35 +133,37 @@ public sealed class WechatClawbotSession : IDisposable
                 }
 
                 consecutiveFailures = 0;
-                // 回写游标到配置（AllConfig 已排除该字段，不会触发通知器刷新）
-                if (!string.IsNullOrWhiteSpace(resp.GetUpdatesBuf) && resp.GetUpdatesBuf != _getUpdatesBuf)
-                {
+                if (!string.IsNullOrWhiteSpace(resp.GetUpdatesBuf))
                     _getUpdatesBuf = resp.GetUpdatesBuf;
-                    _config.WechatClawbotGetUpdatesBuf = resp.GetUpdatesBuf;
-                }
 
                 if (resp.LongPollingTimeoutMs is > 0)
                     timeoutMs = resp.LongPollingTimeoutMs.Value;
 
+                var tokenDirty = false;
                 foreach (var msg in resp.Msgs ?? [])
                 {
-                    if (string.Equals(msg.FromUserId, _config.WechatClawbotToUserId, StringComparison.Ordinal) &&
+                    if (string.Equals(msg.FromUserId, _toUserId, StringComparison.Ordinal) &&
                         !string.IsNullOrWhiteSpace(msg.ContextToken))
                     {
-                        // 回写 context_token（AllConfig 已排除，不会触发通知器刷新）
                         await _tokenSemaphore.WaitAsync(ct);
                         try
                         {
-                            _contextToken = msg.ContextToken!;
+                            if (_contextToken != msg.ContextToken)
+                            {
+                                _contextToken = msg.ContextToken!;
+                                tokenDirty = true;
+                            }
                         }
                         finally
                         {
                             _tokenSemaphore.Release();
                         }
-
-                        _config.WechatClawbotContextToken = msg.ContextToken!;
                     }
                 }
+
+                // 独立持久化最新会话状态（不触发全局配置变更）
+                if (tokenDirty || !string.IsNullOrWhiteSpace(resp.GetUpdatesBuf))
+                    await WechatClawbotSessionStore.SaveAsync(_botToken, _contextToken, _getUpdatesBuf);
             }
             catch (OperationCanceledException) when (ct.IsCancellationRequested)
             {

--- a/BetterGenshinImpact/Service/Notifier/WechatClawbotSession.cs
+++ b/BetterGenshinImpact/Service/Notifier/WechatClawbotSession.cs
@@ -8,9 +8,15 @@ namespace BetterGenshinImpact.Service.Notifier;
 
 /// <summary>
 /// 微信 Clawbot 会话维持器。
-/// 后台长轮询 getupdates，持续刷新 context_token（会过期）和 get_updates_buf（同步游标）。
-/// 轮询状态通过 WechatClawbotSessionStore 独立持久化（User/WechatClawbot/），
-/// 不写入 NotificationConfig，避免触发全局配置保存与通知器刷新。
+///
+/// 生命周期：构造 → StartAsync() → InitAsync（从 Store 恢复状态）+ RunLoopAsync（长轮询循环）→ Dispose。
+/// - StartAsync 仅恢复上次会话状态（快速完成），不阻塞发送。
+/// - RunLoopAsync 持续轮询 getupdates，刷新 context_token/get_updates_buf，
+///   并通过 WechatClawbotSessionStore 独立持久化，不写入 NotificationConfig，
+///   避免触发 AllConfig 的 PropertyChanged → Save() / RefreshNotifiers() 副作用。
+/// - Dispose 依次取消令牌、等待 _initTask 和 _loopTask 完整退出、再释放依赖资源，
+///   避免旧循环仍访问已释放的信号量/HttpClient 造成 ObjectDisposedException。
+///
 /// 类似 QQ 渠道的 WebSocket 心跳，但 iLink 协议用 HTTP 长轮询实现。
 /// </summary>
 public sealed class WechatClawbotSession : IDisposable
@@ -74,7 +80,8 @@ public sealed class WechatClawbotSession : IDisposable
     }
 
     /// <summary>
-    /// 获取当前缓存的 context_token（线程安全）。在会话初始化完成前会等待。
+    /// 获取当前缓存的 context_token（线程安全，SemaphoreSlim 保护）。
+    /// 会等待 _initTask 完成（从 Store 恢复状态），确保不返回空令牌。
     /// </summary>
     public async Task<string> GetContextTokenAsync(CancellationToken ct)
     {
@@ -106,8 +113,12 @@ public sealed class WechatClawbotSession : IDisposable
     }
 
     /// <summary>
-    /// 停止会话。取消令牌，并等待初始化任务与其启动的长轮询任务完整退出后再释放依赖资源，
-    /// 避免旧循环仍在访问已释放的信号量/HttpClient。
+    /// 停止会话并释放所有资源。等待顺序：
+    /// 1. 取消 CTS（通知长轮询停止）
+    /// 2. 等待 _initTask（状态恢复）完成
+    /// 3. 等待 _loopTask（长轮询循环）完成
+    /// 4. 释放 CTS / SemaphoreSlim / HttpClient
+    /// 严格按此顺序执行，防止循环在资源释放后仍访问它们。
     /// </summary>
     public void Dispose()
     {

--- a/BetterGenshinImpact/Service/Notifier/WechatClawbotSession.cs
+++ b/BetterGenshinImpact/Service/Notifier/WechatClawbotSession.cs
@@ -2,7 +2,6 @@ using System;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using BetterGenshinImpact.Service.Notification;
 using Microsoft.Extensions.Logging;
 
 namespace BetterGenshinImpact.Service.Notifier;
@@ -32,6 +31,7 @@ public sealed class WechatClawbotSession : IDisposable
 
     private string _contextToken;
     private string _getUpdatesBuf;
+    private Task? _initTask;
     private Task? _loopTask;
     private bool _disposed;
 
@@ -47,28 +47,53 @@ public sealed class WechatClawbotSession : IDisposable
     }
 
     /// <summary>
-    /// 异步启动：先恢复上次的会话状态，再启动后台长轮询循环（幂等）。
+    /// 异步启动：恢复上次会话状态后启动后台长轮询循环（幂等）。
+    /// 返回的初始化任务仅负责恢复状态，在获取 context_token 前会被等待。
     /// </summary>
-    public async Task StartAsync()
+    public Task StartAsync()
     {
-        if (_loopTask != null)
-            return;
+        if (_initTask != null)
+            return _initTask;
         if (string.IsNullOrWhiteSpace(_botToken) || string.IsNullOrWhiteSpace(_toUserId))
-            return;
+            return Task.CompletedTask;
 
+        _initTask = InitAsync(_cts.Token);
+        return _initTask;
+    }
+
+    private async Task InitAsync(CancellationToken ct)
+    {
         // 从独立存储恢复上次会话状态
         var (token, buf) = await WechatClawbotSessionStore.LoadAsync(_botToken);
+        if (ct.IsCancellationRequested)
+            return;
         _contextToken = token;
         _getUpdatesBuf = buf;
 
-        _loopTask = Task.Run(() => RunLoopAsync(_cts.Token));
+        _loopTask = Task.Run(() => RunLoopAsync(ct));
     }
 
     /// <summary>
-    /// 获取当前缓存的 context_token（线程安全）。
+    /// 获取当前缓存的 context_token（线程安全）。在会话初始化完成前会等待。
     /// </summary>
     public async Task<string> GetContextTokenAsync(CancellationToken ct)
     {
+        if (_initTask != null && !_initTask.IsCompleted)
+        {
+            try
+            {
+                await _initTask.WaitAsync(ct);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (System.Exception)
+            {
+                // 初始化失败时继续用空令牌，交由上层报错
+            }
+        }
+
         await _tokenSemaphore.WaitAsync(ct);
         try
         {
@@ -81,7 +106,7 @@ public sealed class WechatClawbotSession : IDisposable
     }
 
     /// <summary>
-    /// 停止会话。取消长轮询令牌，并等待后台任务退出后再释放依赖资源，
+    /// 停止会话。取消令牌，并等待初始化与长轮询任务退出后再释放依赖资源，
     /// 避免旧循环仍在访问已释放的信号量/HttpClient。
     /// </summary>
     public void Dispose()
@@ -92,12 +117,17 @@ public sealed class WechatClawbotSession : IDisposable
         _cts.Cancel();
         try
         {
-            _loopTask?.GetAwaiter().GetResult();
+            _initTask?.GetAwaiter().GetResult();
         }
         catch (OperationCanceledException)
         {
             // 取消导致的退出是预期行为
         }
+        catch (System.Exception ex)
+        {
+            Logger.LogWarning("微信 Clawbot 会话停止异常: {Ex}", ex.Message);
+        }
+
         _cts.Dispose();
         _tokenSemaphore.Dispose();
         _httpClient.Dispose();

--- a/BetterGenshinImpact/Service/Notifier/WechatClawbotSession.cs
+++ b/BetterGenshinImpact/Service/Notifier/WechatClawbotSession.cs
@@ -228,7 +228,7 @@ public sealed class WechatClawbotSession : IDisposable
             }
             catch (OperationCanceledException)
             {
-                // 长轮询超时，继续
+                // 长轮询客户端超时（>35s），视为正常事件间空闲，直接继续下一轮
             }
             catch (System.Exception ex)
             {

--- a/BetterGenshinImpact/Service/Notifier/WechatClawbotSession.cs
+++ b/BetterGenshinImpact/Service/Notifier/WechatClawbotSession.cs
@@ -2,15 +2,15 @@ using System;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using BetterGenshinImpact.Service.Notification;
 using Microsoft.Extensions.Logging;
 
 namespace BetterGenshinImpact.Service.Notifier;
 
 /// <summary>
 /// 微信 Clawbot 会话维持器。
-/// 后台长轮询 getupdates，持续刷新 context_token（会过期）和 get_updates_buf（同步游标），
-/// 并回写配置以便重启后从上次游标继续。类似 QQ 渠道的 WebSocket 心跳，但 iLink 协议用 HTTP 长轮询实现。
+/// 后台长轮询 getupdates，持续刷新 context_token（会过期）和 get_updates_buf（同步游标）。
+/// 轮询状态仅保存在会话内部，不回写 NotificationConfig，避免触发 AllConfig 保存与通知器刷新。
+/// 类似 QQ 渠道的 WebSocket 心跳，但 iLink 协议用 HTTP 长轮询实现。
 /// </summary>
 public sealed class WechatClawbotSession : IDisposable
 {
@@ -23,7 +23,6 @@ public sealed class WechatClawbotSession : IDisposable
 
     private readonly string _botToken;
     private readonly string _toUserId;
-    private readonly NotificationConfig _config;
     private readonly HttpClient _httpClient;
     private readonly CancellationTokenSource _cts = new();
     private readonly SemaphoreSlim _tokenSemaphore = new(1, 1);
@@ -33,13 +32,12 @@ public sealed class WechatClawbotSession : IDisposable
     private Task? _loopTask;
     private bool _disposed;
 
-    public WechatClawbotSession(NotificationConfig config)
+    public WechatClawbotSession(string botToken, string toUserId, string contextToken, string getUpdatesBuf)
     {
-        _config = config;
-        _botToken = config.WechatClawbotBotToken;
-        _toUserId = config.WechatClawbotToUserId;
-        _contextToken = config.WechatClawbotContextToken;
-        _getUpdatesBuf = config.WechatClawbotGetUpdatesBuf;
+        _botToken = botToken;
+        _toUserId = toUserId;
+        _contextToken = contextToken;
+        _getUpdatesBuf = getUpdatesBuf;
         // 长轮询专用 HttpClient：超时需大于服务端 hold 时间（35s），不能复用 30s 的共享客户端
         _httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(60) };
     }
@@ -112,11 +110,10 @@ public sealed class WechatClawbotSession : IDisposable
                 }
 
                 consecutiveFailures = 0;
+                // 轮询游标仅保存在会话内部，不回写 NotificationConfig——
+                // 该属性赋值会触发 AllConfig 保存及 RefreshNotifiers()，导致长轮询会话被反复销毁重建。
                 if (!string.IsNullOrWhiteSpace(resp.GetUpdatesBuf))
-                {
                     _getUpdatesBuf = resp.GetUpdatesBuf;
-                    _config.WechatClawbotGetUpdatesBuf = resp.GetUpdatesBuf;
-                }
 
                 if (resp.LongPollingTimeoutMs is > 0)
                     timeoutMs = resp.LongPollingTimeoutMs.Value;
@@ -126,6 +123,7 @@ public sealed class WechatClawbotSession : IDisposable
                     if (string.Equals(msg.FromUserId, _toUserId, StringComparison.Ordinal) &&
                         !string.IsNullOrWhiteSpace(msg.ContextToken))
                     {
+                        // context_token 同样仅保存在会话内部，避免触发配置刷新
                         await _tokenSemaphore.WaitAsync(ct);
                         try
                         {
@@ -135,8 +133,6 @@ public sealed class WechatClawbotSession : IDisposable
                         {
                             _tokenSemaphore.Release();
                         }
-
-                        _config.WechatClawbotContextToken = msg.ContextToken!;
                     }
                 }
             }

--- a/BetterGenshinImpact/Service/Notifier/WechatClawbotSession.cs
+++ b/BetterGenshinImpact/Service/Notifier/WechatClawbotSession.cs
@@ -2,14 +2,16 @@ using System;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using BetterGenshinImpact.Service.Notification;
 using Microsoft.Extensions.Logging;
 
 namespace BetterGenshinImpact.Service.Notifier;
 
 /// <summary>
 /// 微信 Clawbot 会话维持器。
-/// 后台长轮询 getupdates，持续刷新 context_token（会过期）和 get_updates_buf（同步游标）。
-/// 轮询状态仅保存在会话内部，不回写 NotificationConfig，避免触发 AllConfig 保存与通知器刷新。
+/// 后台长轮询 getupdates，持续刷新 context_token（会过期）和 get_updates_buf（同步游标），
+/// 并回写 NotificationConfig 以便重启/重建后继续。这两个字段已被 AllConfig 排除，
+/// 更新不会触发通知器刷新，因此不会自我销毁。
 /// 类似 QQ 渠道的 WebSocket 心跳，但 iLink 协议用 HTTP 长轮询实现。
 /// </summary>
 public sealed class WechatClawbotSession : IDisposable
@@ -22,7 +24,8 @@ public sealed class WechatClawbotSession : IDisposable
     private const int RetryDelayMs = 2000;
 
     private readonly string _botToken;
-    private readonly string _toUserId;
+    private readonly string _baseUrl;
+    private readonly NotificationConfig _config;
     private readonly HttpClient _httpClient;
     private readonly CancellationTokenSource _cts = new();
     private readonly SemaphoreSlim _tokenSemaphore = new(1, 1);
@@ -32,12 +35,13 @@ public sealed class WechatClawbotSession : IDisposable
     private Task? _loopTask;
     private bool _disposed;
 
-    public WechatClawbotSession(string botToken, string toUserId, string contextToken, string getUpdatesBuf)
+    public WechatClawbotSession(NotificationConfig config)
     {
-        _botToken = botToken;
-        _toUserId = toUserId;
-        _contextToken = contextToken;
-        _getUpdatesBuf = getUpdatesBuf;
+        _config = config;
+        _botToken = config.WechatClawbotBotToken;
+        _baseUrl = WechatClawbotHelper.NormalizeBaseUrl(config.WechatClawbotBaseUrl);
+        _contextToken = config.WechatClawbotContextToken;
+        _getUpdatesBuf = config.WechatClawbotGetUpdatesBuf;
         // 长轮询专用 HttpClient：超时需大于服务端 hold 时间（35s），不能复用 30s 的共享客户端
         _httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(60) };
     }
@@ -49,7 +53,7 @@ public sealed class WechatClawbotSession : IDisposable
     {
         if (_loopTask != null)
             return;
-        if (string.IsNullOrWhiteSpace(_botToken) || string.IsNullOrWhiteSpace(_toUserId))
+        if (string.IsNullOrWhiteSpace(_botToken) || string.IsNullOrWhiteSpace(_config.WechatClawbotToUserId))
             return;
         _loopTask = Task.Run(() => RunLoopAsync(_cts.Token));
     }
@@ -90,7 +94,8 @@ public sealed class WechatClawbotSession : IDisposable
         {
             try
             {
-                var resp = await WechatClawbotHelper.GetUpdatesAsync(_httpClient, _botToken, _getUpdatesBuf, timeoutMs, ct);
+                var resp = await WechatClawbotHelper.GetUpdatesAsync(
+                    _httpClient, _baseUrl, _botToken, _getUpdatesBuf, timeoutMs, ct);
 
                 if (resp.Ret != 0 || resp.ErrCode != 0)
                 {
@@ -110,20 +115,22 @@ public sealed class WechatClawbotSession : IDisposable
                 }
 
                 consecutiveFailures = 0;
-                // 轮询游标仅保存在会话内部，不回写 NotificationConfig——
-                // 该属性赋值会触发 AllConfig 保存及 RefreshNotifiers()，导致长轮询会话被反复销毁重建。
-                if (!string.IsNullOrWhiteSpace(resp.GetUpdatesBuf))
+                // 回写游标到配置（AllConfig 已排除该字段，不会触发通知器刷新）
+                if (!string.IsNullOrWhiteSpace(resp.GetUpdatesBuf) && resp.GetUpdatesBuf != _getUpdatesBuf)
+                {
                     _getUpdatesBuf = resp.GetUpdatesBuf;
+                    _config.WechatClawbotGetUpdatesBuf = resp.GetUpdatesBuf;
+                }
 
                 if (resp.LongPollingTimeoutMs is > 0)
                     timeoutMs = resp.LongPollingTimeoutMs.Value;
 
                 foreach (var msg in resp.Msgs ?? [])
                 {
-                    if (string.Equals(msg.FromUserId, _toUserId, StringComparison.Ordinal) &&
+                    if (string.Equals(msg.FromUserId, _config.WechatClawbotToUserId, StringComparison.Ordinal) &&
                         !string.IsNullOrWhiteSpace(msg.ContextToken))
                     {
-                        // context_token 同样仅保存在会话内部，避免触发配置刷新
+                        // 回写 context_token（AllConfig 已排除，不会触发通知器刷新）
                         await _tokenSemaphore.WaitAsync(ct);
                         try
                         {
@@ -133,6 +140,8 @@ public sealed class WechatClawbotSession : IDisposable
                         {
                             _tokenSemaphore.Release();
                         }
+
+                        _config.WechatClawbotContextToken = msg.ContextToken!;
                     }
                 }
             }

--- a/BetterGenshinImpact/Service/Notifier/WechatClawbotSessionStore.cs
+++ b/BetterGenshinImpact/Service/Notifier/WechatClawbotSessionStore.cs
@@ -80,6 +80,7 @@ public static class WechatClawbotSessionStore
     /// <summary>
     /// 保存 context_token 与 get_updates_buf 到 JSON 文件。
     /// 仅在主实例的轮询循环中调用（token 变化或游标推进时）。
+    /// 持久化失败时抛出异常，让调用方（绑定路径）感知落盘状态并决定是否继续。
     /// </summary>
     public static async Task SaveAsync(string botToken, string? contextToken, string? getUpdatesBuf)
     {
@@ -93,10 +94,6 @@ public static class WechatClawbotSessionStore
             var path = FilePathFor(botToken);
             var state = new SessionState(contextToken, getUpdatesBuf);
             await File.WriteAllTextAsync(path, JsonSerializer.Serialize(state, JsonOptions));
-        }
-        catch (System.Exception ex)
-        {
-            Logger.LogWarning("保存微信 Clawbot 会话状态失败: {Ex}", ex.Message);
         }
         finally
         {

--- a/BetterGenshinImpact/Service/Notifier/WechatClawbotSessionStore.cs
+++ b/BetterGenshinImpact/Service/Notifier/WechatClawbotSessionStore.cs
@@ -11,9 +11,15 @@ using Microsoft.Extensions.Logging;
 namespace BetterGenshinImpact.Service.Notifier;
 
 /// <summary>
-/// 微信 Clawbot 会话状态（context_token / get_updates_buf）的独立持久化存储。
-/// 存于 User/WechatClawbot/ 目录，线程安全（SemaphoreSlim）。
+/// 微信 Clawbot 会话状态的独立持久化存储。
+///
+/// 存储位置：User/WechatClawbot/{SHA256(bot_token前16位hex)}.json
+/// 文件格式：{"contextToken":"...", "getUpdatesBuf":"..."}
+///
+/// 线程安全（SemaphoreSlim），但进程内单进程独占。
 /// 不写入 NotificationConfig，避免触发 AllConfig 的 PropertyChanged → Save() / RefreshNotifiers() 副作用。
+/// 主实例写入（轮询循环中持久化最新游标/令牌），
+/// 子实例只读（桌面分身等保留发送能力，从主实例写入的文件读取最新令牌）。
 /// </summary>
 public static class WechatClawbotSessionStore
 {
@@ -41,7 +47,8 @@ public static class WechatClawbotSessionStore
     }
 
     /// <summary>
-    /// 读取会话状态；无记录时返回空串。
+    /// 读取会话状态（从 JSON 文件）。文件不存在时返回空串。
+    /// 主实例轮询启动时 + 子实例发送时调用。
     /// </summary>
     public static async Task<(string ContextToken, string GetUpdatesBuf)> LoadAsync(string botToken)
     {
@@ -71,7 +78,8 @@ public static class WechatClawbotSessionStore
     }
 
     /// <summary>
-    /// 保存 context_token 与 get_updates_buf。
+    /// 保存 context_token 与 get_updates_buf 到 JSON 文件。
+    /// 仅在主实例的轮询循环中调用（token 变化或游标推进时）。
     /// </summary>
     public static async Task SaveAsync(string botToken, string? contextToken, string? getUpdatesBuf)
     {

--- a/BetterGenshinImpact/Service/Notifier/WechatClawbotSessionStore.cs
+++ b/BetterGenshinImpact/Service/Notifier/WechatClawbotSessionStore.cs
@@ -1,0 +1,98 @@
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using BetterGenshinImpact.Core.Config;
+using Microsoft.Extensions.Logging;
+
+namespace BetterGenshinImpact.Service.Notifier;
+
+/// <summary>
+/// 微信 Clawbot 会话状态（context_token / get_updates_buf）的独立持久化存储。
+/// 存于 User/WechatClawbot/ 目录，线程安全（SemaphoreSlim）。
+/// 不写入 NotificationConfig，避免触发 AllConfig 的 PropertyChanged → Save() / RefreshNotifiers() 副作用。
+/// </summary>
+public static class WechatClawbotSessionStore
+{
+    private static readonly ILogger Logger = App.GetLogger<LoggerHolder>();
+    private sealed class LoggerHolder { }
+
+    private static readonly SemaphoreSlim Gate = new(1, 1);
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+    };
+
+    private sealed record SessionState(string? ContextToken, string? GetUpdatesBuf);
+
+    private static string DirectoryPath => Global.Absolute(Path.Combine("User", "WechatClawbot"));
+
+    /// <summary>
+    /// 按 bot token 生成稳定的文件名（用 SHA256 哈希避免 token 中的特殊字符）。
+    /// </summary>
+    private static string FilePathFor(string botToken)
+    {
+        var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(botToken))).ToLowerInvariant();
+        return Path.Combine(DirectoryPath, $"{hash}.json");
+    }
+
+    /// <summary>
+    /// 读取会话状态；无记录时返回空串。
+    /// </summary>
+    public static async Task<(string ContextToken, string GetUpdatesBuf)> LoadAsync(string botToken)
+    {
+        if (string.IsNullOrWhiteSpace(botToken))
+            return (string.Empty, string.Empty);
+
+        await Gate.WaitAsync();
+        try
+        {
+            var path = FilePathFor(botToken);
+            if (!File.Exists(path))
+                return (string.Empty, string.Empty);
+
+            var json = await File.ReadAllTextAsync(path);
+            var state = JsonSerializer.Deserialize<SessionState>(json, JsonOptions);
+            return (state?.ContextToken ?? string.Empty, state?.GetUpdatesBuf ?? string.Empty);
+        }
+        catch (System.Exception ex)
+        {
+            Logger.LogWarning("读取微信 Clawbot 会话状态失败: {Ex}", ex.Message);
+            return (string.Empty, string.Empty);
+        }
+        finally
+        {
+            Gate.Release();
+        }
+    }
+
+    /// <summary>
+    /// 保存 context_token 与 get_updates_buf。
+    /// </summary>
+    public static async Task SaveAsync(string botToken, string? contextToken, string? getUpdatesBuf)
+    {
+        if (string.IsNullOrWhiteSpace(botToken))
+            return;
+
+        await Gate.WaitAsync();
+        try
+        {
+            Directory.CreateDirectory(DirectoryPath);
+            var path = FilePathFor(botToken);
+            var state = new SessionState(contextToken, getUpdatesBuf);
+            await File.WriteAllTextAsync(path, JsonSerializer.Serialize(state, JsonOptions));
+        }
+        catch (System.Exception ex)
+        {
+            Logger.LogWarning("保存微信 Clawbot 会话状态失败: {Ex}", ex.Message);
+        }
+        finally
+        {
+            Gate.Release();
+        }
+    }
+}

--- a/BetterGenshinImpact/View/Pages/NotificationSettingsPage.xaml
+++ b/BetterGenshinImpact/View/Pages/NotificationSettingsPage.xaml
@@ -1,4 +1,4 @@
-﻿<Page x:Class="BetterGenshinImpact.View.Pages.NotificationSettingsPage"
+<Page x:Class="BetterGenshinImpact.View.Pages.NotificationSettingsPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -2493,6 +2493,122 @@
                     <ui:Button Grid.Row="0" Grid.RowSpan="2" Grid.Column="1"
                                Margin="0,0,36,0"
                                Command="{Binding TestQqNotificationCommand}"
+                               Content="发送" />
+                </Grid>
+            </StackPanel>
+        </ui:CardExpander>
+        <!--  微信 Clawbot 通知（iLink 协议，扫码登录 + 一次性验证码绑定）  -->
+        <ui:CardExpander Margin="0,0,0,12"
+                         ContentPadding="0"
+                         Icon="{ui:SymbolIcon Chat24}">
+            <ui:CardExpander.Header>
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <ui:TextBlock Grid.Row="0" Grid.Column="0" FontTypography="Body"
+                                  Text="启用微信 Clawbot 通知" TextWrapping="Wrap" />
+                    <ui:TextBlock Grid.Row="1" Grid.Column="0"
+                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                  Text="微信 Clawbot 推送，支持文字和截图（内置实现，无需安装 OpenClaw）" TextWrapping="Wrap" />
+                    <ui:ToggleSwitch Grid.Row="0" Grid.RowSpan="2" Grid.Column="1"
+                                     Margin="0,0,24,0"
+                                     IsChecked="{Binding Config.NotificationConfig.WechatClawbotNotificationEnabled, Mode=TwoWay}" />
+                </Grid>
+            </ui:CardExpander.Header>
+            <StackPanel>
+                <Grid Margin="16">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="3*" />
+                        <ColumnDefinition Width="2*" />
+                    </Grid.ColumnDefinitions>
+                    <ui:TextBlock Grid.Row="0" Grid.Column="0" FontTypography="Body" Text="BotToken" TextWrapping="Wrap" />
+                    <ui:TextBlock Grid.Row="1" Grid.Column="0"
+                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                  Text="扫码登录后自动获取，无需手动填写" TextWrapping="Wrap" />
+                    <ui:TextBox Grid.Row="0" Grid.RowSpan="2" Grid.Column="1"
+                                MinWidth="180" MaxWidth="800" Margin="0,0,36,0"
+                                Text="{Binding Config.NotificationConfig.WechatClawbotBotToken, Mode=TwoWay}"
+                                TextWrapping="NoWrap" />
+                </Grid>
+                <Grid Margin="16">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="3*" />
+                        <ColumnDefinition Width="2*" />
+                    </Grid.ColumnDefinitions>
+                    <ui:TextBlock Grid.Row="0" Grid.Column="0" FontTypography="Body" Text="目标用户 ID" TextWrapping="Wrap" />
+                    <ui:TextBlock Grid.Row="1" Grid.Column="0"
+                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                  Text="给 Clawbot 发消息后自动获取，无需手动填写" TextWrapping="Wrap" />
+                    <ui:TextBox Grid.Row="0" Grid.RowSpan="2" Grid.Column="1"
+                                MinWidth="180" MaxWidth="800" Margin="0,0,36,0"
+                                Text="{Binding Config.NotificationConfig.WechatClawbotToUserId, Mode=TwoWay}"
+                                TextWrapping="NoWrap" />
+                </Grid>
+                <!-- 登录并绑定按钮行：扫码登录后等待用户发送一次性验证码，自动回填 BotToken / 目标用户 ID / context_token -->
+                <Grid Margin="16">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="3*" />
+                        <ColumnDefinition Width="2*" />
+                    </Grid.ColumnDefinitions>
+                    <ui:TextBlock Grid.Row="0" Grid.Column="0" FontTypography="Body" Text="登录并绑定" TextWrapping="Wrap" />
+                    <ui:TextBlock Grid.Row="1" Grid.Column="0"
+                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                  Text="点击后扫码登录，再给 Clawbot 发送显示的验证码完成绑定；过程中可点击取消" TextWrapping="Wrap" />
+                    <ui:Button Grid.Row="0" Grid.RowSpan="2" Grid.Column="1"
+                               Margin="0,0,36,0"
+                               HorizontalAlignment="Right">
+                        <ui:Button.Style>
+                            <Style TargetType="ui:Button" BasedOn="{StaticResource {x:Type ui:Button}}">
+                                <Setter Property="Command" Value="{Binding BindWechatClawbotCommand}" />
+                                <Setter Property="Content" Value="登录并绑定" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding IsWechatClawbotBinding}" Value="True">
+                                        <Setter Property="Command" Value="{Binding CancelBindWechatClawbotCommand}" />
+                                        <Setter Property="Content" Value="取消" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </ui:Button.Style>
+                    </ui:Button>
+                </Grid>
+                <ui:TextBlock Margin="16,0,16,0"
+                              Foreground="{ui:ThemeResource TextFillColorSecondaryBrush}"
+                              Text="{Binding WechatClawbotStatus}"
+                              TextWrapping="Wrap" />
+                <Grid Margin="16">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="3*" />
+                        <ColumnDefinition Width="2*" />
+                    </Grid.ColumnDefinitions>
+                    <ui:TextBlock Grid.Row="0" Grid.Column="0" FontTypography="Body" Text="测试微信 Clawbot 通知" TextWrapping="Wrap" />
+                    <ui:TextBlock Grid.Row="1" Grid.Column="0"
+                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                  Text="发送测试通知" TextWrapping="Wrap" />
+                    <ui:Button Grid.Row="0" Grid.RowSpan="2" Grid.Column="1"
+                               Margin="0,0,36,0"
+                               Command="{Binding TestWechatClawbotNotificationCommand}"
                                Content="发送" />
                 </Grid>
             </StackPanel>

--- a/BetterGenshinImpact/View/Pages/NotificationSettingsPage.xaml
+++ b/BetterGenshinImpact/View/Pages/NotificationSettingsPage.xaml
@@ -2492,7 +2492,6 @@
                                   Text="发送测试通知" TextWrapping="Wrap" />
                     <ui:Button Grid.Row="0" Grid.RowSpan="2" Grid.Column="1"
                                Margin="0,0,36,0"
-                               HorizontalAlignment="Right"
                                Command="{Binding TestQqNotificationCommand}"
                                Content="发送" />
                 </Grid>

--- a/BetterGenshinImpact/View/Pages/NotificationSettingsPage.xaml
+++ b/BetterGenshinImpact/View/Pages/NotificationSettingsPage.xaml
@@ -2492,6 +2492,7 @@
                                   Text="发送测试通知" TextWrapping="Wrap" />
                     <ui:Button Grid.Row="0" Grid.RowSpan="2" Grid.Column="1"
                                Margin="0,0,36,0"
+                               HorizontalAlignment="Right"
                                Command="{Binding TestQqNotificationCommand}"
                                Content="发送" />
                 </Grid>
@@ -2608,6 +2609,7 @@
                                   Text="发送测试通知" TextWrapping="Wrap" />
                     <ui:Button Grid.Row="0" Grid.RowSpan="2" Grid.Column="1"
                                Margin="0,0,36,0"
+                               HorizontalAlignment="Right"
                                Command="{Binding TestWechatClawbotNotificationCommand}"
                                Content="发送" />
                 </Grid>

--- a/BetterGenshinImpact/ViewModel/Pages/NotificationSettingsPageViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/NotificationSettingsPageViewModel.cs
@@ -651,6 +651,8 @@ public partial class NotificationSettingsPageViewModel : ObservableObject, IView
 
         try
         {
+            // 先完成整个登录 + 绑定流程，成功后一次性提交全部凭证，
+            // 避免中途取消/失败时遗留“新 BotToken + 旧 ToUserId”的混合状态。
             var login = await WechatClawbotHelper.LoginAsync(
                 qrCodeUrl =>
                 {
@@ -670,11 +672,11 @@ public partial class NotificationSettingsPageViewModel : ObservableObject, IView
                 },
                 _wechatClawbotBindCts.Token);
 
-            Config.NotificationConfig.WechatClawbotBotToken = login.BotToken;
             WechatClawbotStatus = "登录成功，正在等待绑定消息…";
 
             var bind = await WechatClawbotHelper.BindAsync(
                 login.BotToken,
+                login.UserId,
                 code =>
                 {
                     System.Windows.Application.Current.Dispatcher.Invoke(() =>
@@ -684,6 +686,8 @@ public partial class NotificationSettingsPageViewModel : ObservableObject, IView
                 },
                 _wechatClawbotBindCts.Token);
 
+            // 全部成功后再一次性提交配置
+            Config.NotificationConfig.WechatClawbotBotToken = login.BotToken;
             Config.NotificationConfig.WechatClawbotToUserId = bind.ToUserId;
             Config.NotificationConfig.WechatClawbotContextToken = bind.ContextToken;
             Config.NotificationConfig.WechatClawbotGetUpdatesBuf = bind.GetUpdatesBuf;

--- a/BetterGenshinImpact/ViewModel/Pages/NotificationSettingsPageViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/NotificationSettingsPageViewModel.cs
@@ -12,6 +12,7 @@ using BetterGenshinImpact.Service.Notification.Model.Enum;
 using BetterGenshinImpact.Service.Notifier;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Microsoft.Extensions.Logging;
 using Windows.System;
 using Wpf.Ui.Violeta.Controls;
 
@@ -19,6 +20,9 @@ namespace BetterGenshinImpact.ViewModel.Pages;
 
 public partial class NotificationSettingsPageViewModel : ObservableObject, IViewModel
 {
+    private static readonly Microsoft.Extensions.Logging.ILogger<NotificationSettingsPageViewModel> Logger =
+        App.GetLogger<NotificationSettingsPageViewModel>();
+
     private readonly NotificationService _notificationService;
     private readonly HashSet<string> _knownNotificationEventCodes;
     private bool _isSyncingNotificationEventSelection;
@@ -71,15 +75,27 @@ public partial class NotificationSettingsPageViewModel : ObservableObject, IView
 
     [ObservableProperty] private string _qqStatus = string.Empty;
 
+    [ObservableProperty] private string _wechatClawbotStatus = string.Empty;
+
     /// <summary>
     /// 是否正在执行绑定流程（控制按钮显示为"绑定"或"取消"）
     /// </summary>
     [ObservableProperty] private bool _isBinding;
 
     /// <summary>
+    /// 是否正在执行微信 Clawbot 登录/绑定流程
+    /// </summary>
+    [ObservableProperty] private bool _isWechatClawbotBinding;
+
+    /// <summary>
     /// 绑定流程的取消令牌源，用于用户点击取消时中断 WebSocket 连接
     /// </summary>
     private CancellationTokenSource? _bindCts;
+
+    /// <summary>
+    /// 微信 Clawbot 登录/绑定流程的取消令牌源
+    /// </summary>
+    private CancellationTokenSource? _wechatClawbotBindCts;
 
     public NotificationSettingsPageViewModel(IConfigService configService, NotificationService notificationService)
     {
@@ -533,6 +549,23 @@ public partial class NotificationSettingsPageViewModel : ObservableObject, IView
         IsLoading = false;
     }
 
+    [RelayCommand]
+    private async Task OnTestWechatClawbotNotification()
+    {
+        IsLoading = true;
+        WechatClawbotStatus = string.Empty;
+
+        var res = await _notificationService.TestNotifierAsync<WechatClawbotNotifier>();
+
+        WechatClawbotStatus = res.Message;
+        if (res.IsSuccess)
+            Toast.Success(res.Message);
+        else
+            Toast.Error(res.Message);
+
+        IsLoading = false;
+    }
+
     /// <summary>
     /// 绑定 QQ 按钮。连接 QQ 网关，等待用户发送验证码，自动回填 OpenID。
     /// 支持取消（用户点击取消时中断 WebSocket 连接）。
@@ -603,6 +636,84 @@ public partial class NotificationSettingsPageViewModel : ObservableObject, IView
     private void OnCancelBindQq()
     {
         _bindCts?.Cancel();
+    }
+
+    /// <summary>
+    /// 微信 Clawbot 登录并绑定按钮。扫码登录获取 bot_token，再等待用户发送一次性验证码，
+    /// 自动回填 to_user_id 和 context_token。支持取消。
+    /// </summary>
+    [RelayCommand]
+    private async Task OnBindWechatClawbot()
+    {
+        IsWechatClawbotBinding = true;
+        WechatClawbotStatus = "正在获取登录二维码…";
+        _wechatClawbotBindCts = new CancellationTokenSource();
+
+        try
+        {
+            var login = await WechatClawbotHelper.LoginAsync(
+                qrCodeUrl =>
+                {
+                    System.Windows.Application.Current.Dispatcher.Invoke(() =>
+                    {
+                        WechatClawbotStatus = "请用手机微信扫码登录 Clawbot";
+                        try
+                        {
+                            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(qrCodeUrl) { UseShellExecute = true });
+                        }
+                        catch (System.Exception ex)
+                        {
+                            WechatClawbotStatus = $"请用手机微信扫码登录 Clawbot（二维码链接：{qrCodeUrl}）";
+                            Logger.LogWarning("打开微信 Clawbot 二维码链接失败: {Ex}", ex.Message);
+                        }
+                    });
+                },
+                _wechatClawbotBindCts.Token);
+
+            Config.NotificationConfig.WechatClawbotBotToken = login.BotToken;
+            WechatClawbotStatus = "登录成功，正在等待绑定消息…";
+
+            var bind = await WechatClawbotHelper.BindAsync(
+                login.BotToken,
+                code =>
+                {
+                    System.Windows.Application.Current.Dispatcher.Invoke(() =>
+                    {
+                        WechatClawbotStatus = $"请给 Clawbot 发送验证码 [{code}] 完成绑定";
+                    });
+                },
+                _wechatClawbotBindCts.Token);
+
+            Config.NotificationConfig.WechatClawbotToUserId = bind.ToUserId;
+            Config.NotificationConfig.WechatClawbotContextToken = bind.ContextToken;
+            Config.NotificationConfig.WechatClawbotGetUpdatesBuf = bind.GetUpdatesBuf;
+            WechatClawbotStatus = "绑定成功";
+            Toast.Success("微信 Clawbot 绑定成功");
+        }
+        catch (OperationCanceledException)
+        {
+            WechatClawbotStatus = "已取消登录/绑定";
+        }
+        catch (System.Exception ex)
+        {
+            WechatClawbotStatus = $"登录/绑定失败：{ex.Message}";
+            Toast.Error($"登录/绑定失败：{ex.Message}");
+        }
+        finally
+        {
+            IsWechatClawbotBinding = false;
+            _wechatClawbotBindCts.Dispose();
+            _wechatClawbotBindCts = null;
+        }
+    }
+
+    /// <summary>
+    /// 取消微信 Clawbot 登录/绑定按钮。
+    /// </summary>
+    [RelayCommand]
+    private void OnCancelBindWechatClawbot()
+    {
+        _wechatClawbotBindCts?.Cancel();
     }
 
     [RelayCommand]

--- a/BetterGenshinImpact/ViewModel/Pages/NotificationSettingsPageViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/NotificationSettingsPageViewModel.cs
@@ -698,8 +698,9 @@ public partial class NotificationSettingsPageViewModel : ObservableObject, IView
                 Config.NotificationConfig.WechatClawbotToUserId = bind.ToUserId;
             }
 
-            // 无条件刷新一次，确保即使凭证值未变化，通知器也会从独立存储重新加载最新的 context_token
-            _notificationService.RefreshNotifiers();
+            // 无需再显式刷新——SuppressRefreshNotifiers() 退出时已无条件调用 RefreshNotifiers()，
+            // 确保通知器从独立存储重新加载最新 context_token。
+            // 此处不再重复调用，避免第二次刷新销毁刚创建的会话导致 UI 卡死。
 
             WechatClawbotStatus = "绑定成功";
             Toast.Success("微信 Clawbot 绑定成功");

--- a/BetterGenshinImpact/ViewModel/Pages/NotificationSettingsPageViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/NotificationSettingsPageViewModel.cs
@@ -676,6 +676,7 @@ public partial class NotificationSettingsPageViewModel : ObservableObject, IView
 
             var bind = await WechatClawbotHelper.BindAsync(
                 login.BotToken,
+                login.BaseUrl,
                 login.UserId,
                 code =>
                 {
@@ -688,6 +689,7 @@ public partial class NotificationSettingsPageViewModel : ObservableObject, IView
 
             // 全部成功后再一次性提交配置
             Config.NotificationConfig.WechatClawbotBotToken = login.BotToken;
+            Config.NotificationConfig.WechatClawbotBaseUrl = login.BaseUrl;
             Config.NotificationConfig.WechatClawbotToUserId = bind.ToUserId;
             Config.NotificationConfig.WechatClawbotContextToken = bind.ContextToken;
             Config.NotificationConfig.WechatClawbotGetUpdatesBuf = bind.GetUpdatesBuf;

--- a/BetterGenshinImpact/ViewModel/Pages/NotificationSettingsPageViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/NotificationSettingsPageViewModel.cs
@@ -690,13 +690,16 @@ public partial class NotificationSettingsPageViewModel : ObservableObject, IView
             // 把会话令牌/游标存入独立存储（不触发全局配置刷新）
             await WechatClawbotSessionStore.SaveAsync(login.BotToken, bind.ContextToken, bind.GetUpdatesBuf);
 
-            // 全部成功后在抑制刷新的作用域内一次性提交绑定凭证，只触发一次通知器重建
+            // 全部成功后在抑制刷新的作用域内一次性提交绑定凭证
             using (_notificationService.SuppressRefreshNotifiers())
             {
                 Config.NotificationConfig.WechatClawbotBotToken = login.BotToken;
                 Config.NotificationConfig.WechatClawbotBaseUrl = login.BaseUrl;
                 Config.NotificationConfig.WechatClawbotToUserId = bind.ToUserId;
             }
+
+            // 无条件刷新一次，确保即使凭证值未变化，通知器也会从独立存储重新加载最新的 context_token
+            _notificationService.RefreshNotifiers();
 
             WechatClawbotStatus = "绑定成功";
             Toast.Success("微信 Clawbot 绑定成功");

--- a/BetterGenshinImpact/ViewModel/Pages/NotificationSettingsPageViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/NotificationSettingsPageViewModel.cs
@@ -687,12 +687,17 @@ public partial class NotificationSettingsPageViewModel : ObservableObject, IView
                 },
                 _wechatClawbotBindCts.Token);
 
-            // 全部成功后再一次性提交配置
-            Config.NotificationConfig.WechatClawbotBotToken = login.BotToken;
-            Config.NotificationConfig.WechatClawbotBaseUrl = login.BaseUrl;
-            Config.NotificationConfig.WechatClawbotToUserId = bind.ToUserId;
-            Config.NotificationConfig.WechatClawbotContextToken = bind.ContextToken;
-            Config.NotificationConfig.WechatClawbotGetUpdatesBuf = bind.GetUpdatesBuf;
+            // 把会话令牌/游标存入独立存储（不触发全局配置刷新）
+            await WechatClawbotSessionStore.SaveAsync(login.BotToken, bind.ContextToken, bind.GetUpdatesBuf);
+
+            // 全部成功后在抑制刷新的作用域内一次性提交绑定凭证，只触发一次通知器重建
+            using (_notificationService.SuppressRefreshNotifiers())
+            {
+                Config.NotificationConfig.WechatClawbotBotToken = login.BotToken;
+                Config.NotificationConfig.WechatClawbotBaseUrl = login.BaseUrl;
+                Config.NotificationConfig.WechatClawbotToUserId = bind.ToUserId;
+            }
+
             WechatClawbotStatus = "绑定成功";
             Toast.Success("微信 Clawbot 绑定成功");
         }


### PR DESCRIPTION
## 概述

给 BetterGI 新增「微信 Clawbot」通知渠道，参考 QQ 官方推送渠道（PR #3530）实现模式。用户无需安装/运行 OpenClaw，可直接在通知设置页扫码登录、完成绑定后接收推送。

## 主要改动

- **新增 `WechatClawbotNotifier`**：实现 `INotifier`，支持文本 + 截图图片（CDN AES-128-ECB 加密上传）推送
- **新增 `WechatClawbotHelper`**：扫码登录（`get_bot_qrcode` → `get_qrcode_status`）+ 一次性验证码绑定（`getupdates` 长轮询），对接微信 iLink 私有 REST 协议
- **新增 `WechatClawbotSession`**：后台长轮询维持 `context_token`（会过期）与 `get_updates_buf` 同步游标，线程安全缓存
- **`NotificationConfig`**：新增 5 个配置字段（启用开关、BotToken、ToUserId、ContextToken、GetUpdatesBuf）
- **`NotificationService`**：注册微信通知器
- **`NotifierManager`**：`RemoveAllNotifiers` 时释放 `IDisposable` 通知器（修复会话泄漏）
- **UI**：通知设置页新增微信 Clawbot 卡片（启用开关 + 登录并绑定按钮 + 测试按钮 + 状态提示）

## 协议要点

- baseUrl: `https://ilinkai.weixin.qq.com`（生产环境）
- 请求头：`Content-Type` / `Authorization` / `AuthorizationType: ilink_bot_token` / `X-WECHAT-UIN`（随机防重放）/ `iLink-App-Id` / `iLink-App-ClientVersion`
- 绑定方式：扫码登录获取 bot_token，用户给 Clawbot 发一次性验证码，从 `getupdates` 捕获 `to_user_id`（`xxx@im.wechat`）+ `context_token`
- 会话维持：后台长轮询 `getupdates` 持续刷新 `context_token`

## 经验教训落实（对照 QQ 渠道 AI 审核）

- 幂等性：`sendmessage` 非幂等不重试，上传链路幂等可重试
- 重试覆盖完整链路：getuploadurl + CDN 上传均重试
- 错误码检测：响应体在抛异常前读取
- 取消令牌贯穿所有异步操作
- 缓存并发安全：`SemaphoreSlim` 保护 context_token
- 图片失败优雅降级为纯文本，不阻断主流程
- 协议细节：`@im.wechat` 后缀、枚举值、域名对照官方实现
- 超时与取消区分提示
- System.Text.Json 序列化，与 Notifier 目录一致
- 中文注释 UTF-8，emoji 用 Unicode 转义

## 测试

- 真机验证通过：扫码登录 → 一次性验证码绑定 → 纯文本推送 → 带截图推送
- `dotnet build BetterGenshinImpact/BetterGenshinImpact.csproj -c Debug` 通过

> 凭证通过 UI 扫码获取并存入本地 config，代码中不含任何凭证。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增微信 Clawbot 通知渠道，支持扫码绑定、解绑、状态查看和测试通知。
  - 可配置 Bot Token、目标用户及服务地址。
  - 支持发送文字和截图，图片发送失败时自动退回文字通知。

- **改进**
  - 优化微信会话恢复、身份校验及网络错误处理。
  - 提升多实例和并发通知发送的稳定性。
  - 改善通知渠道刷新及资源释放机制。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->