### PR TITLE
feat: 简化 QQ 通知消息格式（时间开头+内容第二行）

### DIFF
--- a/BetterGenshinImpact/Service/Notifier/QqNotifier.cs
+++ b/BetterGenshinImpact/Service/Notifier/QqNotifier.cs
@@ -95,22 +95,15 @@ public sealed class QqNotifier : INotifier
     }
 
     /// <summary>
-    /// 生成通知文本，包含结果标记（成功/失败/警告）和时间戳。
+    /// 生成通知文本。时间戳放在第一行，推送内容在第二行，排版更紧凑。
     /// </summary>
     private static string GenerateMessage(BaseNotificationData data)
     {
         var sb = new StringBuilder();
-        var mark = data.Result switch
-        {
-            NotificationEventResult.Success => "\u2705",
-            NotificationEventResult.Fail => "\u274C",
-            _ => "\u26A0\uFE0F"
-        };
-        sb.Append($"[BetterGI] {mark} ");
+        sb.Append($"[{data.Timestamp:yyyy-MM-dd HH:mm:ss}]");
+        sb.AppendLine();
         if (!string.IsNullOrWhiteSpace(data.Message))
             sb.Append(data.Message);
-        sb.AppendLine();
-        sb.Append($"\uD83D\uDD50 {data.Timestamp:yyyy-MM-dd HH:mm:ss}");
         return sb.ToString();
     }
 

--- a/BetterGenshinImpact/View/Pages/NotificationSettingsPage.xaml
+++ b/BetterGenshinImpact/View/Pages/NotificationSettingsPage.xaml
@@ -2492,6 +2492,7 @@
                                   Text="发送测试通知" TextWrapping="Wrap" />
                     <ui:Button Grid.Row="0" Grid.RowSpan="2" Grid.Column="1"
                                Margin="0,0,36,0"
+                               HorizontalAlignment="Right"
                                Command="{Binding TestQqNotificationCommand}"
                                Content="发送" />
                 </Grid>


### PR DESCRIPTION
## 概述

简化 QQ 官方通知渠道的消息排版，使消息列表更紧凑、信息层级更清晰，并修复测试按钮对齐。

## 改动

### 1. 简化消息格式
- 去掉 \[BetterGI]\ 前缀和 emoji 状态符号（✅/❌/⚠️）
- 时间戳放在消息开头（第一行）
- 推送内容放在第二行

**之前：**
\\\
[BetterGI] ✅ 配置组任务启动
🕐 2026-08-27 06:41:20
\\\

**之后：**
\\\
[2026-08-27 06:41:20]
配置组任务启动
\\\

### 2. 修复 QQ 测试按钮对齐
QQ 通知的「发送」测试按钮原本靠左，与其他通知渠道（靠右）不一致，已改为靠右对齐。

## 涉及文件
- \BetterGenshinImpact/Service/Notifier/QqNotifier.cs\ — 消息格式
- \BetterGenshinImpact/View/Pages/NotificationSettingsPage.xaml\ — 按钮对齐

## 测试
- \dotnet build BetterGenshinImpact/BetterGenshinImpact.csproj -c Debug\ 通过