### PR TITLE
fix: 释放 BitBlt 会话结束后的帧缓冲

### DIFF
--- a/Fischless.GameCapture/BitBlt/BitBltSession.cs
+++ b/Fischless.GameCapture/BitBlt/BitBltSession.cs
@@ -37,6 +37,8 @@ public class BitBltSession : IDisposable
     // Bitmap 内存池
     private readonly ConcurrentStack<IntPtr> _bufferPool = [];
 
+    private volatile bool _disposed;
+
     // 窗口原宽高
     public int Width { get; }
     public int Height { get; }
@@ -45,7 +47,7 @@ public class BitBltSession : IDisposable
     ///     不是所有的失效情况都能被检测到
     /// </summary>
     /// <returns></returns>
-    public bool Invalid => _hWnd.IsNull || _hdcSrc.IsInvalid || _hdcDest.IsInvalid || _hBitmap.IsInvalid || _bitsPtr == 0;
+    public bool Invalid => _disposed || _hWnd.IsNull || _hdcSrc.IsInvalid || _hdcDest.IsInvalid || _hBitmap.IsInvalid || _bitsPtr == 0;
 
     public BitBltSession(HWND hWnd, int w, int h)
     {
@@ -144,6 +146,12 @@ public class BitBltSession : IDisposable
     {
         lock (_lockObject)
         {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
             ReleaseResources();
         }
         GC.SuppressFinalize(this);
@@ -191,7 +199,16 @@ public class BitBltSession : IDisposable
 
     public void ReleaseBuffer(IntPtr buffer)
     {
-        _bufferPool.Push(buffer);
+        lock (_lockObject)
+        {
+            if (_disposed)
+            {
+                Marshal.FreeHGlobal(buffer);
+                return;
+            }
+
+            _bufferPool.Push(buffer);
+        }
     }
 
     /// <summary>
@@ -230,7 +247,7 @@ public class BitBltSession : IDisposable
 
         _bitsPtr = IntPtr.Zero;
 
-        foreach (var buffer in _bufferPool)
+        while (_bufferPool.TryPop(out var buffer))
         {
             Marshal.FreeHGlobal(buffer);
         }


### PR DESCRIPTION
## 问题

BitBlt 截图帧可以比截图会话活得更久。会话关闭后，这些帧归还的非托管缓冲区会进入已经废弃的缓冲池，无法再被释放。

## 修改

- 会话关闭时清空缓冲池
- 会话关闭后归还的帧缓冲直接释放
- 重复关闭会话时不再次释放同一批资源

## 验证

- dotnet build Fischless.GameCapture/Fischless.GameCapture.csproj -c Debug --nologo
- 结果：0 个错误；1 个既有 WinRT 过时警告

尚未完成真实 BitBlt 截图循环与窗口缩放测试，因此先以 Draft 提交。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 改进游戏捕获会话的资源释放逻辑，避免重复释放和资源泄漏。
  * 会话释放后将正确判定为无效。
  * 释放会话后归还缓冲区时，将及时清理非托管内存。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->