### PR TITLE
fix: 释放重复任务使用的 ONNX 推理资源

### DIFF
--- a/BetterGenshinImpact/Core/Recognition/ONNX/BgiOnnxFactory.cs
+++ b/BetterGenshinImpact/Core/Recognition/ONNX/BgiOnnxFactory.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using BetterGenshinImpact.Core.Config;
 using BetterGenshinImpact.GameTask;
+using Compunet.YoloSharp;
 using Microsoft.Extensions.Logging;
 using Microsoft.ML.OnnxRuntime;
 using Microsoft.Win32;
@@ -302,13 +303,15 @@ public class BgiOnnxFactory
     /// <returns>BgiYoloPredictor</returns>
     public BgiYoloPredictor CreateYoloPredictor(BgiOnnxModel model)
     {
-        // logger.LogDebug("[Yolo]创建yolo预测器，模型: {ModelName}", model.Name);
-        if (!EnableCache) return new BgiYoloPredictor(model, model.ModalPath, CreateSessionOptions(model, false));
-
-        var cached = GetCached(model);
-        return cached == null
-            ? new BgiYoloPredictor(model, model.ModalPath, CreateSessionOptions(model, true))
-            : new BgiYoloPredictor(model, cached, CreateSessionOptions(model, false));
+        return new BgiYoloPredictor(model, () =>
+        {
+            var cached = EnableCache ? GetCached(model) : null;
+            using var sessionOptions = CreateSessionOptions(model, EnableCache && cached is null);
+            return new YoloPredictor(cached ?? model.ModalPath, new YoloPredictorOptions
+            {
+                SessionOptions = sessionOptions
+            });
+        });
     }
 
     /// <summary>
@@ -323,13 +326,9 @@ public class BgiOnnxFactory
         ProviderType[]? providerTypes = null;
         if (CpuOcr && ocr) providerTypes = [ProviderType.Cpu];
 
-        if (!EnableCache)
-            return new InferenceSession(model.ModalPath, CreateSessionOptions(model, false, providerTypes));
-
-        var cached = GetCached(model, providerTypes);
-        return cached == null
-            ? new InferenceSession(model.ModalPath, CreateSessionOptions(model, true, providerTypes))
-            : new InferenceSession(cached, CreateSessionOptions(model, false, providerTypes));
+        var cached = EnableCache ? GetCached(model, providerTypes) : null;
+        using var sessionOptions = CreateSessionOptions(model, EnableCache && cached is null, providerTypes);
+        return new InferenceSession(cached ?? model.ModalPath, sessionOptions);
     }
 
     /// <summary>

--- a/BetterGenshinImpact/Core/Recognition/ONNX/BgiYoloPredictor.cs
+++ b/BetterGenshinImpact/Core/Recognition/ONNX/BgiYoloPredictor.cs
@@ -7,34 +7,35 @@ using System.Linq;
 using System.Text.Json;
 using BetterGenshinImpact.View.Drawable;
 using Compunet.YoloSharp;
-using Microsoft.ML.OnnxRuntime;
 
 namespace BetterGenshinImpact.Core.Recognition.ONNX;
 
 public class BgiYoloPredictor : IDisposable
 {
     private readonly BgiOnnxModel _model;
-
-
     private readonly Lazy<YoloPredictor> _lazyPredictor;
+    private readonly object _lifecycleLock = new();
+    private bool _disposed;
 
     /// <summary>
     /// 使用 BgiOnnxFactory 创建这个类的实例
     /// </summary>
     /// <param name="onnxModel">模型</param>
-    /// <param name="modelPath">实际要加载的模型文件的绝对路径，在使用模型缓存的场景下可能有差别</param>
-    /// <param name="sessionOptions">sessionOptions</param>
-    protected internal BgiYoloPredictor(BgiOnnxModel onnxModel, string modelPath, SessionOptions sessionOptions)
+    /// <param name="predictorFactory">底层预测器工厂</param>
+    protected internal BgiYoloPredictor(BgiOnnxModel onnxModel, Func<YoloPredictor> predictorFactory)
     {
         _model = onnxModel;
-        _lazyPredictor = new Lazy<YoloPredictor>(() => new YoloPredictor(modelPath,
-            new YoloPredictorOptions
-            {
-                SessionOptions = sessionOptions
-            }));
+        _lazyPredictor = new Lazy<YoloPredictor>(predictorFactory);
     }
 
-    public YoloPredictor Predictor => _lazyPredictor.Value;
+    public TResult Run<TResult>(Func<YoloPredictor, TResult> inference)
+    {
+        lock (_lifecycleLock)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            return inference(_lazyPredictor.Value);
+        }
+    }
 
     /// <summary>
     /// 检测
@@ -43,7 +44,7 @@ public class BgiYoloPredictor : IDisposable
     /// <returns>类别-矩形框</returns>
     public Dictionary<string, List<Rect>> Detect(ImageRegion region)
     {
-        var result = Predictor.Detect(region.CacheImage);
+        var result = Run(predictor => predictor.Detect(region.CacheImage));
 
 
         var dict = new Dictionary<string, List<Rect>>();
@@ -72,14 +73,18 @@ public class BgiYoloPredictor : IDisposable
 
     public void Dispose()
     {
-        if (_lazyPredictor.IsValueCreated)
+        lock (_lifecycleLock)
         {
-            Predictor.Dispose();
-        }
-    }
+            if (_disposed)
+            {
+                return;
+            }
 
-    ~BgiYoloPredictor()
-    {
-        Dispose();
+            _disposed = true;
+            if (_lazyPredictor.IsValueCreated)
+            {
+                _lazyPredictor.Value.Dispose();
+            }
+        }
     }
 }

--- a/BetterGenshinImpact/Core/Script/Dependence/Dispatcher.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/Dispatcher.cs
@@ -188,12 +188,15 @@ public class Dispatcher
                 return null;
 
             case "AutoDomain":
+            {
                 if (taskSettingsPageViewModel.GetFightStrategy(out var path))
                 {
                     return null;
                 }
 
-                return await new AutoDomainTask(new AutoDomainParam(0, path)).Start(cancellationToken);
+                using var task = new AutoDomainTask(new AutoDomainParam(0, path));
+                return await task.Start(cancellationToken);
+            }
 
             case "AutoBoss":
                 var autoBossConfig = TaskContext.Instance().Config.AutoBossConfig;
@@ -205,9 +208,11 @@ public class Dispatcher
                 return await new AutoBossTask(new AutoBossParam(autoBossPath)).Start(cancellationToken);
 
             case "AutoFishing":
-                await new AutoFishingTask(AutoFishingTaskParam.BuildFromSoloTaskConfig(soloTask.Config)).Start(
-                    cancellationToken);
+            {
+                using var task = new AutoFishingTask(AutoFishingTaskParam.BuildFromSoloTaskConfig(soloTask.Config));
+                await task.Start(cancellationToken);
                 return null;
+            }
             case "AutoCook":
                 await new AutoCookTask().Start(cancellationToken);
                 return null;
@@ -337,7 +342,8 @@ public class Dispatcher
         }  
   
         CancellationToken cancellationToken = customCt ?? CancellationContext.Instance.Cts.Token;  
-        return await new AutoDomainTask(param).Start(cancellationToken);
+        using var task = new AutoDomainTask(param);
+        return await task.Start(cancellationToken);
     }  
 
     /// <summary>

--- a/BetterGenshinImpact/Core/Script/Dependence/Genshin.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/Genshin.cs
@@ -464,7 +464,8 @@ public class Genshin
 
         var param = AutoFishingTaskParam.BuildFromConfig(TaskContext.Instance().Config.AutoFishingConfig, taskSettingsPageViewModel.SaveScreenshotOnKeyTick);
         param.FishingTimePolicy = (FishingTimePolicy)fishingTimePolicy;
-        await new AutoFishingTask(param).Start(CancellationContext.Instance.Cts.Token);
+        using var task = new AutoFishingTask(param);
+        await task.Start(CancellationContext.Instance.Cts.Token);
     }
 
     /// <summary>

--- a/BetterGenshinImpact/Core/Script/Dependence/GlobalMethod.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/GlobalMethod.cs
@@ -261,7 +261,9 @@ public class GlobalMethod
 
     public static string[] GetAvatars()
     {
-        var combatScenes = new CombatScenes().InitializeTeam(CaptureGameRegion());
+        using var capture = CaptureGameRegion();
+        using var combatScenes = new CombatScenes();
+        combatScenes.InitializeTeam(capture);
         ReadOnlyCollection<Avatar> avatars = combatScenes.GetAvatars();
         return avatars.Count > 0
             ? avatars.Select(avatar => avatar.Name).ToArray()

--- a/BetterGenshinImpact/GameTask/AutoBoss/AutoBossTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoBoss/AutoBossTask.cs
@@ -856,11 +856,23 @@ public class AutoBossTask : ISoloTask<Dictionary<string, int>>
         for (var attempt = 1; attempt <= maxRetries; attempt++)
         {
             _ct.ThrowIfCancellationRequested();
-            var combatScenes = new CombatScenes().InitializeTeam(CaptureToRectArea());
-            if (combatScenes.CheckTeamInitialized())
+            using var capture = CaptureToRectArea();
+            var combatScenes = new CombatScenes();
+            try
             {
-                return combatScenes;
+                combatScenes.InitializeTeam(capture);
+                if (combatScenes.CheckTeamInitialized())
+                {
+                    return combatScenes;
+                }
             }
+            catch
+            {
+                combatScenes.Dispose();
+                throw;
+            }
+
+            combatScenes.Dispose();
 
             if (attempt < maxRetries)
             {
@@ -904,7 +916,7 @@ public class AutoBossTask : ISoloTask<Dictionary<string, int>>
         }
         else
         {
-            var combatScenes = GetCombatScenesWithRetry();
+            using var combatScenes = GetCombatScenesWithRetry();
             FindCombatScriptAndSwitchAvatar(combatScenes);
 
             var taskParam = BuildAutoFightParamForBoss();

--- a/BetterGenshinImpact/GameTask/AutoDomain/AutoDomainTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoDomain/AutoDomainTask.cs
@@ -45,7 +45,7 @@ using BetterGenshinImpact.GameTask.AutoFight;
 
 namespace BetterGenshinImpact.GameTask.AutoDomain;
 
-public class AutoDomainTask : ISoloTask<Dictionary<string, int>>
+public class AutoDomainTask : ISoloTask<Dictionary<string, int>>, IDisposable
 {
     public string Name => "自动秘境";
 
@@ -178,7 +178,7 @@ public class AutoDomainTask : ISoloTask<Dictionary<string, int>>
         // 前置进入秘境
         await EnterDomain();
 
-        var combatScenes = new CombatScenes();
+        using var combatScenes = new CombatScenes();
         for (var i = 0; i < _taskParam.DomainRoundNum; i++)
         {
             // 0. 关闭秘境提示
@@ -202,7 +202,8 @@ public class AutoDomainTask : ISoloTask<Dictionary<string, int>>
                 //0.5. 初始化队伍，只执行一次
                 if (i == 0)
                 {
-                    combatScenes = new CombatScenes().InitializeTeam(CaptureToRectArea());
+                    using var capture = CaptureToRectArea();
+                    combatScenes.InitializeTeam(capture);
                 }
 
                 RetryTeamInit(combatScenes);
@@ -1059,7 +1060,7 @@ public class AutoDomainTask : ISoloTask<Dictionary<string, int>>
 
     private Rect DetectTree(ImageRegion region)
     {
-        var result = _predictor.Predictor.Detect(region.CacheImage);
+        var result = _predictor.Run(predictor => predictor.Detect(region.CacheImage));
         var list = new List<RectDrawable>();
         foreach (var box in result)
         {
@@ -1549,5 +1550,10 @@ public class AutoDomainTask : ISoloTask<Dictionary<string, int>>
         }
 
         await new AutoArtifactSalvageTask(new AutoArtifactSalvageTaskParam(star, javaScript: null, artifactSetFilter: null, maxNumToCheck: null, recognitionFailurePolicy: null)).Start(_ct);
+    }
+
+    public void Dispose()
+    {
+        _predictor.Dispose();
     }
 }

--- a/BetterGenshinImpact/GameTask/AutoFight/AutoFightJsonTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/AutoFightJsonTask.cs
@@ -1,4 +1,3 @@
-using BetterGenshinImpact.Core.Recognition.ONNX;
 using BetterGenshinImpact.Core.Simulator;
 using BetterGenshinImpact.Core.Simulator.Extensions;
 using BetterGenshinImpact.GameTask.AutoFight.Assets;
@@ -7,7 +6,6 @@ using BetterGenshinImpact.GameTask.AutoFight.Script;
 using BetterGenshinImpact.GameTask.AutoGeniusInvokation.Exception;
 using BetterGenshinImpact.GameTask.Model.Area;
 using BetterGenshinImpact.Helpers;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
@@ -36,12 +34,6 @@ public class AutoFightJsonTask : ISoloTask
     private readonly JsonCombatStrategy _strategy;
     private CancellationToken _ct;
 
-    /// <summary>
-    /// YOLO目标检测器（BgiWorld模型），用于战斗结束检测
-    /// 当前未使用（战斗结束检测已委托到 AutoFightEndDetection），保留声明以与 TXT 策略保持一致
-    /// 初始化条件：_taskParam.FightFinishDetectEnabled == true
-    /// </summary>
-    private readonly BgiYoloPredictor? _predictor;
     private DateTime _lastFightFlagTime = DateTime.Now;
     private int _skipCheckCounter;
 
@@ -86,11 +78,6 @@ public class AutoFightJsonTask : ISoloTask
         _taskParam = taskParam;
         _strategy = JsonCombatStrategyParser.ParseFile(_taskParam.CombatStrategyPath);
 
-        if (_taskParam.FightFinishDetectEnabled)
-        {
-            _predictor = App.ServiceProvider.GetRequiredService<BgiOnnxFactory>().CreateYoloPredictor(BgiOnnxModel.BgiWorld);
-        }
-
         _finishDetectConfig = new AutoFightTask.TaskFightFinishDetectConfig(_taskParam.FinishDetectConfig);
     }
 
@@ -106,11 +93,23 @@ public class AutoFightJsonTask : ISoloTask
 
         for (int attempt = 1; attempt <= maxRetries; attempt++)
         {
-            var combatScenes = new CombatScenes().InitializeTeam(CaptureToRectArea());
-            if (combatScenes.CheckTeamInitialized())
+            using var capture = CaptureToRectArea();
+            var combatScenes = new CombatScenes();
+            try
             {
-                return combatScenes;
+                combatScenes.InitializeTeam(capture);
+                if (combatScenes.CheckTeamInitialized())
+                {
+                    return combatScenes;
+                }
             }
+            catch
+            {
+                combatScenes.Dispose();
+                throw;
+            }
+
+            combatScenes.Dispose();
 
             if (attempt < maxRetries)
             {
@@ -132,7 +131,7 @@ public class AutoFightJsonTask : ISoloTask
         try
         {
             LogScreenResolution();
-            var combatScenes = GetCombatScenesWithRetry();
+            using var combatScenes = GetCombatScenesWithRetry();
     
             // 收集当前队伍角色名
             foreach (var avatar in combatScenes.GetAvatars())
@@ -474,7 +473,8 @@ public class AutoFightJsonTask : ISoloTask
                     {
                         if (_taskParam is { PickDropsAfterFightEnabled: true })
                         {
-                            await new ScanPickTask().Start(_ct);
+                            using var task = new ScanPickTask();
+                            await task.Start(_ct);
                         }
                         return;
                     }
@@ -831,7 +831,8 @@ public class AutoFightJsonTask : ISoloTask
 
         if (_taskParam is { PickDropsAfterFightEnabled: true })
         {
-            await new ScanPickTask().Start(_ct);
+            using var task = new ScanPickTask();
+            await task.Start(_ct);
         }
     }
 

--- a/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
@@ -1,4 +1,3 @@
-using BetterGenshinImpact.Core.Recognition.ONNX;
 using BetterGenshinImpact.Core.Simulator;
 using BetterGenshinImpact.Core.Simulator.Extensions;
 using BetterGenshinImpact.GameTask.AutoFight.Model;
@@ -19,7 +18,6 @@ using BetterGenshinImpact.GameTask.Common.Job;
 using OpenCvSharp;
 using BetterGenshinImpact.Helpers;
 using Vanara;
-using Microsoft.Extensions.DependencyInjection;
 using BetterGenshinImpact.GameTask.AutoPathing.Model;
 using BetterGenshinImpact.GameTask.AutoPathing.Handler;
 using BetterGenshinImpact.GameTask.AutoPick.Assets;
@@ -39,8 +37,6 @@ public class AutoFightTask : ISoloTask
     private readonly CombatScriptBag _combatScriptBag;
 
     private CancellationToken _ct;
-
-    private readonly BgiYoloPredictor _predictor;
 
     private static DateTime _lastFightFlagTime = DateTime.Now; // 战斗标志最近一次出现的时间
     private static int _skipCheckCounter;
@@ -230,11 +226,6 @@ public class AutoFightTask : ISoloTask
         _taskParam = taskParam;
         _combatScriptBag = CombatScriptParser.ReadAndParse(_taskParam.CombatStrategyPath);
 
-        if (_taskParam.FightFinishDetectEnabled)
-        {
-            _predictor = App.ServiceProvider.GetRequiredService<BgiOnnxFactory>().CreateYoloPredictor(BgiOnnxModel.BgiWorld);
-        }
-
         _finishDetectConfig = new TaskFightFinishDetectConfig(_taskParam.FinishDetectConfig);
     }
     public CombatScenes GetCombatScenesWithRetry()
@@ -244,11 +235,23 @@ public class AutoFightTask : ISoloTask
 
         for (int attempt = 1; attempt <= maxRetries; attempt++)
         {
-            var combatScenes = new CombatScenes().InitializeTeam(CaptureToRectArea());
-            if (combatScenes.CheckTeamInitialized())
+            using var capture = CaptureToRectArea();
+            var combatScenes = new CombatScenes();
+            try
             {
-                return combatScenes;
+                combatScenes.InitializeTeam(capture);
+                if (combatScenes.CheckTeamInitialized())
+                {
+                    return combatScenes;
+                }
             }
+            catch
+            {
+                combatScenes.Dispose();
+                throw;
+            }
+
+            combatScenes.Dispose();
         
             if (attempt < maxRetries)
             {
@@ -273,7 +276,7 @@ public class AutoFightTask : ISoloTask
         try
         {
             LogScreenResolution();
-        var combatScenes = GetCombatScenesWithRetry();
+        using var combatScenes = GetCombatScenesWithRetry();
         /*var combatScenes = new CombatScenes().InitializeTeam(CaptureToRectArea());
         if (!combatScenes.CheckTeamInitialized())
         {
@@ -606,7 +609,8 @@ public class AutoFightTask : ISoloTask
                     // 经验值检测未通过，跳过拾取（但仍执行扫描拾取逻辑）
                     if (_taskParam is { PickDropsAfterFightEnabled: true })
                     {
-                        await new ScanPickTask().Start(ct, _taskParam.PickDropsAfterFightSeconds);
+                        using var task = new ScanPickTask();
+                        await task.Start(ct, _taskParam.PickDropsAfterFightSeconds);
                     }
                     return;
                 }
@@ -882,7 +886,8 @@ public class AutoFightTask : ISoloTask
         if (_taskParam is { PickDropsAfterFightEnabled: true } )
         {
             // 执行扫描掉落物光柱并靠近的功能
-            await new ScanPickTask().Start(ct, _taskParam.PickDropsAfterFightSeconds);
+            using var task = new ScanPickTask();
+            await task.Start(ct, _taskParam.PickDropsAfterFightSeconds);
         }
     }
         finally
@@ -1109,16 +1114,6 @@ public class AutoFightTask : ISoloTask
         }
 
         return dictionary;
-    }
-
-    private bool HasFightFlagByYolo(ImageRegion imageRegion)
-    {
-        // if (RuntimeHelper.IsDebug)
-        // {
-        //     imageRegion.SrcMat.SaveImage(Global.Absolute(@"log\fight\" + $"{DateTime.Now:yyyyMMdd_HHmmss_ffff}.png"));
-        // }
-        var dict = _predictor.Detect(imageRegion);
-        return dict.ContainsKey("health_bar") || dict.ContainsKey("enemy_identify");
     }
 
     // 无用

--- a/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
@@ -639,7 +639,7 @@ public class Avatar
     private static BurstReadyState IsBurstReadyByClassify(ImageRegion imageRegion)
     {
         using var qRa = imageRegion.DeriveCrop(AutoFightAssets.Get(imageRegion).QRectForClassify);
-        var result = QBurstClassifierLazy.Value.Predictor.Classify(qRa.CacheImage);
+        var result = QBurstClassifierLazy.Value.Run(predictor => predictor.Classify(qRa.CacheImage));
         var topClass = result.GetTopClass();
         var topClassName = topClass.Name.Name;
         // Logger.LogInformation("Q技能冷却分类：{ClassName}，置信度：{Confidence:F2}", topClassName, topClass.Confidence);

--- a/BetterGenshinImpact/GameTask/AutoFight/Model/CombatScenes.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Model/CombatScenes.cs
@@ -292,7 +292,7 @@ public class CombatScenes : IDisposable
     {
         SpeedTimer speedTimer = new();
         speedTimer.Record("角色侧面头像图像转换");
-        var result = _predictor.Predictor.Classify(img);
+        var result = _predictor.Run(predictor => predictor.Classify(img));
         speedTimer.Record("角色侧面头像分类识别");
         Debug.WriteLine($"角色侧面头像识别结果：{result}");
         speedTimer.DebugPrint();

--- a/BetterGenshinImpact/GameTask/AutoFishing/AutoFishingTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFishing/AutoFishingTask.cs
@@ -18,7 +18,7 @@ using System.Threading.Tasks;
 
 namespace BetterGenshinImpact.GameTask.AutoFishing
 {
-    public class AutoFishingTask : ISoloTask
+    public class AutoFishingTask : ISoloTask, IDisposable
     {
         private readonly ILogger _logger = App.GetLogger<AutoFishingTask>();
         private readonly InputSimulator input = Simulation.SendInput;
@@ -265,6 +265,11 @@ namespace BetterGenshinImpact.GameTask.AutoFishing
                 behaviourTree.AddVisitor(new ScreenshotVisitor(_logger));
             }
             return behaviourTree;
+        }
+
+        public void Dispose()
+        {
+            _predictor.Dispose();
         }
     }
 }

--- a/BetterGenshinImpact/GameTask/AutoFishing/Behaviours.PartII.cs
+++ b/BetterGenshinImpact/GameTask/AutoFishing/Behaviours.PartII.cs
@@ -137,7 +137,7 @@ namespace BetterGenshinImpact.GameTask.AutoFishing
         {
             var imageRegion = Screenshot.Get();
             Action<int> sleep = Sleep.Get();
-            var result = _bgiYoloPredictor.Predictor.Detect(imageRegion.CacheImage);
+            var result = _bgiYoloPredictor.Run(predictor => predictor.Detect(imageRegion.CacheImage));
             if (result.Any())
             {
                 Fishpond fishpond = new Fishpond(result);

--- a/BetterGenshinImpact/GameTask/AutoFishing/Behaviours.cs
+++ b/BetterGenshinImpact/GameTask/AutoFishing/Behaviours.cs
@@ -94,7 +94,7 @@ namespace BetterGenshinImpact.GameTask.AutoFishing
             {
                 detectInterval = timeProvider.GetLocalNow().AddSeconds(0.5);
             }
-            var result = _predictor.Predictor.Detect(imageRegion.CacheImage);
+            var result = _predictor.Run(predictor => predictor.Detect(imageRegion.CacheImage));
             Debug.WriteLine($"YOLO识别: {result.Speed}");
             var fishpond = new Fishpond(result, ignoreObtained: true);
             if (fishpond.FishpondRect == default)
@@ -493,7 +493,7 @@ namespace BetterGenshinImpact.GameTask.AutoFishing
             Action<int> sleep = Sleep.Get();
 
             // 找 鱼饵落点
-            var result = _predictor.Predictor.Detect(imageRegion.CacheImage);
+            var result = _predictor.Run(predictor => predictor.Detect(imageRegion.CacheImage));
             Debug.WriteLine($"YOLOv8识别: {result.Speed}");
             var fishpond = new Fishpond(result, includeTarget: timeProvider.GetLocalNow() <= ignoreObtainedEndTime);
             Fishpond.Set(fishpond);

--- a/BetterGenshinImpact/GameTask/AutoLeyLineOutcrop/AutoLeyLineOutcropTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoLeyLineOutcrop/AutoLeyLineOutcropTask.cs
@@ -1063,7 +1063,8 @@ public class AutoLeyLineOutcropTask : ISoloTask
         try
         {
             _logger.LogInformation("领取奖励后开始扫描掉落物光柱，时长 {Seconds} 秒", scanSeconds);
-            await new ScanPickTask().Start(_ct, scanSeconds);
+            using var task = new ScanPickTask();
+            await task.Start(_ct, scanSeconds);
         }
         catch (Exception ex) when (ex is OperationCanceledException or TaskCanceledException)
         {

--- a/BetterGenshinImpact/GameTask/AutoPathing/Handler/FishingHandler.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/Handler/FishingHandler.cs
@@ -24,7 +24,7 @@ public class FishingHandler : IActionHandler
         {
             throw new ArgumentNullException(nameof(taskSettingsPageViewModel), "内部视图模型对象为空");
         }
-        AutoFishingTask autoFishingTask = new(AutoFishingTaskParam.BuildFromConfig(TaskContext.Instance().Config.AutoFishingConfig));
+        using AutoFishingTask autoFishingTask = new(AutoFishingTaskParam.BuildFromConfig(TaskContext.Instance().Config.AutoFishingConfig));
 
         await autoFishingTask.Start(ct);
 

--- a/BetterGenshinImpact/GameTask/AutoPathing/Handler/LinneaMiningHandler.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/Handler/LinneaMiningHandler.cs
@@ -39,7 +39,8 @@ public class LinneaMiningHandler : IActionHandler
             return;
         }
 
-        await new LinneaMiningTask(scanRounds, mineCount).Start(ct);
+        using var task = new LinneaMiningTask(scanRounds, mineCount);
+        await task.Start(ct);
     }
 
     private static (int mineCount, int scanRounds) ParseParams(string? actionParams)

--- a/BetterGenshinImpact/GameTask/AutoPathing/Handler/MiningHandler.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/Handler/MiningHandler.cs
@@ -43,8 +43,6 @@ public class MiningHandler : IActionHandler
     ];
     
 
-    private readonly ScanPickTask _scanPickTask = new();
-
     public async Task RunAsync(CancellationToken ct, WaypointForTrack? waypointForTrack = null, object? config = null)
     {
         var combatScenes = await RunnerContext.Instance.GetCombatScenes(ct);
@@ -65,7 +63,8 @@ public class MiningHandler : IActionHandler
             await Delay(1000, ct);
 
             // 拾取
-            await _scanPickTask.Start(ct);
+            using var task = new ScanPickTask();
+            await task.Start(ct);
         }
     }
 

--- a/BetterGenshinImpact/GameTask/AutoStygianOnslaught/AutoStygianOnslaughtTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoStygianOnslaught/AutoStygianOnslaughtTask.cs
@@ -650,7 +650,7 @@ public class AutoStygianOnslaughtTask : StateMachineBase<StygianState, BvPage>, 
         else
         {
             // 初始化战斗
-            var combatScenes = await InitializeCombatScenesLoop();
+            using var combatScenes = await InitializeCombatScenesLoop();
             var combatCommands = await PrepareForBattleLoop(combatScenes);
 
             Logger.LogInformation($"{Name}：执行战斗策略");
@@ -822,18 +822,30 @@ public class AutoStygianOnslaughtTask : StateMachineBase<StygianState, BvPage>, 
     private async Task<CombatScenes> InitializeCombatScenesLoop()
     {
         CombatScenes? result = null;
-        var found = await NewRetry.WaitForAction(() =>
+        try
         {
-            result = new CombatScenes().InitializeTeam(CaptureToRectArea());
-            return result.CheckTeamInitialized();
-        }, _ct, 10, 500);
+            var found = await NewRetry.WaitForAction(() =>
+            {
+                result?.Dispose();
+                using var capture = CaptureToRectArea();
+                result = new CombatScenes();
+                result.InitializeTeam(capture);
+                return result.CheckTeamInitialized();
+            }, _ct, 10, 500);
 
-        if (!found || result == null)
-        {
-            throw new Exception("识别队伍角色失败！");
+            if (!found || result == null)
+            {
+                throw new Exception("识别队伍角色失败！");
+            }
+
+            Logger.LogInformation($"{Name}：队伍初始化成功");
+            return result;
         }
-        Logger.LogInformation($"{Name}：队伍初始化成功");
-        return result;
+        catch
+        {
+            result?.Dispose();
+            throw;
+        }
     }
 
     private async Task<List<CombatCommand>> PrepareForBattleLoop(CombatScenes combatScenes)

--- a/BetterGenshinImpact/GameTask/Common/Job/LinneaMiningTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/LinneaMiningTask.cs
@@ -24,7 +24,7 @@ namespace BetterGenshinImpact.GameTask.Common.Job;
 /// <summary>
 /// 莉奈娅挖矿
 /// </summary>
-public class LinneaMiningTask
+public class LinneaMiningTask : IDisposable
 {
     #region 配置参数
 
@@ -266,7 +266,7 @@ public class LinneaMiningTask
 
         // SaveDebugImage(ra.SrcMat);
 
-        var rawResult = _predictor.Predictor.Detect(ra.CacheImage);
+        var rawResult = _predictor.Run(predictor => predictor.Detect(ra.CacheImage));
 
         var centerX = ra.CacheImage.Width / 2.0;
         var centerY = ra.CacheImage.Height / 2.0;
@@ -365,6 +365,11 @@ public class LinneaMiningTask
         }
 
         return clusters;
+    }
+
+    public void Dispose()
+    {
+        _predictor.Dispose();
     }
 }
 

--- a/BetterGenshinImpact/GameTask/Common/Job/ScanPickTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/ScanPickTask.cs
@@ -21,7 +21,7 @@ namespace BetterGenshinImpact.GameTask.Common.Job;
 /// 扫描拾取任务
 /// 请在安全地区使用
 /// </summary>
-public class ScanPickTask
+public class ScanPickTask : IDisposable
 {
     private readonly BgiYoloPredictor _predictor = App.ServiceProvider.GetRequiredService<BgiOnnxFactory>().CreateYoloPredictor(BgiOnnxModel.BgiWorld);
     private readonly double _dpi = TaskContext.Instance().DpiScale;
@@ -172,5 +172,10 @@ public class ScanPickTask
         await Delay(500, ct);
         Simulation.SendInput.Keyboard.Mouse.MoveMouseBy(0, (int)(500 * _dpi));
         await Delay(100, ct);
+    }
+
+    public void Dispose()
+    {
+        _predictor.Dispose();
     }
 }

--- a/BetterGenshinImpact/GameTask/TaskRunner.cs
+++ b/BetterGenshinImpact/GameTask/TaskRunner.cs
@@ -126,24 +126,31 @@ public class TaskRunner
 
     public async Task RunSoloTaskAsync(ISoloTask soloTask)
     {
-        // 启动等待之前先进行取消操作的初始化，便于在任务开始前终止任务.
-        CancellationContext.Instance.Set();
-
-        // 没启动的时候先启动
-        bool waitForMainUi = soloTask.Name != "自动七圣召唤" && !soloTask.Name.Contains("自动音游") &&
-                             !soloTask.Name.Contains("幽境危战");
-        await ScriptService.StartGameTask(waitForMainUi);
-        if (CancellationContext.Instance.IsCancellationRequested)
+        try
         {
-            _logger.LogInformation("独立任务在启动阶段被取消: {Name}", soloTask.Name);
-            CancellationContext.Instance.Clear();
-            return;
+            // 启动等待之前先进行取消操作的初始化，便于在任务开始前终止任务.
+            CancellationContext.Instance.Set();
+
+            // 没启动的时候先启动
+            bool waitForMainUi = soloTask.Name != "自动七圣召唤" && !soloTask.Name.Contains("自动音游") &&
+                                 !soloTask.Name.Contains("幽境危战");
+            await ScriptService.StartGameTask(waitForMainUi);
+            if (CancellationContext.Instance.IsCancellationRequested)
+            {
+                _logger.LogInformation("独立任务在启动阶段被取消: {Name}", soloTask.Name);
+                CancellationContext.Instance.Clear();
+                return;
+            }
+
+            await Task.Run(() => RunCurrentAsync(
+                async () => await soloTask.Start(CancellationContext.Instance.Cts.Token),
+                resetCancellationContext: false,
+                clearCancellationContextOnLockFailure: true));
         }
-        
-        await Task.Run(() => RunCurrentAsync(
-            async () => await soloTask.Start(CancellationContext.Instance.Cts.Token),
-            resetCancellationContext: false,
-            clearCancellationContextOnLockFailure: true));
+        finally
+        {
+            (soloTask as IDisposable)?.Dispose();
+        }
     }
 
     public void Init()

--- a/BetterGenshinImpact/Model/OneDragonTaskItem.cs
+++ b/BetterGenshinImpact/Model/OneDragonTaskItem.cs
@@ -120,7 +120,8 @@ public partial class OneDragonTaskItem : ObservableObject
                         DomainName = domainName,
                         SundaySelectedValue = sundaySelectedValue
                     };
-                    await new AutoDomainTask(autoDomainParam).Start(CancellationContext.Instance.Cts.Token);
+                    using var task = new AutoDomainTask(autoDomainParam);
+                    await task.Start(CancellationContext.Instance.Cts.Token);
                 };
                 break;
             case "自动首领讨伐":


### PR DESCRIPTION
## 问题

自动战斗、自动钓鱼、秘境和路径任务会创建 YOLO/ONNX 原生会话。任务结束后部分所有者没有释放这些会话，重复运行时可能让显存和原生句柄持续占用。

## 修改

- 推理与释放使用同一生命周期锁，避免释放正在使用的会话
- 任务和路径处理器在自身生命周期结束时释放预测器
- 模型会话创建完成后立即释放 SessionOptions
- 移除两个从未使用、却会创建 BgiWorld 会话的字段

## 范围

本 PR 不修改 provider 选择或回退策略，不包含 BgiWorld 命名修复，也不包含 HDR/WGC、BitBlt 或 CaptureColorMode。

## 验证

- dotnet build BetterGenshinImpact.sln -c Debug
- 结果：0 个错误；635 个既有警告

尚未完成长时间重复任务的显存/句柄实测，因此先以 Draft 提交。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化视觉识别模型的加载与调用，提升推理过程的稳定性。
  * 自动战斗、钓鱼、采矿、拾取等任务现在会更及时地释放识别与场景资源。
  * 优化任务结束和异常情况下的清理流程，降低资源占用与潜在稳定性问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->