### PR TITLE
feat: 优化切换队伍流程，新增滑动距离与延迟系数配置

### DIFF
--- a/BetterGenshinImpact/Core/Config/OtherConfig.cs
+++ b/BetterGenshinImpact/Core/Config/OtherConfig.cs
@@ -33,6 +33,10 @@ public partial class OtherConfig : ObservableObject
     //切换队伍时，单次滑动的距离（单位：栏）
     [ObservableProperty]
     private double _switchPartyScrollDistance = 3;
+
+    //切换队伍时，所有硬编码延迟的放大系数，数值越大等待越久（默认1）
+    [ObservableProperty]
+    private double _switchPartyHardcodeDelayFactor = 1;
     
 
     public partial class AutoRestart : ObservableObject

--- a/BetterGenshinImpact/Core/Config/OtherConfig.cs
+++ b/BetterGenshinImpact/Core/Config/OtherConfig.cs
@@ -30,6 +30,10 @@ public partial class OtherConfig : ObservableObject
     [ObservableProperty]
     private Ocr _ocrConfig = new();
     
+    //切换队伍时，单次滑动的距离（单位：栏）
+    [ObservableProperty]
+    private double _switchPartyScrollDistance = 3;
+    
 
     public partial class AutoRestart : ObservableObject
     {

--- a/BetterGenshinImpact/GameTask/Common/Job/SwitchPartyTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/SwitchPartyTask.cs
@@ -170,6 +170,7 @@ public class SwitchPartyTask
             DrawOnWindowPen= System.Drawing.Pens.White
         };
         // 逐页查找
+        int bottomHitCount = 0;   // 连续判定到底的累计次数
         try
         {
             for (var i = 0; i < 16; i++)    // 6.0版本最多20个队伍
@@ -204,8 +205,18 @@ public class SwitchPartyTask
 
                 if (lowest.Y < 777 * _assetScale)   // 如果最底下是空队伍则不会有队伍名，以此判断是否已遍历完成
                 {
-                    Logger.LogInformation("已抵达最后一个队伍");
-                    break;
+                    // 需要累计 3 次连续判定到底才停止，避免识别抖动造成过早退出
+                    bottomHitCount++;
+                    if (bottomHitCount >= 3)
+                    {
+                        Logger.LogInformation("已连续 3 次判定到底，确认抵达最后一个队伍");
+                        break;
+                    }
+                    Logger.LogInformation("底部判定第 {Count}/3 次，继续向下滚动确认", bottomHitCount);
+                }
+                else
+                {
+                    bottomHitCount = 0;   // 未到底则清零，要求连续 3 次
                 }
 
                 // 点击下一页
@@ -216,8 +227,14 @@ public class SwitchPartyTask
                     await Task.Delay(300, ct); // 等待动画
                 }
 
-                page.ClickTo(regionOfInterest.X + regionOfInterest.Width / 2, lowest.Bottom); // 点击最下方队伍下移
-                await Delay(400, ct);
+                // 点击最下方队伍下移，单次滑动距离为配置的栏数（钳制到 1~5 之间，支持小数向上取整）
+                double scrollDistance = Math.Clamp(TaskContext.Instance().Config.OtherConfig.SwitchPartyScrollDistance, 1, 5);
+                int clickCount = Math.Max(1, (int)Math.Ceiling(scrollDistance));
+                for (int s = 0; s < clickCount; s++)
+                {
+                    page.ClickTo(regionOfInterest.X + regionOfInterest.Width / 2, lowest.Bottom);
+                    await Delay(400, ct);
+                }
             }
         }
         finally

--- a/BetterGenshinImpact/GameTask/Common/Job/SwitchPartyTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/SwitchPartyTask.cs
@@ -173,15 +173,22 @@ public class SwitchPartyTask
         };
 
         // 打开菜单后先识别当前可见页，目标队伍在当前页则直接切换，无需回顶部
-        using (var currentPage = CaptureToRectArea())
+        try
         {
-            var currentPageNameList = currentPage.FindMulti(recognitionObject);
-            if (currentPageNameList != null && currentPageNameList.Count > 0
-                && await TrySwitchToPartyOnPage(currentPage, currentPageNameList, partyName, ct, isInPartyViewUi))
+            using (var currentPage = CaptureToRectArea())
             {
-                VisionContext.Instance().DrawContent.ClearAll();
-                return true;
+                var currentPageNameList = currentPage.FindMulti(recognitionObject);
+                if (currentPageNameList != null && currentPageNameList.Count > 0
+                    && await TrySwitchToPartyOnPage(currentPage, currentPageNameList, partyName, ct, isInPartyViewUi))
+                {
+                    return true;
+                }
             }
+        }
+        finally
+        {
+            // 无论成功、确认超时还是取消，都清理 OCR 绘制，避免残留影响后续任务
+            VisionContext.Instance().DrawContent.ClearAll();
         }
 
         // 点击到最上方

--- a/BetterGenshinImpact/GameTask/Common/Job/SwitchPartyTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/SwitchPartyTask.cs
@@ -233,7 +233,7 @@ public class SwitchPartyTask
                 for (int s = 0; s < clickCount; s++)
                 {
                     page.ClickTo(regionOfInterest.X + regionOfInterest.Width / 2, lowest.Bottom);
-                    await Delay(400, ct);
+                    await Delay(100, ct);
                 }
             }
         }

--- a/BetterGenshinImpact/GameTask/Common/Job/SwitchPartyTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/SwitchPartyTask.cs
@@ -67,7 +67,7 @@ public class SwitchPartyTask
 
                 for (int i = 0; i < 7; i++) // 检查 7 次
                 {
-                    await Delay(Ms(600), ct);
+                    await Delay(600, ct);
                     using var raCheck = CaptureToRectArea();
                     if (Bv.IsInPartyViewUi(raCheck))
                     {

--- a/BetterGenshinImpact/GameTask/Common/Job/SwitchPartyTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/SwitchPartyTask.cs
@@ -9,6 +9,7 @@ using BetterGenshinImpact.View.Drawable;
 using Microsoft.Extensions.Logging;
 using OpenCvSharp;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -21,6 +22,13 @@ namespace BetterGenshinImpact.GameTask.Common.Job;
 public class SwitchPartyTask
 {
     private readonly double _assetScale = TaskContext.Instance().SystemInfo.AssetScale;
+    // 换队硬编码延迟系数，所有固定等待时间统一乘以该系数
+    private readonly double _delayFactor = TaskContext.Instance().Config.OtherConfig.SwitchPartyHardcodeDelayFactor;
+
+    /// <summary>
+    /// 将基础延迟毫秒数乘以换队延迟系数，得到实际等待毫秒数
+    /// </summary>
+    private int Ms(int baseMs) => Math.Max(1, (int)Math.Round(baseMs * _delayFactor));
 
     public string Name => "切换队伍";
 
@@ -40,7 +48,7 @@ public class SwitchPartyTask
             if (!Bv.IsInMainUi(ra1))
             {
                 await _returnMainUiTask.Start(ct);
-                await Delay(200, ct);
+                await Delay(Ms(200), ct);
                 using var raAfterMain = CaptureToRectArea();
                 if (!Bv.IsInMainUi(raAfterMain))
                 {
@@ -59,7 +67,7 @@ public class SwitchPartyTask
 
                 for (int i = 0; i < 7; i++) // 检查 7 次
                 {
-                    await Delay(600, ct);
+                    await Delay(Ms(600), ct);
                     using var raCheck = CaptureToRectArea();
                     if (Bv.IsInPartyViewUi(raCheck))
                     {
@@ -80,7 +88,7 @@ public class SwitchPartyTask
             }
         }
 
-        await Delay(500, ct);
+        await Delay(Ms(500), ct);
 
         using var ra = CaptureToRectArea();
         var partyViewBtn = ra.Find(ElementRecognition.Get("PartyBtnChooseView", ra));
@@ -115,7 +123,7 @@ public class SwitchPartyTask
             if (isInPartyViewUi)
             {
                 Simulation.SendInput.Keyboard.KeyPress(User32.VK.VK_ESCAPE);
-                await Delay(500, ct);
+                await Delay(Ms(500), ct);
                 await _returnMainUiTask.Start(ct);
             }
 
@@ -151,15 +159,6 @@ public class SwitchPartyTask
             }
         }
 
-        // 点击到最上方
-        await Task.Delay(50, ct);
-        GameCaptureRegion.GameRegion1080PPosClick(700, 125);
-        await Task.Delay(50, ct);
-        Simulation.SendInput.Mouse.LeftButtonDown();
-        await Task.Delay(450, ct);
-        Simulation.SendInput.Mouse.LeftButtonUp();
-        await Task.Delay(100, ct);
-
         Rect regionOfInterest = new Rect(0, (int)(80 * _assetScale), partyDeleteBtn.Right, partyDeleteBtn.Top - (int)(80 * _assetScale));
         RecognitionObject recognitionObject = new RecognitionObject
         {
@@ -167,8 +166,30 @@ public class SwitchPartyTask
             RegionOfInterest = regionOfInterest,
             DrawOnWindow = true,
             Name = "队伍名称",
-            DrawOnWindowPen= System.Drawing.Pens.White
+            DrawOnWindowPen = System.Drawing.Pens.White
         };
+
+        // 打开菜单后先识别当前可见页，目标队伍在当前页则直接切换，无需回顶部
+        using (var currentPage = CaptureToRectArea())
+        {
+            var currentPageNameList = currentPage.FindMulti(recognitionObject);
+            if (currentPageNameList != null && currentPageNameList.Count > 0
+                && await TrySwitchToPartyOnPage(currentPage, currentPageNameList, partyName, ct, isInPartyViewUi))
+            {
+                VisionContext.Instance().DrawContent.ClearAll();
+                return true;
+            }
+        }
+
+        // 点击到最上方
+        await Task.Delay(Ms(50), ct);
+        GameCaptureRegion.GameRegion1080PPosClick(700, 125);
+        await Task.Delay(Ms(50), ct);
+        Simulation.SendInput.Mouse.LeftButtonDown();
+        await Task.Delay(Ms(450), ct);
+        Simulation.SendInput.Mouse.LeftButtonUp();
+        await Task.Delay(Ms(100), ct);
+
         // 逐页查找
         int bottomHitCount = 0;   // 连续判定到底的累计次数
         try
@@ -186,18 +207,9 @@ public class SwitchPartyTask
                 }
 
                 // 当前页存在则直接点击
-                foreach (var textRegion in partySwitchNameRaList)
+                if (await TrySwitchToPartyOnPage(page, partySwitchNameRaList, partyName, ct, isInPartyViewUi))
                 {
-                    if (Regex.IsMatch(textRegion.Text, partyName))
-                    {
-                        page.ClickTo(textRegion.Right + textRegion.Width, textRegion.Bottom);
-                        await Delay(200, ct);
-                        Logger.LogInformation("切换队伍成功: {Text}", textRegion.Text);
-                        await ConfirmParty(page, ct, isInPartyViewUi);
-
-                        RunnerContext.Instance.ClearCombatScenes();
-                        return true;
-                    }
+                    return true;
                 }
 
                 Region lowest = partySwitchNameRaList.Where(r => r.X > 35 * _assetScale && r.X < 100 * _assetScale).OrderBy(r => r.Y).Last();
@@ -224,7 +236,7 @@ public class SwitchPartyTask
                 {
                     // #ebe4d8 首次点一下第一个，防止第五个被点击过
                     page.ClickTo(600 * _assetScale, 200 * _assetScale);
-                    await Task.Delay(300, ct); // 等待动画
+                    await Task.Delay(Ms(300), ct); // 等待动画
                 }
 
                 // 点击最下方队伍下移，单次滑动距离为配置的栏数（钳制到 1~5 之间，支持小数向上取整）
@@ -233,8 +245,10 @@ public class SwitchPartyTask
                 for (int s = 0; s < clickCount; s++)
                 {
                     page.ClickTo(regionOfInterest.X + regionOfInterest.Width / 2, lowest.Bottom);
-                    await Delay(100, ct);
+                    await Delay(Ms(250), ct);
                 }
+                // 最后一次点击后再额外等待，等待滚动动画稳定
+                await Delay(Ms(150), ct);
             }
         }
         finally
@@ -246,6 +260,28 @@ public class SwitchPartyTask
         Logger.LogError("未找到队伍: {Name}，返回主界面", partyName);
         Logger.LogInformation("如果找不到设定的队伍名，有可能是文字识别效果不佳，请尝试正则表达式");
         await _returnMainUiTask.Start(ct);
+        return false;
+    }
+
+    /// <summary>
+    /// 在当前页 OCR 出的队伍名列表中查找目标队伍，找到则点击并确认切换
+    /// </summary>
+    private async Task<bool> TrySwitchToPartyOnPage(ImageRegion page, List<Region> partySwitchNameRaList, string partyName, CancellationToken ct, bool isInPartyViewUi)
+    {
+        foreach (var textRegion in partySwitchNameRaList)
+        {
+            if (Regex.IsMatch(textRegion.Text, partyName))
+            {
+                page.ClickTo(textRegion.Right + textRegion.Width, textRegion.Bottom);
+                await Delay(Ms(200), ct);
+                Logger.LogInformation("切换队伍成功: {Text}", textRegion.Text);
+                await ConfirmParty(page, ct, isInPartyViewUi);
+
+                RunnerContext.Instance.ClearCombatScenes();
+                return true;
+            }
+        }
+
         return false;
     }
 
@@ -261,10 +297,10 @@ public class SwitchPartyTask
         {
             throw new PartySetupFailedException("选择队伍失败，等待队伍切换超时！");
         }
-        await Delay(200, ct);
+        await Delay(Ms(200), ct);
         using var ra = CaptureToRectArea();
         var r2 = Bv.ClickWhiteConfirmButton(ra, new Rect(page.Width - page.Width / 4, page.Height / 4, page.Width / 4, page.Height - page.Height / 4));
-        await Delay(500, ct);
+        await Delay(Ms(500), ct);
         if (isInPartyViewUi) await _returnMainUiTask.Start(ct);
     }
 }

--- a/BetterGenshinImpact/GameTask/Common/Job/SwitchPartyTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/SwitchPartyTask.cs
@@ -138,7 +138,7 @@ public class SwitchPartyTask
             () => partyViewBtn.Click(),// 点击队伍选择按钮
             ct,
             4,
-            500
+            Ms(500)
         );
         if (!menu)
         {
@@ -154,7 +154,7 @@ public class SwitchPartyTask
                 switchRa = ocrRa;
                 partyDeleteBtn = switchRa.Find(ElementRecognition.Get("PartyBtnDelete", switchRa));
                 return partyDeleteBtn.IsExist();
-            }, ct, 5);
+            }, ct, 5, Ms(1000));
 
             if (!openPartyChooseSuccess || switchRa == null || partyDeleteBtn == null)
             {
@@ -302,7 +302,7 @@ public class SwitchPartyTask
         {
             using var ra2 = CaptureToRectArea();
             return ra2.Find(ElementRecognition.Get("PartyBtnDelete", ra2)).IsEmpty();
-        }, ct, 10);
+        }, ct, 10, Ms(1000));
         if (!partyChooseUiClosed)
         {
             throw new PartySetupFailedException("选择队伍失败，等待队伍切换超时！");

--- a/BetterGenshinImpact/GameTask/Common/Job/SwitchPartyTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/SwitchPartyTask.cs
@@ -65,9 +65,12 @@ public class SwitchPartyTask
 
                 // 考虑加载时间 2s，共检查 4.2s，如果失败则抛出异常
 
-                for (int i = 0; i < 7; i++) // 检查 7 次
+                // 每次等待 600*系数 ms，循环次数为保证总等待时间不小于 4200ms 的最小整数
+                int waitMs = Ms(600);
+                int pollCount = Math.Max(1, (int)Math.Ceiling(4200d / waitMs));
+                for (int i = 0; i < pollCount; i++)
                 {
-                    await Delay(600, ct);
+                    await Delay(waitMs, ct);
                     using var raCheck = CaptureToRectArea();
                     if (Bv.IsInPartyViewUi(raCheck))
                     {

--- a/BetterGenshinImpact/View/Pages/CommonSettingsPage.xaml
+++ b/BetterGenshinImpact/View/Pages/CommonSettingsPage.xaml
@@ -1745,6 +1745,39 @@
                               SelectedValuePath="Item1"
                               DisplayMemberPath="Item2" />
                 </Grid>
+                <Grid Margin="16">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <ui:TextBlock Grid.Row="0"
+                                  Grid.Column="0"
+                                  FontTypography="Body"
+                                  Text="切换队伍单次滑动距离"
+                                  TextWrapping="Wrap" />
+                    <ui:TextBlock Grid.Row="1"
+                                  Grid.Column="0"
+                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                  Text="切换队伍时，在队伍列表中每次滑动向下移动的栏数，数值越大跨越队伍速度越快。"
+                                  TextWrapping="Wrap" />
+                    <ui:NumberBox Grid.Row="0"
+                                  Grid.RowSpan="2"
+                                  Grid.Column="1"
+                                  MinWidth="100"
+                                  Margin="0,0,36,0"
+                                  AcceptsExpression="False"
+                                  Maximum="5"
+                                  MaxDecimalPlaces="1"
+                                  Minimum="1"
+                                  SmallChange="0.5"
+                                  SpinButtonPlacementMode="Inline"
+                                  ValidationMode="InvalidInputOverwritten"
+                                  Value="{Binding Config.OtherConfig.SwitchPartyScrollDistance, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                </Grid>
                 <ui:CardExpander Margin="16,0,52,12"
                                  ContentPadding="0"
                                  Icon="{ui:SymbolIcon SquareHintSparkles24}">

--- a/BetterGenshinImpact/View/Pages/CommonSettingsPage.xaml
+++ b/BetterGenshinImpact/View/Pages/CommonSettingsPage.xaml
@@ -1762,7 +1762,7 @@
                     <ui:TextBlock Grid.Row="1"
                                   Grid.Column="0"
                                   Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
-                                  Text="切换队伍时，在队伍列表中每次滑动向下移动的栏数，数值越大跨越队伍速度越快。"
+                                  Text="切换队伍时，在队伍列表中每次滑动向下移动的栏数，数值越大跨越队伍速度越快。有效值为1-5。"
                                   TextWrapping="Wrap" />
                     <ui:NumberBox Grid.Row="0"
                                   Grid.RowSpan="2"

--- a/BetterGenshinImpact/View/Pages/CommonSettingsPage.xaml
+++ b/BetterGenshinImpact/View/Pages/CommonSettingsPage.xaml
@@ -1778,6 +1778,39 @@
                                   ValidationMode="InvalidInputOverwritten"
                                   Value="{Binding Config.OtherConfig.SwitchPartyScrollDistance, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                 </Grid>
+                <Grid Margin="16">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <ui:TextBlock Grid.Row="0"
+                                  Grid.Column="0"
+                                  FontTypography="Body"
+                                  Text="换队硬编码延迟系数"
+                                  TextWrapping="Wrap" />
+                    <ui:TextBlock Grid.Row="1"
+                                  Grid.Column="0"
+                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                  Text="切换队伍过程中所有固定等待时间的放大系数，数值大于1会放慢节奏，小于1会加快节奏（存在不稳定风险）。"
+                                  TextWrapping="Wrap" />
+                    <ui:NumberBox Grid.Row="0"
+                                  Grid.RowSpan="2"
+                                  Grid.Column="1"
+                                  MinWidth="100"
+                                  Margin="0,0,36,0"
+                                  AcceptsExpression="False"
+                                  Maximum="5"
+                                  MaxDecimalPlaces="2"
+                                  Minimum="0.2"
+                                  SmallChange="0.1"
+                                  SpinButtonPlacementMode="Inline"
+                                  ValidationMode="InvalidInputOverwritten"
+                                  Value="{Binding Config.OtherConfig.SwitchPartyHardcodeDelayFactor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                </Grid>
                 <ui:CardExpander Margin="16,0,52,12"
                                  ContentPadding="0"
                                  Icon="{ui:SymbolIcon SquareHintSparkles24}">

--- a/BetterGenshinImpact/View/Pages/CommonSettingsPage.xaml
+++ b/BetterGenshinImpact/View/Pages/CommonSettingsPage.xaml
@@ -1774,7 +1774,7 @@
                                   MaxDecimalPlaces="1"
                                   Minimum="1"
                                   SmallChange="0.5"
-                                  SpinButtonPlacementMode="Inline"
+                                  SpinButtonPlacementMode="Hidden"
                                   ValidationMode="InvalidInputOverwritten"
                                   Value="{Binding Config.OtherConfig.SwitchPartyScrollDistance, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                 </Grid>
@@ -1807,7 +1807,7 @@
                                   MaxDecimalPlaces="2"
                                   Minimum="0.2"
                                   SmallChange="0.1"
-                                  SpinButtonPlacementMode="Inline"
+                                  SpinButtonPlacementMode="Hidden"
                                   ValidationMode="InvalidInputOverwritten"
                                   Value="{Binding Config.OtherConfig.SwitchPartyHardcodeDelayFactor, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                 </Grid>

--- a/BetterGenshinImpact/View/Pages/CommonSettingsPage.xaml
+++ b/BetterGenshinImpact/View/Pages/CommonSettingsPage.xaml
@@ -1762,7 +1762,7 @@
                     <ui:TextBlock Grid.Row="1"
                                   Grid.Column="0"
                                   Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
-                                  Text="切换队伍时，在队伍列表中每次滑动向下移动的栏数，数值越大跨越队伍速度越快。有效值为1-5。"
+                                  Text="切换队伍时，在队伍列表中单次滚动下移的栏数。有效值1-5，数值越大滚动越快。"
                                   TextWrapping="Wrap" />
                     <ui:NumberBox Grid.Row="0"
                                   Grid.RowSpan="2"
@@ -1795,7 +1795,7 @@
                     <ui:TextBlock Grid.Row="1"
                                   Grid.Column="0"
                                   Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
-                                  Text="切换队伍过程中所有固定等待时间的放大系数，数值大于1会放慢节奏，小于1会加快节奏（存在不稳定风险）。"
+                                  Text="切换队伍过程中各固定等待时间的放大系数。有效值0.2-5，数值越大节奏越慢，越小节奏越快（过小可能不稳定）。"
                                   TextWrapping="Wrap" />
                     <ui:NumberBox Grid.Row="0"
                                   Grid.RowSpan="2"


### PR DESCRIPTION
## 改动内容

本 PR 优化切换队伍流程，包含以下改动：

### 1. 新增配置项

- **切换队伍单次滑动距离**（`SwitchPartyScrollDistance`，默认 3，范围 1-5）
  - 控制每次翻页下移的栏数，替代原先固定每次只滑 1 栏
- **换队硬编码延迟系数**（`SwitchPartyHardcodeDelayFactor`，默认 1，范围 0.2-5）
  - 统一放大/缩小切换队伍过程中各固定等待时间，便于按机器性能调节节奏

### 2. 滚动与定位优化

- 新增当前可见页预检：目标队伍在当前页则直接切换，无需先回顶部，减少无谓滚动
- 滚动落点为最下方队伍名底部，连续点击驱动连续滚动
- 底部判定需连续 3 次确认到底才停止，避免 OCR 识别抖动过早退出

### 3. 轮询等待优化

- 打开队伍配置页的轮询等待改为 `600*系数`，循环次数为保证总等待时间不小于 4200ms 的最小整数（默认系数下行为不变）

### 4. UI 说明优化

- 两个换队配置项补充有效值说明，去掉上下箭头改为纯数字输入框

## 涉及文件

- `BetterGenshinImpact/Core/Config/OtherConfig.cs`
- `BetterGenshinImpact/GameTask/Common/Job/SwitchPartyTask.cs`
- `BetterGenshinImpact/View/Pages/CommonSettingsPage.xaml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 在“其他设置”中新增队伍切换滚动距离配置，可设置每次下移 1–5 栏。
  * 新增队伍切换等待时间系数配置，可调整固定等待时间（0.2–5 倍）。

* **改进**
  * 优化队伍页面识别与切换流程，提升多页队伍查找的稳定性。
  * 支持根据配置调整滚动步幅及切换等待时间。
  * 改进切换失败后的重试与等待机制，提升操作可靠性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->