### PR TITLE
fix: 修复微信 Clawbot 推送图片无法显示（aes_key 编码与官方客户端不一致）

### DIFF
--- a/BetterGenshinImpact/Service/Notifier/WechatClawbotNotifier.cs
+++ b/BetterGenshinImpact/Service/Notifier/WechatClawbotNotifier.cs
@@ -188,7 +188,11 @@ public sealed class WechatClawbotNotifier : INotifier, IDisposable
                             media = new
                             {
                                 encrypt_query_param = uploaded.DownloadParam,
-                                aes_key = Convert.ToBase64String(uploaded.AesKey),
+                                // 注意：aes_key 是对 hex 字符串（ASCII 文本）做 base64，而非对原始密钥字节。
+                                // 官方实现 UploadedFileInfo.aeskey 为 hex 字符串，发送时
+                                // Buffer.from(hexString).toString("base64")；接收端按
+                                // base64解码 → ASCII → hex解码 还原 16 字节密钥。
+                                aes_key = Convert.ToBase64String(Encoding.UTF8.GetBytes(uploaded.AesKeyHex)),
                                 encrypt_type = 1,
                             },
                             mid_size = uploaded.CiphertextSize,
@@ -243,18 +247,19 @@ public sealed class WechatClawbotNotifier : INotifier, IDisposable
         var filesize = AesEcbPaddedSize(rawsize);
         var filekey = Convert.ToHexString(RandomNumberGenerator.GetBytes(16)).ToLowerInvariant();
         var aeskey = RandomNumberGenerator.GetBytes(16);
+        var aeskeyHex = Convert.ToHexString(aeskey).ToLowerInvariant();
 
-        var uploadUrl = await WithRetryAsync(() => GetUploadUrlAsync(filekey, rawsize, rawfilemd5, filesize, aeskey, ct), ct);
+        var uploadUrl = await WithRetryAsync(() => GetUploadUrlAsync(filekey, rawsize, rawfilemd5, filesize, aeskeyHex, ct), ct);
         var downloadParam = await WithRetryAsync(() => UploadToCdnAsync(uploadUrl, filekey, imageBytes, aeskey, ct), ct);
 
-        return new WechatClawbotUploadedImage(downloadParam, aeskey, filesize);
+        return new WechatClawbotUploadedImage(downloadParam, aeskeyHex, filesize);
     }
 
     /// <summary>
     /// 调用 getuploadurl 接口获取 CDN 上传地址。
     /// </summary>
     private async Task<WechatClawbotUploadUrl> GetUploadUrlAsync(
-        string filekey, int rawsize, string rawfilemd5, int filesize, byte[] aeskey, CancellationToken ct)
+        string filekey, int rawsize, string rawfilemd5, int filesize, string aeskeyHex, CancellationToken ct)
     {
         var body = JsonSerializer.Serialize(new
         {
@@ -265,7 +270,7 @@ public sealed class WechatClawbotNotifier : INotifier, IDisposable
             rawfilemd5,
             filesize,
             no_need_thumb = true,
-            aeskey = Convert.ToHexString(aeskey).ToLowerInvariant(),
+            aeskey = aeskeyHex,
             base_info = WechatClawbotHelper.BuildBaseInfo(),
         });
         var baseUrl = _baseUrl;
@@ -394,7 +399,7 @@ public sealed class WechatClawbotNotifier : INotifier, IDisposable
 
     private sealed record WechatClawbotUploadUrl(string? UploadParam, string? UploadFullUrl);
 
-    private sealed record WechatClawbotUploadedImage(string DownloadParam, byte[] AesKey, int CiphertextSize);
+    private sealed record WechatClawbotUploadedImage(string DownloadParam, string AesKeyHex, int CiphertextSize);
 
     /// <summary>
     /// 携带 HTTP 状态码的通知异常，供重试判定使用（避免把 401/403/404 等客户端错误当成可重试）。


### PR DESCRIPTION
## 概述

修复微信 Clawbot 推送中图片无法正常显示的问题（文字推送正常）。

## 根因

`sendmessage` 图片项的 `image_item.media.aes_key` 编码方式与官方客户端不一致：

| | getuploadurl 的 aeskey | 图片项的 media.aes_key |
|---|---|---|
| 官方客户端 | hex 字符串 | **base64(hex 字符串的 ASCII 文本)**（~44 字符） |
| 修复前 | hex 字符串 ✓ | base64(原始 16 字节密钥)（24 字符）✗ |

接收端微信客户端按官方约定解析 aes_key：base64 解码 → 得到 ASCII hex 文本 → hex 解码 → 16 字节 AES 密钥。修复前发送的 base64 解码后是原始密钥字节，hex 解码失败，导致图片解密失败、无法显示。

## 修复

- `WechatClawbotUploadedImage` 记录改存 hex 字符串（AesKeyHex）
- `image_item.media.aes_key` 改为 `base64(UTF8(hex 字符串))`，与官方客户端 `Buffer.from(hexString).toString("base64")` 行为一致

## 测试

- `dotnet build BetterGenshinImpact/BetterGenshinImpact.csproj -c Debug` 通过
- 独立测试项目编译通过


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **问题修复**
  - 修复微信 Clawbot 图片上传流程中的 AES 密钥传递问题。
  - 优化图片消息发送与上传地址获取，提升图片上传及发送的稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->