### PR TITLE
feat(hotkey)：从大地图获取位置支持全地图

### DIFF
--- a/BetterGenshinImpact/Core/Recognition/OpenCv/FeatureMatch/Feature2DExtensions.cs
+++ b/BetterGenshinImpact/Core/Recognition/OpenCv/FeatureMatch/Feature2DExtensions.cs
@@ -8,6 +8,8 @@ using OpenCvSharp;
 
 namespace BetterGenshinImpact.Core.Recognition.OpenCv.FeatureMatch;
 
+public readonly record struct FeatureMatchResult(Point2f CenterPoint, int GoodMatchCount, int InlierCount);
+
 public static class Feature2DExtensions
 {
     private static readonly Dictionary<DescriptorMatcherType, DescriptorMatcher> MatcherFactory = new()
@@ -51,6 +53,12 @@ public static class Feature2DExtensions
     public static Point2f Match(this Feature2D feature2D, KeyPoint[] trainKeyPoints, Mat trainDescriptors, Mat queryMat, Mat? queryMatMask = null,
         DescriptorMatcherType matcherType = DescriptorMatcherType.FlannBased)
     {
+        return feature2D.MatchWithQuality(trainKeyPoints, trainDescriptors, queryMat, queryMatMask, matcherType).CenterPoint;
+    }
+
+    public static FeatureMatchResult MatchWithQuality(this Feature2D feature2D, KeyPoint[] trainKeyPoints, Mat trainDescriptors, Mat queryMat,
+        Mat? queryMatMask = null, DescriptorMatcherType matcherType = DescriptorMatcherType.FlannBased)
+    {
         SpeedTimer speedTimer = new();
 
         using var queryDescriptors = new Mat();
@@ -58,6 +66,25 @@ public static class Feature2DExtensions
         feature2D.DetectAndCompute(queryMat, queryMatMask, out var queryKeyPoints, queryDescriptors);
 #pragma warning restore CS8604 // 引用类型参数可能为 null。
         speedTimer.Record("模板生成KeyPoint");
+
+        return feature2D.MatchWithQuality(
+            trainKeyPoints,
+            trainDescriptors,
+            queryKeyPoints,
+            queryDescriptors,
+            queryMat.Size(),
+            matcherType);
+    }
+
+    public static FeatureMatchResult MatchWithQuality(this Feature2D feature2D, KeyPoint[] trainKeyPoints, Mat trainDescriptors,
+        KeyPoint[] queryKeyPoints, Mat queryDescriptors, Size querySize,
+        DescriptorMatcherType matcherType = DescriptorMatcherType.FlannBased)
+    {
+        SpeedTimer speedTimer = new();
+        if (queryKeyPoints.Length == 0 || queryDescriptors.Empty())
+        {
+            return default;
+        }
 
         var matches = GetMatcher(matcherType).Match(queryDescriptors, trainDescriptors);
         //Finding the Minimum and Maximum Distance
@@ -103,15 +130,20 @@ public static class Feature2DExtensions
         // algorithm RANSAC Filter the matched results
         var pQuery = pointsQuery.ToPoint2d();
         var pTrain = pointsTrain.ToPoint2d();
-        var outMask = new Mat();
+        using var outMask = new Mat();
         // If the original matching result is null, Skip the filtering step
         if (pQuery.Count > 0 && pTrain.Count > 0)
         {
-            var hMat = Cv2.FindHomography(pQuery, pTrain, HomographyMethods.Ransac, mask: outMask);
+            using var hMat = Cv2.FindHomography(pQuery, pTrain, HomographyMethods.Ransac, mask: outMask);
             speedTimer.Record("FindHomography");
+            if (hMat.Empty())
+            {
+                speedTimer.DebugPrint();
+                return new FeatureMatchResult(default, pointsQuery.Count, 0);
+            }
 
             // 1. 计算查询图像的中心点
-            var queryCenterPoint = new Point2f(queryMat.Cols / 2f, queryMat.Rows / 2f);
+            var queryCenterPoint = new Point2f(querySize.Width / 2f, querySize.Height / 2f);
 
             // 2. 使用单应矩阵进行透视变换
             Point2f[] queryCenterPoints = [queryCenterPoint];
@@ -121,11 +153,11 @@ public static class Feature2DExtensions
             var trainCenterPoint = transformedCenterPoints[0];
             speedTimer.Record("PerspectiveTransform");
             speedTimer.DebugPrint();
-            return trainCenterPoint;
+            return new FeatureMatchResult(trainCenterPoint, pointsQuery.Count, Cv2.CountNonZero(outMask));
         }
 
         speedTimer.DebugPrint();
-        return new Point2f();
+        return new FeatureMatchResult(default, pointsQuery.Count, 0);
     }
 
     #endregion 普通匹配

--- a/BetterGenshinImpact/GameTask/AutoTrackPath/TpTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoTrackPath/TpTask.cs
@@ -1,5 +1,6 @@
 using BetterGenshinImpact.Core.Recognition;
 using BetterGenshinImpact.Core.Recognition.OpenCv;
+using BetterGenshinImpact.Core.Recognition.OpenCv.FeatureMatch;
 using BetterGenshinImpact.Core.Script.Dependence;
 using BetterGenshinImpact.Core.Simulator;
 using BetterGenshinImpact.Core.Simulator.Extensions;
@@ -23,6 +24,7 @@ using Fischless.GameCapture;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 using OpenCvSharp;
+using OpenCvSharp.Features2D;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -2102,6 +2104,86 @@ public class TpTask
     public Point2f GetPositionFromBigMap(string mapName)
     {
         return GetBigMapCenterPoint(mapName);
+    }
+
+    public (MapTypes MapType, Point2f Position) GetPositionFromCurrentBigMap()
+    {
+        const int minGoodMatches = 7;
+        const int minInliers = 6;
+        const double minInlierRatio = 0.5;
+        const double minWinnerScoreRatio = 1.5;
+
+        using var ra = CaptureToRectArea();
+        using var mapScaleButtonRa = ra.Find(GetQuickTeleportRecognitionObject("MapScaleButton", ra));
+        if (!mapScaleButtonRa.IsExist())
+        {
+            throw new InvalidOperationException("当前不在地图界面");
+        }
+
+        using var sift = SIFT.Create();
+        using var queryDescriptors = new Mat();
+        sift.DetectAndCompute(ra.CacheGreyMat, null, out var queryKeyPoints, queryDescriptors);
+
+        using var teyvatQueryMat = ResizeHelper.Resize(ra.CacheGreyMat, 1d / 4);
+        using var teyvatQueryDescriptors = new Mat();
+        sift.DetectAndCompute(teyvatQueryMat, null, out var teyvatQueryKeyPoints, teyvatQueryDescriptors);
+
+        var candidates = new List<(MapTypes MapType, SceneBaseMap Map, FeatureMatchResult Match, double Score)>();
+        foreach (var mapType in Enum.GetValues<MapTypes>())
+        {
+            try
+            {
+                var map = (SceneBaseMap)MapManager.GetMap(mapType, _mapMatchingMethod);
+                var match = mapType == MapTypes.Teyvat
+                    ? map.GetBigMapPositionMatchResult(teyvatQueryKeyPoints, teyvatQueryDescriptors, teyvatQueryMat.Size())
+                    : map.GetBigMapPositionMatchResult(queryKeyPoints, queryDescriptors, ra.CacheGreyMat.Size());
+                if (match.GoodMatchCount < minGoodMatches || match.InlierCount < minInliers)
+                {
+                    continue;
+                }
+
+                var inlierRatio = (double)match.InlierCount / match.GoodMatchCount;
+                if (inlierRatio < minInlierRatio)
+                {
+                    continue;
+                }
+
+                candidates.Add((mapType, map, match, match.InlierCount * inlierRatio));
+            }
+            catch (Exception ex)
+            {
+                Logger.LogDebug(ex, "自动识别大地图时，{MapType} 特征匹配失败", mapType);
+            }
+        }
+
+        var rankedCandidates = candidates.OrderByDescending(x => x.Score).ToList();
+        if (rankedCandidates.Count == 0)
+        {
+            throw new MapPositionNotRecognizedException("无法识别当前大地图类型");
+        }
+
+        var best = rankedCandidates[0];
+        if (rankedCandidates.Count > 1 && best.Score < rankedCandidates[1].Score * minWinnerScoreRatio)
+        {
+            throw new MapPositionNotRecognizedException(
+                $"当前大地图类型识别结果不唯一：{best.MapType} / {rankedCandidates[1].MapType}");
+        }
+
+        var imagePoint = best.Match.CenterPoint;
+        if (best.MapType == MapTypes.Teyvat)
+        {
+            imagePoint = new Point2f(
+                imagePoint.X * TeyvatMap.BigMap256ScaleTo2048,
+                imagePoint.Y * TeyvatMap.BigMap256ScaleTo2048);
+        }
+
+        var position = best.Map.ConvertImageCoordinatesToGenshinMapCoordinates(imagePoint);
+        if (position is not { } recognizedPosition)
+        {
+            throw new MapPositionNotRecognizedException("大地图特征点匹配识别位置失败");
+        }
+
+        return (best.MapType, recognizedPosition);
     }
 
     private Point2f GetPositionFromBigMap(string mapName, Point2f expectedCenterPoint)

--- a/BetterGenshinImpact/GameTask/Common/Map/Maps/Base/SceneBaseMap.cs
+++ b/BetterGenshinImpact/GameTask/Common/Map/Maps/Base/SceneBaseMap.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.IO;
 using BetterGenshinImpact.Core.Recognition.OpenCv;
 using BetterGenshinImpact.Core.Recognition.OpenCv.FeatureMatch;
+using BetterGenshinImpact.Helpers.Extensions;
 using Microsoft.Extensions.Logging;
 using OpenCvSharp;
 
@@ -77,9 +78,9 @@ public abstract class SceneBaseMap : ISceneMap
                 {
                     if (_layers.Count == 0)
                     {
-                        TaskControl.Logger.LogInformation("[SIFT]地图特征点加载中，预计耗时2秒，请等待...");
+                        TaskControl.Logger.LogInformation("[SIFT]{MapType}地图特征点加载中，预计耗时2秒，请等待...", Type.GetDescription());
                         _layers = BaseMapLayer.LoadLayers(this);
-                        TaskControl.Logger.LogInformation("地图特征点加载完成！");
+                        TaskControl.Logger.LogInformation("[SIFT]{MapType}地图特征点加载完成！", Type.GetDescription());
                     }
                 }
             }
@@ -116,6 +117,21 @@ public abstract class SceneBaseMap : ISceneMap
     public virtual Point2f GetBigMapPosition(Mat greyBigMapMat)
     {
         return SiftMatcher.Match(MainLayer.TrainKeyPoints, MainLayer.TrainDescriptors, greyBigMapMat);
+    }
+
+    public virtual FeatureMatchResult GetBigMapPositionMatchResult(Mat greyBigMapMat)
+    {
+        return SiftMatcher.MatchWithQuality(MainLayer.TrainKeyPoints, MainLayer.TrainDescriptors, greyBigMapMat);
+    }
+
+    public virtual FeatureMatchResult GetBigMapPositionMatchResult(KeyPoint[] queryKeyPoints, Mat queryDescriptors, Size querySize)
+    {
+        return SiftMatcher.MatchWithQuality(
+            MainLayer.TrainKeyPoints,
+            MainLayer.TrainDescriptors,
+            queryKeyPoints,
+            queryDescriptors,
+            querySize);
     }
 
     public virtual Point2f GetBigMapPosition(Mat greyBigMapMat, Point2f expectedCenter)

--- a/BetterGenshinImpact/GameTask/Common/Map/Maps/Base/SceneBaseMap.cs
+++ b/BetterGenshinImpact/GameTask/Common/Map/Maps/Base/SceneBaseMap.cs
@@ -78,7 +78,7 @@ public abstract class SceneBaseMap : ISceneMap
                 {
                     if (_layers.Count == 0)
                     {
-                        TaskControl.Logger.LogInformation("[SIFT]{MapType}地图特征点加载中，预计耗时2秒，请等待...", Type.GetDescription());
+                        TaskControl.Logger.LogInformation("[SIFT]{MapType}地图特征点加载中，预计耗时2秒内，请等待...", Type.GetDescription());
                         _layers = BaseMapLayer.LoadLayers(this);
                         TaskControl.Logger.LogInformation("[SIFT]{MapType}地图特征点加载完成！", Type.GetDescription());
                     }

--- a/BetterGenshinImpact/GameTask/Common/Map/Maps/TeyvatMap.cs
+++ b/BetterGenshinImpact/GameTask/Common/Map/Maps/TeyvatMap.cs
@@ -46,6 +46,24 @@ public class TeyvatMap : SceneBaseMap
         return SiftMatcher.Match(layer.TrainKeyPoints, layer.TrainDescriptors, greyBigMapMat);
     }
 
+    public override FeatureMatchResult GetBigMapPositionMatchResult(Mat greyBigMapMat)
+    {
+        using var resizedGrey = ResizeHelper.Resize(greyBigMapMat, 1d / 4);
+        var layer = BigMapTeyvat256Layer.GetInstance(this);
+        return SiftMatcher.MatchWithQuality(layer.TrainKeyPoints, layer.TrainDescriptors, resizedGrey);
+    }
+
+    public override FeatureMatchResult GetBigMapPositionMatchResult(KeyPoint[] queryKeyPoints, Mat queryDescriptors, Size querySize)
+    {
+        var layer = BigMapTeyvat256Layer.GetInstance(this);
+        return SiftMatcher.MatchWithQuality(
+            layer.TrainKeyPoints,
+            layer.TrainDescriptors,
+            queryKeyPoints,
+            queryDescriptors,
+            querySize);
+    }
+
     public override Point2f GetBigMapPosition(Mat greyBigMapMat, Point2f expectedCenter)
     {
         var expectedCenter256 = new Point2f(

--- a/BetterGenshinImpact/GameTask/Common/Map/Maps/TeyvatMapTest.cs
+++ b/BetterGenshinImpact/GameTask/Common/Map/Maps/TeyvatMapTest.cs
@@ -40,6 +40,24 @@ public class TeyvatMapTest : SceneBaseMapByTemplateMatch
         return SiftMatcher.Match(layer.TrainKeyPoints, layer.TrainDescriptors, greyBigMapMat);
     }
 
+    public override FeatureMatchResult GetBigMapPositionMatchResult(Mat greyBigMapMat)
+    {
+        using var resizedGrey = ResizeHelper.Resize(greyBigMapMat, 1d / 4);
+        var layer = BigMapTeyvat256Layer.GetInstance(this);
+        return SiftMatcher.MatchWithQuality(layer.TrainKeyPoints, layer.TrainDescriptors, resizedGrey);
+    }
+
+    public override FeatureMatchResult GetBigMapPositionMatchResult(KeyPoint[] queryKeyPoints, Mat queryDescriptors, Size querySize)
+    {
+        var layer = BigMapTeyvat256Layer.GetInstance(this);
+        return SiftMatcher.MatchWithQuality(
+            layer.TrainKeyPoints,
+            layer.TrainDescriptors,
+            queryKeyPoints,
+            queryDescriptors,
+            querySize);
+    }
+
     public override Point2f GetBigMapPosition(Mat greyBigMapMat, Point2f expectedCenter)
     {
         var expectedCenter256 = new Point2f(

--- a/BetterGenshinImpact/ViewModel/Pages/HotKeyPageViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/HotKeyPageViewModel.cs
@@ -721,8 +721,15 @@ public partial class HotKeyPageViewModel : ObservableObject, IViewModel
             Config.HotKeyConfig.RecBigMapPosHotkeyType,
             (_, _) =>
             {
-                var p = new TpTask(CancellationToken.None).GetPositionFromBigMap(MapTypes.Teyvat.ToString());
-                _logger.LogInformation("大地图位置：{Position}", p);
+                try
+                {
+                    var (mapType, position) = new TpTask(CancellationToken.None).GetPositionFromCurrentBigMap();
+                    _logger.LogInformation("大地图位置（{MapType}）：X={X},Y={Y}", mapType.GetDescription(), position.X, position.Y);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "获取当前大地图位置失败");
+                }
             }
         ));
 

--- a/BetterGenshinImpact/ViewModel/Pages/HotKeyPageViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/HotKeyPageViewModel.cs
@@ -721,7 +721,7 @@ public partial class HotKeyPageViewModel : ObservableObject, IViewModel
             Config.HotKeyConfig.RecBigMapPosHotkeyType,
             (_, _) =>
             {
-                var p = new TpTask(CancellationToken.None).GetPositionFromBigMap(MapTypes.MoonCanon.ToString());
+                var p = new TpTask(CancellationToken.None).GetPositionFromBigMap(MapTypes.Teyvat.ToString());
                 _logger.LogInformation("大地图位置：{Position}", p);
             }
         ));


### PR DESCRIPTION
主要改动如题，加了try catch，以前这里出错时，即使点击忽略按钮，软件还是会闪退。

日志稍微改了一下
> [SIFT]**霜月**地图特征点加载中，预计耗时2秒**内**，请等待...

> 大地图位置（**特瓦特**）：**X=1234.5678,Y=9876.5432**

不懂实现纯AI改的，简单测试了几个图没发现问题。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增自动识别当前大地图类型及坐标的能力，支持多种地图场景。
  * 特征匹配结果现包含中心点、有效匹配数和内点数等质量信息。
  * 开发者快捷操作可自动识别地图类型并显示中心坐标。

* **错误修复**
  * 改进地图匹配筛选与置信度判断，降低误识别和结果不明确的情况。
  * 增强识别失败处理，并记录相关异常信息。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->