### PR TITLE
feat(overlay):遮罩新增快捷键可视化

### DIFF
--- a/BetterGenshinImpact/App.xaml.cs
+++ b/BetterGenshinImpact/App.xaml.cs
@@ -35,6 +35,7 @@ using Microsoft.Extensions.Logging;
 using Serilog;
 using Serilog.Events;
 using Serilog.Sinks.RichTextBox.Abstraction;
+using Serilog.Sinks.RichTextBox.Themes;
 using Wpf.Ui;
 using Wpf.Ui.DependencyInjection;
 using Wpf.Ui.Violeta.Appearance;
@@ -92,8 +93,15 @@ public partial class App : Application
                     .MinimumLevel.Override("Microsoft.Hosting.Lifetime", LogEventLevel.Warning);
                 if (all.MaskWindowConfig is { MaskEnabled: true, ShowLogBox: true })
                 {
+                    // 日志主题在管道构建时固定，运行期修改 LogColorTheme 需重启生效
                     loggerConfiguration.WriteTo.RichTextBox(richTextBox, LogEventLevel.Information,
-                        "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}");
+                        "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}",
+                        theme: all.MaskWindowConfig.LogColorTheme switch
+                        {
+                            "Grayscale" => RichTextBoxConsoleTheme.Grayscale,
+                            "Colored" => RichTextBoxConsoleTheme.Colored,
+                            _ => RichTextBoxConsoleTheme.Literate
+                        });
                 }
 
                 Log.Logger = loggerConfiguration.CreateLogger();

--- a/BetterGenshinImpact/Core/Config/MaskWindowConfig.cs
+++ b/BetterGenshinImpact/Core/Config/MaskWindowConfig.cs
@@ -17,6 +17,7 @@ public partial class MaskWindowConfig : ObservableObject
     public const string DefaultTransparentColor = "#00000000";
     public const string DefaultPanelBorderColor = "#33000000";
     public const string DefaultLogTextColor = "LightGray";
+    public const string DefaultLogColorTheme = "Literate";
     public const string DefaultStatusDisabledTextColor = "LightGray";
     public const string DefaultStatusEnabledTextColor = "LightGreen";
     public const string DefaultMetricsTextColor = "LightGray";
@@ -32,6 +33,14 @@ public partial class MaskWindowConfig : ObservableObject
     public const int MaxCrosshairSize = 1000;
     public const int MinCrosshairGap = 0;
     public const int MaxCrosshairGap = 1000;
+
+    // 快捷键速查条（HotkeyBar）：与状态栏同高、右下角与状态栏对称。
+    // 状态栏 TopRatio 上移至 766/1080 以预留换行空间，速查条与之对齐。
+    public const string DefaultHotkeyBarTextColor = "LightGray";
+    public const double DefaultHotkeyBarLeftRatio = 1420.0 / 1920;
+    public const double DefaultHotkeyBarTopRatio = 766.0 / 1080;
+    public const double DefaultHotkeyBarWidthRatio = 480.0 / 1920;
+    public const double DefaultHotkeyBarHeightRatio = 58.0 / 1080;
 
     // 指标栏布局和遮罩里其它元素一样按 1920x1080 折算比例保存，默认放在状态栏/日志上方以避开游戏底部 UI。
     public const double DefaultMetricsLeftRatio = 20.0 / 1920;
@@ -301,6 +310,13 @@ public partial class MaskWindowConfig : ObservableObject
     [ObservableProperty]
     private double _logFontSize = 12;
 
+    /// <summary>
+    /// 遮罩日志配色主题：Literate（默认，按级别着色）/ Grayscale（灰阶）/ Colored（高对比彩色）。
+    /// 日志管道在启动时构建，修改后需重启软件生效。
+    /// </summary>
+    [ObservableProperty]
+    private string _logColorTheme = DefaultLogColorTheme;
+
     [ObservableProperty]
     private bool _logShadowEnabled = true;
 
@@ -448,8 +464,9 @@ public partial class MaskWindowConfig : ObservableObject
     [ObservableProperty]
     private double _statusListLeftRatio = 20.0 / 1920;
 
+    // 上移自 790/1080：状态栏改为可换行、高度自适应后，需预留约 2 行增长空间以避开日志框（822/1080）
     [ObservableProperty]
-    private double _statusListTopRatio = 790.0 / 1080;
+    private double _statusListTopRatio = 766.0 / 1080;
 
     [ObservableProperty]
     private double _statusListWidthRatio = 480.0 / 1920;
@@ -469,12 +486,59 @@ public partial class MaskWindowConfig : ObservableObject
     [ObservableProperty]
     private double _metricsHeightRatio = DefaultMetricsHeightRatio;
 
+    /// <summary>
+    /// 是否显示快捷键速查条（遮罩右下角的可拖拽面板）
+    /// </summary>
+    [ObservableProperty]
+    private bool _showHotkeyBar = true;
+
+    /// <summary>
+    /// 状态栏功能项是否显示已绑定的快捷键徽章
+    /// </summary>
+    [ObservableProperty]
+    private bool _statusHotkeyBadgeEnabled = true;
+
+    /// <summary>
+    /// 速查条是否排除状态栏已显示的那 5 个实时任务开关项（去重），默认关闭即两处都显示
+    /// </summary>
+    [ObservableProperty]
+    private bool _hotkeyBarExcludeStatusItems = false;
+
+    [ObservableProperty]
+    private double _hotkeyBarLeftRatio = DefaultHotkeyBarLeftRatio;
+
+    [ObservableProperty]
+    private double _hotkeyBarTopRatio = DefaultHotkeyBarTopRatio;
+
+    [ObservableProperty]
+    private double _hotkeyBarWidthRatio = DefaultHotkeyBarWidthRatio;
+
+    [ObservableProperty]
+    private double _hotkeyBarHeightRatio = DefaultHotkeyBarHeightRatio;
+
+    [ObservableProperty]
+    private string _hotkeyBarTextColor = DefaultHotkeyBarTextColor;
+
+    [ObservableProperty]
+    private double _hotkeyBarFontSize = 12;
+
+    // 配置文件里使用 string key（HotKeyConfig 属性名），读取后由 EnsureOverlayHotkeyItems 约束回固定集合。
+    public Dictionary<string, bool> OverlayHotkeyItems { get; set; } = OverlayHotkeyItemDefaults.CreateDefaultItems();
+
     public void ResetOverlayMetricsLayout()
     {
         MetricsLeftRatio = DefaultMetricsLeftRatio;
         MetricsTopRatio = DefaultMetricsTopRatio;
         MetricsWidthRatio = DefaultMetricsWidthRatio;
         MetricsHeightRatio = DefaultMetricsHeightRatio;
+    }
+
+    public void ResetOverlayHotkeyLayout()
+    {
+        HotkeyBarLeftRatio = DefaultHotkeyBarLeftRatio;
+        HotkeyBarTopRatio = DefaultHotkeyBarTopRatio;
+        HotkeyBarWidthRatio = DefaultHotkeyBarWidthRatio;
+        HotkeyBarHeightRatio = DefaultHotkeyBarHeightRatio;
     }
 
     public void ResetOverlayStyle()
@@ -492,6 +556,7 @@ public partial class MaskWindowConfig : ObservableObject
         LogTextColor = DefaultLogTextColor;
         LogFontFamily = DefaultOverlayMonoFontFamily;
         LogFontSize = 12;
+        LogColorTheme = DefaultLogColorTheme;
         LogShadowEnabled = true;
         LogShadowColor = DefaultShadowColor;
         LogShadowOpacity = 0.4;
@@ -536,6 +601,13 @@ public partial class MaskWindowConfig : ObservableObject
         RecognitionLineStrokeThickness = 2;
         RecognitionTextColor = DefaultRecognitionTextColor;
         RecognitionTextFontSize = 36;
+
+        ShowHotkeyBar = true;
+        StatusHotkeyBadgeEnabled = true;
+        HotkeyBarExcludeStatusItems = false;
+        HotkeyBarTextColor = DefaultHotkeyBarTextColor;
+        HotkeyBarFontSize = 12;
+        ResetOverlayHotkeyLayout();
     }
 
     public void MigrateLegacyOverlayMetricsLayout()
@@ -605,6 +677,43 @@ public partial class MaskWindowConfig : ObservableObject
         EnsureOverlayMetricItems();
         OverlayMetricItems[item.ToString()] = enabled;
         OnPropertyChanged(nameof(OverlayMetricItems));
+    }
+
+    /// <summary>
+    /// 补齐缺少的快捷键项、移除非法 key（防止配置被篡改导致 UI 渲染任意字符串）。
+    /// key 为 HotKeyConfig 上的快捷键属性名字符串。
+    /// </summary>
+    public void EnsureOverlayHotkeyItems()
+    {
+        OverlayHotkeyItems ??= [];
+
+        foreach (var item in OverlayHotkeyItemDefaults.AllItems)
+        {
+            if (!OverlayHotkeyItems.ContainsKey(item))
+            {
+                OverlayHotkeyItems[item] = OverlayHotkeyItemDefaults.IsEnabledByDefault(item);
+            }
+        }
+
+        var validKeys = OverlayHotkeyItemDefaults.AllItems.ToHashSet();
+        foreach (var key in OverlayHotkeyItems.Keys.Where(key => !validKeys.Contains(key)).ToList())
+        {
+            OverlayHotkeyItems.Remove(key);
+        }
+    }
+
+    public bool IsOverlayHotkeyEnabled(string configPropertyName)
+    {
+        return OverlayHotkeyItems != null && OverlayHotkeyItems.TryGetValue(configPropertyName, out var enabled)
+            ? enabled
+            : OverlayHotkeyItemDefaults.IsEnabledByDefault(configPropertyName);
+    }
+
+    public void SetOverlayHotkeyEnabled(string configPropertyName, bool enabled)
+    {
+        EnsureOverlayHotkeyItems();
+        OverlayHotkeyItems[configPropertyName] = enabled;
+        OnPropertyChanged(nameof(OverlayHotkeyItems));
     }
 }
 

--- a/BetterGenshinImpact/Core/Config/OverlayHotkeyItem.cs
+++ b/BetterGenshinImpact/Core/Config/OverlayHotkeyItem.cs
@@ -1,0 +1,251 @@
+using BetterGenshinImpact.Model;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Input;
+
+namespace BetterGenshinImpact.Core.Config;
+
+/// <summary>
+/// 速查条显示项：已绑定且生效的快捷键紧凑文本 + 功能短名
+/// </summary>
+public sealed record OverlayHotkeyDisplayItem(string HotkeyText, string DisplayName);
+
+/// <summary>
+/// 遮罩快捷键显示项定义。
+/// key 为 <see cref="HotKeyConfig"/> 上的快捷键属性名字符串（nameof(HotKeyConfig.XxxHotkey)），
+/// 中文名与快捷键设置页（HotKeyPageViewModel）保持一致。
+/// 顺序按设置页的目录分组排列（顶层 / 系统控制 / 实时任务 / 操控辅助 / 独立任务 / 开发者 / 内部测试），
+/// 便于两处对照维护；新增快捷键时需同步更新此处与设置页。
+/// </summary>
+public static class OverlayHotkeyItemDefaults
+{
+    /// <summary>
+    /// 状态栏已展示的 5 个实时任务开关对应的快捷键属性名。
+    /// 「速查条排除状态栏已显示项」开启时用于过滤，必须与 MaskWindowViewModel.InitializeStatusList 中
+    /// 传入 StatusItem 的属性名保持同源，避免两处维护漂移。
+    /// </summary>
+    public static IReadOnlySet<string> StatusBarItemPropertyNames { get; } = new HashSet<string>
+    {
+        nameof(HotKeyConfig.AutoPickEnabledHotkey),
+        nameof(HotKeyConfig.AutoSkipEnabledHotkey),
+        nameof(HotKeyConfig.AutoSkipHangoutEnabledHotkey),
+        nameof(HotKeyConfig.AutoFishingEnabledHotkey),
+        nameof(HotKeyConfig.QuickTeleportEnabledHotkey),
+    };
+
+    /// <summary>
+    /// 显式顺序决定速查条显示顺序，按快捷键设置页的目录分组排列，不要随手改动。
+    /// </summary>
+    public static IReadOnlyList<string> AllItems { get; } =
+    [
+        // 顶层
+        nameof(HotKeyConfig.BgiEnabledHotkey),
+        // 系统控制
+        nameof(HotKeyConfig.CancelTaskHotkey),
+        nameof(HotKeyConfig.SuspendHotkey),
+        nameof(HotKeyConfig.TakeScreenshotHotkey),
+        nameof(HotKeyConfig.LogBoxDisplayHotkey),
+        nameof(HotKeyConfig.OverlayMetricsDisplayHotkey),
+        // 实时任务
+        nameof(HotKeyConfig.AutoPickEnabledHotkey),
+        nameof(HotKeyConfig.AutoSkipEnabledHotkey),
+        nameof(HotKeyConfig.AutoSkipHangoutEnabledHotkey),
+        nameof(HotKeyConfig.AutoFishingEnabledHotkey),
+        nameof(HotKeyConfig.QuickTeleportEnabledHotkey),
+        nameof(HotKeyConfig.SkillCdEnabledHotkey),
+        nameof(HotKeyConfig.QuickTeleportTickHotkey),
+        nameof(HotKeyConfig.MapMaskEnabledHotkey),
+        // 操控辅助
+        nameof(HotKeyConfig.TurnAroundHotkey),
+        nameof(HotKeyConfig.EnhanceArtifactHotkey),
+        nameof(HotKeyConfig.QuickBuyHotkey),
+        nameof(HotKeyConfig.OneKeyClaimRewardHotkey),
+        nameof(HotKeyConfig.QuickSereniteaPotHotkey),
+        nameof(HotKeyConfig.ClickGenshinConfirmButtonHotkey),
+        nameof(HotKeyConfig.ClickGenshinCancelButtonHotkey),
+        nameof(HotKeyConfig.OneKeyFightHotkey),
+        // 独立任务
+        nameof(HotKeyConfig.OnedragonHotkey),
+        nameof(HotKeyConfig.AutoGeniusInvokationHotkey),
+        nameof(HotKeyConfig.AutoWoodHotkey),
+        nameof(HotKeyConfig.AutoFightHotkey),
+        nameof(HotKeyConfig.AutoDomainHotkey),
+        nameof(HotKeyConfig.AutoMusicGameHotkey),
+        nameof(HotKeyConfig.AutoFishingGameHotkey),
+        nameof(HotKeyConfig.AutoCookGameHotkey),
+        // 开发者
+        nameof(HotKeyConfig.KeyMouseMacroRecordHotkey),
+        nameof(HotKeyConfig.RecognitionTemplateEditorHotkey),
+        nameof(HotKeyConfig.RecBigMapPosHotkey),
+        nameof(HotKeyConfig.PathRecorderHotkey),
+        nameof(HotKeyConfig.AddWaypointHotkey),
+        // 内部测试（RuntimeHelper.IsDebug 分支，Release 下通常未绑定）
+        nameof(HotKeyConfig.Test1Hotkey),
+        nameof(HotKeyConfig.Test2Hotkey),
+        nameof(HotKeyConfig.ExecutePathHotkey),
+    ];
+
+    public static Dictionary<string, bool> CreateDefaultItems()
+    {
+        return AllItems.ToDictionary(item => item, IsEnabledByDefault);
+    }
+
+    public static bool IsEnabledByDefault(string configPropertyName)
+    {
+        // 默认全部允许显示：用户绑定新快捷键后自动出现在遮罩上，无需再去设置页勾选；嫌多时可反向取消。
+        return true;
+    }
+
+    /// <summary>
+    /// 获取中文显示名。未知 key 返回空字符串，渲染层应跳过该项，不得回退显示英文属性名。
+    /// </summary>
+    public static string GetDisplayName(string configPropertyName)
+    {
+        return configPropertyName switch
+        {
+            nameof(HotKeyConfig.BgiEnabledHotkey) => "启动停止",
+            nameof(HotKeyConfig.CancelTaskHotkey) => "停止任务",
+            nameof(HotKeyConfig.SuspendHotkey) => "暂停任务",
+            nameof(HotKeyConfig.TakeScreenshotHotkey) => "游戏截图",
+            nameof(HotKeyConfig.LogBoxDisplayHotkey) => "日志开关",
+            nameof(HotKeyConfig.OverlayMetricsDisplayHotkey) => "指标栏开关",
+            nameof(HotKeyConfig.AutoPickEnabledHotkey) => "自动拾取",
+            nameof(HotKeyConfig.AutoSkipEnabledHotkey) => "自动剧情",
+            nameof(HotKeyConfig.AutoSkipHangoutEnabledHotkey) => "自动邀约",
+            nameof(HotKeyConfig.AutoFishingEnabledHotkey) => "自动钓鱼",
+            nameof(HotKeyConfig.QuickTeleportEnabledHotkey) => "快速传送",
+            nameof(HotKeyConfig.SkillCdEnabledHotkey) => "冷却提示",
+            nameof(HotKeyConfig.QuickTeleportTickHotkey) => "触发传送",
+            nameof(HotKeyConfig.MapMaskEnabledHotkey) => "地图遮罩",
+            nameof(HotKeyConfig.TurnAroundHotkey) => "旋转视角",
+            nameof(HotKeyConfig.EnhanceArtifactHotkey) => "快速强化",
+            nameof(HotKeyConfig.QuickBuyHotkey) => "快速购买",
+            nameof(HotKeyConfig.OneKeyClaimRewardHotkey) => "领取奖励",
+            nameof(HotKeyConfig.QuickSereniteaPotHotkey) => "进出尘歌壶",
+            nameof(HotKeyConfig.ClickGenshinConfirmButtonHotkey) => "点击确认",
+            nameof(HotKeyConfig.ClickGenshinCancelButtonHotkey) => "点击取消",
+            nameof(HotKeyConfig.OneKeyFightHotkey) => "一键战斗宏",
+            nameof(HotKeyConfig.OnedragonHotkey) => "一条龙",
+            nameof(HotKeyConfig.AutoGeniusInvokationHotkey) => "七圣召唤",
+            nameof(HotKeyConfig.AutoWoodHotkey) => "自动伐木",
+            nameof(HotKeyConfig.AutoFightHotkey) => "自动战斗",
+            nameof(HotKeyConfig.AutoDomainHotkey) => "自动秘境",
+            nameof(HotKeyConfig.AutoMusicGameHotkey) => "自动音游",
+            nameof(HotKeyConfig.AutoFishingGameHotkey) => "自动钓鱼(任务)",
+            nameof(HotKeyConfig.AutoCookGameHotkey) => "自动烹饪",
+            nameof(HotKeyConfig.KeyMouseMacroRecordHotkey) => "键鼠录制",
+            nameof(HotKeyConfig.RecognitionTemplateEditorHotkey) => "模板素材制作",
+            nameof(HotKeyConfig.RecBigMapPosHotkey) => "获取地图中心点",
+            nameof(HotKeyConfig.PathRecorderHotkey) => "路径记录器",
+            nameof(HotKeyConfig.AddWaypointHotkey) => "添加路径点",
+            nameof(HotKeyConfig.Test1Hotkey) => "测试",
+            nameof(HotKeyConfig.Test2Hotkey) => "测试2",
+            nameof(HotKeyConfig.ExecutePathHotkey) => "播放路径",
+            _ => string.Empty
+        };
+    }
+
+    /// <summary>
+    /// 获取完整功能名（与快捷键设置页一致），用于提示信息等长文本场景。
+    /// </summary>
+    public static string GetFullDisplayName(string configPropertyName)
+    {
+        return configPropertyName switch
+        {
+            nameof(HotKeyConfig.BgiEnabledHotkey) => "启动停止 BetterGI",
+            nameof(HotKeyConfig.CancelTaskHotkey) => "停止当前脚本/独立任务",
+            nameof(HotKeyConfig.SuspendHotkey) => "暂停当前脚本/独立任务",
+            nameof(HotKeyConfig.TakeScreenshotHotkey) => "游戏截图",
+            nameof(HotKeyConfig.LogBoxDisplayHotkey) => "日志与状态窗口展示开关",
+            nameof(HotKeyConfig.OverlayMetricsDisplayHotkey) => "遮罩指标栏展示开关",
+            nameof(HotKeyConfig.AutoPickEnabledHotkey) => "自动拾取开关",
+            nameof(HotKeyConfig.AutoSkipEnabledHotkey) => "自动剧情开关",
+            nameof(HotKeyConfig.AutoSkipHangoutEnabledHotkey) => "自动邀约开关",
+            nameof(HotKeyConfig.AutoFishingEnabledHotkey) => "自动钓鱼开关",
+            nameof(HotKeyConfig.QuickTeleportEnabledHotkey) => "快速传送开关",
+            nameof(HotKeyConfig.SkillCdEnabledHotkey) => "冷却提示开关",
+            nameof(HotKeyConfig.QuickTeleportTickHotkey) => "手动触发快速传送（按住起效）",
+            nameof(HotKeyConfig.MapMaskEnabledHotkey) => "地图遮罩开关",
+            nameof(HotKeyConfig.TurnAroundHotkey) => "长按旋转视角",
+            nameof(HotKeyConfig.EnhanceArtifactHotkey) => "快速强化圣遗物",
+            nameof(HotKeyConfig.QuickBuyHotkey) => "快速购买商店物品",
+            nameof(HotKeyConfig.OneKeyClaimRewardHotkey) => "一键领取奖励",
+            nameof(HotKeyConfig.QuickSereniteaPotHotkey) => "快速进出尘歌壶",
+            nameof(HotKeyConfig.ClickGenshinConfirmButtonHotkey) => "点击原神内确认按钮",
+            nameof(HotKeyConfig.ClickGenshinCancelButtonHotkey) => "点击原神内取消按钮",
+            nameof(HotKeyConfig.OneKeyFightHotkey) => "一键战斗宏",
+            nameof(HotKeyConfig.OnedragonHotkey) => "启动/停止一条龙",
+            nameof(HotKeyConfig.AutoGeniusInvokationHotkey) => "启动/停止自动七圣召唤",
+            nameof(HotKeyConfig.AutoWoodHotkey) => "启动/停止自动伐木",
+            nameof(HotKeyConfig.AutoFightHotkey) => "启动/停止自动战斗",
+            nameof(HotKeyConfig.AutoDomainHotkey) => "启动/停止自动秘境",
+            nameof(HotKeyConfig.AutoMusicGameHotkey) => "启动/停止自动音游",
+            nameof(HotKeyConfig.AutoFishingGameHotkey) => "启动/停止自动钓鱼",
+            nameof(HotKeyConfig.AutoCookGameHotkey) => "启动/停止自动烹饪",
+            nameof(HotKeyConfig.KeyMouseMacroRecordHotkey) => "启动/停止键鼠录制",
+            nameof(HotKeyConfig.RecognitionTemplateEditorHotkey) => "模板素材制作",
+            nameof(HotKeyConfig.RecBigMapPosHotkey) => "获取当前大地图中心点位置",
+            nameof(HotKeyConfig.PathRecorderHotkey) => "启动/停止路径记录器",
+            nameof(HotKeyConfig.AddWaypointHotkey) => "添加路径点",
+            nameof(HotKeyConfig.Test1Hotkey) => "测试",
+            nameof(HotKeyConfig.Test2Hotkey) => "测试2",
+            nameof(HotKeyConfig.ExecutePathHotkey) => "播放内存中的路径",
+            _ => string.Empty
+        };
+    }
+
+    /// <summary>
+    /// 判断快捷键的当前配置值是否实际生效。
+    /// 与 <see cref="HotKeySettingModel.RegisterHotKey"/> 的行为严格对齐：
+    /// 键鼠监听（KeyboardMonitor）类型下的组合键（带 Ctrl/Alt/Shift/Win）会被静默置空、无法触发，
+    /// 必须过滤以免显示按了没反应的按键；全局热键（GlobalRegister）支持组合键；鼠标侧键不受修饰键影响。
+    /// 已知局限：热键被系统占用导致注册失败时无法感知（配置字符串仍保留），接受该误差。
+    /// </summary>
+    public static bool IsHotkeyEffective(string? hotkeyValue, string? hotkeyTypeValue)
+    {
+        if (string.IsNullOrWhiteSpace(hotkeyValue))
+        {
+            return false;
+        }
+
+        HotKey hotkey;
+        try
+        {
+            hotkey = HotKey.FromString(hotkeyValue);
+        }
+        catch (Exception)
+        {
+            // 配置被外部篡改成无法解析的值，视为未生效
+            return false;
+        }
+
+        if (hotkey.IsEmpty)
+        {
+            return false;
+        }
+
+        // 鼠标侧键走 MouseHook 注册，修饰键会被忽略，始终生效
+        if (hotkey.MouseButton != MouseButton.Left)
+        {
+            return true;
+        }
+
+        // 全局热键通过系统 RegisterHotKey 注册，支持组合键
+        if (string.Equals(hotkeyTypeValue, nameof(HotKeyTypeEnum.GlobalRegister), StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        // 键鼠监听仅支持无修饰键的单键
+        return hotkey.Modifiers == ModifierKeys.None;
+    }
+
+    /// <summary>
+    /// 将配置中的快捷键字符串转为适合遮罩显示的紧凑文本："Ctrl + F" → "Ctrl+F"。
+    /// </summary>
+    public static string ToCompactHotkeyText(string hotkeyValue)
+    {
+        return hotkeyValue.Replace(" + ", "+", StringComparison.Ordinal);
+    }
+}

--- a/BetterGenshinImpact/Model/HotKeySettingModel.cs
+++ b/BetterGenshinImpact/Model/HotKeySettingModel.cs
@@ -3,6 +3,8 @@ using BetterGenshinImpact.GameTask;
 using BetterGenshinImpact.GameTask.AutoFight;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
+using CommunityToolkit.Mvvm.Messaging.Messages;
 using Fischless.HotkeyCapture;
 using System;
 using System.Collections.ObjectModel;
@@ -80,6 +82,47 @@ public partial class HotKeySettingModel : ObservableObject
         OnKeyPressAction = onKeyPressAction;
         IsHold = isHold;
         SwitchHotkeyTypeEnabled = !isHold;
+
+        // 初始化遮罩显示勾选状态：直接写 backing field，避免触发 OnShowOnOverlayChanged 把初始值写回配置
+        try
+        {
+            _showOnOverlay = TaskContext.Instance().Config.MaskWindowConfig.IsOverlayHotkeyEnabled(configPropertyName);
+        }
+        catch (Exception e)
+        {
+            Debug.WriteLine(e);
+            _showOnOverlay = false;
+        }
+    }
+
+    /// <summary>
+    /// 是否在遮罩快捷键速查条上显示该快捷键。
+    /// 持久化到 MaskWindowConfig.OverlayHotkeyItems（key 为 ConfigPropertyName）。
+    /// 注意：目录行走单参构造，ConfigPropertyName 为 null，属性恒为 false 且变更被忽略。
+    /// </summary>
+    [ObservableProperty]
+    private bool _showOnOverlay;
+
+    partial void OnShowOnOverlayChanged(bool value)
+    {
+        // 目录行/未携带配置属性名的行：防御性忽略，避免 NullReferenceException
+        // （TreeListView 会为目录行实例化同一个 CellTemplate）
+        if (IsDirectory || string.IsNullOrEmpty(ConfigPropertyName))
+        {
+            return;
+        }
+
+        try
+        {
+            TaskContext.Instance().Config.MaskWindowConfig.SetOverlayHotkeyEnabled(ConfigPropertyName, value);
+            // 通知遮罩重算速查条。勾选是离散点击操作，无需防抖；
+            // 遮罩侧 handler 已通过 UIDispatcherHelper.Invoke 回到 UI 线程，线程安全。
+            WeakReferenceMessenger.Default.Send(new PropertyChangedMessage<object>(this, "RefreshSettings", value, "快捷键遮罩显示变更"));
+        }
+        catch (Exception e)
+        {
+            Debug.WriteLine(e);
+        }
     }
 
     public void RegisterHotKey()

--- a/BetterGenshinImpact/Model/StatusItem.cs
+++ b/BetterGenshinImpact/Model/StatusItem.cs
@@ -1,43 +1,113 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
+﻿using BetterGenshinImpact.Core.Config;
+using BetterGenshinImpact.GameTask;
+using CommunityToolkit.Mvvm.ComponentModel;
 using System;
 using System.ComponentModel;
 
-namespace BetterGenshinImpact.Model
+namespace BetterGenshinImpact.Model;
+
+public partial class StatusItem : ObservableObject, IDisposable
 {
-    public partial class StatusItem : ObservableObject
+    public string Name { get; set; }
+    private INotifyPropertyChanged _sourceObject { get; set; }
+    private string _propertyName { get; set; }
+
+    /// <summary>
+    /// 关联的 HotKeyConfig 快捷键属性名（如 nameof(HotKeyConfig.AutoPickEnabledHotkey)）；
+    /// 为 null 表示该状态项没有可绑定的快捷键（如尚未支持的功能）。
+    /// </summary>
+    public string? HotkeyConfigPropertyName { get; set; }
+
+    /// <summary>
+    /// 关联的 HotKeyConfig 快捷键类型属性名（HotkeyConfigPropertyName + "Type"）
+    /// </summary>
+    public string? HotkeyTypeConfigPropertyName { get; set; }
+
+    [ObservableProperty] private bool _isEnabled;
+
+    /// <summary>
+    /// 已绑定且实际生效的快捷键紧凑文本（如 "Alt+G"）；
+    /// 未绑定或键鼠监听下的组合键（无法触发）时为空字符串，视图层据此隐藏徽章。
+    /// </summary>
+    [ObservableProperty] private string _hotkeyText = string.Empty;
+
+    public StatusItem(string name, INotifyPropertyChanged sourceObject, string propertyName = "Enabled")
     {
-        public string Name { get; set; }
-        private INotifyPropertyChanged _sourceObject { get; set; }
-        private string _propertyName { get; set; }
+        Name = name;
+        _sourceObject = sourceObject;
+        _propertyName = propertyName;
 
-        [ObservableProperty] private bool _isEnabled;
+        _sourceObject.PropertyChanged += OnSourcePropertyChanged;
+        IsEnabled = GetSourceValue();
+    }
 
-        public StatusItem(string name, INotifyPropertyChanged sourceObject, string propertyName = "Enabled")
+    /// <summary>
+    /// 带快捷键徽章的状态项
+    /// </summary>
+    /// <param name="name">显示名</param>
+    /// <param name="sourceObject">功能开关所在的配置对象</param>
+    /// <param name="propertyName">开关属性名</param>
+    /// <param name="hotkeyConfigPropertyName">HotKeyConfig 上的快捷键属性名</param>
+    public StatusItem(string name, INotifyPropertyChanged sourceObject, string propertyName, string? hotkeyConfigPropertyName)
+        : this(name, sourceObject, propertyName)
+    {
+        if (hotkeyConfigPropertyName != null)
         {
-            Name = name;
-            _sourceObject = sourceObject;
-            _propertyName = propertyName;
-
-            _sourceObject.PropertyChanged += OnSourcePropertyChanged;
-            IsEnabled = GetSourceValue();
+            HotkeyConfigPropertyName = hotkeyConfigPropertyName;
+            HotkeyTypeConfigPropertyName = hotkeyConfigPropertyName + "Type";
         }
 
-        private bool GetSourceValue()
+        RefreshHotkey();
+    }
+
+    private bool GetSourceValue()
+    {
+        var property = _sourceObject.GetType().GetProperty(_propertyName);
+        ArgumentNullException.ThrowIfNull(property);
+        var value = property.GetValue(_sourceObject);
+        ArgumentNullException.ThrowIfNull(value);
+        return (bool)value;
+    }
+
+    private void OnSourcePropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == _propertyName)
         {
-            var property = _sourceObject.GetType().GetProperty(_propertyName);
-            ArgumentNullException.ThrowIfNull(property);
-            var value = property.GetValue(_sourceObject);
-            ArgumentNullException.ThrowIfNull(value);
-            return (bool)value;
+            this.IsEnabled = GetSourceValue();
+        }
+    }
+
+    /// <summary>
+    /// 重新读取 HotKeyConfig 计算快捷键文本。
+    /// StatusList 仅在遮罩加载时初始化一次，用户在快捷键设置页改键后，
+    /// 由 MaskWindowViewModel.RefreshSettings 调用本方法刷新徽章，避免重建集合。
+    /// </summary>
+    public void RefreshHotkey()
+    {
+        if (HotkeyConfigPropertyName == null)
+        {
+            return;
         }
 
-
-        private void OnSourcePropertyChanged(object? sender, PropertyChangedEventArgs e)
+        try
         {
-            if (e.PropertyName == _propertyName)
-            {
-                this.IsEnabled = GetSourceValue();
-            }
+            var hotKeyConfig = TaskContext.Instance().Config.HotKeyConfig;
+            var value = hotKeyConfig.GetType().GetProperty(HotkeyConfigPropertyName)?.GetValue(hotKeyConfig) as string;
+            var type = hotKeyConfig.GetType().GetProperty(HotkeyTypeConfigPropertyName ?? "")?.GetValue(hotKeyConfig) as string;
+
+            HotkeyText = OverlayHotkeyItemDefaults.IsHotkeyEffective(value, type) && !string.IsNullOrWhiteSpace(value)
+                ? OverlayHotkeyItemDefaults.ToCompactHotkeyText(value)
+                : string.Empty;
         }
+        catch (Exception)
+        {
+            // 配置尚未加载等异常场景下不显示徽章即可，不中断状态栏初始化
+            HotkeyText = string.Empty;
+        }
+    }
+
+    public void Dispose()
+    {
+        _sourceObject.PropertyChanged -= OnSourcePropertyChanged;
     }
 }

--- a/BetterGenshinImpact/View/MaskWindow.xaml
+++ b/BetterGenshinImpact/View/MaskWindow.xaml
@@ -151,12 +151,7 @@
                             <Binding RelativeSource="{RelativeSource AncestorType=Window}" Path="ActualWidth" />
                         </MultiBinding>
                     </overlay:AdjustableOverlayItem.Width>
-                    <overlay:AdjustableOverlayItem.Height>
-                        <MultiBinding Converter="{StaticResource OverlayRelativeOrAbsoluteConverter}">
-                            <Binding Path="Config.MaskWindowConfig.StatusListHeightRatio" />
-                            <Binding RelativeSource="{RelativeSource AncestorType=Window}" Path="ActualHeight" />
-                        </MultiBinding>
-                    </overlay:AdjustableOverlayItem.Height>
+                    <!-- 高度不固定：状态栏改为可换行、随内容自适应增长（StatusListHeightRatio 语义降级为拖拽时的初始参考） -->
                     <b:Interaction.Triggers>
                         <b:EventTrigger EventName="LayoutCommitted">
                             <b:InvokeCommandAction Command="{Binding OverlayLayoutCommittedCommand}"
@@ -178,32 +173,35 @@
                             </DropShadowEffect.Opacity>
                         </DropShadowEffect>
                     </overlay:AdjustableOverlayItem.Effect>
-                    <ui:ListView ItemsSource="{Binding StatusList}"
-                                 Background="Transparent"
-                                 BorderThickness="0"
-                                 d:ItemsSource="{d:SampleData}">
-                        <ListView.ItemContainerStyle>
-                            <Style TargetType="ListViewItem">
-                                <Setter Property="Focusable" Value="False" />
-                                <Setter Property="IsHitTestVisible" Value="False" />
-                            </Style>
-                        </ListView.ItemContainerStyle>
-                        <ListView.ItemsPanel>
+                    <ItemsControl ItemsSource="{Binding StatusList}"
+                                  Background="Transparent"
+                                  IsHitTestVisible="False">
+                        <ItemsControl.ItemsPanel>
                             <ItemsPanelTemplate>
-                                <StackPanel Orientation="Horizontal" />
+                                <!-- 可换行：徽章追加后超出宽度自动折行，不再被静默裁剪 -->
+                                <WrapPanel />
                             </ItemsPanelTemplate>
-                        </ListView.ItemsPanel>
-                        <ListView.ItemTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <StackPanel Orientation="Horizontal">
-                                    <StackPanel.Resources>
-                                        <Style TargetType="{x:Type TextBlock}">
-                                            <Setter Property="Margin" Value="0,0,8,0" />
-                                        </Style>
-                                    </StackPanel.Resources>
-                                    <TextBlock FontFamily="{StaticResource FgiIconFontFamily}"
+                                <StackPanel Orientation="Horizontal" Margin="0,0,8,0">
+                                    <TextBlock x:Name="StatusIcon" FontFamily="{StaticResource FgiIconFontFamily}"
                                                Opacity="{Binding DataContext.Config.MaskWindowConfig.TextOpacity, RelativeSource={RelativeSource AncestorType=Window}}"
                                                Text="{Binding Name}">
+                                        <TextBlock.Style>
+                                            <Style TargetType="TextBlock">
+                                                <Style.Triggers>
+                                                    <!-- 启用项图标微光：增强"正在工作"的感知（DropShadowEffect 为 CPU 渲染，仅启用项生效） -->
+                                                    <DataTrigger Binding="{Binding IsEnabled}" Value="True">
+                                                        <Setter Property="Effect">
+                                                            <Setter.Value>
+                                                                <DropShadowEffect BlurRadius="5" ShadowDepth="0" Opacity="0.75" Color="#FFFFFF" />
+                                                            </Setter.Value>
+                                                        </Setter>
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
                                         <TextBlock.FontSize>
                                             <MultiBinding Converter="{StaticResource OverlayScaledSizeConverter}">
                                                 <Binding Path="DataContext.Config.MaskWindowConfig.StatusFontSize" RelativeSource="{RelativeSource AncestorType=Window}" />
@@ -221,10 +219,142 @@
                                             </MultiBinding>
                                         </TextBlock.Foreground>
                                     </TextBlock>
+                                    <!-- 快捷键徽章：已绑定且生效时显示按键胶囊，未绑定时收起不占位 -->
+                                    <Border Margin="4,0,0,0"
+                                            Padding="3,0"
+                                            CornerRadius="3"
+                                            Background="#22FFFFFF"
+                                            BorderThickness="1"
+                                            BorderBrush="{Binding Foreground, ElementName=StatusIcon}"
+                                            Opacity="{Binding DataContext.Config.MaskWindowConfig.TextOpacity, RelativeSource={RelativeSource AncestorType=Window}}">
+                                        <Border.Style>
+                                            <Style TargetType="Border">
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding HotkeyText}" Value="">
+                                                        <Setter Property="Visibility" Value="Collapsed" />
+                                                    </DataTrigger>
+                                                    <!--  总开关关闭时全部隐藏  -->
+                                                    <DataTrigger Binding="{Binding DataContext.Config.MaskWindowConfig.StatusHotkeyBadgeEnabled, RelativeSource={RelativeSource AncestorType=Window}}" Value="False">
+                                                        <Setter Property="Visibility" Value="Collapsed" />
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </Border.Style>
+                                        <!-- 键名用默认字体（图标字体显示不了普通字母） -->
+                                        <TextBlock Text="{Binding HotkeyText}"
+                                                   Foreground="{Binding Foreground, ElementName=StatusIcon}">
+                                            <TextBlock.FontSize>
+                                                <MultiBinding Converter="{StaticResource OverlayScaledSizeConverter}">
+                                                    <Binding Path="DataContext.Config.MaskWindowConfig.StatusFontSize" RelativeSource="{RelativeSource AncestorType=Window}" />
+                                                    <Binding Path="DataContext.Config.MaskWindowConfig.LogFontScale" RelativeSource="{RelativeSource AncestorType=Window}" />
+                                                    <Binding Path="DataContext.ScaleTo1080PRatio" RelativeSource="{RelativeSource AncestorType=Window}" />
+                                                    <Binding Path="DataContext.DisplayDpiScale" RelativeSource="{RelativeSource AncestorType=Window}" />
+                                                    <Binding Path="DataContext.Config.MaskWindowConfig.OverlayScalingEnabled" RelativeSource="{RelativeSource AncestorType=Window}" />
+                                                </MultiBinding>
+                                            </TextBlock.FontSize>
+                                        </TextBlock>
+                                    </Border>
                                 </StackPanel>
                             </DataTemplate>
-                        </ListView.ItemTemplate>
-                    </ui:ListView>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </overlay:AdjustableOverlayItem>
+
+                <!--  快捷键速查条：右下角可拖拽面板，列出已绑定且实际生效的快捷键；空集合整体隐藏不占位  -->
+                <overlay:AdjustableOverlayItem x:Name="HotkeyBarWrapper"
+                                               Padding="4,2"
+                                               MinWidth="160"
+                                               MinHeight="24"
+                                               IsEditEnabled="{Binding Config.MaskWindowConfig.OverlayLayoutEditEnabled}"
+                                               LayoutKey="HotkeyBar"
+                                               SnapsToDevicePixels="True"
+                                               UseLayoutRounding="True"
+                                               Visibility="{Binding IsHotkeyBarVisible, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <Canvas.Left>
+                        <MultiBinding Converter="{StaticResource OverlayRelativeOrAbsoluteConverter}">
+                            <Binding Path="Config.MaskWindowConfig.HotkeyBarLeftRatio" />
+                            <Binding RelativeSource="{RelativeSource AncestorType=Window}" Path="ActualWidth" />
+                        </MultiBinding>
+                    </Canvas.Left>
+                    <Canvas.Top>
+                        <MultiBinding Converter="{StaticResource OverlayRelativeOrAbsoluteConverter}">
+                            <Binding Path="Config.MaskWindowConfig.HotkeyBarTopRatio" />
+                            <Binding RelativeSource="{RelativeSource AncestorType=Window}" Path="ActualHeight" />
+                        </MultiBinding>
+                    </Canvas.Top>
+                    <overlay:AdjustableOverlayItem.Width>
+                        <MultiBinding Converter="{StaticResource OverlayRelativeOrAbsoluteConverter}">
+                            <Binding Path="Config.MaskWindowConfig.HotkeyBarWidthRatio" />
+                            <Binding RelativeSource="{RelativeSource AncestorType=Window}" Path="ActualWidth" />
+                        </MultiBinding>
+                    </overlay:AdjustableOverlayItem.Width>
+                    <overlay:AdjustableOverlayItem.Height>
+                        <MultiBinding Converter="{StaticResource OverlayRelativeOrAbsoluteConverter}">
+                            <Binding Path="Config.MaskWindowConfig.HotkeyBarHeightRatio" />
+                            <Binding RelativeSource="{RelativeSource AncestorType=Window}" Path="ActualHeight" />
+                        </MultiBinding>
+                    </overlay:AdjustableOverlayItem.Height>
+                    <b:Interaction.Triggers>
+                        <b:EventTrigger EventName="LayoutCommitted">
+                            <b:InvokeCommandAction Command="{Binding OverlayLayoutCommittedCommand}"
+                                                   PassEventArgsToCommand="True" />
+                        </b:EventTrigger>
+                        <b:EventTrigger EventName="PreviewMouseRightButtonDown">
+                            <b:InvokeCommandAction Command="{Binding ExitOverlayLayoutEditModeCommand}" />
+                        </b:EventTrigger>
+                    </b:Interaction.Triggers>
+                    <ItemsControl HorizontalAlignment="Stretch"
+                                  VerticalAlignment="Top"
+                                  ClipToBounds="True"
+                                  IsHitTestVisible="False"
+                                  ItemsSource="{Binding OverlayHotkeyDisplayItems}"
+                                  Opacity="{Binding Config.MaskWindowConfig.TextOpacity}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <!--  行高随内容自适应；默认面板高度约 3 行，超出换行  -->
+                                <WrapPanel />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <StackPanel Orientation="Horizontal" Margin="0,0,10,0">
+                                    <!--  键名胶囊  -->
+                                    <Border Padding="3,0"
+                                            CornerRadius="3"
+                                            Background="#22FFFFFF"
+                                            BorderThickness="1"
+                                            BorderBrush="{Binding DataContext.Config.MaskWindowConfig.HotkeyBarTextColor, RelativeSource={RelativeSource AncestorType=Window}, Converter={StaticResource ColorStringToBrushConverter}}">
+                                        <TextBlock Text="{Binding HotkeyText}"
+                                                   Foreground="{Binding DataContext.Config.MaskWindowConfig.HotkeyBarTextColor, RelativeSource={RelativeSource AncestorType=Window}, Converter={StaticResource ColorStringToBrushConverter}}">
+                                            <TextBlock.FontSize>
+                                                <MultiBinding Converter="{StaticResource OverlayScaledSizeConverter}">
+                                                    <Binding Path="DataContext.Config.MaskWindowConfig.HotkeyBarFontSize" RelativeSource="{RelativeSource AncestorType=Window}" />
+                                                    <Binding Path="DataContext.Config.MaskWindowConfig.LogFontScale" RelativeSource="{RelativeSource AncestorType=Window}" />
+                                                    <Binding Path="DataContext.ScaleTo1080PRatio" RelativeSource="{RelativeSource AncestorType=Window}" />
+                                                    <Binding Path="DataContext.DisplayDpiScale" RelativeSource="{RelativeSource AncestorType=Window}" />
+                                                    <Binding Path="DataContext.Config.MaskWindowConfig.OverlayScalingEnabled" RelativeSource="{RelativeSource AncestorType=Window}" />
+                                                </MultiBinding>
+                                            </TextBlock.FontSize>
+                                        </TextBlock>
+                                    </Border>
+                                    <TextBlock Margin="4,0,0,0"
+                                               VerticalAlignment="Center"
+                                               Text="{Binding DisplayName}"
+                                               Foreground="{Binding DataContext.Config.MaskWindowConfig.HotkeyBarTextColor, RelativeSource={RelativeSource AncestorType=Window}, Converter={StaticResource ColorStringToBrushConverter}}">
+                                        <TextBlock.FontSize>
+                                            <MultiBinding Converter="{StaticResource OverlayScaledSizeConverter}">
+                                                <Binding Path="DataContext.Config.MaskWindowConfig.HotkeyBarFontSize" RelativeSource="{RelativeSource AncestorType=Window}" />
+                                                <Binding Path="DataContext.Config.MaskWindowConfig.LogFontScale" RelativeSource="{RelativeSource AncestorType=Window}" />
+                                                <Binding Path="DataContext.ScaleTo1080PRatio" RelativeSource="{RelativeSource AncestorType=Window}" />
+                                                <Binding Path="DataContext.DisplayDpiScale" RelativeSource="{RelativeSource AncestorType=Window}" />
+                                                <Binding Path="DataContext.Config.MaskWindowConfig.OverlayScalingEnabled" RelativeSource="{RelativeSource AncestorType=Window}" />
+                                            </MultiBinding>
+                                        </TextBlock.FontSize>
+                                    </TextBlock>
+                                </StackPanel>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
                 </overlay:AdjustableOverlayItem>
 
                 <overlay:AdjustableOverlayItem x:Name="LogTextBoxWrapper"
@@ -512,7 +642,7 @@
                             <DropShadowEffect Opacity="0.8" BlurRadius="10" ShadowDepth="0" />
                         </TextBlock.Effect>
                     </TextBlock>
-                    <TextBlock Text="{i18n:T 可以调整日志框、状态栏控件的位置和大小}"
+                    <TextBlock Text="{i18n:T 可以调整日志框、状态栏、指标栏、快捷键速查条的位置和大小}"
                                Margin="0,8,0,0"
                                FontSize="22"
                                FontWeight="SemiBold"

--- a/BetterGenshinImpact/View/MaskWindow.xaml.cs
+++ b/BetterGenshinImpact/View/MaskWindow.xaml.cs
@@ -232,6 +232,7 @@ public partial class MaskWindow : Window
         if (_viewModel != null)
         {
             _viewModel.PropertyChanged -= ViewModelOnPropertyChanged;
+            _viewModel.DisposeStatusList();
         }
 
         if (_mapLabelSearchWindow != null)

--- a/BetterGenshinImpact/View/Pages/HotkeyPage.xaml
+++ b/BetterGenshinImpact/View/Pages/HotkeyPage.xaml
@@ -41,7 +41,8 @@
                    BorderThickness="1"
                    CornerRadius="{DynamicResource ControlCornerRadius}">
             <Grid Margin="4">
-                <ui:Grid ColumnDefinitions="*,235" Visibility="Hidden">
+                <!--  固定列合计 305（类型 100 + 快捷键 120 + 遮罩显示 70 + 余量 15），功能列占满剩余宽度，避免出现横向滚动条  -->
+                <ui:Grid ColumnDefinitions="*,305" Visibility="Hidden">
                     <Grid x:Name="TreeColumnStar" Grid.Column="0" />
                 </ui:Grid>
                 <ui:TreeListView BorderThickness="0" ItemsSource="{Binding HotKeySettingModels}">
@@ -76,6 +77,18 @@
                                                               Style="{StaticResource DefaultTextBoxStyle}"
                                                               TextAlignment="Center"
                                                               Visibility="{Binding IsDirectory, Converter={StaticResource BooleanToVisibilityRevertConverter}, Mode=OneWay}" />
+                                    </DataTemplate>
+                                </ui:GridViewColumn.CellTemplate>
+                            </ui:GridViewColumn>
+                            <ui:GridViewColumn Width="70" Header="{i18n:T 遮罩显示}">
+                                <ui:GridViewColumn.CellTemplate>
+                                    <DataTemplate>
+                                        <!--  勾选后该快捷键出现在遮罩速查条上（须先绑定快捷键且实际生效）；目录行不渲染  -->
+                                        <CheckBox HorizontalAlignment="Center"
+                                                  VerticalAlignment="Center"
+                                                  IsChecked="{Binding ShowOnOverlay, Mode=TwoWay}"
+                                                  IsEnabled="{Binding HotKey.IsEmpty, Converter={StaticResource InverseBooleanConverter}, Mode=OneWay}"
+                                                  Visibility="{Binding IsDirectory, Converter={StaticResource BooleanToVisibilityRevertConverter}, Mode=OneWay}" />
                                     </DataTemplate>
                                 </ui:GridViewColumn.CellTemplate>
                             </ui:GridViewColumn>

--- a/BetterGenshinImpact/ViewModel/MaskWindowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/MaskWindowViewModel.cs
@@ -40,6 +40,18 @@ namespace BetterGenshinImpact.ViewModel
 
         [ObservableProperty] private ObservableCollection<StatusItem> _statusList = [];
 
+        /// <summary>
+        /// 快捷键速查条显示项（已绑定、实际生效且用户勾选允许显示的快捷键）
+        /// </summary>
+        [ObservableProperty] private IReadOnlyList<OverlayHotkeyDisplayItem> _overlayHotkeyDisplayItems = [];
+
+        public bool HasHotkeyBarItems => OverlayHotkeyDisplayItems.Count > 0;
+
+        /// <summary>
+        /// 速查条整体可见性：总开关开启且至少有一项可显示，空集合不占位
+        /// </summary>
+        public bool IsHotkeyBarVisible => Config?.MaskWindowConfig.ShowHotkeyBar == true && HasHotkeyBarItems;
+
         public AllConfig? Config { get; set; }
 
         [ObservableProperty] private string _fps = "0";
@@ -168,12 +180,71 @@ namespace BetterGenshinImpact.ViewModel
         {
             if (Config != null)
             {
-                StatusList.Add(new StatusItem("\uf256 拾取", Config.AutoPickConfig));
-                StatusList.Add(new StatusItem("\uf075 剧情", Config.AutoSkipConfig));
-                StatusList.Add(new StatusItem("\ue5c8 邀约", Config.AutoSkipConfig, "AutoHangoutEventEnabled"));
-                StatusList.Add(new StatusItem("\uf578 钓鱼", Config.AutoFishingConfig));
-                StatusList.Add(new StatusItem("\uf3c5 传送", Config.QuickTeleportConfig));
+                StatusList.Add(new StatusItem("\uf256 拾取", Config.AutoPickConfig, "Enabled", nameof(HotKeyConfig.AutoPickEnabledHotkey)));
+                StatusList.Add(new StatusItem("\uf075 剧情", Config.AutoSkipConfig, "Enabled", nameof(HotKeyConfig.AutoSkipEnabledHotkey)));
+                StatusList.Add(new StatusItem("\ue5c8 邀约", Config.AutoSkipConfig, "AutoHangoutEventEnabled", nameof(HotKeyConfig.AutoSkipHangoutEnabledHotkey)));
+                StatusList.Add(new StatusItem("\uf578 钓鱼", Config.AutoFishingConfig, "Enabled", nameof(HotKeyConfig.AutoFishingEnabledHotkey)));
+                StatusList.Add(new StatusItem("\uf3c5 传送", Config.QuickTeleportConfig, "Enabled", nameof(HotKeyConfig.QuickTeleportEnabledHotkey)));
             }
+        }
+
+        /// <summary>
+        /// 组装速查条显示项。两级过滤：
+        /// 1. 用户勾选层（MaskWindowConfig.OverlayHotkeyItems，改配置时可整体重算）
+        /// 2. 运行时生效层（未绑定的跳过；键鼠监听下的组合键无法触发，跳过）
+        /// 仅在配置变更时调用（RefreshSettings 消息），绝不进入 50ms 主循环。
+        /// </summary>
+        private void BuildOverlayHotkeyItems()
+        {
+            if (Config == null)
+            {
+                OverlayHotkeyDisplayItems = [];
+                return;
+            }
+
+            var hotKeyConfig = Config.HotKeyConfig;
+            var maskConfig = Config.MaskWindowConfig;
+            maskConfig.EnsureOverlayHotkeyItems();
+
+            var excludeStatusItems = maskConfig.HotkeyBarExcludeStatusItems;
+            var hotKeyConfigType = hotKeyConfig.GetType();
+            var items = new List<OverlayHotkeyDisplayItem>();
+
+            foreach (var propertyName in OverlayHotkeyItemDefaults.AllItems)
+            {
+                // 第一级：用户勾选（默认 true，未绑定不显示由生效层兜底）
+                if (!maskConfig.IsOverlayHotkeyEnabled(propertyName))
+                {
+                    continue;
+                }
+
+                // 去重开关：排除状态栏已展示的那 5 个实时任务开关项
+                if (excludeStatusItems && OverlayHotkeyItemDefaults.StatusBarItemPropertyNames.Contains(propertyName))
+                {
+                    continue;
+                }
+
+                // 未知 key（映射表未同步的新快捷键）跳过渲染，不回退显示英文属性名
+                var displayName = OverlayHotkeyItemDefaults.GetDisplayName(propertyName);
+                if (string.IsNullOrEmpty(displayName))
+                {
+                    continue;
+                }
+
+                var hotkeyValue = hotKeyConfigType.GetProperty(propertyName)?.GetValue(hotKeyConfig) as string;
+                var hotkeyType = hotKeyConfigType.GetProperty(propertyName + "Type")?.GetValue(hotKeyConfig) as string;
+
+                // 第二级：实际生效判定
+                if (!OverlayHotkeyItemDefaults.IsHotkeyEffective(hotkeyValue, hotkeyType))
+                {
+                    continue;
+                }
+
+                items.Add(new OverlayHotkeyDisplayItem(OverlayHotkeyItemDefaults.ToCompactHotkeyText(hotkeyValue!), displayName));
+            }
+
+            OverlayHotkeyDisplayItems = items;
+            OnPropertyChanged(nameof(IsHotkeyBarVisible));
         }
 
         [RelayCommand]
@@ -254,6 +325,13 @@ namespace BetterGenshinImpact.ViewModel
                 RefreshDisplayDpiScale();
                 OnPropertyChanged(nameof(Config));
                 OnPropertyChanged(nameof(IsOverlayMetricsVisible));
+
+                // 快捷键徽章与速查条：StatusList 只初始化一次不重建，逐项刷新徽章文本；速查条整体重算
+                foreach (var statusItem in StatusList)
+                {
+                    statusItem.RefreshHotkey();
+                }
+                BuildOverlayHotkeyItems();
             }
 
             SyncSelectedMapPointApiProviderFromConfig();
@@ -506,6 +584,12 @@ namespace BetterGenshinImpact.ViewModel
                     Config.MaskWindowConfig.MetricsTopRatio = topRatio;
                     Config.MaskWindowConfig.MetricsWidthRatio = widthRatio;
                     Config.MaskWindowConfig.MetricsHeightRatio = heightRatio;
+                    break;
+                case "HotkeyBar":
+                    Config.MaskWindowConfig.HotkeyBarLeftRatio = leftRatio;
+                    Config.MaskWindowConfig.HotkeyBarTopRatio = topRatio;
+                    Config.MaskWindowConfig.HotkeyBarWidthRatio = widthRatio;
+                    Config.MaskWindowConfig.HotkeyBarHeightRatio = heightRatio;
                     break;
             }
         }

--- a/BetterGenshinImpact/ViewModel/MaskWindowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/MaskWindowViewModel.cs
@@ -176,8 +176,24 @@ namespace BetterGenshinImpact.ViewModel
             });
         }
 
+        /// <summary>
+        /// 释放并清空状态栏订阅。StatusItem 订阅了应用级单例配置对象的 PropertyChanged，
+        /// 遮罩窗口关闭时必须退订，否则旧实例无法回收并随遮罩重建累积。
+        /// </summary>
+        public void DisposeStatusList()
+        {
+            foreach (var statusItem in StatusList)
+            {
+                statusItem.Dispose();
+            }
+
+            StatusList.Clear();
+        }
+
         private void InitializeStatusList()
         {
+            // 防御 Loaded 重复触发：先释放旧订阅，避免在同一批配置对象上叠加事件处理器
+            DisposeStatusList();
             if (Config != null)
             {
                 StatusList.Add(new StatusItem("\uf256 拾取", Config.AutoPickConfig, "Enabled", nameof(HotKeyConfig.AutoPickEnabledHotkey)));

--- a/BetterGenshinImpact/ViewModel/Pages/CommonSettingsPageViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/CommonSettingsPageViewModel.cs
@@ -563,6 +563,7 @@ public sealed class OverlayStyleSettingGroup : ObservableObject
                 OverlayStyleSettingItem.Number(config, nameof(MaskWindowConfig.LogPanelBorderThickness), "日志区域边框粗细", "日志窗口边框线宽。填 0 表示不显示边框。", onChanged),
                 OverlayStyleSettingItem.Color(config, nameof(MaskWindowConfig.LogTextColor), "日志文字颜色", "日志内容的文字颜色。", onChanged),
                 OverlayStyleSettingItem.Number(config, nameof(MaskWindowConfig.LogFontSize), "日志文字大小", "日志内容字号。", onChanged),
+                OverlayStyleSettingItem.Text(config, nameof(MaskWindowConfig.LogColorTheme), "日志配色主题", "Literate（默认，按级别着色）、Grayscale（灰阶）或 Colored（高对比彩色）。修改后重启软件生效。", onChanged),
                 OverlayStyleSettingItem.Bool(config, nameof(MaskWindowConfig.LogShadowEnabled), "显示日志阴影", "开启后文字和区域更容易从游戏背景中区分出来。", onChanged),
                 OverlayStyleSettingItem.Color(config, nameof(MaskWindowConfig.LogShadowColor), "日志阴影颜色", "日志阴影颜色。", onChanged),
                 OverlayStyleSettingItem.Number(config, nameof(MaskWindowConfig.LogShadowOpacity), "日志阴影透明度", "日志阴影强度，0 表示没有阴影，1 表示最明显。", onChanged),
@@ -575,6 +576,7 @@ public sealed class OverlayStyleSettingGroup : ObservableObject
                 OverlayStyleSettingItem.Color(config, nameof(MaskWindowConfig.StatusDisabledTextColor), "未启用状态文字颜色", "任务未启用时图标和文字的颜色。", onChanged),
                 OverlayStyleSettingItem.Color(config, nameof(MaskWindowConfig.StatusEnabledTextColor), "已启用状态文字颜色", "任务启用时图标和文字的颜色。", onChanged),
                 OverlayStyleSettingItem.Number(config, nameof(MaskWindowConfig.StatusFontSize), "状态文字大小", "状态栏字号。", onChanged),
+                OverlayStyleSettingItem.Bool(config, nameof(MaskWindowConfig.StatusHotkeyBadgeEnabled), "显示快捷键徽章", "开启后状态栏中已绑定快捷键的功能项会显示按键提示（如「拾取 F」），忘记按键时瞄一眼即可。", onChanged),
                 OverlayStyleSettingItem.Bool(config, nameof(MaskWindowConfig.StatusShadowEnabled), "显示状态栏阴影", "开启后状态栏在复杂背景上更容易看清。", onChanged),
                 OverlayStyleSettingItem.Color(config, nameof(MaskWindowConfig.StatusShadowColor), "状态栏阴影颜色", "状态栏阴影颜色。", onChanged),
                 OverlayStyleSettingItem.Number(config, nameof(MaskWindowConfig.StatusShadowOpacity), "状态栏阴影透明度", "状态栏阴影强度，0 表示没有阴影，1 表示最明显。", onChanged),
@@ -595,6 +597,11 @@ public sealed class OverlayStyleSettingGroup : ObservableObject
                 OverlayStyleSettingItem.Number(config, nameof(MaskWindowConfig.MetricsShadowOpacity), "指标栏阴影透明度", "指标栏阴影强度，0 表示没有阴影，1 表示最明显。", onChanged),
                 OverlayStyleSettingItem.Number(config, nameof(MaskWindowConfig.MetricsShadowBlurRadius), "指标栏阴影模糊半径", "指标栏阴影的扩散范围，数值越大阴影越柔和。", onChanged),
             ], config, nameof(MaskWindowConfig.ShowOverlayMetrics), onChanged),
+            new OverlayStyleSettingGroup("快捷键速查条", "在遮罩右下角显示已绑定且实际生效的快捷键，忘记按键时瞄一眼即可。具体显示哪些快捷键在「快捷键设置」页逐项勾选。", OverlayStyleSettingGroupKind.HotkeyBar, [
+                OverlayStyleSettingItem.Bool(config, nameof(MaskWindowConfig.HotkeyBarExcludeStatusItems), "排除状态栏已显示项", "开启后速查条不再重复显示状态栏已展示的拾取、剧情、邀约、钓鱼、传送等开关项。", onChanged),
+                OverlayStyleSettingItem.Color(config, nameof(MaskWindowConfig.HotkeyBarTextColor), "速查条文字颜色", "速查条按键与功能名的文字颜色。", onChanged),
+                OverlayStyleSettingItem.Number(config, nameof(MaskWindowConfig.HotkeyBarFontSize), "速查条文字大小", "速查条基础字号，实际字号还会随遮罩字体缩放率与游戏分辨率变化。", onChanged),
+            ], config, nameof(MaskWindowConfig.ShowHotkeyBar), onChanged),
             new OverlayStyleSettingGroup("方位遮罩", "在小地图周围显示东、南、西、北文字，辅助判断朝向。", OverlayStyleSettingGroupKind.Direction, [
                 OverlayStyleSettingItem.Color(config, nameof(MaskWindowConfig.DirectionTextColor), "方位文字颜色", "小地图周围方位文字的颜色。", onChanged),
                 OverlayStyleSettingItem.Number(config, nameof(MaskWindowConfig.DirectionFontSize), "方位文字大小", "小地图方位文字字号。", onChanged),
@@ -894,6 +901,7 @@ public enum OverlayStyleSettingGroupKind
     Log,
     Status,
     Metrics,
+    HotkeyBar,
     Direction,
     Recognition,
     CustomHtml

--- a/BetterGenshinImpact/ViewModel/Pages/HotKeyPageViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/HotKeyPageViewModel.cs
@@ -86,6 +86,13 @@ public partial class HotKeyPageViewModel : ObservableObject, IViewModel
             {
                 if (sender is HotKeySettingModel model)
                 {
+                    // 遮罩显示勾选变化：HotKeySettingModel 内部已完成配置写回与消息发送。
+                    // 必须提前返回——下方会无条件重注册热键，误触会导致注册失败时热键静默失效。
+                    if (e.PropertyName == nameof(HotKeySettingModel.ShowOnOverlay))
+                    {
+                        return;
+                    }
+
                     // 反射更新配置
 
                     // 更新快捷键
@@ -104,6 +111,9 @@ public partial class HotKeyPageViewModel : ObservableObject, IViewModel
                             _acceptedHotKeys[model.ConfigPropertyName] = newHotKey;
                             ShowGameKeyBindingConflictWarning(model, newHotKey, previousHotKey);
                         }
+
+                        // 改键会影响遮罩上的快捷键徽章与速查条（绑定/解绑/组合键有效性变化）
+                        SendRefreshSettingsMessageDebounced();
                     }
 
                     // 更新快捷键类型
@@ -116,6 +126,9 @@ public partial class HotKeyPageViewModel : ObservableObject, IViewModel
                         {
                             pi.SetValue(Config.HotKeyConfig, model.HotKeyType.ToString(), null);
                         }
+
+                        // 类型切换（全局热键/键鼠监听）影响组合键的生效判定
+                        SendRefreshSettingsMessageDebounced();
                     }
 
                     RemoveDuplicateHotKey(model);
@@ -262,6 +275,30 @@ public partial class HotKeyPageViewModel : ObservableObject, IViewModel
         if (null != pi && pi.CanWrite)
         {
             pi.SetValue(Config.HotKeyConfig, model.HotKey.IsEmpty ? "" : model.HotKey.ToString(), null);
+        }
+    }
+
+    private CancellationTokenSource? _refreshSettingsCts;
+
+    /// <summary>
+    /// 防抖发送遮罩刷新消息（"RefreshSettings"）。
+    /// HotKeyTextBox 逐键输入会连续触发 HotKey 属性变化回调（含 RemoveDuplicateHotKey 引发的级联置空），
+    /// 直接发送会导致遮罩状态栏徽章与速查条频繁重算，这里合并为最后一次变更后 300ms 发送一次。
+    /// 遮罩侧 handler 已用 UIDispatcherHelper.Invoke 回 UI 线程，线程安全。
+    /// </summary>
+    private async void SendRefreshSettingsMessageDebounced()
+    {
+        _refreshSettingsCts?.Cancel();
+        _refreshSettingsCts?.Dispose();
+        _refreshSettingsCts = new CancellationTokenSource();
+        try
+        {
+            await Task.Delay(300, _refreshSettingsCts.Token);
+            WeakReferenceMessenger.Default.Send(new PropertyChangedMessage<object>(this, "RefreshSettings", new object(), "快捷键配置变更"));
+        }
+        catch (TaskCanceledException)
+        {
+            // 被后续变更取消，正常防抖行为
         }
     }
 


### PR DESCRIPTION
## 结合AI进行的PR整理
## 背景

BetterGI 支持为 40 余项功能绑定快捷键，但设置完成后没有任何地方能看到当前绑定了什么键。使用中很容易忘记（尤其是低频功能如「一键领取奖励」「快速进出尘歌壶」），只能退出游戏去翻设置页。

本 PR 在遮罩窗口上补齐这块信息，让用户在游戏内一眼可查。

## ⚠️ 维护注意：显示名需与快捷键设置页同步维护

**这是本次实现刻意做出的取舍，请 Reviewer 重点关注。**

速查条需要的「功能中文名」在 `HotKeyPageViewModel.BuildHotKeySettingModelList()` 中是 **35+ 处硬编码字符串**，且该 VM 同时持有 `Config` 实例与热键注册回调委托。因此有两个方案：

| 方案 | 收益 | 风险 |
| --- | --- | --- |
| **A. 抽出统一映射表，两处复用**（理想） | 彻底消除重复，无同步成本 | 需改动 35+ 处构造调用，直接触碰热键注册链路（`RegisterHotKey` / `RemoveDuplicateHotKey`），回归风险高 |
| **B. 新建独立只读映射表**（**本次采用**） | 完全不触碰热键注册逻辑，改动面可控 | 显示名两处维护；上游新增快捷键若漏改，该项不会出现在速查条上 |

本次选择 **B**，以「不碰热键链路」优先。新增的映射表位于 `Core/Config/OverlayHotkeyItem.cs`，按设置页的目录分组顺序排列（顶层 / 系统控制 / 实时任务 / 操控辅助 / 独立任务 / 开发者 / 内部测试），便于日后逐项对照。

**失效是安全的**：映射表缺失某项时 `GetDisplayName` 返回空字符串，渲染层跳过该项 —— 结果是「不显示」，而非崩溃或显示英文属性名。

**后续上游新增快捷键时，需同步补两处：**

1. `HotKeyPageViewModel.BuildHotKeySettingModelList()` 的构造调用
2. `OverlayHotkeyItemDefaults.AllItems` 与 `GetDisplayName`

建议后续单独做一次重构落地方案 A，本次为控制 PR 范围未包含。

## 改动内容

### 1. 状态栏快捷键徽章

状态栏每项在绑定快捷键后追加按键胶囊，未绑定则不显示、不占位：

```
拾取 F    剧情    邀约    钓鱼 Alt+F    传送 Alt+G
```

同时：

- 启用中的功能项图标带微光，强化「正在工作」的感知
- 状态栏由单行 `StackPanel` 改为 `WrapPanel`，内容变多时自动换行（原实现会静默裁剪超出部分）

### 2. 快捷键速查条（新增面板）

遮罩右下角新增可拖拽面板，横向列出已绑定且**实际生效**的快捷键：

```
[F11] 启动停止   [F9] 游戏截图   [Alt+Q] 停止任务
```

- 与日志框、状态栏、指标栏一致，支持拖拽 / 缩放 / 复位
- 空集合时整体隐藏，不占屏

### 3. 快捷键设置页新增「遮罩显示」列

每行可单独勾选是否进入速查条：

| 功能 | 快捷键类型 | 配置快捷键 | **遮罩显示** |
| --- | --- | --- | --- |
| 自动拾取开关 | 键鼠监听 | F | ☑ |

- 未绑定快捷键的行勾选框置灰不可用（先绑定键才有意义）
- 分类行（系统控制 / 实时任务等）不渲染勾选框

### 4. 其他

- 设置页新增「快捷键速查条」样式分组（文字颜色 / 字号 / 去重开关）与状态栏「显示快捷键徽章」开关
- 新增 `LogColorTheme` 配置项（Literate / Grayscale / Colored）
- 遮罩编辑模式提示文案补充速查条

## 实现要点

- **两级过滤**

  | 层级 | 判定 | 说明 |
  | --- | --- | --- |
  | 用户勾选层 | `MaskWindowConfig.OverlayHotkeyItems[key]` | 持久化，默认全部为 true |
  | 运行时生效层 | `IsHotkeyEffective(value, type)` | 未绑定 / 键鼠监听下的组合键均判定为不生效 |

- **只显示实际生效的键**：`HotKeySettingModel.RegisterHotKey()` 中，键鼠监听（KeyboardMonitor）模式下带修饰键的组合键会被静默置空、无法触发。若不加过滤，会显示按了没反应的键，比不显示更糟。

- **不触碰热键注册链路**：`PropertyChanged` 回调末尾会**无条件**执行 `RemoveDuplicateHotKey()` + `UnRegisterHotKey()` + `RegisterHotKey()`。若勾选动作进入该回调，一旦注册失败（键被其他程序占用）热键会静默失效，因此回调开头对 `ShowOnOverlay` 提前 `return`。

- **性能**：遮罩主循环 50ms/帧且 `OnRender` 全量重绘，快捷键集合只在配置变更时重算，不进入主循环；改键通知做了 300ms 防抖。

- **修复既有泄漏**：`StatusItem` 订阅 `PropertyChanged` 后从不取消订阅，本次补上 `IDisposable`。

- **中文名映射表独立新建**，未改动 `HotKeyPageViewModel` 中原有 35+ 处硬编码，避免波及热键注册逻辑。这是有代价的取舍，详见上文「⚠️ 维护注意」。

## 兼容性

- 新增配置字段均带默认值，旧 `config.json` 反序列化正常
- 状态栏 `TopRatio` 默认值 `790/1080` → `766/1080`（为换行预留空间）；老用户保留自身已保存位置，不受影响
- 日志配色：改动前未传 `theme`，Sink 本就使用默认 `Literate` 主题按级别着色，本次默认行为不变，仅新增切换能力（重启生效）

## 自测

- [x] 解决方案编译通过（0 警告 0 错误）
- [x] 绑定 / 解绑快捷键后遮罩实时更新
- [x] 勾选框不触发热键重注册
- [x] 目录行不渲染勾选框、无空引用异常
- [x] 键鼠监听模式下的组合键不显示
- [x] 旧配置文件加载正常

## 已知局限

1. 热键被系统占用导致注册失败时无法感知（配置字符串仍保留），理论上可能显示一个按了没反应的键。严谨判定需要 `HotKeyPage` 打开后的实例，遮罩在页面未打开时拿不到。
2. 速查条功能名为硬编码中文，与项目多语言支持不一致（与现有状态栏名称的现状保持一致，避免范围膨胀）。

## 后续 TODO

- `HotkeyBarDisplayHotkey`：速查条显隐快捷键，对齐已有的 `LogBoxDisplayHotkey` / `OverlayMetricsDisplayHotkey`
- 速查条默认位置需实机微调（当前为纸面推算值）

---
---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 遮罩新增快捷键速查条，可自定义显示项目、位置、大小、颜色和字号。
  * 热键设置页新增“遮罩显示”选项，可单独控制快捷键展示。
  * 状态栏支持快捷键徽章，并可配置显示开关。
  * 新增日志配色主题选项，支持灰度、彩色和默认主题。

* **改进**
  * 状态内容支持自动换行和高度自适应。
  * 快捷键或显示设置变更后，遮罩内容会自动刷新。
  * 遮罩编辑提示文案已更新，包含快捷键速查条说明。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->