### PR TITLE
feat: 微信 Clawbot 推送会话过期（ret=-2 prepare failed）时给出友好提示

### DIFF
--- a/BetterGenshinImpact/Service/Notifier/Exception/WechatClawbotSessionExpiredException.cs
+++ b/BetterGenshinImpact/Service/Notifier/Exception/WechatClawbotSessionExpiredException.cs
@@ -1,0 +1,10 @@
+namespace BetterGenshinImpact.Service.Notifier.Exception;
+
+/// <summary>
+/// 微信 Clawbot 推送会话过期异常。
+/// 触发条件：sendmessage 返回 ret=-2 且 errmsg 含 "prepare failed"，
+/// 表示用户超过 12~24 小时未在微信中给 Clawbot 私聊，服务端拒绝推送。
+/// 这不是客户端 token 过期，是微信 ClawBot 协议的服务端推送权限限制，
+/// 用户需在微信侧给 Clawbot 私聊任意内容以重新激活推送通道。
+/// </summary>
+public sealed class WechatClawbotSessionExpiredException(string message) : NotifierException(message);

--- a/BetterGenshinImpact/Service/Notifier/NotifierManager.cs
+++ b/BetterGenshinImpact/Service/Notifier/NotifierManager.cs
@@ -113,6 +113,9 @@ public class NotifierManager
         }
     }
 
+    /// <summary>
+    /// 以租约方式向指定类型的通知器发送通知（在途计数，供普通通知路径使用）。
+    /// </summary>
     public async Task SendNotificationAsync<T>(BaseNotificationData content) where T : INotifier
     {
         INotifier? notifier;

--- a/BetterGenshinImpact/Service/Notifier/NotifierManager.cs
+++ b/BetterGenshinImpact/Service/Notifier/NotifierManager.cs
@@ -1,3 +1,4 @@
+using BetterGenshinImpact.Service.Notifier.Exception;
 using BetterGenshinImpact.Service.Notifier.Interface;
 using Microsoft.Extensions.Logging;
 using System;
@@ -103,7 +104,7 @@ public class NotifierManager
             }
             catch (System.Exception ex)
             {
-                Logger.LogWarning("{name} 通知发送失败: {ex}", notifier.Name, ex.Message);
+                LogNotifierFailure(notifier, ex);
             }
         }
         finally
@@ -133,7 +134,7 @@ public class NotifierManager
             }
             catch (System.Exception ex)
             {
-                Logger.LogWarning("{name} 通知发送失败: {ex}", notifier.Name, ex.Message);
+                LogNotifierFailure(notifier, ex);
             }
         }
         finally
@@ -219,6 +220,22 @@ public class NotifierManager
             await notifier.SendAsync(content);
         }
         catch (System.Exception ex)
+        {
+            Logger.LogWarning("{name} 通知发送失败: {ex}", notifier.Name, ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// 记录通知器发送失败的日志。对微信 Clawbot 推送会话过期（ret=-2 prepare failed）给出
+    /// 明确的解决提示，引导用户在微信侧给 Clawbot 私聊任意内容以激活推送端口。
+    /// </summary>
+    private static void LogNotifierFailure(INotifier notifier, System.Exception ex)
+    {
+        if (ex is WechatClawbotSessionExpiredException)
+        {
+            Logger.LogWarning("微信 Clawbot 推送权限已过期，请在微信侧给 Clawbot 私聊任意内容以激活推送端口");
+        }
+        else
         {
             Logger.LogWarning("{name} 通知发送失败: {ex}", notifier.Name, ex.Message);
         }

--- a/BetterGenshinImpact/Service/Notifier/WechatClawbotNotifier.cs
+++ b/BetterGenshinImpact/Service/Notifier/WechatClawbotNotifier.cs
@@ -243,7 +243,16 @@ public sealed class WechatClawbotNotifier : INotifier, IDisposable
             {
                 const string hint = "微信 Clawbot 推送权限已过期，请在微信侧给 Clawbot 私聊任意内容以激活推送端口";
                 Logger.LogWarning("{Hint}", hint);
-                SessionExpired?.Invoke(hint);
+                try
+                {
+                    // 隔离事件订阅者异常（如应用关闭期间 Dispatcher 不可用），
+                    // 确保订阅者抛出的异常不会吞掉下方要抛出的专门领域异常。
+                    SessionExpired?.Invoke(hint);
+                }
+                catch (System.Exception eventEx)
+                {
+                    Logger.LogWarning("微信 Clawbot 会话过期事件通知订阅者异常: {Ex}", eventEx.Message);
+                }
                 throw new WechatClawbotSessionExpiredException(hint);
             }
 

--- a/BetterGenshinImpact/Service/Notifier/WechatClawbotNotifier.cs
+++ b/BetterGenshinImpact/Service/Notifier/WechatClawbotNotifier.cs
@@ -29,6 +29,12 @@ public sealed class WechatClawbotNotifier : INotifier, IDisposable
 {
     private static readonly ILogger<WechatClawbotNotifier> Logger = App.GetLogger<WechatClawbotNotifier>();
 
+    /// <summary>
+    /// 推送会话过期事件（静态）。sendmessage 检测到 ret=-2 prepare failed 时触发，
+    /// 供 UI（通知设置页）订阅以展示过期激活提示。
+    /// </summary>
+    public static event Action<string>? SessionExpired;
+
     public string Name { get; } = "微信 Clawbot";
 
     private const int MaxRetry = 3;
@@ -229,6 +235,18 @@ public sealed class WechatClawbotNotifier : INotifier, IDisposable
         if (ret != 0 || errcode != 0)
         {
             var errmsg = root.TryGetProperty("errmsg", out var errElement) ? errElement.GetString() : null;
+
+            // 微信 Clawbot 平台限制：超过 12~24 小时未在微信中给 Clawbot 私聊，推送会话过期（ret=-2 prepare failed）。
+            // 这是微信 ClawBot 协议的服务端推送权限限制，并非客户端 token 过期；
+            // 需提示用户在微信侧给 Clawbot 私聊任意内容以激活推送端口。
+            if (ret == -2 && errmsg != null && errmsg.Contains("prepare", StringComparison.OrdinalIgnoreCase))
+            {
+                const string hint = "微信 Clawbot 推送权限已过期，请在微信侧给 Clawbot 私聊任意内容以激活推送端口";
+                Logger.LogWarning("{Hint}", hint);
+                SessionExpired?.Invoke(hint);
+                throw new WechatClawbotSessionExpiredException(hint);
+            }
+
             throw new NotifierException($"sendmessage 返回错误 ret={ret} errcode={errcode} errmsg={errmsg}");
         }
     }

--- a/BetterGenshinImpact/ViewModel/Pages/NotificationSettingsPageViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/NotificationSettingsPageViewModel.cs
@@ -119,6 +119,18 @@ public partial class NotificationSettingsPageViewModel : ObservableObject, IView
 
         Config.NotificationConfig.PropertyChanged += OnNotificationConfigPropertyChanged;
         ApplyNotificationEventSelectionFromConfig();
+
+        // 订阅微信 Clawbot 推送会话过期事件：普通发送（非测试按钮）失败时，
+        // 也能及时在设置页状态文本上提示用户如何重新激活推送端口。
+        WechatClawbotNotifier.SessionExpired += OnWechatClawbotSessionExpired;
+    }
+
+    /// <summary>
+    /// 微信 Clawbot 推送会话过期回调（后台线程触发），编组回 UI 线程更新状态提示。
+    /// </summary>
+    private void OnWechatClawbotSessionExpired(string hint)
+    {
+        System.Windows.Application.Current.Dispatcher.Invoke(() => WechatClawbotStatus = hint);
     }
 
     public AllConfig Config { get; set; }

--- a/BetterGenshinImpact/ViewModel/Pages/NotificationSettingsPageViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/NotificationSettingsPageViewModel.cs
@@ -97,6 +97,10 @@ public partial class NotificationSettingsPageViewModel : ObservableObject, IView
     /// </summary>
     private CancellationTokenSource? _wechatClawbotBindCts;
 
+    /// <summary>
+    /// 构造通知设置页 ViewModel，并订阅微信 Clawbot 推送会话过期事件，
+    /// 使普通发送失败时也能在设置页状态文本上提示用户如何重新激活推送端口。
+    /// </summary>
     public NotificationSettingsPageViewModel(IConfigService configService, NotificationService notificationService)
     {
         Config = configService.Get();


### PR DESCRIPTION
## 背景

微信 Clawbot 推送存在服务端限制：用户超过 12~24 小时未在微信客户端中主动给 ClawBot 发消息时，服务器拒绝推送（sendmessage 返回 `ret=-2 errcode=0 errmsg=prepare failed`）。这是微信 ClawBot 协议的服务端推送权限机制，并非客户端 token 过期，但此前日志只显示"微信 Clawbot 通知发送失败"，用户不知道如何解决。

## 改动

- **新增 `WechatClawbotSessionExpiredException`**：专门的推送会话过期异常，继承自 `NotifierException`。
- **`WechatClawbotNotifier.SendMessageAsync`**：检测 `ret == -2` 且 `errmsg` 含 `prepare` 时抛出该专门异常，并触发静态 `SessionExpired` 事件；异常消息即中文解决提示。
- **`NotifierManager`**：捕获该专门异常时输出友好中文日志：
  `微信 Clawbot 推送权限已过期，请在微信侧给 Clawbot 私聊任意内容以激活推送端口`
- **`NotificationSettingsPageViewModel`**：订阅 `SessionExpired` 静态事件，普通发送（非测试按钮）失败时也会更新设置页的 `WechatClawbotStatus` 状态文本，引导用户重新激活。

## 验证

- `dotnet build BetterGenshinImpact/BetterGenshinImpact.csproj -c Debug -p:Platform=x64` 通过（0 错误）
- 真机验证：扫码+绑定+立即发送成功；应用运行时长时间未私聊 Clawbot 时触发 prepare failed（服务端限制，本改动仅负责向用户展示解决方案）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 优化微信 Clawbot 推送会话过期的识别与提示。
  * 推送会话失效时，设置页会显示重新激活推送通道的指引。
  * 普通通知发送失败时也能及时反馈会话过期状态。
  * 其他通知发送失败仍显示通用错误提示。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->