### PR TITLE
fix: 桌面分身（RDP 子会话）中启动游戏失败（不支持该请求）

### DIFF
--- a/BetterGenshinImpact/GameTask/SystemControl.cs
+++ b/BetterGenshinImpact/GameTask/SystemControl.cs
@@ -55,9 +55,12 @@ public class SystemControl
         }
         else
         {
+            // 不使用 ShellExecuteEx（UseShellExecute=true）：桌面分身（RDP 子会话）中
+            // ShellExecuteEx 会返回“不支持该请求”（Win32 错误 50），导致游戏无法启动。
+            // 直接创建进程即可，主会话下行为不变。
             Process.Start(new ProcessStartInfo(path)
             {
-                UseShellExecute = true,
+                UseShellExecute = false,
                 Arguments = arg,
                 WorkingDirectory = workdir
             });


### PR DESCRIPTION
## 问题

在 BetterGI 的**桌面分身**（RDP 子会话）里点「同时启动原神」，游戏无法启动，BetterGI 日志记录：

```
System.ComponentModel.Win32Exception (50): An error occurred trying to start process
'D:\...\YuanShen.exe' ... 不支持该请求。
   at System.Diagnostics.Process.StartWithShellExecuteEx(ProcessStartInfo startInfo)
```

## 原因

`StartFromLocalAsync` 用 `UseShellExecute = true` 启动游戏进程，走 `ShellExecuteEx`。在桌面分身（RDP 子会话）中，`ShellExecuteEx` 返回 `ERROR_NOT_SUPPORTED`（Win32 错误 50，"不支持该请求"），导致任何经 Shell 启动的操作都失败（同样影响：分身里以管理员身份运行程序、双击快捷方式等）。

## 修复

改为 `UseShellExecute = false`，直接创建进程，绕开 `ShellExecuteEx`。主会话下行为不变。

## 验证

- 桌面分身中通过 BetterGI 启动原神：正常启动，窗口化 1920×1080 运行
- 主会话联动启动：行为不变

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **问题修复**
  * 修复在远程桌面子会话中启动游戏失败的问题。
  * 优化游戏进程的直接启动方式，同时保持主会话下的原有行为不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->