### PR TITLE
fix(pathing): 修复配置组禁用时的配置回退与战斗参数传递

### DIFF
--- a/BetterGenshinImpact/Core/Config/PathingPartyConfig.cs
+++ b/BetterGenshinImpact/Core/Config/PathingPartyConfig.cs
@@ -263,10 +263,12 @@ public partial class PathingPartyConfig : ObservableObject
 
     public static PathingPartyConfig BuildDefault()
     {
-        // 即便是不启用的情况下也设置默认值，减少后续使用的判断
+        // 运行时回退配置保持禁用标记，确保继续使用地图追踪条件和独立战斗配置
         var pathingConditionConfig = TaskContext.Instance().Config.PathingConditionConfig;
         return new PathingPartyConfig
         {
+            Enabled = false,
+            AutoFightEnabled = false,
             OnlyInTeleportRecover = pathingConditionConfig.OnlyInTeleportRecover,
             RecoverTiming = pathingConditionConfig.RecoverTiming,
             UseGadgetIntervalMs = pathingConditionConfig.UseGadgetIntervalMs,

--- a/BetterGenshinImpact/Core/Script/Group/ScriptGroupProject.cs
+++ b/BetterGenshinImpact/Core/Script/Group/ScriptGroupProject.cs
@@ -238,7 +238,7 @@ public partial class ScriptGroupProject : ObservableObject
             }
             var pathingTask = new PathExecutor(CancellationContext.Instance.Cts.Token);
             pathingTask.PartyConfig = GroupInfo?.Config.PathingConfig;
-            if (pathingTask.PartyConfig is null || pathingTask.PartyConfig.AutoPickEnabled)
+            if (!pathingTask.PartyConfig.Enabled || pathingTask.PartyConfig.AutoPickEnabled)
             {
                 TaskTriggerDispatcher.Instance().AddTrigger("AutoPick", null);
             }

--- a/BetterGenshinImpact/GameTask/AutoFight/AutoFightJsonTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/AutoFightJsonTask.cs
@@ -91,7 +91,7 @@ public class AutoFightJsonTask : ISoloTask
             _predictor = App.ServiceProvider.GetRequiredService<BgiOnnxFactory>().CreateYoloPredictor(BgiOnnxModel.BgiWorld);
         }
 
-        _finishDetectConfig = new AutoFightTask.TaskFightFinishDetectConfig(_taskParam.FinishDetectConfig);
+        _finishDetectConfig = new AutoFightTask.TaskFightFinishDetectConfig(_taskParam);
     }
 
     /// <summary>
@@ -474,7 +474,7 @@ public class AutoFightJsonTask : ISoloTask
                     {
                         if (_taskParam is { PickDropsAfterFightEnabled: true })
                         {
-                            await new ScanPickTask().Start(_ct);
+                            await new ScanPickTask().Start(_ct, _taskParam.PickDropsAfterFightSeconds);
                         }
                         return;
                     }
@@ -831,7 +831,7 @@ public class AutoFightJsonTask : ISoloTask
 
         if (_taskParam is { PickDropsAfterFightEnabled: true })
         {
-            await new ScanPickTask().Start(_ct);
+            await new ScanPickTask().Start(_ct, _taskParam.PickDropsAfterFightSeconds);
         }
     }
 

--- a/BetterGenshinImpact/GameTask/AutoFight/AutoFightParam.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/AutoFightParam.cs
@@ -30,49 +30,10 @@ public class AutoFightParam : BaseTaskParam<AutoFightTask>
     public AutoFightParam(string path, AutoFightConfig autoFightConfig) : base(null, null)
     {
         CombatStrategyPath = path;
-        Timeout = autoFightConfig.Timeout;
-        FightFinishDetectEnabled = autoFightConfig.FightFinishDetectEnabled;
-        PickDropsAfterFightEnabled = autoFightConfig.PickDropsAfterFightEnabled;
-        PickDropsAfterFightSeconds = autoFightConfig.PickDropsAfterFightSeconds;
-        KazuhaPickupEnabled = autoFightConfig.KazuhaPickupEnabled;
-        ActionSchedulerByCd = autoFightConfig.ActionSchedulerByCd;
-
-        FinishDetectConfig.FastCheckEnabled = autoFightConfig.FinishDetectConfig.FastCheckEnabled;
-        FinishDetectConfig.FastCheckParams = autoFightConfig.FinishDetectConfig.FastCheckParams;
-        FinishDetectConfig.CheckAfterSwitchAvatar = autoFightConfig.FinishDetectConfig.CheckAfterSwitchAvatar;
-        FinishDetectConfig.CheckEndDelay = autoFightConfig.FinishDetectConfig.CheckEndDelay;
-        FinishDetectConfig.BeforeDetectDelay = autoFightConfig.FinishDetectConfig.BeforeDetectDelay;
-        FinishDetectConfig.RotateFindEnemyEnabled = autoFightConfig.FinishDetectConfig.RotateFindEnemyEnabled;
-        FinishDetectConfig.SkipFightEndCheckWhenEnemyVisible = autoFightConfig.FinishDetectConfig.SkipFightEndCheckWhenEnemyVisible;
-        FinishDetectConfig.BlockCheckBeforeBattleSeconds = autoFightConfig.FinishDetectConfig.BlockCheckBeforeBattleSeconds;
-        FinishDetectConfig.PaimonEndCheckEnabled = autoFightConfig.FinishDetectConfig.PaimonEndCheckEnabled;
-        FinishDetectConfig.PaimonEndCheckDelay = autoFightConfig.FinishDetectConfig.PaimonEndCheckDelay;
-
-
-        KazuhaPartyName = autoFightConfig.KazuhaPartyName;
-        OnlyPickEliteDropsMode = autoFightConfig.OnlyPickEliteDropsMode;
-        BattleThresholdForLoot = autoFightConfig.BattleThresholdForLoot ?? BattleThresholdForLoot;
+        ApplyConfig(autoFightConfig);
         //下面参数固定，只取自动战斗里面的
         FinishDetectConfig.BattleEndProgressBarColor = TaskContext.Instance().Config.AutoFightConfig.FinishDetectConfig.BattleEndProgressBarColor;
         FinishDetectConfig.BattleEndProgressBarColorTolerance = TaskContext.Instance().Config.AutoFightConfig.FinishDetectConfig.BattleEndProgressBarColorTolerance;
-
-        GuardianAvatar = autoFightConfig.GuardianAvatar;
-        GuardianCombatSkip = autoFightConfig.GuardianCombatSkip;
-        GuardianAvatarHold = autoFightConfig.GuardianAvatarHold;
-        BurstEnabled = autoFightConfig.BurstEnabled;
-        
-        CheckBeforeBurst = autoFightConfig.FinishDetectConfig.CheckBeforeBurst;
-        IsFirstCheck = autoFightConfig.FinishDetectConfig.IsFirstCheck;
-        RotaryFactor = autoFightConfig.FinishDetectConfig.RotaryFactor;
-        FinishDetectConfig.SkipFightEndCheckWhenEnemyVisible = autoFightConfig.FinishDetectConfig.SkipFightEndCheckWhenEnemyVisible;
-        EnableCombatTargeting = autoFightConfig.EnableCombatTargeting;
-        TargetingDetectionInterval = autoFightConfig.TargetingDetectionInterval;
-        DrawRecognitionResults = autoFightConfig.DrawRecognitionResults;
-        LockLostWaitTime = autoFightConfig.LockLostWaitTime;
-        DamageNumberRecognitionMode = autoFightConfig.DamageNumberRecognitionMode;
-        QinDoublePickUp = autoFightConfig.QinDoublePickUp;
-        SwimmingEnabled = autoFightConfig.SwimmingEnabled;
-        ExpBasedPickupEnabled = autoFightConfig.ExpBasedPickupEnabled;
     }
 
     public FightFinishDetectConfig FinishDetectConfig { get; set; } = new();
@@ -168,7 +129,11 @@ public class AutoFightParam : BaseTaskParam<AutoFightTask>
 
     public void SetDefault()
     {
-        var autoFightConfig = TaskContext.Instance().Config.AutoFightConfig;
+        ApplyConfig(TaskContext.Instance().Config.AutoFightConfig);
+    }
+
+    private void ApplyConfig(AutoFightConfig autoFightConfig)
+    {
         Timeout = autoFightConfig.Timeout;
         FightFinishDetectEnabled = autoFightConfig.FightFinishDetectEnabled;
         PickDropsAfterFightEnabled = autoFightConfig.PickDropsAfterFightEnabled;
@@ -190,13 +155,16 @@ public class AutoFightParam : BaseTaskParam<AutoFightTask>
         KazuhaPartyName = autoFightConfig.KazuhaPartyName;
         OnlyPickEliteDropsMode = autoFightConfig.OnlyPickEliteDropsMode;
         BattleThresholdForLoot = autoFightConfig.BattleThresholdForLoot ?? BattleThresholdForLoot;
-        //下面参数固定，只取自动战斗里面的
         FinishDetectConfig.BattleEndProgressBarColor = autoFightConfig.FinishDetectConfig.BattleEndProgressBarColor;
         FinishDetectConfig.BattleEndProgressBarColorTolerance = autoFightConfig.FinishDetectConfig.BattleEndProgressBarColorTolerance;
 
         GuardianAvatar = autoFightConfig.GuardianAvatar;
         GuardianCombatSkip = autoFightConfig.GuardianCombatSkip;
         GuardianAvatarHold = autoFightConfig.GuardianAvatarHold;
+        BurstEnabled = autoFightConfig.BurstEnabled;
+        CheckBeforeBurst = autoFightConfig.FinishDetectConfig.CheckBeforeBurst;
+        IsFirstCheck = autoFightConfig.FinishDetectConfig.IsFirstCheck;
+        RotaryFactor = autoFightConfig.FinishDetectConfig.RotaryFactor;
         SwimmingEnabled = autoFightConfig.SwimmingEnabled;
         QinDoublePickUp = autoFightConfig.QinDoublePickUp;
         EnableCombatTargeting = autoFightConfig.EnableCombatTargeting;

--- a/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
@@ -87,9 +87,11 @@ public class AutoFightTask : ISoloTask
         public double BlockCheckBeforeBattleSeconds = 0;
         public bool PaimonEndCheckEnabled = true;
         public int PaimonEndCheckDelayMs = 75;
+        public int RotaryFactor = 6;
 
-        public TaskFightFinishDetectConfig(AutoFightParam.FightFinishDetectConfig finishDetectConfig)
+        public TaskFightFinishDetectConfig(AutoFightParam taskParam)
         {
+            var finishDetectConfig = taskParam.FinishDetectConfig;
             FastCheckEnabled = finishDetectConfig.FastCheckEnabled;
             CheckAfterSwitchAvatar = finishDetectConfig.CheckAfterSwitchAvatar;
             ParseCheckTimeString(finishDetectConfig.FastCheckParams, out CheckTime, CheckNames);
@@ -107,6 +109,7 @@ public class AutoFightTask : ISoloTask
             PaimonEndCheckEnabled = finishDetectConfig.PaimonEndCheckEnabled;
             // 派蒙检测延时（秒）限制在 0.05-0.4 之间，超出范围时修饰到对应上下限
             PaimonEndCheckDelayMs = (int)(Math.Clamp(finishDetectConfig.PaimonEndCheckDelay, 0.05, 0.4) * 1000);
+            RotaryFactor = Math.Clamp(taskParam.RotaryFactor, 1, 13);
         }
 
         public (int, int, int) BattleEndProgressBarColor { get; }
@@ -235,7 +238,7 @@ public class AutoFightTask : ISoloTask
             _predictor = App.ServiceProvider.GetRequiredService<BgiOnnxFactory>().CreateYoloPredictor(BgiOnnxModel.BgiWorld);
         }
 
-        _finishDetectConfig = new TaskFightFinishDetectConfig(_taskParam.FinishDetectConfig);
+        _finishDetectConfig = new TaskFightFinishDetectConfig(_taskParam);
     }
     public CombatScenes GetCombatScenesWithRetry()
     {
@@ -399,7 +402,7 @@ public class AutoFightTask : ISoloTask
                         {
                             using (AvatarRecognition.BeginExclusiveOperation())
                             {
-                                await AutoFightSeek.SeekAndFightAsync(Logger, detectDelayTime, delayTime, ct, true, _taskParam.RotaryFactor);
+                                await AutoFightSeek.SeekAndFightAsync(Logger, detectDelayTime, delayTime, ct, true, _finishDetectConfig.RotaryFactor);
                             }
                         }
                         
@@ -958,7 +961,8 @@ public class AutoFightTask : ISoloTask
                 bool? result = null;
                 try
                 {
-                    result = await AutoFightSeek.SeekAndFightAsync(Logger, detectDelayTime, delayTime, ct);
+                    result = await AutoFightSeek.SeekAndFightAsync(Logger, detectDelayTime, delayTime, ct,
+                        rotaryFactor: finishDetectConfig.RotaryFactor);
                 }
                 catch (Exception ex)
                 {

--- a/BetterGenshinImpact/GameTask/AutoFight/Model/CombatScenes.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Model/CombatScenes.cs
@@ -390,18 +390,12 @@ public class CombatScenes : IDisposable
     /// <returns>返回配置中有效的角色名</returns>
     public List<string> UpdateActionSchedulerByCd(string cdConfig)
     {
-        if (string.IsNullOrEmpty(cdConfig))
-        {
-            return [];
-        }
-
         List<string> names = [];
         foreach (var t in Avatars)
         {
             var mCd = Avatar.ParseActionSchedulerByCd(t.Name, cdConfig);
-            // 手动cd不为0，不是麦当劳不是0
+            t.ManualSkillCd = mCd ?? -1;
             if (mCd is null) continue;
-            t.ManualSkillCd = (double)mCd;
             names.Add(t.Name);
         }
 

--- a/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
@@ -64,7 +64,7 @@ public partial class PathExecutor
 
     public PathingPartyConfig PartyConfig
     {
-        get => _partyConfig ?? PathingPartyConfig.BuildDefault();
+        get => _partyConfig ??= PathingPartyConfig.BuildDefault();
         set => _partyConfig = value;
     }
 
@@ -356,7 +356,7 @@ public partial class PathExecutor
             {
                 // 调度器未配置的情况下，根据地图追踪条件配置切换队伍
                 var partyName = FilterPartyNameByConditionConfig(task);
-                if (!await SwitchParty(partyName))
+                if (!await SwitchParty(partyName, false))
                 {
                     Logger.LogError("切换队伍失败，无法执行此路径！请检查地图追踪设置！");
                     return false;
@@ -364,7 +364,7 @@ public partial class PathExecutor
             }
             else if (!string.IsNullOrEmpty(PartyConfig.PartyName))
             {
-                if (!await SwitchParty(PartyConfig.PartyName))
+                if (!await SwitchParty(PartyConfig.PartyName, PartyConfig.IsVisitStatueBeforeSwitchParty))
                 {
                     Logger.LogError("切换队伍失败，无法执行此路径！请检查配置组中的地图追踪配置！");
                     return false;
@@ -405,8 +405,9 @@ public partial class PathExecutor
     /// 切换队伍
     /// </summary>
     /// <param name="partyName"></param>
+    /// <param name="forceTp">切换前是否前往七天神像</param>
     /// <returns></returns>
-    private async Task<bool> SwitchParty(string? partyName)
+    private async Task<bool> SwitchParty(string? partyName, bool forceTp)
     {
         bool success = true;
         if (!string.IsNullOrEmpty(partyName))
@@ -415,8 +416,6 @@ public partial class PathExecutor
             {
                 return success;
             }
-
-            bool forceTp = PartyConfig.IsVisitStatueBeforeSwitchParty;
 
             if (forceTp) // 强制传送模式
             {


### PR DESCRIPTION
## 问题背景

配置组未勾选启用地图追踪配置或自动战斗配置时，运行时回退对象仍保留默认启用状态，导致后续逻辑将其视为配置组配置，实际使用各字段默认值，而不是对应独立任务中的配置。

同时，配置组自动战斗配置传入 AutoFightParam 时存在部分字段遗漏，部分运行逻辑也仍使用固定默认值。

## 改动内容

### 1. 修复配置组禁用时的配置回退

- PathingPartyConfig.BuildDefault 明确保持 Enabled 和 AutoFightEnabled 为 false。
- 配置组未启用时，自动战斗回退到独立自动战斗任务配置。
- 地图追踪行走配置继续使用独立地图追踪条件配置。
- 自动拾取触发器与切换队伍前传送逻辑按配置组启用状态分别处理。

### 2. 完善自动战斗配置参数传递

- 新增统一的 ApplyConfig 映射，独立任务与配置组共用同一套参数复制逻辑。
- 对两处有效 UI 配置逐项核对，共 35 项，除 StrategyName 转换为 CombatStrategyPath 外，其余配置均进入 AutoFightParam。
- 补齐 BurstEnabled、CheckBeforeBurst、IsFirstCheck、RotaryFactor 等此前遗漏字段。
- 配置组独有的 BattleThresholdForLoot、OnlyPickEliteDropsMode、KazuhaPartyName 保持正常传递。

### 3. 修复配置在执行阶段被默认值覆盖

- 战斗结束检测使用当前任务传入的旋转因子，并限制在 1-13 范围内。
- JSON 策略的战后扫描拾取使用配置的持续时间。
- 当前任务未配置技能 CD 调度时，清除队伍初始化阶段从独立任务配置带入的手动 CD。
- JSON 暂无执行语义的 TXT 专属配置仅传入 AutoFightParam，不额外改变 JSON 策略行为。

## 验证

- 有效 UI 配置项：35
- 参数映射缺失项：0
- dotnet build BetterGenshinImpact.sln -c Debug
- 编译结果：0 个错误；警告均为仓库现有警告

## 涉及文件

- BetterGenshinImpact/Core/Config/PathingPartyConfig.cs
- BetterGenshinImpact/Core/Script/Group/ScriptGroupProject.cs
- BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
- BetterGenshinImpact/GameTask/AutoFight/AutoFightParam.cs
- BetterGenshinImpact/GameTask/AutoFight/AutoFightTask.cs
- BetterGenshinImpact/GameTask/AutoFight/AutoFightJsonTask.cs
- BetterGenshinImpact/GameTask/AutoFight/Model/CombatScenes.cs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 修复路径追踪任务在队伍配置未启用时的自动拾取触发逻辑。
  * 修复自动战斗配置部分选项未正确应用的问题。
  * 修复技能冷却时间读取失败后仍保留旧值的问题。
  * 改善战斗结束检测及寻敌流程，提升战斗稳定性。
  * 修复队伍切换与传送行为，避免不必要的传送。

* **改进**
  * 优化战后拾取时长配置，使拾取行为更符合设置。
  * 支持调整战斗中的旋转检测系数。
  * 缓存路径追踪默认队伍配置，提升运行一致性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->