### PR TITLE
feat(one-dragon): 为一条龙任务新增日期判断机制

### DIFF
--- a/BetterGenshinImpact/Core/Config/OneDragonFlowConfig.cs
+++ b/BetterGenshinImpact/Core/Config/OneDragonFlowConfig.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using BetterGenshinImpact.GameTask;
 using BetterGenshinImpact.GameTask.AutoLeyLineOutcrop;
 using BetterGenshinImpact.Helpers;
+using BetterGenshinImpact.Model;
 using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace BetterGenshinImpact.Core.Config;
@@ -32,6 +33,20 @@ public partial class OneDragonFlowConfig : ObservableObject
     /// 任务定义（Id → 任务名），用于支持同名任务重复添加
     /// </summary>
     public Dictionary<string, string> TaskDefinitions { get; set; } = new();
+
+    /// <summary>
+    /// 任务条件（Id → 条件对象），键不存在或条件对象所有属性为 false 表示每天运行
+    /// </summary>
+    public Dictionary<string, OneDragonTaskCondition> TaskConditions { get; set; } = new();
+
+    public OneDragonTaskCondition GetTaskCondition(string id)
+    {
+        if (TaskConditions != null && TaskConditions.TryGetValue(id, out var condition) && condition != null)
+        {
+            return condition;
+        }
+        return new OneDragonTaskCondition();
+    }
     // 合成树脂的国家
     [ObservableProperty]
     private string _craftingBenchCountry = "枫丹";

--- a/BetterGenshinImpact/Model/OneDragonTaskCondition.cs
+++ b/BetterGenshinImpact/Model/OneDragonTaskCondition.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace BetterGenshinImpact.Model;
+
+[Serializable]
+public class OneDragonTaskCondition
+{
+    public bool RunMonday { get; set; } = false;
+
+    public bool RunTuesday { get; set; } = false;
+
+    public bool RunWednesday { get; set; } = false;
+
+    public bool RunThursday { get; set; } = false;
+
+    public bool RunFriday { get; set; } = false;
+
+    public bool RunSaturday { get; set; } = false;
+
+    public bool RunSunday { get; set; } = false;
+
+    public OneDragonTaskCondition()
+    {
+    }
+}

--- a/BetterGenshinImpact/Model/OneDragonTaskItem.cs
+++ b/BetterGenshinImpact/Model/OneDragonTaskItem.cs
@@ -97,6 +97,26 @@ public partial class OneDragonTaskItem : ObservableObject
         }
     }
 
+    /// <summary>
+    /// 在服务器游戏日切换或外部强制刷新时，手动触发 ShouldRunToday 及 HasCondition 的属性变更通知。
+    /// </summary>
+    public void NotifyDateStateChanged()
+    {
+        OnPropertyChanged(nameof(ShouldRunToday));
+        OnPropertyChanged(nameof(HasCondition));
+    }
+
+    /// <summary>
+    /// 创建一个用于条件弹窗编辑的临时副本，仅复制名称、Id 与运行日条件，
+    /// 修改此副本不会影响原任务在列表中的状态或触发自动保存。
+    /// </summary>
+    public OneDragonTaskItem CreateConditionEditingClone()
+    {
+        var clone = new OneDragonTaskItem(Name, Id);
+        clone.ApplyCondition(ToCondition());
+        return clone;
+    }
+
     public OneDragonTaskItem(string name)
     {
         Name = name;

--- a/BetterGenshinImpact/Model/OneDragonTaskItem.cs
+++ b/BetterGenshinImpact/Model/OneDragonTaskItem.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
+using BetterGenshinImpact.Helpers;
 using BetterGenshinImpact.ViewModel.Pages.OneDragon;
 using CommunityToolkit.Mvvm.ComponentModel;
 using System.Windows.Media;
@@ -31,7 +33,69 @@ public partial class OneDragonTaskItem : ObservableObject
 
     [ObservableProperty] private OneDragonBaseViewModel? _viewModel;
 
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasCondition))]
+    [NotifyPropertyChangedFor(nameof(ShouldRunToday))]
+    private bool _runMonday = false;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasCondition))]
+    [NotifyPropertyChangedFor(nameof(ShouldRunToday))]
+    private bool _runTuesday = false;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasCondition))]
+    [NotifyPropertyChangedFor(nameof(ShouldRunToday))]
+    private bool _runWednesday = false;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasCondition))]
+    [NotifyPropertyChangedFor(nameof(ShouldRunToday))]
+    private bool _runThursday = false;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasCondition))]
+    [NotifyPropertyChangedFor(nameof(ShouldRunToday))]
+    private bool _runFriday = false;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasCondition))]
+    [NotifyPropertyChangedFor(nameof(ShouldRunToday))]
+    private bool _runSaturday = false;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasCondition))]
+    [NotifyPropertyChangedFor(nameof(ShouldRunToday))]
+    private bool _runSunday = false;
+
     public Func<Task>? Action { get; private set; }
+
+    public bool HasCondition => RunMonday || RunTuesday || RunWednesday || RunThursday || RunFriday || RunSaturday || RunSunday;
+
+    public bool ShouldRunToday
+    {
+        get
+        {
+            if (!HasCondition)
+            {
+                return true;
+            }
+
+            var serverTime = ServerTimeHelper.GetServerTimeNow();
+            var dayOfWeek = (serverTime.Hour >= 4 ? serverTime : serverTime.AddDays(-1)).DayOfWeek;
+            return dayOfWeek switch
+            {
+                DayOfWeek.Monday => RunMonday,
+                DayOfWeek.Tuesday => RunTuesday,
+                DayOfWeek.Wednesday => RunWednesday,
+                DayOfWeek.Thursday => RunThursday,
+                DayOfWeek.Friday => RunFriday,
+                DayOfWeek.Saturday => RunSaturday,
+                DayOfWeek.Sunday => RunSunday,
+                _ => true
+            };
+        }
+    }
 
     public OneDragonTaskItem(string name)
     {
@@ -41,6 +105,61 @@ public partial class OneDragonTaskItem : ObservableObject
     public OneDragonTaskItem(string name, string id) : this(name)
     {
         _id = id;
+    }
+
+    public string GetConditionSummaryText()
+    {
+        if (!HasCondition)
+        {
+            return "每天";
+        }
+
+        var list = new List<string>();
+        if (RunMonday) list.Add("周一");
+        if (RunTuesday) list.Add("周二");
+        if (RunWednesday) list.Add("周三");
+        if (RunThursday) list.Add("周四");
+        if (RunFriday) list.Add("周五");
+        if (RunSaturday) list.Add("周六");
+        if (RunSunday) list.Add("周日");
+        return string.Join("、", list);
+    }
+
+    public OneDragonTaskCondition ToCondition()
+    {
+        return new OneDragonTaskCondition
+        {
+            RunMonday = RunMonday,
+            RunTuesday = RunTuesday,
+            RunWednesday = RunWednesday,
+            RunThursday = RunThursday,
+            RunFriday = RunFriday,
+            RunSaturday = RunSaturday,
+            RunSunday = RunSunday
+        };
+    }
+
+    public void ApplyCondition(OneDragonTaskCondition? condition)
+    {
+        if (condition == null)
+        {
+            RunMonday = false;
+            RunTuesday = false;
+            RunWednesday = false;
+            RunThursday = false;
+            RunFriday = false;
+            RunSaturday = false;
+            RunSunday = false;
+            return;
+        }
+
+        RunMonday = condition.RunMonday;
+        RunTuesday = condition.RunTuesday;
+        RunWednesday = condition.RunWednesday;
+        RunThursday = condition.RunThursday;
+        RunFriday = condition.RunFriday;
+        RunSaturday = condition.RunSaturday;
+        RunSunday = condition.RunSunday;
     }
 
     // public OneDragonTaskItem(Type viewModelType, Func<Task> action)

--- a/BetterGenshinImpact/View/Behavior/RightClickSelectBehavior.cs
+++ b/BetterGenshinImpact/View/Behavior/RightClickSelectBehavior.cs
@@ -1,4 +1,4 @@
-﻿using System.Windows;
+using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
@@ -22,15 +22,28 @@ public static class RightClickSelectBehavior
 
     private static void OnEnabledChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
-        if (d is TreeView treeView)
+        if ((bool)e.NewValue)
         {
-            if ((bool)e.NewValue)
-            {
-                treeView.PreviewMouseRightButtonDown += OnPreviewMouseRightButtonDown;
-            }
-            else
+            if (d is TreeView treeView)
             {
                 treeView.PreviewMouseRightButtonDown -= OnPreviewMouseRightButtonDown;
+                treeView.PreviewMouseRightButtonDown += OnPreviewMouseRightButtonDown;
+            }
+            else if (d is ListView listView)
+            {
+                listView.PreviewMouseRightButtonDown -= OnPreviewMouseRightButtonDown;
+                listView.PreviewMouseRightButtonDown += OnPreviewMouseRightButtonDown;
+            }
+        }
+        else
+        {
+            if (d is TreeView treeView)
+            {
+                treeView.PreviewMouseRightButtonDown -= OnPreviewMouseRightButtonDown;
+            }
+            else if (d is ListView listView)
+            {
+                listView.PreviewMouseRightButtonDown -= OnPreviewMouseRightButtonDown;
             }
         }
     }
@@ -40,6 +53,15 @@ public static class RightClickSelectBehavior
         if (sender is TreeView treeView)
         {
             var item = VisualUpwardSearch<TreeViewItem>(e.OriginalSource as DependencyObject);
+            if (item != null)
+            {
+                item.Focus();
+                item.IsSelected = true;
+            }
+        }
+        else if (sender is ListView listView)
+        {
+            var item = VisualUpwardSearch<ListViewItem>(e.OriginalSource as DependencyObject);
             if (item != null)
             {
                 item.Focus();

--- a/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml
+++ b/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml
@@ -1,4 +1,5 @@
 <UserControl x:Class="BetterGenshinImpact.View.Pages.OneDragonFlowPage"
+             x:Name="OneDragonRoot"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:b="http://schemas.microsoft.com/xaml/behaviors"
@@ -38,19 +39,24 @@
 
         <!--  左侧任务列表  -->
        <DockPanel Grid.Column="0"
+                  Tag="{Binding ElementName=TaskListView}"
                   ContextMenuOpening="DockPanel_ContextMenuOpening">
            <DockPanel.ContextMenu>
                <ContextMenu>
                    <MenuItem Command="{Binding AddTaskGroupCommand}" Header="{i18n:T 新增配置}" />
                    <MenuItem Command="{Binding DeleteTaskGroupCommand}"
-                             CommandParameter="{Binding SelectedItem, RelativeSource={RelativeSource AncestorType=ui:ListView}}"
+                             CommandParameter="{Binding PlacementTarget.Tag.SelectedItem, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
                              Header="{i18n:T 删除}" />
                    <Separator />
                    <MenuItem Command="{Binding NextTaskGroupCommand}"
-                             CommandParameter="{Binding SelectedItem, RelativeSource={RelativeSource AncestorType=ui:ListView}}"
+                             CommandParameter="{Binding PlacementTarget.Tag.SelectedItem, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
                              Header="{i18n:T 从此执行}" />
                    <MenuItem Command="{Binding ClearNextTaskGroupCommand}"
                              Header="{i18n:T 清除标记}" />
+                   <Separator />
+                   <MenuItem Header="设置执行条件…"
+                             Command="{Binding OpenTaskConditionCommand}"
+                             CommandParameter="{Binding PlacementTarget.Tag.SelectedItem, RelativeSource={RelativeSource AncestorType=ContextMenu}}" />
                </ContextMenu>
            </DockPanel.ContextMenu>
        <Grid DockPanel.Dock="Top"
@@ -145,7 +151,8 @@
             <Style TargetType="ContentControl">
                 <Setter Property="Content">
                     <Setter.Value>
-                        <ui:ListView dd:DragDrop.IsDragSource="True"
+                        <ui:ListView x:Name="TaskListView"
+                                     dd:DragDrop.IsDragSource="True"
                                      dd:DragDrop.IsDropTarget="True"
                                      dd:DragDrop.UseDefaultDragAdorner="True"
                                      ItemsSource="{Binding TaskList}"
@@ -159,6 +166,7 @@
                                                 <ColumnDefinition Width="Auto" />
                                                 <ColumnDefinition Width="Auto" />
                                                 <ColumnDefinition Width="*" />
+                                                <ColumnDefinition Width="Auto" />
                                                 <ColumnDefinition Width="Auto" />
                                             </Grid.ColumnDefinitions>
                                             <ui:FontIcon Grid.Column="0"
@@ -185,9 +193,62 @@
                                                     </Style>
                                                 </TextBlock.Style>
                                             </TextBlock>
-                                            
-                                            
-                                            <ui:ToggleSwitch Grid.Column="3" IsChecked="{Binding IsEnabled, Mode=TwoWay}" />
+
+                                            <ui:Button Grid.Column="3"
+                                                       Command="{Binding DataContext.OpenTaskConditionCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                                       CommandParameter="{Binding}">
+                                                <ui:Button.Style>
+                                                    <Style TargetType="ui:Button">
+                                                        <Setter Property="Background" Value="Transparent" />
+                                                        <Setter Property="BorderBrush" Value="Transparent" />
+                                                        <Setter Property="BorderThickness" Value="0" />
+                                                        <Setter Property="Padding" Value="4" />
+                                                        <Setter Property="ToolTip" Value="未设置执行条件（每天执行），点击设置" />
+                                                        <Setter Property="Template">
+                                                            <Setter.Value>
+                                                                <ControlTemplate TargetType="ui:Button">
+                                                                    <ContentPresenter Content="{TemplateBinding Content}"
+                                                                                      ContentTemplate="{TemplateBinding ContentTemplate}"
+                                                                                      HorizontalAlignment="Center"
+                                                                                      VerticalAlignment="Center" />
+                                                                </ControlTemplate>
+                                                            </Setter.Value>
+                                                        </Setter>
+                                                        <Style.Triggers>
+                                                            <DataTrigger Binding="{Binding HasCondition}" Value="True">
+                                                                <Setter Property="ToolTip" Value="已设置执行条件，点击修改" />
+                                                            </DataTrigger>
+                                                        </Style.Triggers>
+                                                    </Style>
+                                                </ui:Button.Style>
+                                                <ui:SymbolIcon Symbol="CalendarDay24">
+                                                    <ui:SymbolIcon.Style>
+                                                        <Style TargetType="ui:SymbolIcon">
+                                                            <Setter Property="Opacity" Value="1.0" />
+                                                            <Setter Property="Foreground" Value="{ui:ThemeResource TextFillColorTertiaryBrush}" />
+                                                            <Style.Triggers>
+                                                                <DataTrigger Binding="{Binding HasCondition}" Value="True">
+                                                                    <Setter Property="Opacity" Value="1.0" />
+                                                                    <Setter Property="Foreground">
+                                                                        <Setter.Value>
+                                                                            <SolidColorBrush Color="#FF1E90FF" />
+                                                                        </Setter.Value>
+                                                                    </Setter>
+                                                                </DataTrigger>
+                                                                <MultiDataTrigger>
+                                                                    <MultiDataTrigger.Conditions>
+                                                                        <Condition Binding="{Binding HasCondition}" Value="True" />
+                                                                        <Condition Binding="{Binding ShouldRunToday}" Value="False" />
+                                                                    </MultiDataTrigger.Conditions>
+                                                                    <Setter Property="Opacity" Value="0.6" />
+                                                                </MultiDataTrigger>
+                                                            </Style.Triggers>
+                                                        </Style>
+                                                    </ui:SymbolIcon.Style>
+                                                </ui:SymbolIcon>
+                                            </ui:Button>
+
+                                            <ui:ToggleSwitch Grid.Column="4" IsChecked="{Binding IsEnabled, Mode=TwoWay}" />
                                         </Grid>
                                     </ui:Card>
                                 </DataTemplate>
@@ -2161,5 +2222,92 @@
                 </StackPanel>
             </ScrollViewer>
         </DockPanel>
+
+        <!--  任务执行条件设置 Popup  -->
+        <Popup x:Name="TaskConditionPopup"
+               PlacementTarget="{Binding ElementName=OneDragonRoot}"
+               Placement="Center"
+               AllowsTransparency="True"
+               PopupAnimation="Fade"
+               StaysOpen="True"
+               IsOpen="{Binding ShouldShowTaskConditionPopup, Mode=TwoWay}">
+            <Border CornerRadius="8"
+                    Background="{DynamicResource ApplicationBackgroundBrush}"
+                    BorderBrush="{DynamicResource SystemAccentColorPrimaryBrush}"
+                    BorderThickness="1"
+                    MinWidth="380">
+                <StackPanel Margin="18">
+                    <TextBlock FontSize="16"
+                               FontWeight="Bold"
+                               Margin="0,0,0,12"
+                               HorizontalAlignment="Center"
+                               Text="{Binding ConditionEditingTask.Name, StringFormat=任务执行条件 - {0}}" />
+
+                    <UniformGrid Rows="2" Columns="4" Margin="0,0,0,8">
+                        <CheckBox Content="周一" Margin="6"
+                                  IsChecked="{Binding ConditionEditingTask.RunMonday, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                        <CheckBox Content="周二" Margin="6"
+                                  IsChecked="{Binding ConditionEditingTask.RunTuesday, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                        <CheckBox Content="周三" Margin="6"
+                                  IsChecked="{Binding ConditionEditingTask.RunWednesday, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                        <CheckBox Content="周四" Margin="6"
+                                  IsChecked="{Binding ConditionEditingTask.RunThursday, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                        <CheckBox Content="周五" Margin="6"
+                                  IsChecked="{Binding ConditionEditingTask.RunFriday, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                        <CheckBox Content="周六" Margin="6"
+                                  IsChecked="{Binding ConditionEditingTask.RunSaturday, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                        <CheckBox Content="周日" Margin="6"
+                                  IsChecked="{Binding ConditionEditingTask.RunSunday, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                    </UniformGrid>
+
+                    <Grid Margin="0,4,0,12">
+                        <TextBlock Foreground="{DynamicResource TextFillColorTertiaryBrush}"
+                                   FontSize="12"
+                                   Text="当前：每天执行（未勾选任何日期则为每天）">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="Visibility" Value="Visible" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding ConditionEditingTask.HasCondition}" Value="True">
+                                            <Setter Property="Visibility" Value="Collapsed" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
+                        <TextBlock Foreground="{DynamicResource SystemAccentColorPrimaryBrush}"
+                                   FontSize="12"
+                                   Text="当前：设置了执行日期，仅勾选日运行">
+                            <TextBlock.Style>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding ConditionEditingTask.HasCondition}" Value="True">
+                                            <Setter Property="Visibility" Value="Visible" />
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </TextBlock.Style>
+                        </TextBlock>
+                    </Grid>
+
+                    <StackPanel Orientation="Horizontal"
+                                HorizontalAlignment="Center">
+                        <ui:Button Content="重置"
+                                   Width="72"
+                                   Margin="0,0,8,0"
+                                   Command="{Binding ResetTaskConditionCommand}" />
+                        <ui:Button Content="取消"
+                                   Width="72"
+                                   Margin="0,0,8,0"
+                                   Command="{Binding CancelTaskConditionCommand}" />
+                        <ui:Button Content="确认"
+                                   Width="72"
+                                   Appearance="Primary"
+                                   Command="{Binding CloseTaskConditionCommand}" />
+                    </StackPanel>
+                </StackPanel>
+            </Border>
+        </Popup>
     </Grid>
 </UserControl>

--- a/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml
+++ b/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml
@@ -39,10 +39,9 @@
 
         <!--  左侧任务列表  -->
        <DockPanel Grid.Column="0"
-                  Tag="{Binding ElementName=TaskListView}"
-                  ContextMenuOpening="DockPanel_ContextMenuOpening">
+                  Tag="{Binding ElementName=TaskListView}">
            <DockPanel.ContextMenu>
-               <ContextMenu>
+               <ContextMenu DataContext="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource Self}}">
                    <MenuItem Command="{Binding AddTaskGroupCommand}" Header="{i18n:T 新增配置}" />
                    <MenuItem Command="{Binding DeleteTaskGroupCommand}"
                              CommandParameter="{Binding PlacementTarget.Tag.SelectedItem, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
@@ -157,7 +156,8 @@
                                      dd:DragDrop.UseDefaultDragAdorner="True"
                                      ItemsSource="{Binding TaskList}"
                                      SelectedItem="{Binding SelectedTask, Mode=TwoWay}"
-                                     SelectionMode="Single">
+                                     SelectionMode="Single"
+                                     behavior:RightClickSelectBehavior.Enabled="True">
                             <ui:ListView.ItemTemplate>
                                 <DataTemplate>
                                     <ui:Card Margin="0,2,14,2">

--- a/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml
+++ b/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml
@@ -185,9 +185,19 @@
                                                 <TextBlock.Style>
                                                     <Style TargetType="TextBlock" BasedOn="{StaticResource {x:Type TextBlock}}">
                                                         <Setter Property="Foreground" Value="{DynamicResource TextFillColorPrimaryBrush}" />
+                                                        <Setter Property="Opacity" Value="1.0" />
                                                         <Style.Triggers>
+                                                            <MultiDataTrigger>
+                                                                <MultiDataTrigger.Conditions>
+                                                                    <Condition Binding="{Binding HasCondition}" Value="True" />
+                                                                    <Condition Binding="{Binding ShouldRunToday}" Value="False" />
+                                                                </MultiDataTrigger.Conditions>
+                                                                <Setter Property="Foreground" Value="{DynamicResource TextFillColorTertiaryBrush}" />
+                                                                <Setter Property="Opacity" Value="0.7" />
+                                                            </MultiDataTrigger>
                                                             <DataTrigger Binding="{Binding IsNextTask}" Value="True">
                                                                 <Setter Property="Foreground" Value="DodgerBlue" />
+                                                                <Setter Property="Opacity" Value="1.0" />
                                                             </DataTrigger>
                                                         </Style.Triggers>
                                                     </Style>
@@ -221,7 +231,7 @@
                                                         </Style.Triggers>
                                                     </Style>
                                                 </ui:Button.Style>
-                                                <ui:SymbolIcon Symbol="CalendarDay24">
+                                                <ui:SymbolIcon Symbol="Filter24">
                                                     <ui:SymbolIcon.Style>
                                                         <Style TargetType="ui:SymbolIcon">
                                                             <Setter Property="Opacity" Value="1.0" />

--- a/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml
+++ b/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml
@@ -27,7 +27,10 @@
 
     <b:Interaction.Triggers>
         <b:EventTrigger EventName="Loaded">
-            <b:InvokeCommandAction Command="{Binding LoadedCommand}" CommandParameter="{Binding}" />
+            <b:InvokeCommandAction Command="{Binding OnLoadedCommand}" />
+        </b:EventTrigger>
+        <b:EventTrigger EventName="Unloaded">
+            <b:InvokeCommandAction Command="{Binding UnloadedCommand}" />
         </b:EventTrigger>
     </b:Interaction.Triggers>
     

--- a/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml.cs
+++ b/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml.cs
@@ -2,28 +2,27 @@ using BetterGenshinImpact.ViewModel.Pages;
 using System.Windows;
 using System.Windows.Controls;
 using Wpf.Ui.Violeta.Controls;
-using System.Linq; 
+using System.Linq;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using BetterGenshinImpact.Core.Script.Group;
 using System;
-using System.Threading.Tasks;
 
 namespace BetterGenshinImpact.View.Pages;
 
 public partial class OneDragonFlowPage
 {
     public OneDragonFlowViewModel ViewModel { get; }
-    
+
     private readonly Dictionary<CheckBox, string> _checkBoxMappings;
-    
+
     public static readonly List<string> SereniteaPotSchedule = new List<string> { "每天重复", "星期一", "星期二", "星期三", "星期四", "星期五", "星期六", "星期日" };
 
     public OneDragonFlowPage(OneDragonFlowViewModel viewModel)
     {
         DataContext = ViewModel = viewModel;
         InitializeComponent();
-        
+
         _checkBoxMappings = new Dictionary<CheckBox, string>
         {
             { ClothCheckBox, "布匹" },
@@ -35,34 +34,10 @@ public partial class OneDragonFlowPage
             { ExpBottleBigCheckBox, "祝圣精华" },
             { ExpBottleSmallCheckBox, "祝圣油膏" }
         };
-        
+
         // 监听ViewModel的属性变化
         ViewModel.PropertyChanged += ViewModel_PropertyChanged;
-        Loaded += OnPageLoaded;
-        Unloaded += OnPageUnloaded;
-    }
-
-    private void OnPageLoaded(object sender, RoutedEventArgs e)
-    {
-        // 每次页面重新进入时，让 ViewModel 触发一次 OnLoaded（命令行/刷新循环），避免在 NavigationCache 模式下不复用构造函数导致刷新循环停止。
-        ViewModel?.OnLoaded();
-    }
-
-    private async void OnPageUnloaded(object sender, RoutedEventArgs e)
-    {
-        // 页面卸载时释放服务器日界刷新后台循环的 CancellationTokenSource，
-        // 避免后台任务保持对 ViewModel/TaskList 的引用导致内存泄漏或退出后仍运行。
-        try
-        {
-            if (ViewModel != null)
-            {
-                await ViewModel.StopDailyRefreshLoopAsync(true).ConfigureAwait(false);
-            }
-        }
-        catch (Exception ex)
-        {
-            System.Diagnostics.Debug.WriteLine($"[OneDragonFlowPage] StopDailyRefreshLoopAsync error: {ex.Message}");
-        }
+        // 页面 Loaded/Unloaded 生命周期通过 XAML 中的 b:EventTrigger 绑定命令处理
     }
     
     private void ViewModel_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)

--- a/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml.cs
+++ b/BetterGenshinImpact/View/Pages/OneDragonFlowPage.xaml.cs
@@ -1,5 +1,4 @@
 using BetterGenshinImpact.ViewModel.Pages;
-using BetterGenshinImpact.ViewModel.Pages;
 using System.Windows;
 using System.Windows.Controls;
 using Wpf.Ui.Violeta.Controls;
@@ -8,6 +7,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using BetterGenshinImpact.Core.Script.Group;
 using System;
+using System.Threading.Tasks;
 
 namespace BetterGenshinImpact.View.Pages;
 
@@ -38,6 +38,31 @@ public partial class OneDragonFlowPage
         
         // 监听ViewModel的属性变化
         ViewModel.PropertyChanged += ViewModel_PropertyChanged;
+        Loaded += OnPageLoaded;
+        Unloaded += OnPageUnloaded;
+    }
+
+    private void OnPageLoaded(object sender, RoutedEventArgs e)
+    {
+        // 每次页面重新进入时，让 ViewModel 触发一次 OnLoaded（命令行/刷新循环），避免在 NavigationCache 模式下不复用构造函数导致刷新循环停止。
+        ViewModel?.OnLoaded();
+    }
+
+    private async void OnPageUnloaded(object sender, RoutedEventArgs e)
+    {
+        // 页面卸载时释放服务器日界刷新后台循环的 CancellationTokenSource，
+        // 避免后台任务保持对 ViewModel/TaskList 的引用导致内存泄漏或退出后仍运行。
+        try
+        {
+            if (ViewModel != null)
+            {
+                await ViewModel.StopDailyRefreshLoopAsync(true).ConfigureAwait(false);
+            }
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[OneDragonFlowPage] StopDailyRefreshLoopAsync error: {ex.Message}");
+        }
     }
     
     private void ViewModel_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
@@ -153,31 +178,7 @@ public partial class OneDragonFlowPage
         }
         return null;
     }
-    
-    private void DockPanel_ContextMenuOpening(object sender, ContextMenuEventArgs e)
-    {
-        var dockPanel = sender as DockPanel;
-        if (dockPanel == null) return;
-        
-        var hitTest = System.Windows.Media.VisualTreeHelper.HitTest(dockPanel, System.Windows.Input.Mouse.GetPosition(dockPanel));
-        if (hitTest != null)
-        {
-            var listViewItem = FindVisualParent<ListViewItem>(hitTest.VisualHit);
-            if (listViewItem != null)
-            {
-                listViewItem.IsSelected = true;
-            }
-        }
-    }
-    
-    private static T FindVisualParent<T>(DependencyObject child) where T : DependencyObject
-    {
-        var parent = System.Windows.Media.VisualTreeHelper.GetParent(child);
-        if (parent == null) return null;
-        if (parent is T result) return result;
-        return FindVisualParent<T>(parent);
-    }
-    
+
     private async void SereniteaPotTpType_Clicked(object sender, RoutedEventArgs e)
     {
         if (ViewModel.SelectedConfig == null)

--- a/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
@@ -7,6 +7,7 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using BetterGenshinImpact.Core.Config;
@@ -60,7 +61,20 @@ public partial class OneDragonFlowViewModel : ViewModel
 
     [ObservableProperty] private bool _shouldShowTaskConditionPopup = false;
 
+    /// <summary>
+    /// 条件弹窗当前正在编辑的原始任务 Id（非副本）。
+    /// 为空或 null 表示当前未处于条件编辑状态。
+    /// </summary>
+    private string? _conditionEditingTargetId;
+
     private OneDragonTaskCondition? _conditionEditingBackup;
+
+    /// <summary>
+    /// 服务器 4:00 日界刷新调度器：在到达下一个服务器游戏日时刷新 TaskList 中所有任务的 ShouldRunToday。
+    /// </summary>
+    private CancellationTokenSource? _dailyRefreshCts;
+
+    private Task? _dailyRefreshTask;
 
     partial void OnSelectedTaskChanged(OneDragonTaskItem value)
     {
@@ -495,6 +509,24 @@ public partial class OneDragonFlowViewModel : ViewModel
 
     private async void TaskPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
+        // 条件弹窗中的编辑副本永远不会参与 TaskList（Add 时才订阅），
+        // 这里加一道 Id 过滤，避免任何误用仍触发保存。
+        if (_conditionEditingTargetId != null &&
+            sender is OneDragonTaskItem item &&
+            item.Id == _conditionEditingTargetId &&
+            e.PropertyName is nameof(OneDragonTaskItem.RunMonday)
+                or nameof(OneDragonTaskItem.RunTuesday)
+                or nameof(OneDragonTaskItem.RunWednesday)
+                or nameof(OneDragonTaskItem.RunThursday)
+                or nameof(OneDragonTaskItem.RunFriday)
+                or nameof(OneDragonTaskItem.RunSaturday)
+                or nameof(OneDragonTaskItem.RunSunday)
+                or nameof(OneDragonTaskItem.HasCondition)
+                or nameof(OneDragonTaskItem.ShouldRunToday))
+        {
+            return;
+        }
+
         await Task.Delay(100); //等会加载完再保存
         SaveConfig();
     }
@@ -529,8 +561,10 @@ public partial class OneDragonFlowViewModel : ViewModel
     private bool _autoRun = true;
     
     [RelayCommand]
-    private void OnLoaded()
+    internal void OnLoaded()
     {
+        StartDailyRefreshLoop();
+
         // 组件首次加载时运行一次。
         if (!_autoRun)
         {
@@ -566,6 +600,131 @@ public partial class OneDragonFlowViewModel : ViewModel
         }
     }
 
+    /// <summary>
+    /// 启动服务器日界（4:00）刷新循环：每次计算距离下一个服务器 4:00 的剩余时间并等待，
+    /// 唤醒后刷新所有任务的 ShouldRunToday / HasCondition 通知，然后为下一个日界重新调度。
+    /// </summary>
+    private void StartDailyRefreshLoop()
+    {
+        if (_dailyRefreshTask != null && !_dailyRefreshTask.IsCompleted)
+        {
+            return;
+        }
+
+        StopDailyRefreshLoopAsync(false).GetAwaiter().GetResult();
+        _dailyRefreshCts = new CancellationTokenSource();
+        var token = _dailyRefreshCts.Token;
+
+        _dailyRefreshTask = Task.Run(async () =>
+        {
+            try
+            {
+                while (!token.IsCancellationRequested)
+                {
+                    DateTimeOffset now;
+                    try
+                    {
+                        now = ServerTimeHelper.GetServerTimeNow();
+                    }
+                    catch
+                    {
+                        now = DateTimeOffset.Now;
+                    }
+
+                    var next4am = now.Date.AddHours(4);
+                    if (now.TimeOfDay >= TimeSpan.FromHours(4))
+                    {
+                        next4am = next4am.AddDays(1);
+                    }
+
+                    var delay = next4am - now;
+                    if (delay <= TimeSpan.Zero)
+                    {
+                        delay = TimeSpan.FromMinutes(1);
+                    }
+
+                    await Task.Delay(delay, token).ConfigureAwait(false);
+                    if (token.IsCancellationRequested)
+                    {
+                        return;
+                    }
+
+                    Application.Current?.Dispatcher.Invoke(() =>
+                    {
+                        foreach (var t in TaskList)
+                        {
+                            t.NotifyDateStateChanged();
+                        }
+                    });
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // 预期取消路径
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "一条龙服务器日界刷新循环异常");
+            }
+        }, token);
+    }
+
+    /// <summary>
+    /// 停止服务器日界刷新循环并释放 CancellationTokenSource 与后台任务引用。
+    /// 从 View 卸载或应用退出时调用，避免后台线程挂起与 ViewModel 内存泄漏。
+    /// </summary>
+    public Task StopDailyRefreshLoopAsync(bool waitForCompletion = true)
+    {
+        var cts = _dailyRefreshCts;
+        var task = _dailyRefreshTask;
+
+        try
+        {
+            if (cts != null)
+            {
+                if (!cts.IsCancellationRequested)
+                {
+                    cts.Cancel();
+                }
+            }
+        }
+        catch (AggregateException ex)
+        {
+            // Task.Delay 的 OperationCanceledException 在 Cancel 回调注册时已被抛出时聚合
+            foreach (var inner in ex.InnerExceptions)
+            {
+                _logger.LogDebug(inner, "停止一条龙日界刷新循环时抛出已预期的取消异常");
+            }
+        }
+
+        Task stopTask;
+        if (task == null || task.IsCompleted)
+        {
+            stopTask = Task.CompletedTask;
+        }
+        else if (waitForCompletion)
+        {
+            // 最多等待 1.5 秒。Token 已经 Cancel，正常情况 Delay 会马上抛 OCE，应当很快完成。
+            stopTask = Task.WhenAny(task, Task.Delay(1500, CancellationToken.None)).ContinueWith(_ => { }, CancellationToken.None);
+        }
+        else
+        {
+            stopTask = Task.CompletedTask;
+        }
+
+        // null 化字段，确保下一次 StartDailyRefreshLoop 能重新调度，同时让 GC 能回收旧任务。
+        if (ReferenceEquals(_dailyRefreshCts, cts))
+        {
+            _dailyRefreshCts = null;
+        }
+        if (ReferenceEquals(_dailyRefreshTask, task))
+        {
+            _dailyRefreshTask = null;
+        }
+        cts?.Dispose();
+        return stopTask;
+    }
+
     [RelayCommand]
     public async Task OnOneKeyExecute()
     {
@@ -598,10 +757,11 @@ public partial class OneDragonFlowViewModel : ViewModel
             task.InitAction(SelectedConfig);
         }
 
+        int enabledTaskCountall = taskListCopy.Count(t => t.IsEnabled);
+        int runnableTodayCount = taskListCopy.Count(t => t.IsEnabled && t.ShouldRunToday);
         int finishOneTaskcount = 1;
         int finishTaskcount = 1;
-        int enabledTaskCountall = taskListCopy.Count(t => t.IsEnabled);
-        _logger.LogInformation($"启用任务总数量: {enabledTaskCountall}");
+        _logger.LogInformation($"启用任务总数量: {enabledTaskCountall}，今日可执行数量: {runnableTodayCount}");
         
         ReadScriptGroup();
         foreach (var task in ScriptGroupsdefault)
@@ -609,10 +769,17 @@ public partial class OneDragonFlowViewModel : ViewModel
             ScriptGroups.Remove(task);
         }
 
-        if (SelectedConfig == null || taskListCopy.Count(t => t.IsEnabled) == 0)
+        if (SelectedConfig == null || enabledTaskCountall == 0)
         {
             Toast.Warning("请先选择任务");
             _logger.LogInformation("没有配置,退出执行!");
+            return;
+        }
+
+        if (runnableTodayCount == 0)
+        {
+            Toast.Information("今日无符合执行条件的任务，已跳过启动一条龙");
+            _logger.LogInformation("今日所有启用任务均不满足执行日期条件，跳过启动一条龙");
             return;
         }
 
@@ -1019,8 +1186,11 @@ public partial class OneDragonFlowViewModel : ViewModel
             Toast.Warning("请先选择一个任务");
             return;
         }
-        ConditionEditingTask = task;
-        _conditionEditingBackup = ConditionEditingTask.ToCondition();
+        // 使用独立副本进行弹窗编辑：副本不加入 TaskList 订阅，不触发自动保存，
+        // 用户取消即丢弃副本，确认时才把条件写回原任务。
+        ConditionEditingTask = task.CreateConditionEditingClone();
+        _conditionEditingTargetId = task.Id;
+        _conditionEditingBackup = task.ToCondition();
         ShouldShowTaskConditionPopup = true;
         if (task != SelectedTask)
         {
@@ -1031,8 +1201,25 @@ public partial class OneDragonFlowViewModel : ViewModel
     [RelayCommand]
     private void CloseTaskCondition()
     {
-        ShouldShowTaskConditionPopup = false;
-        SaveConfig();
+        try
+        {
+            if (!string.IsNullOrEmpty(_conditionEditingTargetId) && ConditionEditingTask != null)
+            {
+                var target = TaskList.FirstOrDefault(t => t.Id == _conditionEditingTargetId);
+                if (target != null)
+                {
+                    target.ApplyCondition(ConditionEditingTask.ToCondition());
+                    SaveConfig();
+                }
+            }
+        }
+        finally
+        {
+            _conditionEditingTargetId = null;
+            _conditionEditingBackup = null;
+            ConditionEditingTask = null;
+            ShouldShowTaskConditionPopup = false;
+        }
     }
 
     [RelayCommand]
@@ -1044,10 +1231,10 @@ public partial class OneDragonFlowViewModel : ViewModel
     [RelayCommand]
     private void CancelTaskCondition()
     {
-        if (ConditionEditingTask != null && _conditionEditingBackup != null)
-        {
-            ConditionEditingTask.ApplyCondition(_conditionEditingBackup);
-        }
+        // 取消编辑：副本改动直接丢弃，不再 Apply 到原任务。
+        _conditionEditingTargetId = null;
+        _conditionEditingBackup = null;
+        ConditionEditingTask = null;
         ShouldShowTaskConditionPopup = false;
     }
 }

--- a/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
@@ -56,6 +56,12 @@ public partial class OneDragonFlowViewModel : ViewModel
 
     [ObservableProperty] private OneDragonTaskItem _selectedTask;
 
+    [ObservableProperty] private OneDragonTaskItem? _conditionEditingTask;
+
+    [ObservableProperty] private bool _shouldShowTaskConditionPopup = false;
+
+    private OneDragonTaskCondition? _conditionEditingBackup;
+
     partial void OnSelectedTaskChanged(OneDragonTaskItem value)
     {
         if (value != null)
@@ -368,6 +374,7 @@ public partial class OneDragonFlowViewModel : ViewModel
             if (isOldFormat)
             {
                 taskItem = new OneDragonTaskItem(key) { IsEnabled = enabled };
+                taskItem.ApplyCondition(SelectedConfig.GetTaskCondition(key));
             }
             else
             {
@@ -376,6 +383,7 @@ public partial class OneDragonFlowViewModel : ViewModel
                     continue;
                 }
                 taskItem = new OneDragonTaskItem(name, key) { IsEnabled = enabled };
+                taskItem.ApplyCondition(SelectedConfig.GetTaskCondition(key));
             }
             taskItem.IsNextTask = key == SelectedConfig.NextTaskId;
             TaskList.Add(taskItem);
@@ -413,14 +421,32 @@ public partial class OneDragonFlowViewModel : ViewModel
             return;
         }
 
+        if (SelectedConfig.TaskDefinitions == null)
+        {
+            SelectedConfig.TaskDefinitions = new Dictionary<string, string>();
+        }
         SelectedConfig.TaskDefinitions.Clear();
+        if (SelectedConfig.TaskEnabledList == null)
+        {
+            SelectedConfig.TaskEnabledList = new Dictionary<string, bool>();
+        }
         SelectedConfig.TaskEnabledList.Clear();
+        if (SelectedConfig.TaskOrder == null)
+        {
+            SelectedConfig.TaskOrder = new List<string>();
+        }
         SelectedConfig.TaskOrder.Clear();
+        if (SelectedConfig.TaskConditions == null)
+        {
+            SelectedConfig.TaskConditions = new Dictionary<string, OneDragonTaskCondition>();
+        }
+        SelectedConfig.TaskConditions.Clear();
         foreach (var task in TaskList)
         {
             SelectedConfig.TaskDefinitions[task.Id] = task.Name;
             SelectedConfig.TaskEnabledList[task.Id] = task.IsEnabled;
             SelectedConfig.TaskOrder.Add(task.Id);
+            SelectedConfig.TaskConditions[task.Id] = task.ToCondition();
         }
 
         WriteConfig(SelectedConfig);
@@ -615,6 +641,12 @@ public partial class OneDragonFlowViewModel : ViewModel
         {
             if (task is { IsEnabled: true, Action: not null })
             {
+                if (!task.ShouldRunToday)
+                {
+                    _logger.LogInformation($"任务 {task.Name} 不满足执行条件（运行日：{task.GetConditionSummaryText()}），跳过");
+                    continue;
+                }
+
                 if (ScriptGroupsdefault.Any(defaultSg => defaultSg.Name == task.Name))
                 {
                     _logger.LogInformation($"一条龙任务执行: {finishOneTaskcount++}/{enabledoneTaskCount}");
@@ -722,6 +754,7 @@ public partial class OneDragonFlowViewModel : ViewModel
 
         var copy = new OneDragonTaskItem(taskItem.Name) { IsEnabled = taskItem.IsEnabled };
         copy.Id = GenerateUniqueTaskId();
+        copy.ApplyCondition(taskItem.ToCondition());
 
         var index = TaskList.IndexOf(taskItem);
         if (index >= 0)
@@ -975,5 +1008,46 @@ public partial class OneDragonFlowViewModel : ViewModel
             _logger.LogError(e, "重命名配置时失败");
             Toast.Error("重命名配置时失败");
         }
+    }
+
+    [RelayCommand]
+    private void OpenTaskCondition(OneDragonTaskItem? task)
+    {
+        task ??= SelectedTask;
+        if (task == null)
+        {
+            Toast.Warning("请先选择一个任务");
+            return;
+        }
+        ConditionEditingTask = task;
+        _conditionEditingBackup = ConditionEditingTask.ToCondition();
+        ShouldShowTaskConditionPopup = true;
+        if (task != SelectedTask)
+        {
+            SelectedTask = task;
+        }
+    }
+
+    [RelayCommand]
+    private void CloseTaskCondition()
+    {
+        ShouldShowTaskConditionPopup = false;
+        SaveConfig();
+    }
+
+    [RelayCommand]
+    private void ResetTaskCondition()
+    {
+        ConditionEditingTask?.ApplyCondition(null);
+    }
+
+    [RelayCommand]
+    private void CancelTaskCondition()
+    {
+        if (ConditionEditingTask != null && _conditionEditingBackup != null)
+        {
+            ConditionEditingTask.ApplyCondition(_conditionEditingBackup);
+        }
+        ShouldShowTaskConditionPopup = false;
     }
 }

--- a/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
@@ -62,12 +62,10 @@ public partial class OneDragonFlowViewModel : ViewModel
     [ObservableProperty] private bool _shouldShowTaskConditionPopup = false;
 
     /// <summary>
-    /// 条件弹窗当前正在编辑的原始任务 Id（非副本）。
-    /// 为空或 null 表示当前未处于条件编辑状态。
+    /// 条件弹窗当前正在编辑的原始任务引用（非副本）。
+    /// 为 null 表示当前未处于条件编辑状态。
     /// </summary>
-    private string? _conditionEditingTargetId;
-
-    private OneDragonTaskCondition? _conditionEditingBackup;
+    private OneDragonTaskItem? _conditionEditingTarget;
 
     /// <summary>
     /// 服务器 4:00 日界刷新调度器：在到达下一个服务器游戏日时刷新 TaskList 中所有任务的 ShouldRunToday。
@@ -367,6 +365,12 @@ public partial class OneDragonFlowViewModel : ViewModel
             return;
         }
 
+        // 配置切换/重载会重建 TaskList，条件弹窗的编辑目标已失效，直接丢弃避免误写入新配置
+        if (ShouldShowTaskConditionPopup)
+        {
+            CancelTaskCondition();
+        }
+
         TaskList.Clear();
 
         // 旧格式兼容：TaskDefinitions 为空时，TaskEnabledList 键为任务名
@@ -509,19 +513,11 @@ public partial class OneDragonFlowViewModel : ViewModel
 
     private async void TaskPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
-        // 条件弹窗中的编辑副本永远不会参与 TaskList（Add 时才订阅），
-        // 这里加一道 Id 过滤，避免任何误用仍触发保存。
-        if (_conditionEditingTargetId != null &&
-            sender is OneDragonTaskItem item &&
-            item.Id == _conditionEditingTargetId &&
-            e.PropertyName is nameof(OneDragonTaskItem.RunMonday)
-                or nameof(OneDragonTaskItem.RunTuesday)
-                or nameof(OneDragonTaskItem.RunWednesday)
-                or nameof(OneDragonTaskItem.RunThursday)
-                or nameof(OneDragonTaskItem.RunFriday)
-                or nameof(OneDragonTaskItem.RunSaturday)
-                or nameof(OneDragonTaskItem.RunSunday)
-                or nameof(OneDragonTaskItem.HasCondition)
+        // 1) 条件弹窗编辑的是独立副本，不加入 TaskList 订阅，此处按引用防御，避免误触发保存；
+        // 2) HasCondition / ShouldRunToday 为派生属性（由星期字段或 4:00 日界刷新触发），
+        //    其变化不携带新数据，无需触发持久化。
+        if (ReferenceEquals(sender, ConditionEditingTask) ||
+            e.PropertyName is nameof(OneDragonTaskItem.HasCondition)
                 or nameof(OneDragonTaskItem.ShouldRunToday))
         {
             return;
@@ -561,7 +557,7 @@ public partial class OneDragonFlowViewModel : ViewModel
     private bool _autoRun = true;
     
     [RelayCommand]
-    internal void OnLoaded()
+    private void OnLoaded()
     {
         StartDailyRefreshLoop();
 
@@ -600,6 +596,14 @@ public partial class OneDragonFlowViewModel : ViewModel
         }
     }
 
+    [RelayCommand]
+    private async Task Unloaded()
+    {
+        // 页面卸载时停止服务器日界刷新循环并释放 CancellationTokenSource，
+        // 避免后台任务持有 ViewModel 引用造成泄漏或退出后仍运行。
+        await StopDailyRefreshLoopAsync(true);
+    }
+
     /// <summary>
     /// 启动服务器日界（4:00）刷新循环：每次计算距离下一个服务器 4:00 的剩余时间并等待，
     /// 唤醒后刷新所有任务的 ShouldRunToday / HasCondition 通知，然后为下一个日界重新调度。
@@ -631,7 +635,9 @@ public partial class OneDragonFlowViewModel : ViewModel
                         now = DateTimeOffset.Now;
                     }
 
-                    var next4am = now.Date.AddHours(4);
+                    // now.Date 为 Kind=Unspecified 的 DateTime，直接参与 DateTimeOffset 运算会被按本机时区解释；
+                    // 服务器时区与本机不一致时 delay 会偏差两个时区的差值，必须用 now.Offset 显式重建。
+                    var next4am = new DateTimeOffset(now.Date, now.Offset).AddHours(4);
                     if (now.TimeOfDay >= TimeSpan.FromHours(4))
                     {
                         next4am = next4am.AddDays(1);
@@ -816,7 +822,7 @@ public partial class OneDragonFlowViewModel : ViewModel
 
                 if (ScriptGroupsdefault.Any(defaultSg => defaultSg.Name == task.Name))
                 {
-                    _logger.LogInformation($"一条龙任务执行: {finishOneTaskcount++}/{enabledoneTaskCount}");
+                    _logger.LogInformation($"一条龙任务执行: {finishOneTaskcount++}/{runnableTodayCount}");
                     await new TaskRunner().RunThreadAsync(async () =>
                     {
                         await task.Action();
@@ -1189,8 +1195,7 @@ public partial class OneDragonFlowViewModel : ViewModel
         // 使用独立副本进行弹窗编辑：副本不加入 TaskList 订阅，不触发自动保存，
         // 用户取消即丢弃副本，确认时才把条件写回原任务。
         ConditionEditingTask = task.CreateConditionEditingClone();
-        _conditionEditingTargetId = task.Id;
-        _conditionEditingBackup = task.ToCondition();
+        _conditionEditingTarget = task;
         ShouldShowTaskConditionPopup = true;
         if (task != SelectedTask)
         {
@@ -1203,20 +1208,24 @@ public partial class OneDragonFlowViewModel : ViewModel
     {
         try
         {
-            if (!string.IsNullOrEmpty(_conditionEditingTargetId) && ConditionEditingTask != null)
+            if (_conditionEditingTarget != null && ConditionEditingTask != null)
             {
-                var target = TaskList.FirstOrDefault(t => t.Id == _conditionEditingTargetId);
-                if (target != null)
+                // 引用校验：目标任务必须仍在当前 TaskList 中（配置未被切换）。
+                // 旧格式配置的任务 Id 为任务名，切换配置后按 Id 查找可能命中其它配置的同名任务。
+                if (TaskList.Contains(_conditionEditingTarget))
                 {
-                    target.ApplyCondition(ConditionEditingTask.ToCondition());
+                    _conditionEditingTarget.ApplyCondition(ConditionEditingTask.ToCondition());
                     SaveConfig();
+                }
+                else
+                {
+                    Toast.Warning("配置已切换，本次条件修改已丢弃");
                 }
             }
         }
         finally
         {
-            _conditionEditingTargetId = null;
-            _conditionEditingBackup = null;
+            _conditionEditingTarget = null;
             ConditionEditingTask = null;
             ShouldShowTaskConditionPopup = false;
         }
@@ -1231,9 +1240,8 @@ public partial class OneDragonFlowViewModel : ViewModel
     [RelayCommand]
     private void CancelTaskCondition()
     {
-        // 取消编辑：副本改动直接丢弃，不再 Apply 到原任务。
-        _conditionEditingTargetId = null;
-        _conditionEditingBackup = null;
+        // 取消编辑：副本改动直接丢弃。
+        _conditionEditingTarget = null;
         ConditionEditingTask = null;
         ShouldShowTaskConditionPopup = false;
     }


### PR DESCRIPTION
支持为指定的项目添加日期判断机制
如该任务仅在周六与周日执行
为每一项增加一个条件选择按钮，点击后可勾选日期进行设置
<img width="447" height="312" alt="image" src="https://github.com/user-attachments/assets/aedc6473-6752-4347-9127-09ce60756fc7" />
<img width="654" height="321" alt="image" src="https://github.com/user-attachments/assets/3f340da0-12c1-40d9-97a9-cbb29ca36533" />
或右键条目
<img width="206" height="241" alt="image" src="https://github.com/user-attachments/assets/0e38228e-9069-486c-9b74-4aed66cbf62e" />
另外，可以自动检测日期并判断当日能否运行此任务，今日不在可运行范围内则表现为灰色
<img width="302" height="211" alt="image" src="https://github.com/user-attachments/assets/ba24b1e6-f262-4e5b-83f0-fc78256ae722" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增任务按星期设置执行条件，可选择周一至周日。
  * 支持查看条件摘要、启用或停用条件，并提供重置、取消和确认操作。
  * 执行任务时自动跳过当天不符合条件的任务，复制任务时同步复制执行条件。
  * 右键点击任务即可快速选中并打开条件设置。
  * 按服务器时间每日凌晨 4 点自动刷新任务日期状态。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->