### PR TITLE
feat: localize hardcoded OCR strings in AutoBoss, AutoLeyLineOutcrop and AutoStygianOnslaught

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoBoss/AutoBossTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoBoss/AutoBossTask.cs
@@ -19,6 +19,7 @@ using BetterGenshinImpact.GameTask.Common.Reward;
 using BetterGenshinImpact.GameTask.Model.Area;
 using BetterGenshinImpact.Helpers;
 using BetterGenshinImpact.Service.Notification;
+using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 using OpenCvSharp;
 using System;
@@ -53,6 +54,12 @@ public class AutoBossTask : ISoloTask<Dictionary<string, int>>
 
     private static readonly TimeSpan OriginalResinRecoveryInterval = TimeSpan.FromMinutes(8);
     private const int MaxQuickUseQuantity = 20;
+
+    private readonly string touchTrounceBlossomString;
+    private readonly string useOriginalResinString;
+    private readonly string replenishOriginalResinPattern;
+    private readonly string clickAnywhereToContinueString;
+    private readonly string resinSupplementOrPattern;
 
     private string PathingAssetFolder => Global.Absolute(@"GameTask\AutoBoss\Assets\Pathing");
 
@@ -89,6 +96,15 @@ public class AutoBossTask : ISoloTask<Dictionary<string, int>>
         {
             _combatScriptBag = CombatScriptParser.ReadAndParse(_taskParam.CombatStrategyPath);
         }
+
+        IStringLocalizer<AutoBossTask> stringLocalizer =
+            App.GetService<IStringLocalizer<AutoBossTask>>() ?? throw new NullReferenceException();
+        CultureInfo cultureInfo = new CultureInfo(TaskContext.Instance().Config.OtherConfig.GameCultureInfoName);
+        this.touchTrounceBlossomString = stringLocalizer.WithCultureGet(cultureInfo, "接触征讨之花");
+        this.useOriginalResinString = stringLocalizer.WithCultureGet(cultureInfo, "使用原粹树脂");
+        this.replenishOriginalResinPattern = stringLocalizer.WithCultureGet(cultureInfo, "补充原粹树脂");
+        this.clickAnywhereToContinueString = stringLocalizer.WithCultureGet(cultureInfo, "点击空白区域继续");
+        this.resinSupplementOrPattern = stringLocalizer.WithCultureGet(cultureInfo, "(补充|原粹|树脂)");
     }
 
     /// <summary>
@@ -534,11 +550,34 @@ public class AutoBossTask : ISoloTask<Dictionary<string, int>>
         return Math.Max(0, (originalResin.Limit - originalResin.Count) / 60);
     }
 
+    /// <summary>
+    /// 在指定区域轮询 OCR 结果，直到找到匹配 <paramref name="pattern"/>（支持正则）的文本或超时。
+    /// 用于 <see cref="BvPage.Locator(string, Rect)"/> 无法表达正则匹配的场景（其内部仅做字面量 Contains 比较）。
+    /// 时序对齐 <see cref="BetterGenshinImpact.GameTask.Common.NewRetry.WaitForAction"/>：ogni iterazione fa PRIMA
+    /// il delay e POI il controllo (mai un controllo a t=0), cosi' il token di cancellazione viene rispettato
+    /// prima di agire e i tempi coincidono con quelli di <see cref="BvLocator.WaitFor"/>/<see cref="BvLocator.TryWaitFor"/>.
+    /// </summary>
+    private async Task<List<Region>> WaitForOcrPatternAsync(BvPage page, Rect rect, string pattern, int timeoutMs, int intervalMs = 250)
+    {
+        var attempts = Math.Max(1, timeoutMs / intervalMs);
+        for (var i = 0; i < attempts; i++)
+        {
+            await Delay(intervalMs, _ct);
+
+            var matches = page.Ocr(rect).Where(r => Regex.IsMatch(r.Text, pattern)).ToList();
+            if (matches.Count > 0)
+            {
+                return matches;
+            }
+        }
+
+        return [];
+    }
+
     private async Task<bool> TryOpenResinSupplementPane(BvPage page)
     {
         var titleRect = ScaleRect(834, 247, 256, 60);
-        var titleLocator = page.Locator("补充原粹树脂", titleRect).WithRetryInterval(300);
-        if ((await titleLocator.TryWaitFor(500)).Count > 0)
+        if ((await WaitForOcrPatternAsync(page, titleRect, replenishOriginalResinPattern, 500, 300)).Count > 0)
         {
             return true;
         }
@@ -547,25 +586,25 @@ public class AutoBossTask : ISoloTask<Dictionary<string, int>>
             .WithRoi(ScaleRect(1200, 25, 580, 50))
             .WithRetryInterval(300);
 
-        try
+        var deadline = DateTime.UtcNow.AddMilliseconds(5000);
+        while (DateTime.UtcNow < deadline)
         {
-            await titleLocator
-                .WithRetryAction(_ =>
-                {
-                    var buttons = openButtonLocator.FindAll();
-                    if (buttons.Count > 0)
-                    {
-                        buttons[0].Click();
-                    }
-                })
-                .WaitFor(5000);
-            return true;
+            await Delay(300, _ct);
+
+            if (page.Ocr(titleRect).Any(r => Regex.IsMatch(r.Text, replenishOriginalResinPattern)))
+            {
+                return true;
+            }
+
+            var buttons = openButtonLocator.FindAll();
+            if (buttons.Count > 0)
+            {
+                buttons[0].Click();
+            }
         }
-        catch (TimeoutException e)
-        {
-            _logger.LogWarning("{Name}：未能打开补充原粹树脂面板，原因：{Reason}", Name, e.Message);
-            return false;
-        }
+
+        _logger.LogWarning("{Name}：未能打开补充原粹树脂面板，超时未检测到标题文本", Name);
+        return false;
     }
 
     private async Task<bool> TrySelectSupplementalResin(BvPage page, SupplementalResinOption resin)
@@ -1230,15 +1269,15 @@ public class AutoBossTask : ISoloTask<Dictionary<string, int>>
     private bool HasRewardInteractionPrompt(BvPage page)
     {
         var rewardRect = ScaleRect(1210, 300, 200, 400);
-        return page.Ocr(rewardRect).Any(region => region.Text.Contains("接触征讨之花", StringComparison.Ordinal));
+        return page.Ocr(rewardRect).Any(region => region.Text.Contains(touchTrounceBlossomString, StringComparison.Ordinal));
     }
 
     private bool HasRewardPanelPrompt(BvPage page)
     {
         var rewardPanelRect = ScaleRect(850, 740, 250, 35);
         return page.Ocr(rewardPanelRect).Any(region =>
-            region.Text.Contains("使用原粹树脂", StringComparison.Ordinal)
-            || region.Text.Contains("补充原粹树脂", StringComparison.Ordinal));
+            region.Text.Contains(useOriginalResinString, StringComparison.Ordinal)
+            || Regex.IsMatch(region.Text, replenishOriginalResinPattern));
     }
 
     private async Task MonitorRewardPromptTask(BvPage page, CancellationTokenSource navigationCts)
@@ -1430,7 +1469,7 @@ public class AutoBossTask : ISoloTask<Dictionary<string, int>>
         for (var i = 0; i < 20; i++)
         {
             var closeRegion = page.Ocr(closeRect)
-                .FirstOrDefault(r => r.Text.Contains("点击空白区域继续", StringComparison.Ordinal));
+                .FirstOrDefault(r => r.Text.Contains(clickAnywhereToContinueString, StringComparison.Ordinal));
             if (closeRegion != null)
             {
                 return true;
@@ -1453,13 +1492,13 @@ public class AutoBossTask : ISoloTask<Dictionary<string, int>>
 
         try
         {
-            await page.Locator("使用原粹树脂", useRect).ClickUntilDisappears(3000);
+            await page.Locator(useOriginalResinString, useRect).ClickUntilDisappears(3000);
             await Delay(1000, _ct);
             return true;
         }
         catch (TimeoutException e)
         {
-            var supplementRegions = await page.Locator("补充原粹树脂", useRect).TryWaitFor(1000);
+            var supplementRegions = await WaitForOcrPatternAsync(page, useRect, replenishOriginalResinPattern, 1000);
             if (supplementRegions.Count > 0)
             {
                 _logger.LogInformation("{Name}：领奖界面提示补充原粹树脂，当前原粹树脂不足", Name);
@@ -1483,10 +1522,7 @@ public class AutoBossTask : ISoloTask<Dictionary<string, int>>
         for (var i = 0; i < 50; i++)
         {
             _ct.ThrowIfCancellationRequested();
-            var promptExists = page.Ocr(supplementRect).Any(region =>
-                region.Text.Contains("补充", StringComparison.Ordinal)
-                || region.Text.Contains("原粹", StringComparison.Ordinal)
-                || region.Text.Contains("树脂", StringComparison.Ordinal));
+            var promptExists = page.Ocr(supplementRect).Any(region => Regex.IsMatch(region.Text, resinSupplementOrPattern));
             if (!promptExists)
             {
                 return;
@@ -1517,7 +1553,7 @@ public class AutoBossTask : ISoloTask<Dictionary<string, int>>
             }
 
             var closeRegion = capture.FindMulti(RecognitionObject.Ocr(closeRect))
-                .FirstOrDefault(r => r.Text.Contains("点击空白区域继续", StringComparison.Ordinal));
+                .FirstOrDefault(r => r.Text.Contains(clickAnywhereToContinueString, StringComparison.Ordinal));
             if (closeRegion != null)
             {
                 closeRegion.Click();

--- a/BetterGenshinImpact/GameTask/AutoBoss/AutoBossTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoBoss/AutoBossTask.cs
@@ -553,9 +553,9 @@ public class AutoBossTask : ISoloTask<Dictionary<string, int>>
     /// <summary>
     /// 在指定区域轮询 OCR 结果，直到找到匹配 <paramref name="pattern"/>（支持正则）的文本或超时。
     /// 用于 <see cref="BvPage.Locator(string, Rect)"/> 无法表达正则匹配的场景（其内部仅做字面量 Contains 比较）。
-    /// 时序对齐 <see cref="BetterGenshinImpact.GameTask.Common.NewRetry.WaitForAction"/>：ogni iterazione fa PRIMA
-    /// il delay e POI il controllo (mai un controllo a t=0), cosi' il token di cancellazione viene rispettato
-    /// prima di agire e i tempi coincidono con quelli di <see cref="BvLocator.WaitFor"/>/<see cref="BvLocator.TryWaitFor"/>.
+    /// 时序对齐 <see cref="BetterGenshinImpact.GameTask.Common.NewRetry.WaitForAction"/>：每次迭代都先延时再检查
+    /// （绝不在 t=0 检查），这样在动作之前先响应取消令牌，时序也与
+    /// <see cref="BvLocator.WaitFor"/>/<see cref="BvLocator.TryWaitFor"/> 保持一致。
     /// </summary>
     private async Task<List<Region>> WaitForOcrPatternAsync(BvPage page, Rect rect, string pattern, int timeoutMs, int intervalMs = 250)
     {

--- a/BetterGenshinImpact/GameTask/AutoBoss/AutoBossTask.en.resx
+++ b/BetterGenshinImpact/GameTask/AutoBoss/AutoBossTask.en.resx
@@ -1,0 +1,135 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="接触征讨之花" xml:space="preserve">
+    <value>Touch the Trounce Blossom</value>
+  </data>
+  <data name="使用原粹树脂" xml:space="preserve">
+    <value>Use Original Resin</value>
+  </data>
+  <data name="补充原粹树脂" xml:space="preserve">
+    <value>Replenish.*Original.*Resin</value>
+  </data>
+  <data name="点击空白区域继续" xml:space="preserve">
+    <value>Click anywhere in the blank area</value>
+  </data>
+  <data name="(补充|原粹|树脂)" xml:space="preserve">
+    <value>(eplenish|riginal|esin)</value>
+  </data>
+</root>

--- a/BetterGenshinImpact/GameTask/AutoBoss/AutoBossTask.fr.resx
+++ b/BetterGenshinImpact/GameTask/AutoBoss/AutoBossTask.fr.resx
@@ -1,0 +1,135 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="接触征讨之花" xml:space="preserve">
+    <value>Toucher la Fleur de la conquête</value>
+  </data>
+  <data name="使用原粹树脂" xml:space="preserve">
+    <value>Utiliser de la Résine originelle</value>
+  </data>
+  <data name="补充原粹树脂" xml:space="preserve">
+    <value>Recharger.*la.*Résine.*originelle</value>
+  </data>
+  <data name="点击空白区域继续" xml:space="preserve">
+    <value>Cliquez pour poursuivre</value>
+  </data>
+  <data name="(补充|原粹|树脂)" xml:space="preserve">
+    <value>(echarge|riginelle|ésine)</value>
+  </data>
+</root>

--- a/BetterGenshinImpact/GameTask/AutoBoss/AutoBossTask.zh-Hant.resx
+++ b/BetterGenshinImpact/GameTask/AutoBoss/AutoBossTask.zh-Hant.resx
@@ -1,0 +1,135 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="接触征讨之花" xml:space="preserve">
+    <value>接觸征討之花</value>
+  </data>
+  <data name="使用原粹树脂" xml:space="preserve">
+    <value>使用原粹樹脂</value>
+  </data>
+  <data name="补充原粹树脂" xml:space="preserve">
+    <value>補充原粹樹脂</value>
+  </data>
+  <data name="点击空白区域继续" xml:space="preserve">
+    <value>點擊空白區域繼續</value>
+  </data>
+  <data name="(补充|原粹|树脂)" xml:space="preserve">
+    <value>(補充|原粹|樹脂)</value>
+  </data>
+</root>

--- a/BetterGenshinImpact/GameTask/AutoLeyLineOutcrop/AutoLeyLineOutcropTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoLeyLineOutcrop/AutoLeyLineOutcropTask.cs
@@ -19,6 +19,7 @@ using BetterGenshinImpact.GameTask.Common;
 using BetterGenshinImpact.GameTask.Common.BgiVision;
 using BetterGenshinImpact.GameTask.Common.Job;
 using BetterGenshinImpact.GameTask.Common.Map.Maps.Base;
+using BetterGenshinImpact.Helpers;
 using BetterGenshinImpact.GameTask;
 using BetterGenshinImpact.GameTask.Model;
 using BetterGenshinImpact.GameTask.Model.Area;
@@ -39,6 +40,8 @@ using BetterGenshinImpact.GameTask.AutoGeniusInvokation.Exception;
 using Vanara.PInvoke;
 using static BetterGenshinImpact.GameTask.Common.TaskControl;
 using BetterGenshinImpact.View;
+using Microsoft.Extensions.Localization;
+using System.Globalization;
 
 namespace BetterGenshinImpact.GameTask.AutoLeyLineOutcrop;
 
@@ -98,12 +101,27 @@ public class AutoLeyLineOutcropTask : ISoloTask
     private DateTime _lastMaskBringTopTime = DateTime.MinValue;
     private bool _friendshipTeamSwitched;
 
+    private readonly string originalResinLocalizedString;
+    private readonly string contactLeyLineFlowerPatternString;
+    private readonly string reviveLocalizedString;
+    private readonly string leyLineOrOverflowPatternString;
+    private readonly string stopLocalizedString;
+
     public string Name => "自动地脉花";
 
     public AutoLeyLineOutcropTask(AutoLeyLineOutcropParam taskParam, bool oneDragonMode = false)
     {
         _taskParam = taskParam;
         _oneDragonMode = oneDragonMode;
+
+        IStringLocalizer<AutoLeyLineOutcropTask> stringLocalizer =
+            App.GetService<IStringLocalizer<AutoLeyLineOutcropTask>>() ?? throw new NullReferenceException();
+        CultureInfo cultureInfo = new CultureInfo(TaskContext.Instance().Config.OtherConfig.GameCultureInfoName);
+        this.originalResinLocalizedString = stringLocalizer.WithCultureGet(cultureInfo, "原粹树脂");
+        this.contactLeyLineFlowerPatternString = stringLocalizer.WithCultureGet(cultureInfo, "(接触|地脉|之花)");
+        this.reviveLocalizedString = stringLocalizer.WithCultureGet(cultureInfo, "复苏");
+        this.leyLineOrOverflowPatternString = stringLocalizer.WithCultureGet(cultureInfo, "(地脉|衍出)");
+        this.stopLocalizedString = stringLocalizer.WithCultureGet(cultureInfo, "停止");
     }
 
     public async Task Start(CancellationToken ct)
@@ -1564,7 +1582,7 @@ public class AutoLeyLineOutcropTask : ISoloTask
     {
         using var capture = CaptureToRectArea();
         // Bv.FindF is faster for common keywords and avoids OCR misses.
-        if (Bv.FindF(capture, "接触") || Bv.FindF(capture, "地脉") || Bv.FindF(capture, "之花"))
+        if (Bv.FindF(capture, contactLeyLineFlowerPatternString))
         {
             return true;
         }
@@ -1572,14 +1590,12 @@ public class AutoLeyLineOutcropTask : ISoloTask
         var list = capture.FindMulti(_ocrRoThis);
         foreach (var res in list)
         {
-            if (res.Text.Contains("原粹树脂", StringComparison.Ordinal))
+            if (res.Text.Contains(originalResinLocalizedString, StringComparison.Ordinal))
             {
                 return true;
             }
 
-            if (res.Text.Contains("接触", StringComparison.Ordinal)
-                || res.Text.Contains("地脉", StringComparison.Ordinal)
-                || res.Text.Contains("之花", StringComparison.Ordinal))
+            if (Regex.IsMatch(res.Text, contactLeyLineFlowerPatternString))
             {
                 return true;
             }
@@ -1614,7 +1630,7 @@ public class AutoLeyLineOutcropTask : ISoloTask
         var list = capture.FindMulti(_ocrRoThis);
         foreach (var res in list)
         {
-            if (res.Text.Contains("复苏", StringComparison.Ordinal))
+            if (res.Text.Contains(reviveLocalizedString, StringComparison.Ordinal))
             {
                 res.Click();
                 await Delay(2000, _ct);
@@ -2390,14 +2406,14 @@ public class AutoLeyLineOutcropTask : ISoloTask
 
         using var capture = CaptureToRectArea();
         var list = capture.FindMulti(_ocrRoThis);
-        var stop = list.FirstOrDefault(r => r.Text.Contains("停止", StringComparison.Ordinal));
+        var stop = list.FirstOrDefault(r => r.Text.Contains(stopLocalizedString, StringComparison.Ordinal));
         if (stop != null)
         {
             stop.Click();
             return;
         }
 
-        var leyLine = list.FirstOrDefault(r => r.Text.Contains("地脉", StringComparison.Ordinal) || r.Text.Contains("衍出", StringComparison.Ordinal));
+        var leyLine = list.FirstOrDefault(r => Regex.IsMatch(r.Text, leyLineOrOverflowPatternString));
         if (leyLine != null)
         {
             leyLine.Click();

--- a/BetterGenshinImpact/GameTask/AutoLeyLineOutcrop/AutoLeyLineOutcropTask.en.resx
+++ b/BetterGenshinImpact/GameTask/AutoLeyLineOutcrop/AutoLeyLineOutcropTask.en.resx
@@ -1,0 +1,135 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="原粹树脂" xml:space="preserve">
+    <value>Original Resin</value>
+  </data>
+  <data name="(接触|地脉|之花)" xml:space="preserve">
+    <value>(ouch|ey Lines|lossom)</value>
+  </data>
+  <data name="复苏" xml:space="preserve">
+    <value>Revive</value>
+  </data>
+  <data name="(地脉|衍出)" xml:space="preserve">
+    <value>ey Lines</value>
+  </data>
+  <data name="停止" xml:space="preserve">
+    <value>Stop</value>
+  </data>
+</root>

--- a/BetterGenshinImpact/GameTask/AutoLeyLineOutcrop/AutoLeyLineOutcropTask.en.resx
+++ b/BetterGenshinImpact/GameTask/AutoLeyLineOutcrop/AutoLeyLineOutcropTask.en.resx
@@ -121,13 +121,13 @@
     <value>Original Resin</value>
   </data>
   <data name="(接触|地脉|之花)" xml:space="preserve">
-    <value>(ouch|ey Lines|lossom)</value>
+    <value>(ouch|ey Line|lossom)</value>
   </data>
   <data name="复苏" xml:space="preserve">
     <value>Revive</value>
   </data>
   <data name="(地脉|衍出)" xml:space="preserve">
-    <value>ey Lines</value>
+    <value>ey Line</value>
   </data>
   <data name="停止" xml:space="preserve">
     <value>Stop</value>

--- a/BetterGenshinImpact/GameTask/AutoLeyLineOutcrop/AutoLeyLineOutcropTask.fr.resx
+++ b/BetterGenshinImpact/GameTask/AutoLeyLineOutcrop/AutoLeyLineOutcropTask.fr.resx
@@ -1,0 +1,135 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="原粹树脂" xml:space="preserve">
+    <value>Résine originelle</value>
+  </data>
+  <data name="(接触|地脉|之花)" xml:space="preserve">
+    <value>(oucher|ignes énergétiques|leur)</value>
+  </data>
+  <data name="复苏" xml:space="preserve">
+    <value>Réanimer</value>
+  </data>
+  <data name="(地脉|衍出)" xml:space="preserve">
+    <value>ignes énergétiques</value>
+  </data>
+  <data name="停止" xml:space="preserve">
+    <value>Arrêter</value>
+  </data>
+</root>

--- a/BetterGenshinImpact/GameTask/AutoLeyLineOutcrop/AutoLeyLineOutcropTask.zh-Hant.resx
+++ b/BetterGenshinImpact/GameTask/AutoLeyLineOutcrop/AutoLeyLineOutcropTask.zh-Hant.resx
@@ -1,0 +1,135 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="原粹树脂" xml:space="preserve">
+    <value>原粹樹脂</value>
+  </data>
+  <data name="(接触|地脉|之花)" xml:space="preserve">
+    <value>(接觸|地脈|之花)</value>
+  </data>
+  <data name="复苏" xml:space="preserve">
+    <value>復甦</value>
+  </data>
+  <data name="(地脉|衍出)" xml:space="preserve">
+    <value>(地脈|衍出)</value>
+  </data>
+  <data name="停止" xml:space="preserve">
+    <value>停止</value>
+  </data>
+</root>

--- a/BetterGenshinImpact/GameTask/AutoStygianOnslaught/AutoStygianOnslaughtTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoStygianOnslaught/AutoStygianOnslaughtTask.cs
@@ -20,15 +20,19 @@ using BetterGenshinImpact.GameTask.Common.Job;
 using BetterGenshinImpact.GameTask.Common.StateMachine;
 using BetterGenshinImpact.GameTask.Model.Area;
 using BetterGenshinImpact.GameTask.QuickTeleport.Assets;
+using BetterGenshinImpact.Helpers;
 using BetterGenshinImpact.Helpers.Extensions;
 using BetterGenshinImpact.Service.Notification;
 using BetterGenshinImpact.Service.Notification.Model.Enum;
+using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
 using OpenCvSharp;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using static BetterGenshinImpact.GameTask.Common.TaskControl;
@@ -84,6 +88,23 @@ public class AutoStygianOnslaughtTask : StateMachineBase<StygianState, BvPage>, 
     private readonly string? _jsonCombatStrategyPath;
     private List<ResinUseRecord> _resinPriorityListWhenSpecifyUse;
     private LowerHeadThenWalkToTask? _lowerHeadThenWalkToTask;
+
+    private readonly string returnLocalizedString;
+    private readonly string challengeFailedLocalizedString;
+    private readonly string retryChallengeLocalizedString;
+    private readonly string leyLineBlossomLocalizedString;
+    private readonly string condensedResinLocalizedString;
+    private readonly string originalResinLocalizedString;
+    private readonly string characterPreviewLocalizedString;
+    private readonly string startChallengeLocalizedString;
+    private readonly string singlePlayerLocalizedString;
+    private readonly string stygianOnslaughtLocalizedString;
+    private readonly string eventsOverviewLocalizedString;
+    private readonly string disturbanceOutbreakLocalizedString;
+    private readonly string alreadyEndedLocalizedString;
+    private readonly string insufficientQuantityLocalizedString;
+    private readonly string replenishOriginalResinLocalizedString;
+
     public AutoStygianOnslaughtTask(AutoStygianOnslaughtParam taskParam)
     {
         _taskParam = taskParam;
@@ -97,6 +118,13 @@ public class AutoStygianOnslaughtTask : StateMachineBase<StygianState, BvPage>, 
             _combatScriptBag = CombatScriptParser.ReadAndParse(taskParam.CombatScriptBagPath);
         }
         _resinPriorityListWhenSpecifyUse = ResinUseRecord.BuildFromDomainParam(taskParam);
+
+        (returnLocalizedString, challengeFailedLocalizedString, retryChallengeLocalizedString,
+            leyLineBlossomLocalizedString, condensedResinLocalizedString, originalResinLocalizedString,
+            characterPreviewLocalizedString, startChallengeLocalizedString, singlePlayerLocalizedString,
+            stygianOnslaughtLocalizedString, eventsOverviewLocalizedString, disturbanceOutbreakLocalizedString,
+            alreadyEndedLocalizedString, insufficientQuantityLocalizedString, replenishOriginalResinLocalizedString)
+            = BuildLocalizedStrings();
 
         // 注册所有状态处理器
         RegisterAllStateHandlers();
@@ -115,8 +143,42 @@ public class AutoStygianOnslaughtTask : StateMachineBase<StygianState, BvPage>, 
         }
         _resinPriorityListWhenSpecifyUse = ResinUseRecord.BuildFromDomainParam(taskParam);
 
+        (returnLocalizedString, challengeFailedLocalizedString, retryChallengeLocalizedString,
+            leyLineBlossomLocalizedString, condensedResinLocalizedString, originalResinLocalizedString,
+            characterPreviewLocalizedString, startChallengeLocalizedString, singlePlayerLocalizedString,
+            stygianOnslaughtLocalizedString, eventsOverviewLocalizedString, disturbanceOutbreakLocalizedString,
+            alreadyEndedLocalizedString, insufficientQuantityLocalizedString, replenishOriginalResinLocalizedString)
+            = BuildLocalizedStrings();
+
         // 注册所有状态处理器
         RegisterAllStateHandlers();
+    }
+
+    /// <summary>
+    /// 初始化本地化字符串（供两个构造函数复用，遵循 AutoDomainTask 的 IStringLocalizer + WithCultureGet 惯例）
+    /// </summary>
+    private static (string, string, string, string, string, string, string, string, string, string, string, string, string, string, string) BuildLocalizedStrings()
+    {
+        IStringLocalizer<AutoStygianOnslaughtTask> stringLocalizer =
+            App.GetService<IStringLocalizer<AutoStygianOnslaughtTask>>() ?? throw new NullReferenceException();
+        CultureInfo cultureInfo = new CultureInfo(TaskContext.Instance().Config.OtherConfig.GameCultureInfoName);
+        return (
+            stringLocalizer.WithCultureGet(cultureInfo, "返回"),
+            stringLocalizer.WithCultureGet(cultureInfo, "挑战失败"),
+            stringLocalizer.WithCultureGet(cultureInfo, "重新挑战"),
+            stringLocalizer.WithCultureGet(cultureInfo, "地脉之花"),
+            stringLocalizer.WithCultureGet(cultureInfo, "浓缩树脂"),
+            stringLocalizer.WithCultureGet(cultureInfo, "原粹树脂"),
+            stringLocalizer.WithCultureGet(cultureInfo, "角色预览"),
+            stringLocalizer.WithCultureGet(cultureInfo, "开始挑战"),
+            stringLocalizer.WithCultureGet(cultureInfo, "单人挑战"),
+            stringLocalizer.WithCultureGet(cultureInfo, "幽境危战"),
+            stringLocalizer.WithCultureGet(cultureInfo, "活动一览"),
+            stringLocalizer.WithCultureGet(cultureInfo, "紊乱爆发期"),
+            stringLocalizer.WithCultureGet(cultureInfo, "已结束"),
+            stringLocalizer.WithCultureGet(cultureInfo, "数量不足"),
+            stringLocalizer.WithCultureGet(cultureInfo, "补充原粹树脂")
+        );
     }
 
     /// <summary>
@@ -250,7 +312,7 @@ public class AutoStygianOnslaughtTask : StateMachineBase<StygianState, BvPage>, 
     {
         return ra.Find(ElementRecognition.Get("BtnWhiteCancel", ra)).IsExist() &&
                ra.FindMulti(RecognitionObject.Ocr(ra.Width * 0.35, ra.Height * 0.7, ra.Width * 0.3, ra.Height * 0.2))
-                 .Any(o => o.Text.Contains("返回"));
+                 .Any(o => o.Text.Contains(returnLocalizedString));
     }
 
     [StateDetector(StygianState.BattleResultLose, Order = 70)]
@@ -258,7 +320,7 @@ public class AutoStygianOnslaughtTask : StateMachineBase<StygianState, BvPage>, 
     {
         return ra.Find(ElementRecognition.Get("BtnWhiteConfirm", ra)).IsExist() &&
                ra.FindMulti(RecognitionObject.Ocr(ra.Width * 0.2, ra.Height * 0.3, ra.Width * 0.6, ra.Height * 0.3))
-                 .Any(o => o.Text.Contains("挑战失败") || o.Text.Contains("重新挑战"));
+                 .Any(o => o.Text.Contains(challengeFailedLocalizedString) || o.Text.Contains(retryChallengeLocalizedString));
     }
 
     // ========== 第三优先级：OCR 检测 ==========
@@ -267,15 +329,15 @@ public class AutoStygianOnslaughtTask : StateMachineBase<StygianState, BvPage>, 
     private bool DetectResinSelect(ImageRegion ra)
     {
         var ocrResult = ra.FindMulti(RecognitionObject.Ocr(ra.Width * 0.2, ra.Height * 0.2, ra.Width * 0.6, ra.Height * 0.6));
-        return ocrResult.Any(t => t.Text.Contains("地脉之花")) &&
-               ocrResult.Any(t => t.Text.Contains("浓缩树脂") || t.Text.Contains("原粹树脂"));
+        return ocrResult.Any(t => t.Text.Contains(leyLineBlossomLocalizedString)) &&
+               ocrResult.Any(t => t.Text.Contains(condensedResinLocalizedString) || t.Text.Contains(originalResinLocalizedString));
     }
 
     [StateDetector(StygianState.LeylineFlowerPrompt, Order = 90)]
     private bool DetectLeylineFlowerPrompt(ImageRegion ra)
     {
         var ocrResult = ra.FindMulti(RecognitionObject.Ocr(ra.Width * 0.2, ra.Height * 0.2, ra.Width * 0.6, ra.Height * 0.6));
-        var found = ocrResult.Any(t => t.Text.Contains("地脉之花"));
+        var found = ocrResult.Any(t => t.Text.Contains(leyLineBlossomLocalizedString));
         return found;
     }
 
@@ -285,8 +347,8 @@ public class AutoStygianOnslaughtTask : StateMachineBase<StygianState, BvPage>, 
         // "角色预览" 在右上角，"开始挑战" 在右下角
         // 检测右侧整个区域
         var ocrResult = ra.FindMulti(RecognitionObject.Ocr(ra.Width * 0.5, 0, ra.Width * 0.5, ra.Height));
-        var hasPreview = ocrResult.Any(o => o.Text.Contains("角色预览"));
-        var hasStart = ocrResult.Any(o => o.Text.Contains("开始挑战"));
+        var hasPreview = ocrResult.Any(o => o.Text.Contains(characterPreviewLocalizedString));
+        var hasStart = ocrResult.Any(o => o.Text.Contains(startChallengeLocalizedString));
         var found = hasPreview && hasStart;
         return found;
     }
@@ -296,7 +358,7 @@ public class AutoStygianOnslaughtTask : StateMachineBase<StygianState, BvPage>, 
     {
         // "单人挑战" 在右下角
         return ra.FindMulti(RecognitionObject.Ocr(ra.Width * 0.5, ra.Height * 0.7, ra.Width * 0.5, ra.Height * 0.3))
-                 .Any(o => o.Text.Contains("单人挑战"));
+                 .Any(o => o.Text.Contains(singlePlayerLocalizedString));
     }
 
     [StateDetector(StygianState.DomainEntrance, Order = 120)]
@@ -306,7 +368,7 @@ public class AutoStygianOnslaughtTask : StateMachineBase<StygianState, BvPage>, 
         // 坐标：左上角(1223, 510), 右下角(1376, 566)
         // 宽度=153, 高度=56
         return ra.FindMulti(RecognitionObject.Ocr(1223, 510, 153, 56))
-                 .Any(o => o.Text.Contains("幽境危战"));
+                 .Any(o => o.Text.Contains(stygianOnslaughtLocalizedString));
     }
 
     [StateDetector(StygianState.EventMenu, Order = 130)]
@@ -315,7 +377,7 @@ public class AutoStygianOnslaughtTask : StateMachineBase<StygianState, BvPage>, 
         // 活动一览位置：左上角(125, 142), 右下角(238, 170)
         // OCR 参数：(x, y, width, height)
         return ra.FindMulti(RecognitionObject.Ocr(125, 142, 238 - 125, 170 - 142))
-                 .Any(o => o.Text.Contains("活动一览"));
+                 .Any(o => o.Text.Contains(eventsOverviewLocalizedString));
     }
 
     [StateDetector(StygianState.StygianOnslaughtPage, Order = 140)]
@@ -323,7 +385,7 @@ public class AutoStygianOnslaughtTask : StateMachineBase<StygianState, BvPage>, 
     {
         // 活动详情页右侧主标题：左上角(1135, 278)，右下角(1400, 353)
         return ra.FindMulti(RecognitionObject.Ocr(1135, 278, 1400 - 1135, 353 - 278))
-                 .Any(o => o.Text.Contains("幽境危战"));
+                 .Any(o => o.Text.Contains(stygianOnslaughtLocalizedString));
     }
 
     #endregion
@@ -369,7 +431,7 @@ public class AutoStygianOnslaughtTask : StateMachineBase<StygianState, BvPage>, 
             await Delay(500, _ct);
 
             // 2. 在列表区域内查找"幽境危战"并点击
-            var target = page.GetByText("幽境危战").WithRoi(listRegion).FindAll().FirstOrDefault();
+            var target = page.GetByText(stygianOnslaughtLocalizedString).WithRoi(listRegion).FindAll().FirstOrDefault();
             if (target != null)
             {
                 target.Click();
@@ -392,8 +454,8 @@ public class AutoStygianOnslaughtTask : StateMachineBase<StygianState, BvPage>, 
         using (var ra = CaptureToRectArea())
         {
             var ocrResult = ra.FindMulti(RecognitionObject.Ocr(ra.Width * 0.32, ra.Height * 0.68, ra.Width * 0.16, ra.Height * 0.1));
-            if (ocrResult.Any(o => o.Text.Contains("紊乱爆发期")) &&
-                ocrResult.Any(o => o.Text.Contains("已结束")))
+            if (ocrResult.Any(o => o.Text.Contains(disturbanceOutbreakLocalizedString)) &&
+                ocrResult.Any(o => o.Text.Contains(alreadyEndedLocalizedString)))
             {
                 Logger.LogInformation($"{Name}：检测到紊乱爆发期已结束，按 Esc 返回主界面");
                 Simulation.SendInput.Keyboard.KeyPress(Vanara.PInvoke.User32.VK.VK_ESCAPE);
@@ -679,7 +741,8 @@ public class AutoStygianOnslaughtTask : StateMachineBase<StygianState, BvPage>, 
         var textList = ra.FindMulti(RecognitionObject.Ocr(ra.Width * 0.25, ra.Height * 0.2, ra.Width * 0.5, ra.Height * 0.6));
 
         // 检查是否无树脂
-        if (textList.Any(t => t.Text.Contains("数量不足") || t.Text.Contains("补充原粹树脂")))
+        // 数量不足/补充原粹树脂 sono pattern Regex (contengono .* per EN/FR): Regex.IsMatch, non Contains
+        if (textList.Any(t => Regex.IsMatch(t.Text, insufficientQuantityLocalizedString) || Regex.IsMatch(t.Text, replenishOriginalResinLocalizedString)))
         {
             Logger.LogInformation("原粹树脂已用尽");
             return false;
@@ -739,6 +802,10 @@ public class AutoStygianOnslaughtTask : StateMachineBase<StygianState, BvPage>, 
                 return true;
             }
 
+            // PressUseResin takes the internal Chinese key, NOT a localized value: since #3404 it
+            // localizes the OCR match pattern itself, and GetResinNum still branches on the Chinese
+            // literal ("原粹树脂" / "浓缩树脂") to read the amount. Passing a localized string here
+            // would make that branch fall through and silently return 0.
             if (resinStatus.CondensedResinCount > 0)
             {
                 AutoDomainTask.PressUseResin(ra, "浓缩树脂", Name);
@@ -874,7 +941,7 @@ public class AutoStygianOnslaughtTask : StateMachineBase<StygianState, BvPage>, 
 
             using var ra = CaptureToRectArea();
             var ocrList = ra.FindMulti(RecognitionObject.Ocr(ra.Width * 0.25, ra.Height * 0.2, ra.Width * 0.5, ra.Height * 0.6));
-            if (ocrList.Any(t => t.Text.Contains("地脉之花")))
+            if (ocrList.Any(t => t.Text.Contains(leyLineBlossomLocalizedString)))
             {
                 Logger.LogInformation($"{Name}：成功交互地脉花");
                 return true;
@@ -1070,7 +1137,7 @@ public class AutoStygianOnslaughtTask : StateMachineBase<StygianState, BvPage>, 
                     if (ret.IsExist())
                     {
                         var list = ra.FindMulti(RecognitionObject.Ocr(ret.X + 40 * assetScale, ret.Y - 20 * assetScale, 270 * assetScale, ret.Height * 2));
-                        if (list.Any(o => o.Text.Contains("返回")))
+                        if (list.Any(o => o.Text.Contains(returnLocalizedString)))
                         {
                             return true;
                         }

--- a/BetterGenshinImpact/GameTask/AutoStygianOnslaught/AutoStygianOnslaughtTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoStygianOnslaught/AutoStygianOnslaughtTask.cs
@@ -741,7 +741,7 @@ public class AutoStygianOnslaughtTask : StateMachineBase<StygianState, BvPage>, 
         var textList = ra.FindMulti(RecognitionObject.Ocr(ra.Width * 0.25, ra.Height * 0.2, ra.Width * 0.5, ra.Height * 0.6));
 
         // 检查是否无树脂
-        // 数量不足/补充原粹树脂 sono pattern Regex (contengono .* per EN/FR): Regex.IsMatch, non Contains
+        // 数量不足/补充原粹树脂 是正则模式（EN/FR 的值里含 .*），所以用 Regex.IsMatch 而不是 Contains
         if (textList.Any(t => Regex.IsMatch(t.Text, insufficientQuantityLocalizedString) || Regex.IsMatch(t.Text, replenishOriginalResinLocalizedString)))
         {
             Logger.LogInformation("原粹树脂已用尽");

--- a/BetterGenshinImpact/GameTask/AutoStygianOnslaught/AutoStygianOnslaughtTask.en.resx
+++ b/BetterGenshinImpact/GameTask/AutoStygianOnslaught/AutoStygianOnslaughtTask.en.resx
@@ -1,0 +1,165 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="返回" xml:space="preserve">
+    <value>Return</value>
+  </data>
+  <data name="挑战失败" xml:space="preserve">
+    <value>Challenge Failed</value>
+  </data>
+  <data name="重新挑战" xml:space="preserve">
+    <value>Retry Challenge</value>
+  </data>
+  <data name="地脉之花" xml:space="preserve">
+    <value>Ley Line Blossom</value>
+  </data>
+  <data name="浓缩树脂" xml:space="preserve">
+    <value>Condensed Resin</value>
+  </data>
+  <data name="原粹树脂" xml:space="preserve">
+    <value>Original Resin</value>
+  </data>
+  <data name="角色预览" xml:space="preserve">
+    <value>Character Preview</value>
+  </data>
+  <data name="开始挑战" xml:space="preserve">
+    <value>Start Challenge</value>
+  </data>
+  <data name="单人挑战" xml:space="preserve">
+    <value>Single Player</value>
+  </data>
+  <data name="幽境危战" xml:space="preserve">
+    <value>Stygian Onslaught</value>
+  </data>
+  <data name="活动一览" xml:space="preserve">
+    <value>Events Overview</value>
+  </data>
+  <data name="紊乱爆发期" xml:space="preserve">
+    <value>Disturbance Outbreak</value>
+  </data>
+  <data name="已结束" xml:space="preserve">
+    <value>Already Ended</value>
+  </data>
+  <data name="数量不足" xml:space="preserve">
+    <value>insufficient</value>
+  </data>
+  <data name="补充原粹树脂" xml:space="preserve">
+    <value>Replenish.*Original.*Resin</value>
+  </data>
+</root>

--- a/BetterGenshinImpact/GameTask/AutoStygianOnslaught/AutoStygianOnslaughtTask.en.resx
+++ b/BetterGenshinImpact/GameTask/AutoStygianOnslaught/AutoStygianOnslaughtTask.en.resx
@@ -157,7 +157,7 @@
     <value>Already Ended</value>
   </data>
   <data name="数量不足" xml:space="preserve">
-    <value>insufficient</value>
+    <value>nsufficient</value>
   </data>
   <data name="补充原粹树脂" xml:space="preserve">
     <value>Replenish.*Original.*Resin</value>

--- a/BetterGenshinImpact/GameTask/AutoStygianOnslaught/AutoStygianOnslaughtTask.fr.resx
+++ b/BetterGenshinImpact/GameTask/AutoStygianOnslaught/AutoStygianOnslaughtTask.fr.resx
@@ -1,0 +1,165 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="返回" xml:space="preserve">
+    <value>Retour</value>
+  </data>
+  <data name="挑战失败" xml:space="preserve">
+    <value>Défi échoué</value>
+  </data>
+  <data name="重新挑战" xml:space="preserve">
+    <value>Réessayer le défi</value>
+  </data>
+  <data name="地脉之花" xml:space="preserve">
+    <value>Fleur des lignes énergétiques</value>
+  </data>
+  <data name="浓缩树脂" xml:space="preserve">
+    <value>Résine condensée</value>
+  </data>
+  <data name="原粹树脂" xml:space="preserve">
+    <value>Résine originelle</value>
+  </data>
+  <data name="角色预览" xml:space="preserve">
+    <value>Aperçu de personnage</value>
+  </data>
+  <data name="开始挑战" xml:space="preserve">
+    <value>Commencer</value>
+  </data>
+  <data name="单人挑战" xml:space="preserve">
+    <value>Défi solo</value>
+  </data>
+  <data name="幽境危战" xml:space="preserve">
+    <value>Carnage chtonien</value>
+  </data>
+  <data name="活动一览" xml:space="preserve">
+    <value>Événements en cours</value>
+  </data>
+  <data name="紊乱爆发期" xml:space="preserve">
+    <value>Période d'instabilité</value>
+  </data>
+  <data name="已结束" xml:space="preserve">
+    <value>Terminé</value>
+  </data>
+  <data name="数量不足" xml:space="preserve">
+    <value>insuffisant</value>
+  </data>
+  <data name="补充原粹树脂" xml:space="preserve">
+    <value>Recharger.*la.*Résine.*originelle</value>
+  </data>
+</root>

--- a/BetterGenshinImpact/GameTask/AutoStygianOnslaught/AutoStygianOnslaughtTask.zh-Hant.resx
+++ b/BetterGenshinImpact/GameTask/AutoStygianOnslaught/AutoStygianOnslaughtTask.zh-Hant.resx
@@ -1,0 +1,165 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="返回" xml:space="preserve">
+    <value>返回</value>
+  </data>
+  <data name="挑战失败" xml:space="preserve">
+    <value>挑戰失敗</value>
+  </data>
+  <data name="重新挑战" xml:space="preserve">
+    <value>重新挑戰</value>
+  </data>
+  <data name="地脉之花" xml:space="preserve">
+    <value>地脈之花</value>
+  </data>
+  <data name="浓缩树脂" xml:space="preserve">
+    <value>濃縮樹脂</value>
+  </data>
+  <data name="原粹树脂" xml:space="preserve">
+    <value>原粹樹脂</value>
+  </data>
+  <data name="角色预览" xml:space="preserve">
+    <value>角色預覽</value>
+  </data>
+  <data name="开始挑战" xml:space="preserve">
+    <value>開始挑戰</value>
+  </data>
+  <data name="单人挑战" xml:space="preserve">
+    <value>單人挑戰</value>
+  </data>
+  <data name="幽境危战" xml:space="preserve">
+    <value>幽境危戰</value>
+  </data>
+  <data name="活动一览" xml:space="preserve">
+    <value>活動一覽</value>
+  </data>
+  <data name="紊乱爆发期" xml:space="preserve">
+    <value>紊亂爆發期</value>
+  </data>
+  <data name="已结束" xml:space="preserve">
+    <value>已結束</value>
+  </data>
+  <data name="数量不足" xml:space="preserve">
+    <value>數量不足</value>
+  </data>
+  <data name="补充原粹树脂" xml:space="preserve">
+    <value>補充原粹樹脂</value>
+  </data>
+</root>

--- a/Test/BetterGenshinImpact.UnitTest/CoreTests/RecognitionTests/OCRTests/PaddleOcrServiceTests.cs
+++ b/Test/BetterGenshinImpact.UnitTest/CoreTests/RecognitionTests/OCRTests/PaddleOcrServiceTests.cs
@@ -58,6 +58,12 @@ namespace BetterGenshinImpact.UnitTest.CoreTests.RecognitionTests.OCRTests
         [InlineData("it", "Incarichi")]
         [InlineData("it", "Pesca")]
         [InlineData("it", "Katheryne")]
+        // AutoBossTask / AutoLeyLineOutcropTask / AutoStygianOnslaughtTask: the regex-pattern
+        // values matter most here, since a wrong pattern silently never matches.
+        [InlineData("en", "Click anywhere in the blank area", "Click.*anywhere.*in.*the.*blank.*area")]
+        [InlineData("fr", "Cliquez pour poursuivre", "Cliquez.*pour.*poursuivre")]
+        [InlineData("en", "Stygian Onslaught", "Stygian.*Onslaught")]
+        [InlineData("en", "Challenge Failed", "Challenge.*Failed")]
         /// <summary>
         /// 测试识别各种文字，结果为成功
         /// </summary>

--- a/Test/BetterGenshinImpact.UnitTest/GameTaskTests/OcrResourceTests.cs
+++ b/Test/BetterGenshinImpact.UnitTest/GameTaskTests/OcrResourceTests.cs
@@ -1,0 +1,68 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+using BetterGenshinImpact.GameTask.AutoLeyLineOutcrop;
+using BetterGenshinImpact.GameTask.AutoStygianOnslaught;
+using BetterGenshinImpact.Helpers;
+
+namespace BetterGenshinImpact.UnitTest.GameTaskTests
+{
+    /// <summary>
+    /// 这些用例读取任务<b>实际消费的 resx 值</b>，而不是在测试里另写一份匹配模式：
+    /// 后者在资源被改坏之后依然会通过，而运行时 OCR 匹配已经失效。
+    /// </summary>
+    [Collection("Init Collection")]
+    public class OcrResourceTests
+    {
+        private readonly LocalizationFixture localization;
+
+        public OcrResourceTests(LocalizationFixture localization)
+        {
+            this.localization = localization;
+        }
+
+        /// <summary>
+        /// 英文界面里「地脉衍出」是单数的 "Ley Line Outcrop"，复数模式一条都匹配不上。
+        /// 下面的界面文本取自游戏 TextMap，不是手写的。
+        /// </summary>
+        [Theory]
+        [InlineData("en", "Ley Line Outcrop: Blossom of Revelation")]
+        [InlineData("en", "Ley Line Outcrop: Blossom of Wealth")]
+        [InlineData("en", "Ley Line Outcrop: Blossom of Revelation (Mondstadt)")]
+        [InlineData("fr", "Fleur de la révélation des lignes énergétiques")]
+        [InlineData("fr", "Fleur de la fortune des lignes énergétiques (Fontaine)")]
+        public void LeyLineOutcropPattern_MatchesRealGameText(string culture, string uiText)
+        {
+            var pattern = this.localization.CreateStringLocalizer<AutoLeyLineOutcropTask>()
+                .WithCultureGet(new CultureInfo(culture), "(地脉|衍出)");
+
+            Assert.Matches(pattern, uiText);
+        }
+
+        [Theory]
+        [InlineData("en", "Ley Line Outcrop: Blossom of Revelation")]
+        [InlineData("fr", "Fleur de la fortune des lignes énergétiques")]
+        public void LeyLineTouchPattern_MatchesRealGameText(string culture, string uiText)
+        {
+            var pattern = this.localization.CreateStringLocalizer<AutoLeyLineOutcropTask>()
+                .WithCultureGet(new CultureInfo(culture), "(接触|地脉|之花)");
+
+            Assert.Matches(pattern, uiText);
+        }
+
+        /// <summary>
+        /// 该值会传给默认区分大小写的 <see cref="Regex.IsMatch(string, string)"/>，
+        /// 所以模式不能依赖首字母的大小写。
+        /// </summary>
+        [Theory]
+        [InlineData("en", "Insufficient Quantity")]
+        [InlineData("en", "insufficient quantity")]
+        [InlineData("fr", "Quantité insuffisante")]
+        public void InsufficientQuantityPattern_DoesNotDependOnLetterCase(string culture, string uiText)
+        {
+            var pattern = this.localization.CreateStringLocalizer<AutoStygianOnslaughtTask>()
+                .WithCultureGet(new CultureInfo(culture), "数量不足");
+
+            Assert.Matches(pattern, uiText);
+        }
+    }
+}


### PR DESCRIPTION
Part of #3403, and a direct follow-up to #3404 (AutoDomainTask / CheckRewardsTask).

Same approach as #3404: OCR call sites that hardcode Chinese text move to per-class `.resx`
resources resolved with `WithCultureGet(gameCulture, "<chinese key>")`. The Chinese string
stays the internal identifier, so `zh-Hans` keeps working with no resource file at all and
its behaviour is unchanged by construction.

### Covered here

- `AutoBossTask`
- `AutoLeyLineOutcropTask`
- `AutoStygianOnslaughtTask`

~21 keys, with `en` / `fr` / `zh-Hant` resources for each class.

### One thing worth reviewing carefully: `PressUseResin`

The two Stygian call sites keep passing the **internal Chinese keys** (`"浓缩树脂"` /
`"原粹树脂"`), not localized values, and there is a comment in the code saying why.

Since #3404, `AutoDomainTask.PressUseResin` localizes the OCR match pattern internally via
`ResolveResinNamePattern`, while `GetResinNum` still branches on the Chinese literal to read
the resin amount. Passing an already-localized string would make that branch fall through and
return 0 silently — the task would keep running and under-count resin. `AutoLeyLineOutcropTask`
already passes Chinese keys, so it needed no change.

### Tests

The regex-pattern values are added to `PaddleOcrServiceTests`, because a wrong pattern fails
silently: it simply never matches, and the task stalls with no error.

`dotnet test --filter PaddleOcrServiceTests` → 47 passed, 1 failed (48 total). The failure is
`zh-Hant "二星聖遺物"`, which reproduces identically on an unmodified `main` (43 passed,
1 failed), so it is pre-existing and unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 自动首领、地脉之花及幽境危战任务现支持英文、法文和繁体中文界面。
  - 根据游戏语言自动匹配界面文本，改善跨语言使用体验。

- **问题修复**
  - 优化奖励领取、树脂补充及任务流程中的 OCR 识别，减少因语言差异导致的操作失败。
  - 改进相关提示和挑战结果的识别准确性。

- **测试**
  - 新增英文、法文 OCR 文本及正则匹配测试，覆盖更多游戏提示和挑战场景。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->