### PR TITLE
fix(pathing): 路线重试期间禁用赶路逻辑

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
@@ -303,6 +303,8 @@ public partial class PathExecutor
                     // 不管咋样，松开所有按键
                     Simulation.SendInput.Keyboard.KeyUp(User32.VK.VK_W);
                     Simulation.SendInput.Mouse.RightButtonUp();
+                    // 赶路技能可能按住冲刺键，重试时即使跳过赶路逻辑也必须释放。
+                    Simulation.SendInput.SimulateAction(GIActions.SprintMouse, KeyType.KeyUp);
                     Simulation.SendInput.SimulateAction(GIActions.NormalAttack, KeyType.KeyUp);
                 }
             }

--- a/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
+++ b/BetterGenshinImpact/GameTask/AutoPathing/PathExecutor.cs
@@ -171,6 +171,7 @@ public partial class PathExecutor
         foreach (var waypoints in waypointsList) // 按传送点分割的路径
         {
             CurWaypoints = (waypointsList.FindIndex(wps => wps == waypoints), waypoints);
+            var isRouteRetry = false;
             for (var i = 0; i < RetryTimes; i++)
             {
                 try
@@ -221,7 +222,8 @@ public partial class PathExecutor
                             }
                             else if (waypoint.Action != ActionEnum.UpDownGrabLeaf.Code)
                             {
-                                await MoveTo(waypoint);
+                                // 路线重试时使用基础移动，避免再次触发赶路技能导致重复偏离或状态残留。
+                                await MoveTo(waypoint, !isRouteRetry);
                             }
 
                             await BeforeMoveCloseToTarget(waypoint);
@@ -284,6 +286,7 @@ public partial class PathExecutor
                 }
                 catch (RetryException retryException)
                 {
+                    isRouteRetry = true;
                     StartSkipOtherOperations();
                     Logger.LogWarning(retryException.Message);
                 }
@@ -291,6 +294,7 @@ public partial class PathExecutor
                 {
                     //特殊情况下，重试不消耗次数
                     i--;
+                    isRouteRetry = true;
                     StartSkipOtherOperations();
                     Logger.LogWarning(retryException.Message);
                 }
@@ -750,7 +754,7 @@ public partial class PathExecutor
 
     public DateTime moveToStartTime;
 
-    public async Task MoveTo(WaypointForTrack waypoint)
+    public async Task MoveTo(WaypointForTrack waypoint, bool enableHurry = true)
     {
         // 切人
         await SwitchAvatar(PartyConfig.MainAvatarIndex);
@@ -927,15 +931,19 @@ public partial class PathExecutor
                 }
             }
 
-            // 赶路逻辑（使用角色技能加速赶路）
-            var hurryOnResult = await TryHurryOnAsync(diff, waypoint, distance, screen, num, hurryOnState);
-            if (hurryOnResult)
+            // 路线重试时禁用角色技能赶路，避免重试再次进入可能导致失败的移动状态。
+            if (enableHurry)
             {
-                // continue 会跳过底部 await Delay(...)，
-                // 导致 async state machine 的 MoveNext() 永不返回，调用栈逐轮叠加直到溢出。
-                // 在此处显式等待以展开栈。
-                await Delay(hurryFrameInterval, ct);
-                continue;
+                // 赶路逻辑（使用角色技能加速赶路）
+                var hurryOnResult = await TryHurryOnAsync(diff, waypoint, distance, screen, num, hurryOnState);
+                if (hurryOnResult)
+                {
+                    // continue 会跳过底部 await Delay(...),
+                    // 导致 async state machine 的 MoveNext() 永不返回，调用栈逐轮叠加直到溢出。
+                    // 在此处显式等待以展开栈。
+                    await Delay(hurryFrameInterval, ct);
+                    continue;
+                }
             }
 
             // 根据指定方式进行移动


### PR DESCRIPTION
## 变更说明

- 路线分段首次尝试保留角色技能赶路。
- 捕获 `RetryException` 或 `RetryNoCountException` 后，当前分段后续重试禁用赶路逻辑，避免重复触发技能导致移动状态异常。
- 使用重试状态标记覆盖不计数重试（`RetryNoCountException` 会回退重试计数）。
- `MoveTo` 的新增参数默认为启用，保持其他调用方行为不变。

## 验证

- `dotnet build BetterGenshinImpact/BetterGenshinImpact.csproj --no-restore --property:RunAnalyzers=false --property:WarningLevel=0`
- 构建结果：0 警告，0 错误。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化自动寻路路线重试逻辑，重试移动时将暂停赶路技能，减少移动异常。
  * 重试结束后会自动释放冲刺按键，提升路线执行的稳定性。
  * 改进赶路操作的时序处理，使移动过程更加平滑可靠。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->