### PR TITLE
fix: 提高背包尘歌壶进入流程可靠性

### DIFF
--- a/BetterGenshinImpact/GameTask/Common/Job/GoToSereniteaPotTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/GoToSereniteaPotTask.cs
@@ -200,12 +200,27 @@ internal class GoToSereniteaPotTask
     private async Task<bool> IntoSereniteaPotByBag(CancellationToken ct)
     {
         // 尝试使用背包的壶进入。
-        QuickSereniteaPotTask.Done();
+        if (!await QuickSereniteaPotTask.Start(ct))
+        {
+            Logger.LogWarning("领取尘歌壶奖励:通过背包触发进入尘歌壶失败");
+            return false;
+        }
+
         await Delay(5000, ct); // 在点击壶之后的特殊加载页面会有 mainUI
-        await Bv.WaitForMainUi(ct);
+        if (!await Bv.WaitForMainUi(ct))
+        {
+            Logger.LogWarning("领取尘歌壶奖励:进入尘歌壶后未检测到主界面");
+            return false;
+        }
+
         // 判断是否在尘歌壶中
-        using var ra0 = CaptureToRectArea();
-        if (ra0.Find(ElementRecognition.Get("FingerIcon", ra0)).IsExist())
+        var fingerIconFound = await NewRetry.WaitForAction(() =>
+        {
+            using var capture = CaptureToRectArea();
+            using var fingerIcon = capture.Find(ElementRecognition.Get("FingerIcon", capture));
+            return fingerIcon.IsExist();
+        }, ct, 5, 500);
+        if (fingerIconFound)
         {
             await Delay(1000, ct);
             // 尝试获取尘歌壶名称

--- a/BetterGenshinImpact/GameTask/QuickSereniteaPot/QuickSereniteaPotTask.cs
+++ b/BetterGenshinImpact/GameTask/QuickSereniteaPot/QuickSereniteaPotTask.cs
@@ -8,6 +8,7 @@ using BetterGenshinImpact.GameTask.Common.BgiVision;
 using BetterGenshinImpact.GameTask.Common.Element.Assets;
 using BetterGenshinImpact.GameTask.Model.Area;
 using BetterGenshinImpact.GameTask.Model.GameUI;
+using BetterGenshinImpact.Helpers;
 using BetterGenshinImpact.View.Drawable;
 using Microsoft.Extensions.Logging;
 using System;
@@ -19,6 +20,9 @@ namespace BetterGenshinImpact.GameTask.QuickSereniteaPot;
 
 public class QuickSereniteaPotTask
 {
+    private const int MaxGadgetPageCount = 20;
+    private const int MaxScrollToTopPageCount = 20;
+
     /// <summary>
     /// 快捷键兼容入口。
     /// </summary>
@@ -36,7 +40,7 @@ public class QuickSereniteaPotTask
     {
         if (!TaskContext.Instance().IsInitialized)
         {
-            Toast.Warning("请先启动");
+            UIDispatcherHelper.Invoke(() => Toast.Warning("请先启动"));
             return false;
         }
 
@@ -152,11 +156,13 @@ public class QuickSereniteaPotTask
     private static async Task<bool> FindAndClickPotIcon(CancellationToken ct)
     {
         var gridParams = GridParams.Templates[GridScreenName.Gadget];
-        await ScrollToTop(gridParams, ct);
+        if (!await ScrollToTop(gridParams, ct))
+        {
+            return false;
+        }
 
         var scroller = new GridScroller(gridParams, TaskControl.Logger, Simulation.SendInput, ct);
-        var page = 1;
-        while (true)
+        for (var page = 1; page <= MaxGadgetPageCount; page++)
         {
             for (var attempt = 1; attempt <= 3; attempt++)
             {
@@ -173,13 +179,12 @@ public class QuickSereniteaPotTask
 
             if (!await scroller.TryVerticalScollDown((src, columns) => GridScreen.GridEnumerator.GetGridItems(src, columns)))
             {
-                break;
+                TaskControl.Logger.LogWarning("快速进出尘歌壶:检查小道具 {PageCount} 页后仍未检测到壶", page);
+                return false;
             }
-
-            page++;
         }
 
-        TaskControl.Logger.LogWarning("快速进出尘歌壶:检查小道具 {PageCount} 页后仍未检测到壶", page);
+        TaskControl.Logger.LogWarning("快速进出尘歌壶:达到小道具扫描安全上限 {PageCount} 页后仍未检测到壶", MaxGadgetPageCount);
         return false;
     }
 
@@ -188,13 +193,14 @@ public class QuickSereniteaPotTask
     /// </summary>
     /// <param name="gridParams">小道具网格参数。</param>
     /// <param name="ct">用于取消任务的令牌。</param>
-    private static async Task ScrollToTop(GridParams gridParams, CancellationToken ct)
+    /// <returns>确认到达列表顶部时返回 true；达到安全上限时返回 false。</returns>
+    private static async Task<bool> ScrollToTop(GridParams gridParams, CancellationToken ct)
     {
         using var capture = TaskControl.CaptureToRectArea(forceNew: true);
         using var grid = capture.DeriveCrop(gridParams.Roi);
         grid.Move();
 
-        while (true)
+        for (var page = 1; page <= MaxScrollToTopPageCount; page++)
         {
             using var previousCapture = TaskControl.CaptureToRectArea(forceNew: true);
             using var previousGrid = previousCapture.DeriveCrop(gridParams.Roi);
@@ -214,10 +220,20 @@ public class QuickSereniteaPotTask
                     out _,
                     logger: TaskControl.Logger))
             {
-                break;
+                await TaskControl.Delay(300, ct);
+                return true;
             }
+
+            for (var i = 0; i < gridParams.S2Round; i++)
+            {
+                Simulation.SendInput.Mouse.VerticalScroll(2);
+                await TaskControl.Delay(gridParams.RoundMilliseconds, ct);
+            }
+
+            await TaskControl.Delay(300, ct);
         }
 
-        await TaskControl.Delay(300, ct);
+        TaskControl.Logger.LogWarning("快速进出尘歌壶:达到回顶安全上限 {PageCount} 页，无法确认已到达小道具列表顶部", MaxScrollToTopPageCount);
+        return false;
     }
 }

--- a/BetterGenshinImpact/GameTask/QuickSereniteaPot/QuickSereniteaPotTask.cs
+++ b/BetterGenshinImpact/GameTask/QuickSereniteaPot/QuickSereniteaPotTask.cs
@@ -19,20 +19,18 @@ namespace BetterGenshinImpact.GameTask.QuickSereniteaPot;
 
 public class QuickSereniteaPotTask
 {
-    private const int MaxGadgetPageCount = 5;
-    private const int ScrollToTopCount = 40;
-
     /// <summary>
     /// 快捷键兼容入口。
     /// </summary>
     public static void Done()
     {
-        Task.Run(() => Start(CancellationToken.None)).GetAwaiter().GetResult();
+        _ = Task.Run(() => Start(CancellationToken.None));
     }
 
     /// <summary>
     /// 尝试放置尘歌壶并触发进入或离开交互。
     /// </summary>
+    /// <param name="ct">用于取消任务的令牌。</param>
     /// <returns>成功触发进入或离开尘歌壶时返回 true。</returns>
     public static async Task<bool> Start(CancellationToken ct)
     {
@@ -135,6 +133,10 @@ public class QuickSereniteaPotTask
         }
     }
 
+    /// <summary>
+    /// 检查背包当前是否位于小道具页。
+    /// </summary>
+    /// <returns>小道具页已选中时返回 true。</returns>
     private static bool IsGadgetPageOpen()
     {
         using var capture = TaskControl.CaptureToRectArea(forceNew: true);
@@ -142,16 +144,20 @@ public class QuickSereniteaPotTask
         return gadgetTab.IsExist();
     }
 
+    /// <summary>
+    /// 从小道具列表顶部开始逐页查找并点击尘歌壶。
+    /// </summary>
+    /// <param name="ct">用于取消任务的令牌。</param>
+    /// <returns>找到并点击尘歌壶时返回 true。</returns>
     private static async Task<bool> FindAndClickPotIcon(CancellationToken ct)
     {
         var gridParams = GridParams.Templates[GridScreenName.Gadget];
         await ScrollToTop(gridParams, ct);
 
         var scroller = new GridScroller(gridParams, TaskControl.Logger, Simulation.SendInput, ct);
-        var scannedPageCount = 0;
-        for (var page = 1; page <= MaxGadgetPageCount; page++)
+        var page = 1;
+        while (true)
         {
-            scannedPageCount = page;
             for (var attempt = 1; attempt <= 3; attempt++)
             {
                 await TaskControl.Delay(attempt == 1 ? 500 : 300, ct);
@@ -165,29 +171,53 @@ public class QuickSereniteaPotTask
                 }
             }
 
-            if (page == MaxGadgetPageCount ||
-                !await scroller.TryVerticalScollDown((src, columns) => GridScreen.GridEnumerator.GetGridItems(src, columns)))
+            if (!await scroller.TryVerticalScollDown((src, columns) => GridScreen.GridEnumerator.GetGridItems(src, columns)))
             {
                 break;
             }
+
+            page++;
         }
 
-        TaskControl.Logger.LogWarning("快速进出尘歌壶:检查小道具 {PageCount} 页后仍未检测到壶", scannedPageCount);
+        TaskControl.Logger.LogWarning("快速进出尘歌壶:检查小道具 {PageCount} 页后仍未检测到壶", page);
         return false;
     }
 
+    /// <summary>
+    /// 持续向上滚动小道具列表，直到网格内容不再移动。
+    /// </summary>
+    /// <param name="gridParams">小道具网格参数。</param>
+    /// <param name="ct">用于取消任务的令牌。</param>
     private static async Task ScrollToTop(GridParams gridParams, CancellationToken ct)
     {
         using var capture = TaskControl.CaptureToRectArea(forceNew: true);
         using var grid = capture.DeriveCrop(gridParams.Roi);
         grid.Move();
 
-        for (var i = 0; i < ScrollToTopCount; i++)
+        while (true)
         {
-            Simulation.SendInput.Mouse.VerticalScroll(2);
-            await TaskControl.Delay(20, ct);
+            using var previousCapture = TaskControl.CaptureToRectArea(forceNew: true);
+            using var previousGrid = previousCapture.DeriveCrop(gridParams.Roi);
+
+            for (var i = 0; i < gridParams.S1Round; i++)
+            {
+                Simulation.SendInput.Mouse.VerticalScroll(2);
+                await TaskControl.Delay(gridParams.RoundMilliseconds, ct);
+            }
+
+            await TaskControl.Delay(300, ct);
+            using var currentCapture = TaskControl.CaptureToRectArea(forceNew: true);
+            using var currentGrid = currentCapture.DeriveCrop(gridParams.Roi);
+            if (!GridScroller.IsScrolling(
+                    previousGrid.CacheGreyMat,
+                    currentGrid.CacheGreyMat,
+                    out _,
+                    logger: TaskControl.Logger))
+            {
+                break;
+            }
         }
 
-        await TaskControl.Delay(500, ct);
+        await TaskControl.Delay(300, ct);
     }
 }

--- a/BetterGenshinImpact/GameTask/QuickSereniteaPot/QuickSereniteaPotTask.cs
+++ b/BetterGenshinImpact/GameTask/QuickSereniteaPot/QuickSereniteaPotTask.cs
@@ -22,6 +22,7 @@ public class QuickSereniteaPotTask
 {
     private const int MaxGadgetPageCount = 20;
     private const int MaxScrollToTopPageCount = 20;
+    private static readonly SemaphoreSlim ExecutionLock = new(1, 1);
 
     /// <summary>
     /// 快捷键兼容入口。
@@ -38,19 +39,25 @@ public class QuickSereniteaPotTask
     /// <returns>成功触发进入或离开尘歌壶时返回 true。</returns>
     public static async Task<bool> Start(CancellationToken ct)
     {
-        if (!TaskContext.Instance().IsInitialized)
+        if (!await ExecutionLock.WaitAsync(0, ct))
         {
-            UIDispatcherHelper.Invoke(() => Toast.Warning("请先启动"));
-            return false;
-        }
-
-        if (!SystemControl.IsGenshinImpactActiveByProcess())
-        {
+            TaskControl.Logger.LogWarning("快速进出尘歌壶:已有任务正在执行，忽略重复触发");
             return false;
         }
 
         try
         {
+            if (!TaskContext.Instance().IsInitialized)
+            {
+                UIDispatcherHelper.Invoke(() => Toast.Warning("请先启动"));
+                return false;
+            }
+
+            if (!SystemControl.IsGenshinImpactActiveByProcess())
+            {
+                return false;
+            }
+
             await AutoArtifactSalvageTask.OpenInventory(
                 GridScreenName.Gadget,
                 Simulation.SendInput,
@@ -134,6 +141,7 @@ public class QuickSereniteaPotTask
         finally
         {
             VisionContext.Instance().DrawContent.ClearAll();
+            ExecutionLock.Release();
         }
     }
 

--- a/BetterGenshinImpact/GameTask/QuickSereniteaPot/QuickSereniteaPotTask.cs
+++ b/BetterGenshinImpact/GameTask/QuickSereniteaPot/QuickSereniteaPotTask.cs
@@ -1,142 +1,193 @@
 using BetterGenshinImpact.Core.Recognition;
 using BetterGenshinImpact.Core.Simulator;
 using BetterGenshinImpact.Core.Simulator.Extensions;
+using BetterGenshinImpact.GameTask.AutoArtifactSalvage;
 using BetterGenshinImpact.GameTask.AutoGeniusInvokation.Exception;
 using BetterGenshinImpact.GameTask.Common;
 using BetterGenshinImpact.GameTask.Common.BgiVision;
+using BetterGenshinImpact.GameTask.Common.Element.Assets;
 using BetterGenshinImpact.GameTask.Model.Area;
+using BetterGenshinImpact.GameTask.Model.GameUI;
 using BetterGenshinImpact.View.Drawable;
 using Microsoft.Extensions.Logging;
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Wpf.Ui.Violeta.Controls;
-using static Vanara.PInvoke.User32;
 
 namespace BetterGenshinImpact.GameTask.QuickSereniteaPot;
 
 public class QuickSereniteaPotTask
 {
-    private static void WaitForBagToOpen()
-    {
-        NewRetry.Do(() =>
-        {
-            TaskControl.Sleep(1);
-            using var ra1 = TaskControl.CaptureToRectArea(forceNew: true);
-            using var ra2 = ra1.Find(RecognitionAssets.Get("QuickTeleport", "MapCloseButton", ra1));
-            if (ra2.IsEmpty())
-            {
-                throw new RetryException("背包未打开");
-            }
-        }, TimeSpan.FromMilliseconds(500), 5);
-    }
+    private const int MaxGadgetPageCount = 5;
+    private const int ScrollToTopCount = 40;
 
-    private static void FindPotIcon()
-    {
-        NewRetry.Do(() =>
-        {
-            TaskControl.Sleep(1);
-            using var ra1 = TaskControl.CaptureToRectArea(forceNew: true);
-            using var ra2 = ra1.Find(RecognitionAssets.Get("QuickSereniteaPot", "SereniteaPotIcon", ra1));
-            if (ra2.IsEmpty())
-            {
-                throw new RetryException("未检测到壶");
-            }
-            else
-            {
-                ra2.Click();
-            }
-        }, TimeSpan.FromMilliseconds(200), 3);
-    }
-
+    /// <summary>
+    /// 快捷键兼容入口。
+    /// </summary>
     public static void Done()
+    {
+        Task.Run(() => Start(CancellationToken.None)).GetAwaiter().GetResult();
+    }
+
+    /// <summary>
+    /// 尝试放置尘歌壶并触发进入或离开交互。
+    /// </summary>
+    /// <returns>成功触发进入或离开尘歌壶时返回 true。</returns>
+    public static async Task<bool> Start(CancellationToken ct)
     {
         if (!TaskContext.Instance().IsInitialized)
         {
             Toast.Warning("请先启动");
-            return;
+            return false;
         }
 
         if (!SystemControl.IsGenshinImpactActiveByProcess())
         {
-            return;
+            return false;
         }
 
         try
         {
-            // 打开背包
-            Simulation.SendInput.SimulateAction(GIActions.OpenInventory);
-            TaskControl.CheckAndSleep(500);
-            WaitForBagToOpen();
+            await AutoArtifactSalvageTask.OpenInventory(
+                GridScreenName.Gadget,
+                Simulation.SendInput,
+                TaskControl.Logger,
+                ct);
 
-            // 点击道具页
-            GameCaptureRegion.GameRegion1080PPosClick(1050, 50);
-            TaskControl.CheckAndSleep(200);
-
-            // 尝试放置壶
-            FindPotIcon();
-            TaskControl.CheckAndSleep(200);
-
-            // 点击放置 右下225,60
-            // GameCaptureRegion.GameRegionClick((size, assetScale) => (size.Width - 225 * assetScale, size.Height - 60 * assetScale));
-            // 也可以使用下面的方法点击放置按钮
-            using (var confirmCapture = TaskControl.CaptureToRectArea())
+            if (!IsGadgetPageOpen())
             {
-                Bv.ClickWhiteConfirmButton(confirmCapture);
+                TaskControl.Logger.LogWarning("快速进出尘歌壶:未能打开背包小道具页");
+                return false;
             }
-            TaskControl.CheckAndSleep(800);
-            // 校验是否部署成功
-            var seccess = false;
-            for (int i = 0; i < 5; i++)
+
+            if (!await FindAndClickPotIcon(ct))
             {
-                using var mainUiCapture = TaskControl.CaptureToRectArea();
-                if (Bv.IsInMainUi(mainUiCapture))
+                return false;
+            }
+
+            var confirmClicked = await NewRetry.WaitForAction(() =>
+            {
+                using var capture = TaskControl.CaptureToRectArea(forceNew: true);
+                return Bv.ClickWhiteConfirmButton(capture);
+            }, ct, 5, 400);
+            if (!confirmClicked)
+            {
+                TaskControl.Logger.LogWarning("快速进出尘歌壶:未找到放置按钮");
+                return false;
+            }
+
+            if (!await Bv.WaitForMainUi(ct, 8))
+            {
+                TaskControl.Logger.LogWarning("快速进出尘歌壶:放置后未返回主界面");
+                return false;
+            }
+
+            string? action = null;
+            var interactionFound = await NewRetry.WaitForAction(() =>
+            {
+                using var capture = TaskControl.CaptureToRectArea(forceNew: true);
+                if (Bv.FindF(capture, "进入", "尘歌壶"))
                 {
-                    seccess = true;
-                    break;
+                    action = "进入";
+                    return true;
                 }
-            }
-            if (!seccess) {
-                for (int i = 0; i < 5; ++i)
-                {
-                    using var bigMapCapture = TaskControl.CaptureToRectArea();
-                    if (!Bv.IsInBigMapUi(bigMapCapture))
-                    {
-                        Simulation.SendInput.SimulateAction(GIActions.OpenInventory);
-                    }
-                    else
-                    {
-                        return;
-                    }
-                }
-            }
-            // 校验F交互是否是 进入/离开[尘歌壶] 
-            using var capture = TaskControl.CaptureToRectArea();
-            bool isEnter = Bv.FindF(capture, "进入", "尘歌壶");
-            bool isLeave = Bv.FindF(capture, "离开", "尘歌壶");
 
-            if (isEnter || isLeave) {
-                string action = isEnter ? "进入" : "离开";
-                TaskControl.Logger.LogInformation($"快速进出尘歌壶:识别到 {action}尘歌壶");
-                
-                // 按F触发交互
-                Simulation.SendInput.SimulateAction(GIActions.PickUpOrInteract);
-                TaskControl.Logger.LogInformation($"快速进出尘歌壶:F{action}尘歌壶");
-                TaskControl.CheckAndSleep(200);
-                // 点击进入/离开尘歌壶
-                // 如果不是联机状态，此时玩家应已进入传送界面，本次点击不会影响实际功能
-                GameCaptureRegion.GameRegion1080PPosClick(1010, 760);
-            }
-            else
+                if (Bv.FindF(capture, "离开", "尘歌壶"))
+                {
+                    action = "离开";
+                    return true;
+                }
+
+                return false;
+            }, ct, 8, 500);
+            if (!interactionFound)
             {
-                TaskControl.Logger.LogInformation("快速进出尘歌壶:未识别到 进入或离开尘歌壶");
+                TaskControl.Logger.LogWarning("快速进出尘歌壶:未识别到进入或离开尘歌壶交互");
+                return false;
             }
+
+            TaskControl.Logger.LogInformation("快速进出尘歌壶:识别到 {Action}尘歌壶", action);
+            Simulation.SendInput.SimulateAction(GIActions.PickUpOrInteract);
+            TaskControl.Logger.LogInformation("快速进出尘歌壶:F{Action}尘歌壶", action);
+            await TaskControl.Delay(500, ct);
+
+            // 联机状态下需要额外点击进入/离开选项；单人状态下该点击不会影响传送。
+            GameCaptureRegion.GameRegion1080PPosClick(1010, 760);
+            return true;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (NormalEndException)
+        {
+            throw;
         }
         catch (Exception e)
         {
-            TaskControl.Logger.LogWarning(e.Message);
+            TaskControl.Logger.LogWarning(e, "快速进出尘歌壶失败");
+            return false;
         }
         finally
         {
             VisionContext.Instance().DrawContent.ClearAll();
         }
+    }
+
+    private static bool IsGadgetPageOpen()
+    {
+        using var capture = TaskControl.CaptureToRectArea(forceNew: true);
+        using var gadgetTab = capture.Find(ElementRecognition.Get("BagGadgetChecked", capture));
+        return gadgetTab.IsExist();
+    }
+
+    private static async Task<bool> FindAndClickPotIcon(CancellationToken ct)
+    {
+        var gridParams = GridParams.Templates[GridScreenName.Gadget];
+        await ScrollToTop(gridParams, ct);
+
+        var scroller = new GridScroller(gridParams, TaskControl.Logger, Simulation.SendInput, ct);
+        var scannedPageCount = 0;
+        for (var page = 1; page <= MaxGadgetPageCount; page++)
+        {
+            scannedPageCount = page;
+            for (var attempt = 1; attempt <= 3; attempt++)
+            {
+                await TaskControl.Delay(attempt == 1 ? 500 : 300, ct);
+                using var capture = TaskControl.CaptureToRectArea(forceNew: true);
+                using var potIcon = capture.Find(RecognitionAssets.Get("QuickSereniteaPot", "SereniteaPotIcon", capture));
+                if (potIcon.IsExist())
+                {
+                    TaskControl.Logger.LogInformation("快速进出尘歌壶:在小道具第 {Page} 页找到尘歌壶", page);
+                    potIcon.Click();
+                    return true;
+                }
+            }
+
+            if (page == MaxGadgetPageCount ||
+                !await scroller.TryVerticalScollDown((src, columns) => GridScreen.GridEnumerator.GetGridItems(src, columns)))
+            {
+                break;
+            }
+        }
+
+        TaskControl.Logger.LogWarning("快速进出尘歌壶:检查小道具 {PageCount} 页后仍未检测到壶", scannedPageCount);
+        return false;
+    }
+
+    private static async Task ScrollToTop(GridParams gridParams, CancellationToken ct)
+    {
+        using var capture = TaskControl.CaptureToRectArea(forceNew: true);
+        using var grid = capture.DeriveCrop(gridParams.Roi);
+        grid.Move();
+
+        for (var i = 0; i < ScrollToTopCount; i++)
+        {
+            Simulation.SendInput.Mouse.VerticalScroll(2);
+            await TaskControl.Delay(20, ct);
+        }
+
+        await TaskControl.Delay(500, ct);
     }
 }

--- a/BetterGenshinImpact/GameTask/QuickSereniteaPot/QuickSereniteaPotTask.cs
+++ b/BetterGenshinImpact/GameTask/QuickSereniteaPot/QuickSereniteaPotTask.cs
@@ -1,6 +1,8 @@
 using BetterGenshinImpact.Core.Recognition;
+using BetterGenshinImpact.Core.Script;
 using BetterGenshinImpact.Core.Simulator;
 using BetterGenshinImpact.Core.Simulator.Extensions;
+using BetterGenshinImpact.GameTask;
 using BetterGenshinImpact.GameTask.AutoArtifactSalvage;
 using BetterGenshinImpact.GameTask.AutoGeniusInvokation.Exception;
 using BetterGenshinImpact.GameTask.Common;
@@ -29,7 +31,7 @@ public class QuickSereniteaPotTask
     /// </summary>
     public static void Done()
     {
-        _ = Task.Run(() => Start(CancellationToken.None));
+        new TaskRunner().FireAndForget(() => Start(CancellationContext.Instance.Cts.Token));
     }
 
     /// <summary>


### PR DESCRIPTION
## 问题

背包尘歌壶流程原先通过固定坐标切换小道具页，只在当前画面中短暂识别 3 次壶图标。识别失败时异常会被吞掉，调用方仍继续等待传送并最终记录“未识别到手指”，不容易看出实际失败点。

## 修改

- 复用通用背包入口，通过已选中/未选中图标可靠切换小道具页。
- 进入小道具页后检测实际到顶状态，再逐页查找尘歌壶并以实际到底状态终止；回顶和扫描均设置 20 页异常熔断上限。
- 将快速进出流程改为可等待且返回成功状态，并传递取消令牌。
- 分别校验放置按钮、返回主界面和“进入/离开尘歌壶”交互提示，输出具体失败日志。
- 一条龙在触发进壶失败或未检测到主界面时及时退出；进入后对手指图标进行多帧重试。
- 保留原快捷键入口兼容性，并通过 `TaskRunner` 参与全局任务互斥；流程内部另有非等待互斥，避免重复触发并发操作界面。

## 验证

- `dotnet build BetterGenshinImpact.sln -c Debug --no-restore --no-incremental --nologo -clp:ErrorsOnly`：通过，0 errors。
- `dotnet format BetterGenshinImpact/BetterGenshinImpact.csproj --no-restore --include BetterGenshinImpact/GameTask/QuickSereniteaPot/QuickSereniteaPotTask.cs --verify-no-changes`：通过。
- `git diff --check origin/main...HEAD`：通过。
- 完整 UnitTest 在本地为 145 passed / 113 failed；失败集中在仓库图像测试数据、中文路径 OpenCV 编码和 OCR 环境，堆栈不涉及本次修改的尘歌壶流程。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **功能优化**
  - 优化进入尘歌壶流程，增加启动结果与主界面检测。
  - 优化尘歌壶图标识别，支持最多 5 次重试，每次间隔 500 毫秒。

- **稳定性**
  - 进入失败或未检测到主界面时记录警告，并正确返回失败状态。
  - 防止尘歌壶任务重复执行，已有任务运行时将忽略重复触发。
  - 优化任务结束处理，确保成功、失败或取消后均能正常释放执行状态。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
