### PR TITLE
fix: separate overlay status icon and text rendering

### DIFF
--- a/BetterGenshinImpact/Model/StatusItem.cs
+++ b/BetterGenshinImpact/Model/StatusItem.cs
@@ -6,7 +6,9 @@ namespace BetterGenshinImpact.Model
 {
     public partial class StatusItem : ObservableObject
     {
-        public string Name { get; set; }
+        public string Name { get; }
+        public string Icon { get; }
+        public string DisplayName { get; }
         private INotifyPropertyChanged _sourceObject { get; set; }
         private string _propertyName { get; set; }
 
@@ -15,6 +17,17 @@ namespace BetterGenshinImpact.Model
         public StatusItem(string name, INotifyPropertyChanged sourceObject, string propertyName = "Enabled")
         {
             Name = name;
+            var separatorIndex = name.IndexOf(' ');
+            if (separatorIndex > 0)
+            {
+                Icon = name[..separatorIndex];
+                DisplayName = name[(separatorIndex + 1)..];
+            }
+            else
+            {
+                Icon = string.Empty;
+                DisplayName = name;
+            }
             _sourceObject = sourceObject;
             _propertyName = propertyName;
 

--- a/BetterGenshinImpact/View/MaskWindow.xaml
+++ b/BetterGenshinImpact/View/MaskWindow.xaml
@@ -203,7 +203,27 @@
                                     </StackPanel.Resources>
                                     <TextBlock FontFamily="{StaticResource FgiIconFontFamily}"
                                                Opacity="{Binding DataContext.Config.MaskWindowConfig.TextOpacity, RelativeSource={RelativeSource AncestorType=Window}}"
-                                               Text="{Binding Name}">
+                                               Text="{Binding Icon}">
+                                        <TextBlock.FontSize>
+                                            <MultiBinding Converter="{StaticResource OverlayScaledSizeConverter}">
+                                                <Binding Path="DataContext.Config.MaskWindowConfig.StatusFontSize" RelativeSource="{RelativeSource AncestorType=Window}" />
+                                                <Binding Path="DataContext.Config.MaskWindowConfig.LogFontScale" RelativeSource="{RelativeSource AncestorType=Window}" />
+                                                <Binding Path="DataContext.ScaleTo1080PRatio" RelativeSource="{RelativeSource AncestorType=Window}" />
+                                                <Binding Path="DataContext.DisplayDpiScale" RelativeSource="{RelativeSource AncestorType=Window}" />
+                                                <Binding Path="DataContext.Config.MaskWindowConfig.OverlayScalingEnabled" RelativeSource="{RelativeSource AncestorType=Window}" />
+                                            </MultiBinding>
+                                        </TextBlock.FontSize>
+                                        <TextBlock.Foreground>
+                                            <MultiBinding Converter="{StaticResource EnabledColorBrushConverter}">
+                                                <Binding Path="IsEnabled" />
+                                                <Binding Path="DataContext.Config.MaskWindowConfig.StatusDisabledTextColor" RelativeSource="{RelativeSource AncestorType=Window}" />
+                                                <Binding Path="DataContext.Config.MaskWindowConfig.StatusEnabledTextColor" RelativeSource="{RelativeSource AncestorType=Window}" />
+                                            </MultiBinding>
+                                        </TextBlock.Foreground>
+                                    </TextBlock>
+                                    <TextBlock FontFamily="{StaticResource TextThemeFontFamily}"
+                                               Opacity="{Binding DataContext.Config.MaskWindowConfig.TextOpacity, RelativeSource={RelativeSource AncestorType=Window}}"
+                                               Text="{Binding DisplayName}">
                                         <TextBlock.FontSize>
                                             <MultiBinding Converter="{StaticResource OverlayScaledSizeConverter}">
                                                 <Binding Path="DataContext.Config.MaskWindowConfig.StatusFontSize" RelativeSource="{RelativeSource AncestorType=Window}" />


### PR DESCRIPTION
## Summary

Fixes an in-game overlay rendering issue where status text was rendered using the icon font.

## Changes

- Separate status icon and status text rendering
- Render status icons with `FgiIconFontFamily`
- Render normal status text with `TextThemeFontFamily`
- Preserve existing overlay behavior

## Result

Fixes the white/yellow horizontal artifact in the in-game overlay while keeping status icons and text readable.

## Validation

- Build: 0 errors
- `git diff --check`: passed
- Changed files: 2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 状态栏项目现支持将图标与显示名称分开展示。
  - 当名称包含空格时，前半部分显示为图标，后半部分显示为名称；不包含空格时，将完整名称作为显示内容。
  - 图标和名称会保持原有的字体缩放、透明度及启用状态颜色效果。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->