### PR TITLE
fix: 点「AI推理设备设置 - 更多」打不开窗口

### DIFF
--- a/BetterGenshinImpact/View/Pages/MusicPage.xaml
+++ b/BetterGenshinImpact/View/Pages/MusicPage.xaml
@@ -238,7 +238,7 @@
                                    Foreground="{DynamicResource TextFillColorTertiaryBrush}"
                                    TextTrimming="CharacterEllipsis"
                                    ToolTip="{Binding ViewModel.Config.MusicConfig.MusicFolder}">
-                            <Run Text="{i18n:T 曲谱目录：}" /><Run Text="{Binding ViewModel.MusicFolderDisplayText}" />
+                            <Run Text="{i18n:T 曲谱目录：}" /><Run Text="{Binding ViewModel.MusicFolderDisplayText, Mode=OneWay}" />
                         </TextBlock>
                         <ui:Button Grid.Column="2"
                                    Width="36"
@@ -403,7 +403,7 @@
                                                            HorizontalAlignment="Right"
                                                            FontSize="11"
                                                            Foreground="{DynamicResource TextFillColorTertiaryBrush}">
-                                                    <Run Text="{i18n:T 可演奏 }" /><Run Text="{Binding PlayableRatioText}" />
+                                                    <Run Text="{i18n:T 可演奏 }" /><Run Text="{Binding PlayableRatioText, Mode=OneWay}" />
                                                 </TextBlock>
                                             </StackPanel>
                                         </Grid>

--- a/BetterGenshinImpact/View/Pages/View/HardwareAccelerationView.xaml
+++ b/BetterGenshinImpact/View/Pages/View/HardwareAccelerationView.xaml
@@ -84,7 +84,7 @@
                         <TextBlock Grid.Row="2"
                                    Grid.Column="0"
                                    Foreground="{ui:ThemeResource TextFillColorSecondaryBrush}">
-                            <Run Text="{i18n:T 当前加载：}" /><Run Text="{Binding ProviderTypesText}" />
+                            <Run Text="{i18n:T 当前加载：}" /><Run Text="{Binding ProviderTypesText, Mode=OneWay}" />
                         </TextBlock>
                     </Grid>
                     <!--  缓存管理  -->
@@ -137,7 +137,7 @@
                         <TextBlock Grid.Row="2"
                                    Grid.Column="0"
                                    Foreground="{ui:ThemeResource TextFillColorSecondaryBrush}">
-                            <Run Text="{i18n:T 当前状态：}" /><Run Text="{Binding Status.CpuOcr}" />
+                            <Run Text="{i18n:T 当前状态：}" /><Run Text="{Binding Status.CpuOcr, Mode=OneWay}" />
                         </TextBlock>
                     </Grid>
                     <!--  GPU Device  -->
@@ -167,7 +167,7 @@
                         <TextBlock Grid.Row="2"
                                    Grid.Column="0"
                                    Foreground="{ui:ThemeResource TextFillColorSecondaryBrush}">
-                            <Run Text="{i18n:T 当前DML设备：}" /><Run Text="{Binding Status.DmlDeviceId}" />
+                            <Run Text="{i18n:T 当前DML设备：}" /><Run Text="{Binding Status.DmlDeviceId, Mode=OneWay}" />
                         </TextBlock>
                     </Grid>
                     <!--  _optimizedModel  -->
@@ -196,7 +196,7 @@
                         <TextBlock Grid.Row="2"
                                    Grid.Column="0"
                                    Foreground="{ui:ThemeResource TextFillColorSecondaryBrush}">
-                            <Run Text="{i18n:T 当前状态：}" /><Run Text="{Binding Status.OptimizedModel}" />
+                            <Run Text="{i18n:T 当前状态：}" /><Run Text="{Binding Status.OptimizedModel, Mode=OneWay}" />
                         </TextBlock>
                     </Grid>
 
@@ -255,7 +255,7 @@
                         <TextBlock Grid.Row="2"
                                    Grid.Column="0"
                                    Foreground="{ui:ThemeResource TextFillColorSecondaryBrush}">
-                            <Run Text="{i18n:T 当前CUDA设备：}" /><Run Text="{Binding Status.CudaDeviceId}" />
+                            <Run Text="{i18n:T 当前CUDA设备：}" /><Run Text="{Binding Status.CudaDeviceId, Mode=OneWay}" />
                         </TextBlock>
                     </Grid>
                     <!--  Auto Append CUDA Path  -->
@@ -366,7 +366,7 @@
                         <TextBlock Grid.Row="2"
                                    Grid.Column="0"
                                    Foreground="{ui:ThemeResource TextFillColorSecondaryBrush}">
-                            <Run Text="{i18n:T 缓存状态：}" /><Run Text="{Binding Status.EnableCache}" />
+                            <Run Text="{i18n:T 缓存状态：}" /><Run Text="{Binding Status.EnableCache, Mode=OneWay}" />
                         </TextBlock>
                     </Grid>
 
@@ -396,7 +396,7 @@
                         <TextBlock Grid.Row="2"
                                    Grid.Column="0"
                                    Foreground="{ui:ThemeResource TextFillColorSecondaryBrush}">
-                            <Run Text="{i18n:T 嵌入模式：}" /><Run Text="{Binding Status.TrtUseEmbedMode}" />
+                            <Run Text="{i18n:T 嵌入模式：}" /><Run Text="{Binding Status.TrtUseEmbedMode, Mode=OneWay}" />
                         </TextBlock>
                     </Grid>
                 </StackPanel>
@@ -462,7 +462,7 @@
                         <TextBlock Grid.Row="3"
                                    Grid.Column="0"
                                    Foreground="{ui:ThemeResource TextFillColorSecondaryBrush}">
-                            <Run Text="{i18n:T 当前参数：}" /><Run Text="{Binding Status.OpenVinoDevice}" />
+                            <Run Text="{i18n:T 当前参数：}" /><Run Text="{Binding Status.OpenVinoDevice, Mode=OneWay}" />
                         </TextBlock>
                     </Grid>
                     <!--  _enableOpenVinoCache  -->
@@ -491,7 +491,7 @@
                         <TextBlock Grid.Row="2"
                                    Grid.Column="0"
                                    Foreground="{ui:ThemeResource TextFillColorSecondaryBrush}">
-                            <Run Text="{i18n:T 当前状态：}" /><Run Text="{Binding Status.OpenVinoCache}" />
+                            <Run Text="{i18n:T 当前状态：}" /><Run Text="{Binding Status.OpenVinoCache, Mode=OneWay}" />
                         </TextBlock>
                     </Grid>
                 </StackPanel>


### PR DESCRIPTION
点「AI推理设备设置」旁边的「更多」，窗口直接打不开，日志里报 CpuOcr 这个只读属性不能 TwoWay 绑定。

0.64.0 发行版没这问题。后面国际化改文案的时候把 TextBlock 拆成 Run 了，Run.Text 默认 TwoWay，这些当前状态又是只读的，一点就炸。

展示绑定改成 OneWay 就行。硬件加速设置页同类的都补了，曲谱页有一处一样的也一起改了。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 明确只读状态文本采用单向绑定，提升界面状态显示的一致性与可预测性。
  * 优化曲谱目录、曲目可演奏比例及硬件加速相关状态信息的显示绑定行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->