### PR TITLE
fix: 未勾选性能指标遮罩时不启动采样

### DIFF
--- a/BetterGenshinImpact/GameTask/TaskTriggerDispatcher.cs
+++ b/BetterGenshinImpact/GameTask/TaskTriggerDispatcher.cs
@@ -360,7 +360,11 @@ namespace BetterGenshinImpact.GameTask
 
                 var speedTimer = new SpeedTimer();
                 // 从真正开始截图处计时，前面的窗口状态检查不计入 BetterGI 本轮处理耗时。
-                tickMetrics.Begin();
+                // 仅在遮罩指标开启时启动采样：未 Begin 时 EndCapture/AddTriggerCost/Publish 均按设计空转。
+                if (_metricsService is { IsEnabled: true })
+                {
+                    tickMetrics.Begin();
+                }
                 // 捕获游戏画面
                 var captureFrame = GameCapture.Capture();
                 var bitmap = captureFrame?.Frame;

--- a/BetterGenshinImpact/Service/OverlayMetricsService.cs
+++ b/BetterGenshinImpact/Service/OverlayMetricsService.cs
@@ -58,10 +58,17 @@ public sealed class OverlayMetricsService : IDisposable
 
     public OverlayMetricsSnapshot CurrentSnapshot { get; private set; } = OverlayMetricsSnapshot.Empty;
 
+    /// <summary>
+    /// 性能指标遮罩开关的缓存，所有采样入口的统一门控：
+    /// 未勾选时不加锁、不读配置、不发布；开关变化经 PropertyChanged 同步到本属性。
+    /// </summary>
+    public bool IsEnabled { get; private set; }
+
     public OverlayMetricsService()
     {
         _maskWindowConfig = _configService?.Get().MaskWindowConfig;
         _maskWindowConfig?.EnsureOverlayMetricItems();
+        IsEnabled = _maskWindowConfig?.ShowOverlayMetrics == true;
         if (_maskWindowConfig != null)
         {
             _maskWindowConfig.PropertyChanged += MaskWindowConfigOnPropertyChanged;
@@ -70,6 +77,11 @@ public sealed class OverlayMetricsService : IDisposable
 
     public void UpdateGameFps(double fps)
     {
+        if (!IsEnabled)
+        {
+            return;
+        }
+
         lock (_locker)
         {
             _gameFps = fps;
@@ -80,6 +92,11 @@ public sealed class OverlayMetricsService : IDisposable
 
     public void RecordSkippedTick()
     {
+        if (!IsEnabled)
+        {
+            return;
+        }
+
         lock (_locker)
         {
             _skippedTicks++;
@@ -90,6 +107,11 @@ public sealed class OverlayMetricsService : IDisposable
 
     public void RecordDispatcherTick(double processingCostMs, double captureCostMs, double triggerCostMs)
     {
+        if (!IsEnabled)
+        {
+            return;
+        }
+
         lock (_locker)
         {
             RecordPeakProcessingCost(processingCostMs, DateTime.UtcNow);
@@ -111,7 +133,34 @@ public sealed class OverlayMetricsService : IDisposable
         if (e.PropertyName is nameof(MaskWindowConfig.ShowOverlayMetrics)
             or nameof(MaskWindowConfig.OverlayMetricItems))
         {
+            SyncEnabledState();
             TryPublish(force: true, refreshHardware: false);
+        }
+    }
+
+    private void SyncEnabledState()
+    {
+        var enabled = _maskWindowConfig?.ShowOverlayMetrics == true;
+        if (IsEnabled == enabled)
+        {
+            return;
+        }
+
+        IsEnabled = enabled;
+        if (!enabled)
+        {
+            // 关闭时清空瞬态采样值，重新打开后由新采样自然回填，避免短暂展示关闭前的旧数据。
+            lock (_locker)
+            {
+                _processingCostSamples.Clear();
+                _gameFps = null;
+                _processingCostMs = null;
+                _peakProcessingCostMs = null;
+                _captureCostMs = null;
+                _triggerCostMs = null;
+                _skippedTicks = 0;
+                _lastPublishedSkippedTicks = 0;
+            }
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **性能优化**
  * 关闭遮罩指标后，将停止帧率、跳帧及调度器指标采样，减少不必要的性能开销。
  * 指标开关或项目配置变更后会及时同步状态。

* **数据一致性**
  * 关闭指标时会清除临时采样、历史峰值和跳帧计数，并立即发布更新，避免继续显示过期数据。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->