### PR TITLE
feat(AutoBoss): 更新至冬BOSS

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoBoss/Assets/Pathing/不灭衍生造物前往.json
+++ b/BetterGenshinImpact/GameTask/AutoBoss/Assets/Pathing/不灭衍生造物前往.json
@@ -1,0 +1,59 @@
+{
+  "info": {
+    "authors": [
+      {
+        "links": "https://github.com/1004452714",
+        "name": "DarkFlameMaster"
+      }
+    ],
+    "bgi_version": "0.45.0",
+    "description": "",
+    "enable_monster_loot_split": false,
+    "last_modified_time": 1788555902054,
+    "map_match_method": "SIFT",
+    "map_name": "Teyvat",
+    "name": "不灭衍生造物前往",
+    "tags": [],
+    "type": "collect",
+    "version": "1.0"
+  },
+  "positions": [
+    {
+      "action": "",
+      "action_params": "",
+      "id": 1,
+      "locked": false,
+      "move_mode": "walk",
+      "type": "teleport",
+      "x": 7163.7637,
+      "y": 9309.7236
+    },
+    {
+      "action": "log_output",
+      "action_params": "受限于地图追踪支持，存在位置偏移的情况是正常的，开战后boss会主动靠近",
+      "id": 2,
+      "move_mode": "walk",
+      "type": "path",
+      "x": 7162.5387,
+      "y": 9310.8765
+    },
+    {
+      "action": "",
+      "action_params": "",
+      "id": 3,
+      "move_mode": "walk",
+      "type": "target",
+      "x": 7151.4766,
+      "y": 9321.6953
+    },
+    {
+      "action": "combat_script",
+      "action_params": "keydown(w),keydown(shift),wait(15),keyup(w),keyup(shift)",
+      "id": 4,
+      "move_mode": "walk",
+      "type": "path",
+      "x": 7160.3281,
+      "y": 9333.8125
+    }
+  ]
+}

--- a/BetterGenshinImpact/GameTask/AutoBoss/Assets/Pathing/嵌合翼骏狮前往.json
+++ b/BetterGenshinImpact/GameTask/AutoBoss/Assets/Pathing/嵌合翼骏狮前往.json
@@ -1,0 +1,40 @@
+{
+  "info": {
+    "authors": [
+      {
+        "links": "https://github.com/1004452714",
+        "name": "DarkFlameMaster"
+      }
+    ],
+    "bgi_version": "0.45.0",
+    "description": "",
+    "enable_monster_loot_split": false,
+    "last_modified_time": 1786528552840,
+    "map_match_method": "SIFT",
+    "map_name": "Teyvat",
+    "name": "嵌合翼骏狮前往",
+    "tags": [],
+    "type": "collect",
+    "version": "1.0"
+  },
+  "positions": [
+    {
+      "action": "",
+      "action_params": "",
+      "id": 1,
+      "move_mode": "walk",
+      "type": "teleport",
+      "x": 8250.2588,
+      "y": 8158.9434
+    },
+    {
+      "action": "",
+      "action_params": "",
+      "id": 2,
+      "move_mode": "walk",
+      "type": "path",
+      "x": 8284.0762,
+      "y": 8123.4551
+    }
+  ]
+}

--- a/BetterGenshinImpact/GameTask/AutoBoss/Assets/Pathing/无相之草前往.json
+++ b/BetterGenshinImpact/GameTask/AutoBoss/Assets/Pathing/无相之草前往.json
@@ -1,94 +1,94 @@
 {
   "info": {
-    "name": "无相之草前往",
-    "type": "collect",
     "authors": [
       {
-        "name": "Tool_tingsu",
-        "links": ""
+        "links": "https://github.com/1004452714",
+        "name": "DarkFlameMaster"
       }
     ],
-    "version": "1.0",
+    "bgi_version": "0.45.0",
     "description": "",
-    "map_name": "Teyvat",
-    "bgi_version": "0.52.0",
+    "enable_monster_loot_split": false,
+    "last_modified_time": 1788835720032,
     "map_match_method": "TemplateMatch",
+    "map_name": "Teyvat",
+    "name": "无相之草前往",
     "tags": [],
-    "last_modified_time": 1753788793031,
-    "enable_monster_loot_split": false
+    "type": "collect",
+    "version": "1.0"
   },
   "positions": [
     {
+      "action": "",
+      "action_params": "",
       "id": 1,
-      "x": 4036.58203125,
-      "y": -2464.6328125,
+      "move_mode": "walk",
       "type": "teleport",
-      "move_mode": "walk",
-      "action": "",
-      "action_params": ""
+      "x": 4036.583,
+      "y": -2464.6309
     },
     {
+      "action": "log_output",
+      "action_params": "洞口会小概率坐标识别错，为追求稳定，不使用四叶印",
       "id": 2,
-      "x": 4032.9716796875,
-      "y": -2476.08203125,
-      "type": "path",
       "move_mode": "walk",
-      "action": "",
-      "action_params": ""
+      "type": "path",
+      "x": 4026.0117,
+      "y": -2474.8037
     },
     {
+      "action": "stop_flying",
+      "action_params": "1000",
       "id": 3,
-      "x": 4020.458984375,
-      "y": -2489.951171875,
-      "type": "path",
       "move_mode": "fly",
-      "action": "stop_flying",
-      "action_params": "1000"
+      "type": "path",
+      "x": 4015.2695,
+      "y": -2483.1543
     },
     {
+      "action": "combat_script",
+      "action_params": "wait(1)",
       "id": 4,
-      "x": 4004.5302734375,
-      "y": -2468.169921875,
-      "type": "path",
       "move_mode": "walk",
-      "action": "up_down_grab_leaf",
-      "action_params": ""
+      "type": "path",
+      "x": 4011.8594,
+      "y": -2472.1455
     },
     {
+      "action": "",
+      "action_params": "",
       "id": 5,
-      "x": 4003.3828125,
-      "y": -2441.16796875,
+      "move_mode": "run",
       "type": "path",
-      "move_mode": "walk",
-      "action": "up_down_grab_leaf",
-      "action_params": ""
+      "x": 3999.5293,
+      "y": -2436.6504
     },
     {
+      "action": "",
+      "action_params": "",
       "id": 6,
-      "x": 3986.103515625,
-      "y": -2428.77734375,
+      "move_mode": "run",
       "type": "path",
-      "move_mode": "walk",
-      "action": "up_down_grab_leaf",
-      "action_params": ""
+      "x": 3977.2295,
+      "y": -2414.6641
     },
     {
-      "id": 7,
-      "x": 3975.9375,
-      "y": -2412.4384765625,
-      "type": "path",
-      "move_mode": "walk",
-      "action": "up_down_grab_leaf",
-      "action_params": ""
-    },
-    {
-      "id": 8,
-      "x": 3902.85546875,
-      "y": -2437.8798828125,
-      "type": "path",
-      "move_mode": "fly",
       "action": "stop_flying",
-      "action_params": ""
+      "action_params": "",
+      "id": 7,
+      "move_mode": "fly",
+      "type": "path",
+      "x": 3923.5967,
+      "y": -2431.9766
+    },
+    {
+      "action": "",
+      "action_params": "",
+      "id": 8,
+      "move_mode": "run",
+      "type": "path",
+      "x": 3902.0371,
+      "y": -2438.2422
     }
   ]
 }

--- a/BetterGenshinImpact/GameTask/AutoBoss/AutoBossData.cs
+++ b/BetterGenshinImpact/GameTask/AutoBoss/AutoBossData.cs
@@ -22,7 +22,8 @@ public static class AutoBossData
             ["须弥"] = ["掣电树", "半永恒统辖矩阵", "翠翎恐蕈", "风蚀沙虫", "无相之草", "深罪浸礼者", "兆载永劫龙兽"],
             ["枫丹"] = ["歌裴莉娅的葬送", "科培琉司的劫罚", "实验性场力发生装置", "魔像督军", "千年珍珠骏麟", "水形幻人", "铁甲熔火帝皇"],
             ["纳塔"] = ["金焰绒翼龙暴君", "灵觉隐修的迷者", "秘源机兵·构型械", "秘源机兵·统御械", "熔岩辉龙像", "深邃摹结株", "贪食匿叶龙山王"],
-            ["挪德卡莱"] = ["蕴光月守宫", "深黯魇语之主", "超重型陆巡舰·机动战垒", "霜夜巡天灵主", "蕴光月幻蝶", "重拳出击鸭"]
+            ["挪德卡莱"] = ["蕴光月守宫", "深黯魇语之主", "超重型陆巡舰·机动战垒", "霜夜巡天灵主", "蕴光月幻蝶", "重拳出击鸭"],
+            ["至冬"] = ["不灭衍生造物", "嵌合翼骏狮"]
         };
 
     /// <summary>
@@ -54,6 +55,14 @@ public static class AutoBossData
     ];
 
     /// <summary>
+    /// 战斗后需要重新执行完整前往路线的 Boss。
+    /// </summary>
+    public static readonly HashSet<string> RerunRouteBosses =
+    [
+        "不灭衍生造物"
+    ];
+
+    /// <summary>
     /// 判断 Boss 是否在支持列表中。
     /// </summary>
     /// <param name="bossName">Boss 名称。</param>
@@ -81,5 +90,13 @@ public static class AutoBossData
     public static bool IsNoPathingSupportBoss(string bossName)
     {
         return NoPathingSupportBosses.Contains(bossName);
+    }
+
+    /// <summary>
+    /// 判断 Boss 战斗后是否需要重新执行完整前往路线。
+    /// </summary>
+    public static bool ShouldRerunRoute(string bossName)
+    {
+        return RerunRouteBosses.Contains(bossName);
     }
 }

--- a/BetterGenshinImpact/GameTask/AutoBoss/AutoBossTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoBoss/AutoBossTask.cs
@@ -1524,6 +1524,13 @@ public class AutoBossTask : ISoloTask<Dictionary<string, int>>
             return;
         }
 
+        if (AutoBossData.ShouldRerunRoute(_taskParam.BossName))
+        {
+            _logger.LogInformation("{Name}：重新执行完整路线靠近首领", Name);
+            await RunPathingFile($"{_taskParam.BossName}前往.json");
+            return;
+        }
+
         _logger.LogInformation("{Name}：重新靠近首领位置并等待 4 秒", Name);
         var routePath = BuildPathingAssetPath($"{_taskParam.BossName}前往.json");
         var originalTask = PathingTask.BuildFromFilePath(routePath) ?? throw new Exception($"路径文件解析失败：{routePath}");

--- a/BetterGenshinImpact/GameTask/AutoBoss/AutoBossTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoBoss/AutoBossTask.cs
@@ -221,7 +221,7 @@ public class AutoBossTask : ISoloTask<Dictionary<string, int>>
     {
         try
         {
-            await OpenBigMapForResinCheck();
+            await _returnMainUiTask.Start(_ct);
 
             OriginalResinInfo originalResin;
             try
@@ -266,72 +266,46 @@ public class AutoBossTask : ISoloTask<Dictionary<string, int>>
     }
 
     /// <summary>
-    /// 使用用户配置的打开地图按键进入大地图，识别右上角原粹树脂数量，并在结束后回到主界面。
+    /// 打开大地图并通过树脂详情中的全部恢复时间反推当前原粹树脂。
     /// </summary>
-    /// <returns>识别到的原粹树脂数量；识别失败时返回 null。</returns>
-    private async Task<int?> TryRecognizeOriginalResinCountInBigMap()
-    {
-        try
-        {
-            await OpenBigMapForResinCheck();
-            try
-            {
-                var originalResin = await RecognizeOriginalResinInfoFromBigMap();
-                return originalResin.Count;
-            }
-            catch (Exception e) when (e is not OperationCanceledException)
-            {
-                _logger.LogWarning("{Name}：战前原粹树脂预检失败，将继续通过领奖界面兜底，原因：{Reason}", Name, e.Message);
-                return null;
-            }
-        }
-        finally
-        {
-            await _returnMainUiTask.Start(_ct);
-        }
-    }
-
-    /// <summary>
-    /// 释放输入并打开大地图界面，用于在右上角读取原粹树脂数量。
-    /// </summary>
-    private async Task OpenBigMapForResinCheck()
-    {
-        await new TpTask(_ct).OpenBigMapUi();
-    }
-
-    /// <summary>
-    /// AutoBoss 专用大地图原粹树脂识别：点击右上角树脂图标后，通过全部恢复时间反推剩余树脂。
-    /// </summary>
-    /// <returns>当前剩余原粹树脂。</returns>
     private async Task<OriginalResinInfo> RecognizeOriginalResinInfoFromBigMap()
     {
-        using var capture = CaptureToRectArea();
-        using var resinIconSearchRegion = capture.DeriveCrop(ScaleRect(1200, 25, 580, 50));
-        var resinIconRegion = resinIconSearchRegion.Find(LoadRecognitionObject("OriginalResinTopIcon"));
-        if (resinIconRegion.IsEmpty())
-        {
-            throw new InvalidOperationException("未找到原粹树脂图标");
-        }
+        var page = new BvPage(_ct);
+        //树脂图标
+        var resinIconLocator = page
+            .Locator(LoadRecognitionObject("OriginalResinTopIcon"))
+            .WithRoi(ScaleRect(1200, 25, 580, 50));
+        
+        await page.Flow()
+            //按B打开地图直到识别到树脂图标
+            .Do((Action)(() =>
+            {
+                if (!resinIconLocator.IsExist())
+                {
+                    Simulation.SendInput.SimulateAction(GIActions.OpenMap);
+                }
+            })).Until(resinIconLocator)
+            //点击树脂图标直到识别到目标文本
+            .Click().UntilAnyText(new[] { "全部恢复", "原粹树脂已完全恢复" }, ScaleRect(1180, 75, 620, 200))
+            .Run();
 
-        var iconLeft = resinIconSearchRegion.X + resinIconRegion.Left;
-        var iconRight = resinIconSearchRegion.X + resinIconRegion.Right;
-        var iconBottom = resinIconSearchRegion.Y + resinIconRegion.Bottom;
-
-        resinIconRegion.Click();
-        await Delay(500, _ct);
-
+        //根据树脂图标位置偏移，计算出体力恢复时间的弹窗位置
+        var resinIconRegion = (await resinIconLocator.WaitFor()).First();
+        var detailRect = new Rect(resinIconRegion.Left - 13, resinIconRegion.Bottom + 29, 220, 150);
+        
+        //根据弹窗位置 OCR 出当前树脂上限和全部恢复时间，反推当前原粹树脂
         using var clickedCapture = CaptureToRectArea();
-        var resinLimit = RecognizeOriginalResinLimit(clickedCapture, iconRight);
-        var fullRecoveryTime = RecognizeFullRecoveryTime(clickedCapture, iconLeft, iconBottom);
+        var resinLimit = RecognizeOriginalResinLimit(clickedCapture, resinIconRegion.Right);
+        var fullRecoveryTime = RecognizeFullRecoveryTime(clickedCapture, detailRect);
         var missingResin = (int)Math.Ceiling(fullRecoveryTime.TotalSeconds / OriginalResinRecoveryInterval.TotalSeconds);
         if (missingResin > resinLimit)
         {
             throw new InvalidOperationException($"计算缺失树脂 {missingResin} 超过树脂上限 {resinLimit}");
         }
 
-        var originalResin = resinLimit - missingResin;
-        _logger.LogInformation("{Name}：剩余树脂 {Count}", Name, originalResin);
-        return new OriginalResinInfo(originalResin, resinLimit);
+        var originalResin = new OriginalResinInfo(resinLimit - missingResin, resinLimit);
+        _logger.LogInformation("{Name}：剩余树脂 {Count}", Name, originalResin.Count);
+        return originalResin;
     }
 
     /// <summary>
@@ -361,14 +335,8 @@ public class AutoBossTask : ISoloTask<Dictionary<string, int>>
     /// <summary>
     /// 读取树脂详情弹窗中的全部恢复时间；已完全恢复时返回零时长。
     /// </summary>
-    private TimeSpan RecognizeFullRecoveryTime(ImageRegion capture, int resinIconLeft, int resinIconBottom)
+    private TimeSpan RecognizeFullRecoveryTime(ImageRegion capture, Rect detailRect)
     {
-        // 该偏移来自截图实际像素，不随 AssetScale 缩放。
-        var detailRect = new Rect(
-            resinIconLeft - 13,
-            resinIconBottom + 29,
-            220,
-            150);
         using var detailRegion = capture.DeriveCrop(detailRect);
         var result = OcrFactory.Paddle.OcrResult(detailRegion.SrcMat);
         var text = string.Concat(result.Regions


### PR DESCRIPTION
添加两个至冬boss，分层的boss寻路硬编码按住w跟延时，等地图追踪支持分层时再改

战斗前预检树脂阶段：打开地图短时间内点击树脂图标无响应。用bvFlow简单重写了这部分流程。

更换无相草寻路文件，因为在洞口有小概率坐标识别出错，回头拉错四叶印。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 新功能
- 自动讨伐新增“至冬”地区的“不灭衍生造物”和“嵌合翼骏狮”。
- 新增上述首领的自动传送、寻路与战斗路线。
- “不灭衍生造物”战斗后支持重新执行完整前往路线。

## 问题修复
- 优化树脂信息识别、地图操作及战斗后的路线恢复流程。
- 更新“无相之草”前往路线，调整路径点与移动方式，提升路线执行稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->