### PR TITLE
fix：容忍OCR结果中字形相近的错字

### DIFF
--- a/BetterGenshinImpact/GameTask/CharacterDevelopment/CharacterDevelopmentTask.cs
+++ b/BetterGenshinImpact/GameTask/CharacterDevelopment/CharacterDevelopmentTask.cs
@@ -412,6 +412,7 @@ internal sealed class CharacterDevelopmentStateMachineTask : StateMachineBase<Ch
         }
 
         var text = OcrText(capture, Rect1080(1466, 131, 244, 38));
+        _logger.LogDebug("角色养成识别：OCR角色名称({name})", text);
         var matched = CurrentTarget.MatchesDisplayText(text);
         return matched;
     }

--- a/BetterGenshinImpact/GameTask/CharacterDevelopment/CharacterSelectionHelper.cs
+++ b/BetterGenshinImpact/GameTask/CharacterDevelopment/CharacterSelectionHelper.cs
@@ -36,9 +36,18 @@ internal sealed record CharacterSelectionTarget(
     public bool Matches(string? characterName) =>
         characterName != null && CandidateNames.Contains(characterName, StringComparer.Ordinal);
 
-    public bool MatchesDisplayText(string? text) =>
-        !string.IsNullOrWhiteSpace(text)
-        && CandidateNames.Any(candidate => text.Contains(candidate, StringComparison.Ordinal));
+    public bool MatchesDisplayText(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return false;
+        }
+
+        var normalizedText = text.Trim();
+        return CandidateNames.Any(candidate =>
+            1 - WeaponNameMatcher.LevenshteinDistance(normalizedText, candidate)
+            / (double)Math.Max(normalizedText.Length, candidate.Length) >= 0.5);
+    }
 }
 
 /// <summary>


### PR DESCRIPTION

<img width="587" height="391" alt="image" src="https://github.com/user-attachments/assets/2919681f-a9f1-4861-96ff-1f26d24d8ed1" />
<img width="336" height="115" alt="image" src="https://github.com/user-attachments/assets/e43a6b00-1ab0-45e2-9713-4edff3faaa9e" />

以前偷懒的回旋镖还是打到了自己身上

识别角色信息时，选择角色后的OCR名称兜底改用编辑距离判断

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 优化角色选择时的名称匹配，即使 OCR 识别结果存在一定差异，也能更可靠地匹配目标角色。
  - 忽略识别文本首尾空格，并避免将空文本误判为有效匹配。
  - 增加角色名称识别结果的调试日志，便于查看 OCR 识别内容。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->