### PR TITLE
fix(tp): 地图拖动起点避开传送图标

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoTrackPath/TpTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoTrackPath/TpTask.cs
@@ -1811,6 +1811,7 @@ public class TpTask
         double forbiddenWidth,
         double forbiddenHeight,
         double avoidPadding,
+        IReadOnlyList<Rect> teleportRects,
         out double startX,
         out double startY)
     {
@@ -1832,6 +1833,11 @@ public class TpTask
             x = Math.Clamp(x, startMinX, startMaxX);
             y = Math.Clamp(y, startMinY, startMaxY);
             if (!IsSafePoint(x, y) || !IsSafePoint(x + deltaX, y + deltaY))
+            {
+                return;
+            }
+
+            if (teleportRects.Any(rect => x >= rect.Left && x < rect.Right && y >= rect.Top && y < rect.Bottom))
             {
                 return;
             }
@@ -1884,6 +1890,18 @@ public class TpTask
 
     private async Task<(int SentDeltaX, int SentDeltaY, int Steps, double StartX, double StartY, double EndX, double EndY, double ActualDeltaX, double ActualDeltaY)> MouseMoveMap(int pixelDeltaX, int pixelDeltaY)
     {
+        // 每次拖动前重新识别，避免地图移动或缩放后使用过期的传送点矩形。
+        List<Rect> teleportRects;
+        using (var capture = CaptureToRectArea())
+        {
+            teleportRects = GetMapIconsInRect(
+                    capture,
+                    new Rect(0, 0, capture.Width, capture.Height),
+                    0, 0, double.PositiveInfinity)
+                .Select(icon => icon.Rect)
+                .ToList();
+        }
+
         // 起点向预期拖动方向的反方向偏移，并保留随机性；位移按可拖动地图区域裁剪。
         double startX = 0;
         double startY = 0;
@@ -1945,6 +1963,7 @@ public class TpTask
                         forbiddenWidth,
                         forbiddenHeight,
                         avoidPadding,
+                        teleportRects,
                         out startX,
                         out startY))
                 {

--- a/BetterGenshinImpact/GameTask/AutoTrackPath/TpTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoTrackPath/TpTask.cs
@@ -798,7 +798,8 @@ public class TpTask
 
         await MouseMoveMap(
             GetDisplayScaleAdjustedMouseDelta(moveMouseX),
-            GetDisplayScaleAdjustedMouseDelta(moveMouseY));
+            GetDisplayScaleAdjustedMouseDelta(moveMouseY),
+            GetVisibleTeleportPointRects(clickView.MapName, clickView.BigMapInAllMapRect));
     }
 
     private async Task<bool> AdjustInitialTeleportMoveZoomLevel(string mapName, double targetX, double targetY)
@@ -1411,7 +1412,10 @@ public class TpTask
             int effectiveMoveMouseX = GetDisplayScaleAdjustedMouseDelta(moveMouseX);
             int effectiveMoveMouseY = GetDisplayScaleAdjustedMouseDelta(moveMouseY);
 
-            var mouseMoveResult = await MouseMoveMap(effectiveMoveMouseX, effectiveMoveMouseY);
+            var mouseMoveResult = await MouseMoveMap(
+                effectiveMoveMouseX,
+                effectiveMoveMouseY,
+                GetVisibleTeleportPointRects(mapName, targetBigMapRect));
             await Delay(30, ct);
 
             // 推算理论上的移动后坐标 (惯性预测)
@@ -1888,20 +1892,11 @@ public class TpTask
         return true;
     }
 
-    private async Task<(int SentDeltaX, int SentDeltaY, int Steps, double StartX, double StartY, double EndX, double EndY, double ActualDeltaX, double ActualDeltaY)> MouseMoveMap(int pixelDeltaX, int pixelDeltaY)
+    private async Task<(int SentDeltaX, int SentDeltaY, int Steps, double StartX, double StartY, double EndX, double EndY, double ActualDeltaX, double ActualDeltaY)> MouseMoveMap(
+        int pixelDeltaX,
+        int pixelDeltaY,
+        IReadOnlyList<Rect> teleportRects)
     {
-        // 每次拖动前重新识别，避免地图移动或缩放后使用过期的传送点矩形。
-        List<Rect> teleportRects;
-        using (var capture = CaptureToRectArea())
-        {
-            teleportRects = GetMapIconsInRect(
-                    capture,
-                    new Rect(0, 0, capture.Width, capture.Height),
-                    0, 0, double.PositiveInfinity)
-                .Select(icon => icon.Rect)
-                .ToList();
-        }
-
         // 起点向预期拖动方向的反方向偏移，并保留随机性；位移按可拖动地图区域裁剪。
         double startX = 0;
         double startY = 0;
@@ -2942,6 +2937,28 @@ public class TpTask
         }
 
         return result;
+    }
+
+    private List<Rect> GetVisibleTeleportPointRects(string mapName, Rect bigMapInAllMapRect)
+    {
+        return GetVisibleExpectedMapIcons(mapName, bigMapInAllMapRect)
+            .Select(expected =>
+            {
+                var templates = _assets.MapChooseIconGreyMatList
+                    .Where((_, index) => expected.IconTypes.Contains(
+                        GetMapChooseIconType(GetMapChooseIconFileName(_assets.MapChooseIconRoList[index]))))
+                    .Where(template => !template.Empty())
+                    .ToList();
+                var width = templates.Count == 0 ? 0 : templates.Max(template => template.Width);
+                var height = templates.Count == 0 ? 0 : templates.Max(template => template.Height);
+                return new Rect(
+                    (int)Math.Round(expected.ScreenX - width / 2d),
+                    (int)Math.Round(expected.ScreenY - height / 2d),
+                    width,
+                    height);
+            })
+            .Where(rect => rect.Width > 0 && rect.Height > 0)
+            .ToList();
     }
 
     private List<NearbyMapIcon> GetVisibleMapIcons(


### PR DESCRIPTION
地图拖动的随机起点可能落在传送图标上，从而触发图标点击并干扰后续拖动。

本改动复用现有地图定位结果和内置传送点数据，将当前视野内传送点坐标换算为屏幕 Rect，并在选择拖动起点时排除这些 Rect。该过程不增加截图或模板匹配；随机偏移、重试和原有回退行为保持不变。

验证：

- `git diff --check`
- `dotnet build BetterGenshinImpact/BetterGenshinImpact.csproj -c Debug --no-restore -p:OutDir=<临时目录>`：0 错误


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **错误修复**
  * 地图拖动起点选择会避开传送点图标所在区域，减少误触传送点的情况。
  * 根据当前可见传送点及其图标尺寸计算避让范围，提升地图拖动操作的稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->