### PR TITLE
fix(auto-fight): 修复 JSON 战斗异常被吞掉导致路径段不重试

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoFight/AutoFightJsonTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/AutoFightJsonTask.cs
@@ -129,6 +129,26 @@ public class AutoFightJsonTask : ISoloTask
         _ct = ct;
         AvatarRecognition.SetCurrentAutoFightParam(_taskParam);
         AvatarRecognition.ClearLegendaryBarTracker();
+        CancellationTokenSource? cts2 = null;
+        CancellationTokenRegistration cts2Registration = default;
+        ExperienceDetector? expDetector = null;
+
+        async Task StopExperienceDetectorAsync()
+        {
+            var detector = expDetector;
+            if (detector == null) return;
+
+            expDetector = null;
+            try
+            {
+                await detector.StopAsync();
+            }
+            finally
+            {
+                detector.Dispose();
+            }
+        }
+
         try
         {
             LogScreenResolution();
@@ -184,8 +204,8 @@ public class AutoFightJsonTask : ISoloTask
             }
     
             // 新的取消token
-            var cts2 = new CancellationTokenSource();
-            ct.Register(cts2.Cancel);
+            cts2 = new CancellationTokenSource();
+            cts2Registration = ct.Register(cts2.Cancel);
     
             combatScenes.BeforeTask(cts2.Token);
             // 设置初始当前角色名（用于无 Character 字段的通用 action 回退）
@@ -205,7 +225,6 @@ public class AutoFightJsonTask : ISoloTask
                 _strategy.Actions.Where(a => !string.IsNullOrEmpty(a.Name)).Select(a => a.Name));
     
             // 基于经验值的战后拾取检测
-            ExperienceDetector? expDetector = null;
             if (_taskParam.KazuhaPickupEnabled && _taskParam.ExpBasedPickupEnabled)
             {
                 using var gameCaptureRegion = CaptureToRectArea();
@@ -213,7 +232,7 @@ public class AutoFightJsonTask : ISoloTask
                 expDetector = new ExperienceDetector(expRos, cts2.Token);
                 expDetector.Start();
             }
-    
+
             // 战斗前动作
             await RunPreActions(combatScenes, evaluator);
     
@@ -482,11 +501,7 @@ public class AutoFightJsonTask : ISoloTask
             }
             finally
             {
-                if (expDetector != null)
-                {
-                    await expDetector.StopAsync();
-                    expDetector.Dispose();
-                }
+                await StopExperienceDetectorAsync();
             }
     
             // 战后拾取（完全参照 AutoFightTask）
@@ -497,6 +512,27 @@ public class AutoFightJsonTask : ISoloTask
             // 战斗可能在创建 fightTask 前因复活/恢复异常退出，统一清理战斗状态。
             AutoFightTask.FightStatusFlag = false;
             AvatarRecognition.ClearCurrentAutoFightParam();
+            try
+            {
+                await StopExperienceDetectorAsync();
+            }
+            catch (Exception e)
+            {
+                Logger.LogWarning(e, "停止 JSON 战斗经验检测时发生异常");
+            }
+            try
+            {
+                cts2?.Cancel();
+            }
+            catch (Exception e)
+            {
+                Logger.LogWarning(e, "取消 JSON 战斗令牌时发生异常");
+            }
+            finally
+            {
+                cts2Registration.Dispose();
+                cts2?.Dispose();
+            }
         }
     }
 

--- a/BetterGenshinImpact/GameTask/AutoFight/AutoFightJsonTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/AutoFightJsonTask.cs
@@ -494,6 +494,8 @@ public class AutoFightJsonTask : ISoloTask
         }
         finally
         {
+            // 战斗可能在创建 fightTask 前因复活/恢复异常退出，统一清理战斗状态。
+            AutoFightTask.FightStatusFlag = false;
             AvatarRecognition.ClearCurrentAutoFightParam();
         }
     }
@@ -539,6 +541,11 @@ public class AutoFightJsonTask : ISoloTask
 
             // 更新当前角色名，供后续无指定角色动作使用
             _currentAvatarName = character;
+        }
+        catch (RetryException)
+        {
+            // 复活/恢复信号必须传递给 PathExecutor，以便重跑当前路径段。
+            throw;
         }
         catch (Exception e)
         {
@@ -594,7 +601,8 @@ public class AutoFightJsonTask : ISoloTask
             }
             catch (RetryException e)
             {
-                Logger.LogWarning("战斗前动作重试异常，跳过此动作继续：{Msg}", e.Message);
+                Logger.LogWarning("战斗前动作要求中断当前战斗：{Msg}", e.Message);
+                throw;
             }
             Logger.LogInformation("战斗前动作：{Action}", preAction);
             await Delay(300, _ct);


### PR DESCRIPTION
## 问题
JSON 战斗执行战斗前动作或普通动作时，复活/恢复流程抛出的 RetryException 可能被通用异常处理吞掉，导致 PathExecutor 无法收到重试信号。角色传送到七天神像后，任务继续执行当前路径点，而不是重跑当前路径段。

## 修复
- 让 JSON 战斗普通动作中的 RetryException 向上传播。
- 让战斗前动作中的 RetryException 向上传播，交由 PathExecutor 重跑当前路径段。
- 在 JSON 战斗外层 finally 中兜底清理 FightStatusFlag，避免异常发生在 fightTask 创建前时残留战斗状态。

## 验证
- dotnet build BetterGenshinImpact\\BetterGenshinImpact.csproj --no-restore：成功，0 个错误。
- 现有编译警告未涉及本次修改。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - 修复自动战斗过程中复活或恢复异常导致战斗状态未正确清理的问题。
  - 优化异常重试处理：相关恢复信号可正确触发当前路径段重试，避免被错误忽略。
  - 当战斗前置操作需要重试时，将及时中断当前战斗并执行后续恢复流程，提升自动战斗稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->