### PR TITLE
fix: 升级 Sdl.MultiSelectComboBox 并适配深浅色主题，修复深色模式下角色多选下拉框文字不可见

### DIFF
--- a/BetterGenshinImpact/BetterGenshinImpact.csproj
+++ b/BetterGenshinImpact/BetterGenshinImpact.csproj
@@ -83,7 +83,7 @@
 		<PackageReference Include="MouseKeyHook" Version="5.7.1" />
 		<PackageReference Include="NCalc" Version="6.2.0" />
 		<PackageReference Include="PresentMonFps" Version="2.0.5" />
-		<PackageReference Include="Sdl.MultiSelectComboBox" Version="1.0.103" />
+		<PackageReference Include="Sdl.MultiSelectComboBox" Version="1.0.114" />
 		<PackageReference Include="Semver" Version="3.0.0" />
 		<PackageReference Include="Serilog.Extensions.Logging" Version="9.0.1" />
 		<PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />

--- a/BetterGenshinImpact/ViewModel/MainWindowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/MainWindowViewModel.cs
@@ -299,7 +299,7 @@ public partial class MainWindowViewModel : ObservableObject, IViewModel
             WindowHelper.ApplyThemeToWindow(Application.Current.MainWindow, themeType);
         }
 
-        // 同步第三方多选控件(Sdl.MultiSelectComboBox)的主题，避免其下拉在深色模式下黑底黑字看不清
+        // 同步第三方多选控件(Sdl.MultiSelectComboBox)的主题，避免深色主题下其下拉弹层文字与背景对比不足不可读
         var isDarkTheme = themeType is ThemeType.DarkNone or ThemeType.DarkMica or ThemeType.DarkAcrylic;
         try
         {
@@ -318,15 +318,12 @@ public partial class MainWindowViewModel : ObservableObject, IViewModel
         // 这里在应用级资源中按主题覆盖这两个系统色键，使所有实例(含寻路角色设置窗口)一致适配。
         try
         {
-            if (Application.Current is not null)
-            {
-                var bg = new SolidColorBrush(isDarkTheme ? Color.FromRgb(0x2B, 0x2B, 0x2B) : Colors.White);
-                var frame = new SolidColorBrush(isDarkTheme ? Color.FromRgb(0x40, 0x40, 0x40) : Colors.LightGray);
-                bg.Freeze();
-                frame.Freeze();
-                Application.Current.Resources[SystemColors.WindowBrushKey] = bg;
-                Application.Current.Resources[SystemColors.WindowFrameBrushKey] = frame;
-            }
+            var bg = new SolidColorBrush(isDarkTheme ? Color.FromRgb(0x2B, 0x2B, 0x2B) : Colors.White);
+            var frame = new SolidColorBrush(isDarkTheme ? Color.FromRgb(0x40, 0x40, 0x40) : Colors.LightGray);
+            bg.Freeze();
+            frame.Freeze();
+            Application.Current.Resources[SystemColors.WindowBrushKey] = bg;
+            Application.Current.Resources[SystemColors.WindowFrameBrushKey] = frame;
         }
         catch (Exception e)
         {

--- a/BetterGenshinImpact/ViewModel/MainWindowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/MainWindowViewModel.cs
@@ -313,22 +313,19 @@ public partial class MainWindowViewModel : ObservableObject, IViewModel
             _logger.LogWarning(e, "同步 Sdl.MultiSelectComboBox 主题失败：{Message}", e.Message);
         }
 
-        // Sdl.MultiSelectComboBox 下拉弹层的边框/背景硬编码使用系统色 SystemColors.WindowBrushKey，
+        // Sdl.MultiSelectComboBox 下拉弹层的边框/背景硬编码使用系统色 SystemColors.WindowBrushKey/WindowFrameBrushKey，
         // 不会跟随 BetterGI 主题，导致深色模式下“深色底 + 白字”或“白底 + 白字”不可读。
-        // 这里在应用级资源中按主题覆盖该系统色键，使所有实例(含寻路角色设置窗口)一致适配。
+        // 这里在应用级资源中按主题覆盖这两个系统色键，使所有实例(含寻路角色设置窗口)一致适配。
         try
         {
             if (Application.Current is not null)
             {
                 var bg = new SolidColorBrush(isDarkTheme ? Color.FromRgb(0x2B, 0x2B, 0x2B) : Colors.White);
                 var frame = new SolidColorBrush(isDarkTheme ? Color.FromRgb(0x40, 0x40, 0x40) : Colors.LightGray);
-                var text = new SolidColorBrush(isDarkTheme ? Colors.White : Colors.Black);
                 bg.Freeze();
                 frame.Freeze();
-                text.Freeze();
                 Application.Current.Resources[SystemColors.WindowBrushKey] = bg;
                 Application.Current.Resources[SystemColors.WindowFrameBrushKey] = frame;
-                Application.Current.Resources[SystemColors.WindowTextBrushKey] = text;
             }
         }
         catch (Exception e)

--- a/BetterGenshinImpact/ViewModel/MainWindowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/MainWindowViewModel.cs
@@ -299,6 +299,43 @@ public partial class MainWindowViewModel : ObservableObject, IViewModel
             WindowHelper.ApplyThemeToWindow(Application.Current.MainWindow, themeType);
         }
 
+        // 同步第三方多选控件(Sdl.MultiSelectComboBox)的主题，避免其下拉在深色模式下黑底黑字看不清
+        var isDarkTheme = themeType is ThemeType.DarkNone or ThemeType.DarkMica or ThemeType.DarkAcrylic;
+        try
+        {
+            Sdl.MultiSelectComboBox.Themes.ThemeManager.SetTheme(
+                isDarkTheme
+                    ? Sdl.MultiSelectComboBox.Themes.MultiSelectComboBoxTheme.Dark
+                    : Sdl.MultiSelectComboBox.Themes.MultiSelectComboBoxTheme.Light);
+        }
+        catch (Exception e)
+        {
+            _logger.LogWarning(e, "同步 Sdl.MultiSelectComboBox 主题失败：{Message}", e.Message);
+        }
+
+        // Sdl.MultiSelectComboBox 下拉弹层的边框/背景硬编码使用系统色 SystemColors.WindowBrushKey，
+        // 不会跟随 BetterGI 主题，导致深色模式下“深色底 + 白字”或“白底 + 白字”不可读。
+        // 这里在应用级资源中按主题覆盖该系统色键，使所有实例(含寻路角色设置窗口)一致适配。
+        try
+        {
+            if (Application.Current is not null)
+            {
+                var bg = new SolidColorBrush(isDarkTheme ? Color.FromRgb(0x2B, 0x2B, 0x2B) : Colors.White);
+                var frame = new SolidColorBrush(isDarkTheme ? Color.FromRgb(0x40, 0x40, 0x40) : Colors.LightGray);
+                var text = new SolidColorBrush(isDarkTheme ? Colors.White : Colors.Black);
+                bg.Freeze();
+                frame.Freeze();
+                text.Freeze();
+                Application.Current.Resources[SystemColors.WindowBrushKey] = bg;
+                Application.Current.Resources[SystemColors.WindowFrameBrushKey] = frame;
+                Application.Current.Resources[SystemColors.WindowTextBrushKey] = text;
+            }
+        }
+        catch (Exception e)
+        {
+            _logger.LogWarning(e, "覆盖系统色以适配 Sdl.MultiSelectComboBox 弹层失败：{Message}", e.Message);
+        }
+
         // 根据当前主题更新兑换码按钮的默认前景色（若无更新高亮）
         if (!HasPendingRedeemCodeUpdate)
         {


### PR DESCRIPTION
### 问题描述

使用角色多选下拉框（`Sdl.MultiSelectComboBox`，寻路【角色设置】及自动战斗盾奶名单等场景）时：
- **深色主题**下，BetterGI 切到深色后控件文字已被切成白色，但下拉弹层的背景/边框仍引用 Windows 系统色（`SystemColors.WindowBrushKey`），不会跟随 BetterGI 主题，出现白底白字（或黑底黑字），未选中项完全看不清；
- 根因：① 控件版本 1.0.103 内置不支持主题切换，没有 Light/Dark 两套颜色资源；② 控件模板中下拉弹层背景硬编码使用系统色键。

### 修改内容

1. 升级依赖：`Sdl.MultiSelectComboBox` `1.0.103` -> `1.0.114`（该版本自带 `ThemeManager`/`MultiSelectComboBoxTheme` 与完整 `Dark.xaml` 主题资源）。
2. `ViewModel/MainWindowViewModel.cs` 的 `ApplyTheme`：
   - BetterGI 切换深/浅主题时同步调用 `Sdl.MultiSelectComboBox.Themes.ThemeManager.SetTheme(Dark/Light)`；
   - 同时按主题覆盖应用级 `SystemColors.WindowBrushKey / WindowFrameBrushKey / WindowTextBrushKey`，修复控件模板“下拉弹层背景使用系统色、不跟随主题”的问题（深色 `#2B2B2B` 底 + 白字，浅色白底 + 黑字）；
   - 对所有使用该控件的窗口生效（寻路【角色设置】等），无需逐个 XAML 配置。

### 验证方式

1. 打开任意含 `Sdl.MultiSelectComboBox` 的设置（例如寻路配置 → 角色设置）；
2. 分别在 BetterGI 浅色/深色主题下点开角色多选下拉：深色应为深底白字、浅色保持白底黑字，未选中项可读；
3. 确认其余 UI 无颜色回归。

### 影响范围

仅涉及多选下拉框的显示主题，无数据/配置/逻辑改动。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 多选控件现可自动同步应用的深色或浅色主题。
  - 优化主题下拉弹层的边框与背景颜色显示，提升视觉一致性。

- **改进**
  - 优化窗口主题资源的应用逻辑，使深色和浅色模式下的界面显示更加协调。
  - 改进主题切换过程中的异常处理，相关问题将记录为警告信息。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->