### PR TITLE
fix: 修复日志框隐藏状态下重启后快捷键无法恢复日志显示

### DIFF
--- a/BetterGenshinImpact/App.xaml.cs
+++ b/BetterGenshinImpact/App.xaml.cs
@@ -90,11 +90,16 @@ public partial class App : Application
                     .MinimumLevel.Debug()
                     .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
                     .MinimumLevel.Override("Microsoft.Hosting.Lifetime", LogEventLevel.Warning);
-                if (all.MaskWindowConfig is { MaskEnabled: true, ShowLogBox: true })
-                {
-                    loggerConfiguration.WriteTo.RichTextBox(richTextBox, LogEventLevel.Information,
-                        "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}");
-                }
+                // 日志遮罩输出：仅当“遮罩启用且日志框可见”时才真正写入，隐藏时避免不必要的 UI 开销（#3161）。
+                // 条件改为运行时每次写入时动态判断，因此启动后通过快捷键切换 ShowLogBox 也能即时恢复日志（#3357）。
+                loggerConfiguration.WriteTo.Sink(
+                    new ConditionalLogEventSink(
+                        new LoggerConfiguration()
+                            .WriteTo.RichTextBox(richTextBox, LogEventLevel.Information,
+                                "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}")
+                            .CreateLogger(),
+                        () => all.MaskWindowConfig is { MaskEnabled: true, ShowLogBox: true }),
+                    LogEventLevel.Information);
 
                 Log.Logger = loggerConfiguration.CreateLogger();
                 services.AddLogging(c => c.AddSerilog());

--- a/BetterGenshinImpact/Helpers/ConditionalLogEventSink.cs
+++ b/BetterGenshinImpact/Helpers/ConditionalLogEventSink.cs
@@ -1,0 +1,35 @@
+using System;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace BetterGenshinImpact.Helpers;
+
+/// <summary>
+/// 仅在条件满足时才将日志事件转发给内部 sink 的包装器。
+/// 条件在每次写入时动态判断（而非创建时固定），因此运行中切换状态也能即时生效。
+/// 用于“遮罩日志框：仅当遮罩启用且日志框可见时才写入，隐藏时零 UI 开销”的场景（#3357）。
+/// </summary>
+public sealed class ConditionalLogEventSink : ILogEventSink, IDisposable
+{
+    private readonly ILogEventSink _innerSink;
+    private readonly Func<bool> _isEnabled;
+
+    public ConditionalLogEventSink(ILogEventSink innerSink, Func<bool> isEnabled)
+    {
+        _innerSink = innerSink;
+        _isEnabled = isEnabled;
+    }
+
+    public void Emit(LogEvent logEvent)
+    {
+        if (_isEnabled())
+        {
+            _innerSink.Emit(logEvent);
+        }
+    }
+
+    public void Dispose()
+    {
+        (_innerSink as IDisposable)?.Dispose();
+    }
+}


### PR DESCRIPTION
## 问题

#3357：日志框处于隐藏状态时退出 BetterGI，下次启动后即使再次按下“日志与状态窗口展示开关”快捷键，遮罩日志也不会恢复显示（打开后是空框）。

## 根因

commit `6f7c78b4`（为修复 #3161 日志堆积卡顿）把 `App.xaml.cs` 中 RichTextBox sink 的注册条件从 `MaskEnabled` 收紧为 `MaskEnabled && ShowLogBox`，且只在启动时判断一次。Serilog 管道在 `CreateLogger()` 后不可变：

- 以 `ShowLogBox=false` 启动 → sink 从未进入日志管道；
- 之后通过快捷键或设置把 `ShowLogBox` 切回 `true`，只会改变日志框可见性（XAML Visibility 绑定），日志事件永远不会被写入，重启前无法恢复。

反向也存在同类不一致：以 `ShowLogBox=true` 启动后热键隐藏日志框，隐藏期间仍会继续向 Collapsed 的 RichTextBox 追加日志——#3161 的性能优化只对“以隐藏态启动”的会话生效，运行时开关两方向行为并不对称。

## 修复方案

新增 `ConditionalLogEventSink`（`ILogEventSink` 包装器，每次 Emit 前实时求值 `Func<bool>`），把“启动时一次性判断”改为“每次写入时动态判断”：仅当遮罩启用且日志框可见时才把日志转发给 RichTextBox sink。

- 修复 #3357：任意时刻打开日志框，新日志立即恢复显示，无需重启；
- 保留 #3161 的性能收益：日志框隐藏期间不向隐藏框写入，零 UI 开销；
- `ShowLogBox` 回归其本意——只做“可见性”开关，不再决定日志链路是否建立。

## 变更

- `BetterGenshinImpact/App.xaml.cs`（+10/-5）：用动态条件 sink 替换启动期静态条件注册；
- `BetterGenshinImpact/Helpers/ConditionalLogEventSink.cs`（新增）：条件转发 sink。

## 验证

- `dotnet build BetterGenshinImpact.sln -c Debug`：0 错误；
- 复现路径（隐藏态启动 → 热键打开 → 日志恢复）已按代码链路核对。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 日志遮罩状态现在可在运行期间动态生效。
  * 通过快捷键显示或隐藏日志框后，日志输出会即时恢复或停止，无需重启应用。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->