### PR TITLE
fix: 修复切换一条龙预设时配置界面选项不刷新

### DIFF
--- a/BetterGenshinImpact/View/Behavior/DomainCascadingComboBoxBehavior.cs
+++ b/BetterGenshinImpact/View/Behavior/DomainCascadingComboBoxBehavior.cs
@@ -1,3 +1,5 @@
+using System;
+using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
@@ -8,6 +10,9 @@ namespace BetterGenshinImpact.View.Behavior;
 
 public static class DomainCascadingComboBoxBehavior
 {
+    private static readonly DependencyPropertyDescriptor SelectedCascadingItemDescriptor =
+        DependencyPropertyDescriptor.FromProperty(CascadingComboBox.SelectedCascadingItemProperty, typeof(CascadingComboBox));
+
     private static readonly DependencyProperty LastCommittedItemProperty =
         DependencyProperty.RegisterAttached(
             "LastCommittedItem",
@@ -66,6 +71,7 @@ public static class DomainCascadingComboBoxBehavior
         comboBox.SelectionChanged -= OnSelectionChanged;
         comboBox.Loaded -= OnLoaded;
         comboBox.RemoveHandler(Button.ClickEvent, new RoutedEventHandler(OnButtonClick));
+        SelectedCascadingItemDescriptor.RemoveValueChanged(comboBox, OnSelectedCascadingItemChanged);
 
         if (e.NewValue is true)
         {
@@ -74,6 +80,17 @@ public static class DomainCascadingComboBoxBehavior
             comboBox.SelectionChanged += OnSelectionChanged;
             comboBox.Loaded += OnLoaded;
             comboBox.AddHandler(Button.ClickEvent, new RoutedEventHandler(OnButtonClick), true);
+            // 程序化修改 SelectedCascadingItem（例如切换一条龙预设导致绑定值变化）不会触发交互事件，
+            // 这里额外监听依赖属性变化，使折叠态展示文案随绑定值同步刷新（#3235）。
+            SelectedCascadingItemDescriptor.AddValueChanged(comboBox, OnSelectedCascadingItemChanged);
+            comboBox.Dispatcher.BeginInvoke(() => UpdateCommittedSelection(comboBox, restoreInvalidSelection: false));
+        }
+    }
+
+    private static void OnSelectedCascadingItemChanged(object? sender, EventArgs e)
+    {
+        if (sender is CascadingComboBox comboBox)
+        {
             comboBox.Dispatcher.BeginInvoke(() => UpdateCommittedSelection(comboBox, restoreInvalidSelection: false));
         }
     }

--- a/BetterGenshinImpact/View/Behavior/DomainCascadingComboBoxBehavior.cs
+++ b/BetterGenshinImpact/View/Behavior/DomainCascadingComboBoxBehavior.cs
@@ -70,8 +70,10 @@ public static class DomainCascadingComboBoxBehavior
         comboBox.DropDownOpened -= OnDropDownOpened;
         comboBox.SelectionChanged -= OnSelectionChanged;
         comboBox.Loaded -= OnLoaded;
+        comboBox.Loaded -= OnLoadedForBindingSync;
+        comboBox.Unloaded -= OnUnloadedForBindingSync;
         comboBox.RemoveHandler(Button.ClickEvent, new RoutedEventHandler(OnButtonClick));
-        SelectedCascadingItemDescriptor.RemoveValueChanged(comboBox, OnSelectedCascadingItemChanged);
+        SyncSelectedCascadingItemListener(comboBox, attach: false);
 
         if (e.NewValue is true)
         {
@@ -82,17 +84,67 @@ public static class DomainCascadingComboBoxBehavior
             comboBox.AddHandler(Button.ClickEvent, new RoutedEventHandler(OnButtonClick), true);
             // 程序化修改 SelectedCascadingItem（例如切换一条龙预设导致绑定值变化）不会触发交互事件，
             // 这里额外监听依赖属性变化，使折叠态展示文案随绑定值同步刷新（#3235）。
-            SelectedCascadingItemDescriptor.AddValueChanged(comboBox, OnSelectedCascadingItemChanged);
+            // 订阅挂在 Loaded/Unloaded 生命周期上配对移除，避免 Descriptor 的强引用把已卸载元素钉死。
+            comboBox.Loaded += OnLoadedForBindingSync;
+            comboBox.Unloaded += OnUnloadedForBindingSync;
+            SyncSelectedCascadingItemListener(comboBox, attach: true);
             comboBox.Dispatcher.BeginInvoke(() => UpdateCommittedSelection(comboBox, restoreInvalidSelection: false));
+        }
+    }
+
+    private static void OnLoadedForBindingSync(object sender, RoutedEventArgs e)
+    {
+        if (sender is CascadingComboBox comboBox)
+        {
+            SyncSelectedCascadingItemListener(comboBox, attach: true);
+        }
+    }
+
+    private static void OnUnloadedForBindingSync(object sender, RoutedEventArgs e)
+    {
+        if (sender is CascadingComboBox comboBox)
+        {
+            SyncSelectedCascadingItemListener(comboBox, attach: false);
+        }
+    }
+
+    /// <summary>
+    /// 幂等挂接/摘除 SelectedCascadingItem 的值变化监听（先移除再挂接，避免重复订阅）。
+    /// </summary>
+    private static void SyncSelectedCascadingItemListener(CascadingComboBox comboBox, bool attach)
+    {
+        SelectedCascadingItemDescriptor.RemoveValueChanged(comboBox, OnSelectedCascadingItemChanged);
+        if (attach)
+        {
+            SelectedCascadingItemDescriptor.AddValueChanged(comboBox, OnSelectedCascadingItemChanged);
         }
     }
 
     private static void OnSelectedCascadingItemChanged(object? sender, EventArgs e)
     {
-        if (sender is CascadingComboBox comboBox)
+        if (sender is not CascadingComboBox comboBox)
         {
-            comboBox.Dispatcher.BeginInvoke(() => UpdateCommittedSelection(comboBox, restoreInvalidSelection: false));
+            return;
         }
+
+        comboBox.Dispatcher.BeginInvoke(() =>
+        {
+            // 绑定/程序化驱动（如切换一条龙预设）的值变化：直接以当前绑定值为准提交。
+            // 值为空或无法解析时清空提交状态：既不残留上一预设的旧文案，
+            // 也防止 DropDownClosed 的恢复逻辑把上一预设的值回写进新预设（#3235 自审）。
+            var item = comboBox.SelectedCascadingItem;
+            if (IsSelectableDomain(item))
+            {
+                CommitSelectedItem(comboBox, item);
+            }
+            else
+            {
+                comboBox.SetValue(LastCommittedItemProperty, null);
+                comboBox.SetValue(LastCommittedTextProperty, comboBox.PlaceholderText);
+            }
+
+            ApplySelectedPreviewBinding(comboBox);
+        });
     }
 
     private static void OnButtonClick(object sender, RoutedEventArgs e)

--- a/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
@@ -417,18 +417,19 @@ public partial class OneDragonFlowViewModel : ViewModel
         // 切换预设时从磁盘重读对应文件，让运行中外部编辑的预设文件生效，
         // 也避免后续自动保存把内存中的旧值覆盖回文件（#3235）。
         var configName = SelectedConfig.Name;
-        if (_lastAppliedConfigReload is { } lastApplied && lastApplied.Name == configName)
+
+        // 只做一次读取：取到磁盘内容（含反序列化与 Name 校验），读取/解析失败则沿用内存实例。
+        var diskConfig = ReadOneDragonConfigFromDisk(configName, out var json);
+
+        // 内容与最近一次应用的一致（例如绑定异步回写再次触发的本命令）：无需重复替换。
+        if (diskConfig != null && _lastAppliedConfigReload is { } lastApplied
+            && lastApplied.Name == configName && lastApplied.Json == json)
         {
-            // 文件内容与最近一次应用的一致（例如绑定的异步回写再次触发本命令）：无需重复替换。
-            if (IsSameFileContent(configName, lastApplied.Json))
-            {
-                SetSomeSelectedConfig(SelectedConfig);
-                SelectedTask = null;
-                return;
-            }
+            SetSomeSelectedConfig(SelectedConfig);
+            SelectedTask = null;
+            return;
         }
 
-        var diskConfig = ReadOneDragonConfigFromDisk(configName);
         if (diskConfig != null)
         {
             _isApplyingConfigReload = true;
@@ -443,9 +444,9 @@ public partial class OneDragonFlowViewModel : ViewModel
                 // SelectedConfig 是预设下拉框的 TwoWay 绑定源：赋入新实例后绑定引擎会异步回写
                 // ComboBox.SelectedItem 并再次触发本命令。守卫打开期间同步泵完 DataBind 优先级的
                 // 回写，把这次重入拦掉，避免实例被反复替换（死循环）。
+                _lastAppliedConfigReload = (configName, json);
                 SelectedConfig = diskConfig;
                 Application.Current?.Dispatcher.Invoke(() => { }, DispatcherPriority.DataBind);
-                _lastAppliedConfigReload = (configName, File.ReadAllText(Path.Combine(OneDragonFlowConfigFolder, $"{configName}.json")));
             }
             finally
             {
@@ -457,26 +458,14 @@ public partial class OneDragonFlowViewModel : ViewModel
         SelectedTask = null;
     }
 
-    private bool IsSameFileContent(string configName, string lastAppliedJson)
-    {
-        try
-        {
-            var filePath = Path.Combine(OneDragonFlowConfigFolder, $"{configName}.json");
-            return File.Exists(filePath) && File.ReadAllText(filePath) == lastAppliedJson;
-        }
-        catch (Exception e)
-        {
-            _logger.LogDebug(e, "比较一条龙配置文件内容失败: {ConfigName}", configName);
-            return false;
-        }
-    }
-
     /// <summary>
-    /// 按配置名反序列化 <see cref="OneDragonFlowConfigFolder" /> 下的文件为全新实例；文件缺失、
-    /// 解析失败或名称与来源文件不一致时返回 null（沿用内存中的实例，活对象不会被部分修改）。
+    /// 按配置名读取并反序列化 <see cref="OneDragonFlowConfigFolder" /> 下的文件为全新实例；
+    /// 文件缺失、解析失败或名称与来源文件不一致时返回 null（沿用内存中的实例，活对象不会被部分修改）。
+    /// 成功时通过 <paramref name="json" /> 返回本次实际应用的原始内容，供后续幂等比较使用（单次读取）。
     /// </summary>
-    private OneDragonFlowConfig? ReadOneDragonConfigFromDisk(string configName)
+    private OneDragonFlowConfig? ReadOneDragonConfigFromDisk(string configName, out string json)
     {
+        json = string.Empty;
         try
         {
             var filePath = Path.Combine(OneDragonFlowConfigFolder, $"{configName}.json");
@@ -486,7 +475,7 @@ public partial class OneDragonFlowViewModel : ViewModel
                 return null;
             }
 
-            var json = File.ReadAllText(filePath);
+            json = File.ReadAllText(filePath);
             var config = JsonConvert.DeserializeObject<OneDragonFlowConfig>(json);
             // 仅接受与来源文件名一致的非空 Name：否则后续保存会用对象里的 Name 生成路径，
             // 导致原预设文件未被更新或写入错误的 .json 文件。

--- a/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
@@ -444,10 +444,26 @@ public partial class OneDragonFlowViewModel : ViewModel
             }
 
             // 原地应用，避免逐个属性触发自动保存；属性变更仍会通过 PropertyChanged 通知 UI 刷新。
+            // 先对当前实例做快照：若应用中途抛异常（如个别字段转换失败），回滚到原状态，
+            // 避免磁盘与内存值混合的实例被界面使用或被后续自动保存写回文件。
+            var snapshotJson = JsonConvert.SerializeObject(SelectedConfig);
             SelectedConfig.PropertyChanged -= ConfigPropertyChanged;
             try
             {
                 JsonConvert.PopulateObject(json, SelectedConfig);
+            }
+            catch
+            {
+                try
+                {
+                    JsonConvert.PopulateObject(snapshotJson, SelectedConfig);
+                }
+                catch (Exception rollbackException)
+                {
+                    _logger.LogDebug(rollbackException, "回滚重读的一条龙配置失败: {ConfigName}", configName);
+                }
+
+                throw;
             }
             finally
             {

--- a/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
@@ -402,8 +402,50 @@ public partial class OneDragonFlowViewModel : ViewModel
     [RelayCommand]
     private void OnConfigDropDownChanged()
     {
+        if (SelectedConfig == null)
+        {
+            return;
+        }
+
+        // 切换预设时重新从磁盘读取所选配置：用户在运行中外部编辑的文件才能生效，
+        // 也避免后续自动保存把内存中的旧值覆盖回文件（#3235）。
+        var diskConfig = ReadOneDragonConfigFromDisk(SelectedConfig.Name);
+        if (diskConfig != null)
+        {
+            var index = ConfigList.IndexOf(SelectedConfig);
+            if (index >= 0)
+            {
+                ConfigList[index] = diskConfig;
+            }
+
+            SelectedConfig = diskConfig;
+        }
+
         SetSomeSelectedConfig(SelectedConfig);
         SelectedTask = null;
+    }
+
+    /// <summary>
+    /// 按配置名重读 <see cref="OneDragonFlowConfigFolder" /> 下的文件；文件缺失或解析失败时返回 null（沿用内存中的实例）。
+    /// </summary>
+    private OneDragonFlowConfig? ReadOneDragonConfigFromDisk(string configName)
+    {
+        try
+        {
+            var filePath = Path.Combine(OneDragonFlowConfigFolder, $"{configName}.json");
+            if (!File.Exists(filePath))
+            {
+                return null;
+            }
+
+            var json = File.ReadAllText(filePath);
+            return JsonConvert.DeserializeObject<OneDragonFlowConfig>(json);
+        }
+        catch (Exception e)
+        {
+            _logger.LogDebug(e, "重读一条龙配置失败: {ConfigName}", configName);
+            return null;
+        }
     }
 
     public void SaveConfig()

--- a/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
@@ -454,7 +454,8 @@ public partial class OneDragonFlowViewModel : ViewModel
             }
         }
 
-        SetSomeSelectedConfig(SelectedConfig);
+        // 收尾以本次读取结果为准（读取失败则保持原实例），不依赖绑定回写回显来完成状态收敛。
+        SetSomeSelectedConfig(diskConfig ?? SelectedConfig);
         SelectedTask = null;
     }
 
@@ -484,6 +485,11 @@ public partial class OneDragonFlowViewModel : ViewModel
                 _logger.LogDebug("忽略重读的一条龙配置，名称与来源文件不一致: {ConfigName}", configName);
                 return null;
             }
+
+            // 防御外部文件把任务集合显式写成 null 的情况，避免后续 SaveConfig 对空集合调用 Clear() 崩溃。
+            config.TaskEnabledList ??= [];
+            config.TaskOrder ??= [];
+            config.TaskDefinitions ??= [];
 
             return config;
         }
@@ -540,25 +546,45 @@ public partial class OneDragonFlowViewModel : ViewModel
 
     public void SetSomeSelectedConfig(OneDragonFlowConfig? selected)
     {
-        if (SelectedConfig != null)
+        if (selected == null)
         {
-            TaskContext.Instance().Config.SelectedOneDragonFlowConfigName = SelectedConfig.Name;
-            foreach (var task in TaskList)
-            {
-                if (SelectedConfig.TaskEnabledList.TryGetValue(task.Id, out var value))
-                {
-                    task.IsEnabled = value;
-                }
-            }
-
-            LoadDisplayTaskListFromConfig();
+            return;
         }
+
+        // 以入参为准收口：绑定的异步回写可能让 SelectedConfig 短暂为 null 或滞后（自审），
+        // 先确保属性指向本次要应用的实例，后续刷新才具备确定性。
+        if (!ReferenceEquals(SelectedConfig, selected))
+        {
+            SelectedConfig = selected;
+        }
+
+        TaskContext.Instance().Config.SelectedOneDragonFlowConfigName = selected.Name;
+        foreach (var task in TaskList)
+        {
+            if (selected.TaskEnabledList.TryGetValue(task.Id, out var value))
+            {
+                task.IsEnabled = value;
+            }
+        }
+
+        LoadDisplayTaskListFromConfig();
     }
 
     private async void TaskPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
+        if (SelectedConfig == null)
+        {
+            return;
+        }
+
+        // 捕获本次变更所属的预设实例：防抖期间若用户已切换预设，
+        // 不再用当前 TaskList/SelectedConfig 覆盖新预设（自审）。
+        var config = SelectedConfig;
         await Task.Delay(100); //等会加载完再保存
-        SaveConfig();
+        if (ReferenceEquals(SelectedConfig, config))
+        {
+            SaveConfig();
+        }
     }
 
     private void ConfigPropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
@@ -407,74 +407,59 @@ public partial class OneDragonFlowViewModel : ViewModel
             return;
         }
 
-        var configName = SelectedConfig.Name;
-
         // 切换预设时重新从磁盘读取所选配置：用户在运行中外部编辑的文件才能生效，
         // 也避免后续自动保存把内存中的旧值覆盖回文件（#3235）。
-        //
-        // SelectedConfig 是预设下拉框的 TwoWay 绑定源：这里赋入新实例后，绑定会异步回写
-        // ComboBox.SelectedItem 并再次触发本命令（且每次重读都会产生新实例）。
-        // 因此重读后先记录配置名，等这次由回写引起的重入到达时按同名直接消费掉，避免持续重读（Code Review #3639）。
-        if (_lastReloadedConfigName == configName)
-        {
-            _lastReloadedConfigName = null;
-            SetSomeSelectedConfig(SelectedConfig);
-            SelectedTask = null;
-            return;
-        }
-
-        var diskConfig = ReadOneDragonConfigFromDisk(configName);
-        if (diskConfig != null)
-        {
-            _lastReloadedConfigName = configName;
-            var index = ConfigList.IndexOf(SelectedConfig);
-            if (index >= 0)
-            {
-                ConfigList[index] = diskConfig;
-            }
-
-            SelectedConfig = diskConfig;
-        }
+        TryReloadSelectedConfigFromDisk(SelectedConfig.Name);
 
         SetSomeSelectedConfig(SelectedConfig);
         SelectedTask = null;
     }
 
     /// <summary>
-    /// 上一次重读所选预设时记录的配置名，用于拦住 SelectedConfig 回写导致的命令重入。
+    /// 按配置名重读 <see cref="OneDragonFlowConfigFolder" /> 下的文件，并把磁盘内容原地应用到
+    /// 当前 <see cref="SelectedConfig" /> 实例。成功返回 true。
+    /// <para>保持实例身份不变（不做 ConfigList 元素替换），避免预设下拉框的双向绑定回写再次触发
+    /// 本命令造成的重入；文件缺失、解析失败或名称与来源文件不一致时返回 false（沿用内存中的实例）。</para>
     /// </summary>
-    private string? _lastReloadedConfigName;
-
-    /// <summary>
-    /// 按配置名重读 <see cref="OneDragonFlowConfigFolder" /> 下的文件；文件缺失、解析失败或
-    /// 名称与来源文件不一致时返回 null（沿用内存中的实例）。
-    /// </summary>
-    private OneDragonFlowConfig? ReadOneDragonConfigFromDisk(string configName)
+    private bool TryReloadSelectedConfigFromDisk(string configName)
     {
         try
         {
             var filePath = Path.Combine(OneDragonFlowConfigFolder, $"{configName}.json");
             if (!File.Exists(filePath))
             {
-                return null;
+                _logger.LogDebug("重读一条龙配置失败，文件不存在: {ConfigName}", configName);
+                return false;
             }
 
             var json = File.ReadAllText(filePath);
-            var config = JsonConvert.DeserializeObject<OneDragonFlowConfig>(json);
+
             // 仅接受与来源文件名一致的非空 Name：否则后续保存会用对象里的 Name 生成路径，
             // 导致原预设文件未被更新或写入错误的 .json 文件。
-            if (config == null || string.IsNullOrEmpty(config.Name) || config.Name != configName)
+            var parsed = JsonConvert.DeserializeObject<OneDragonFlowConfig>(json);
+            if (parsed == null || string.IsNullOrEmpty(parsed.Name) || parsed.Name != configName)
             {
                 _logger.LogDebug("忽略重读的一条龙配置，名称与来源文件不一致: {ConfigName}", configName);
-                return null;
+                return false;
             }
 
-            return config;
+            // 原地应用，避免逐个属性触发自动保存；属性变更仍会通过 PropertyChanged 通知 UI 刷新。
+            SelectedConfig.PropertyChanged -= ConfigPropertyChanged;
+            try
+            {
+                JsonConvert.PopulateObject(json, SelectedConfig);
+            }
+            finally
+            {
+                SelectedConfig.PropertyChanged += ConfigPropertyChanged;
+            }
+
+            return true;
         }
         catch (Exception e)
         {
             _logger.LogDebug(e, "重读一条龙配置失败: {ConfigName}", configName);
-            return null;
+            return false;
         }
     }
 

--- a/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Threading;
 using BetterGenshinImpact.Core.Config;
 using BetterGenshinImpact.Core.Script;
 using BetterGenshinImpact.Core.Script.Group;
@@ -399,29 +400,82 @@ public partial class OneDragonFlowViewModel : ViewModel
         }
     }
 
+    /// <summary>true 时表示正在应用磁盘重读结果，忽略由绑定回写引起的本命令重入。</summary>
+    private bool _isApplyingConfigReload;
+
+    /// <summary>最近一次成功应用到当前所选预设的原始 JSON（按名称记忆），内容未变化时跳过重复替换。</summary>
+    private (string Name, string Json)? _lastAppliedConfigReload;
+
     [RelayCommand]
     private void OnConfigDropDownChanged()
     {
-        if (SelectedConfig == null)
+        if (SelectedConfig == null || _isApplyingConfigReload)
         {
             return;
         }
 
-        // 切换预设时重新从磁盘读取所选配置：用户在运行中外部编辑的文件才能生效，
+        // 切换预设时从磁盘重读对应文件，让运行中外部编辑的预设文件生效，
         // 也避免后续自动保存把内存中的旧值覆盖回文件（#3235）。
-        TryReloadSelectedConfigFromDisk(SelectedConfig.Name);
+        var configName = SelectedConfig.Name;
+        if (_lastAppliedConfigReload is { } lastApplied && lastApplied.Name == configName)
+        {
+            // 文件内容与最近一次应用的一致（例如绑定的异步回写再次触发本命令）：无需重复替换。
+            if (IsSameFileContent(configName, lastApplied.Json))
+            {
+                SetSomeSelectedConfig(SelectedConfig);
+                SelectedTask = null;
+                return;
+            }
+        }
+
+        var diskConfig = ReadOneDragonConfigFromDisk(configName);
+        if (diskConfig != null)
+        {
+            _isApplyingConfigReload = true;
+            try
+            {
+                var index = ConfigList.IndexOf(SelectedConfig);
+                if (index >= 0)
+                {
+                    ConfigList[index] = diskConfig;
+                }
+
+                // SelectedConfig 是预设下拉框的 TwoWay 绑定源：赋入新实例后绑定引擎会异步回写
+                // ComboBox.SelectedItem 并再次触发本命令。守卫打开期间同步泵完 DataBind 优先级的
+                // 回写，把这次重入拦掉，避免实例被反复替换（死循环）。
+                SelectedConfig = diskConfig;
+                Application.Current?.Dispatcher.Invoke(() => { }, DispatcherPriority.DataBind);
+                _lastAppliedConfigReload = (configName, File.ReadAllText(Path.Combine(OneDragonFlowConfigFolder, $"{configName}.json")));
+            }
+            finally
+            {
+                _isApplyingConfigReload = false;
+            }
+        }
 
         SetSomeSelectedConfig(SelectedConfig);
         SelectedTask = null;
     }
 
+    private bool IsSameFileContent(string configName, string lastAppliedJson)
+    {
+        try
+        {
+            var filePath = Path.Combine(OneDragonFlowConfigFolder, $"{configName}.json");
+            return File.Exists(filePath) && File.ReadAllText(filePath) == lastAppliedJson;
+        }
+        catch (Exception e)
+        {
+            _logger.LogDebug(e, "比较一条龙配置文件内容失败: {ConfigName}", configName);
+            return false;
+        }
+    }
+
     /// <summary>
-    /// 按配置名重读 <see cref="OneDragonFlowConfigFolder" /> 下的文件，并把磁盘内容原地应用到
-    /// 当前 <see cref="SelectedConfig" /> 实例。成功返回 true。
-    /// <para>保持实例身份不变（不做 ConfigList 元素替换），避免预设下拉框的双向绑定回写再次触发
-    /// 本命令造成的重入；文件缺失、解析失败或名称与来源文件不一致时返回 false（沿用内存中的实例）。</para>
+    /// 按配置名反序列化 <see cref="OneDragonFlowConfigFolder" /> 下的文件为全新实例；文件缺失、
+    /// 解析失败或名称与来源文件不一致时返回 null（沿用内存中的实例，活对象不会被部分修改）。
     /// </summary>
-    private bool TryReloadSelectedConfigFromDisk(string configName)
+    private OneDragonFlowConfig? ReadOneDragonConfigFromDisk(string configName)
     {
         try
         {
@@ -429,53 +483,25 @@ public partial class OneDragonFlowViewModel : ViewModel
             if (!File.Exists(filePath))
             {
                 _logger.LogDebug("重读一条龙配置失败，文件不存在: {ConfigName}", configName);
-                return false;
+                return null;
             }
 
             var json = File.ReadAllText(filePath);
-
+            var config = JsonConvert.DeserializeObject<OneDragonFlowConfig>(json);
             // 仅接受与来源文件名一致的非空 Name：否则后续保存会用对象里的 Name 生成路径，
             // 导致原预设文件未被更新或写入错误的 .json 文件。
-            var parsed = JsonConvert.DeserializeObject<OneDragonFlowConfig>(json);
-            if (parsed == null || string.IsNullOrEmpty(parsed.Name) || parsed.Name != configName)
+            if (config == null || string.IsNullOrEmpty(config.Name) || config.Name != configName)
             {
                 _logger.LogDebug("忽略重读的一条龙配置，名称与来源文件不一致: {ConfigName}", configName);
-                return false;
+                return null;
             }
 
-            // 原地应用，避免逐个属性触发自动保存；属性变更仍会通过 PropertyChanged 通知 UI 刷新。
-            // 先对当前实例做快照：若应用中途抛异常（如个别字段转换失败），回滚到原状态，
-            // 避免磁盘与内存值混合的实例被界面使用或被后续自动保存写回文件。
-            var snapshotJson = JsonConvert.SerializeObject(SelectedConfig);
-            SelectedConfig.PropertyChanged -= ConfigPropertyChanged;
-            try
-            {
-                JsonConvert.PopulateObject(json, SelectedConfig);
-            }
-            catch
-            {
-                try
-                {
-                    JsonConvert.PopulateObject(snapshotJson, SelectedConfig);
-                }
-                catch (Exception rollbackException)
-                {
-                    _logger.LogDebug(rollbackException, "回滚重读的一条龙配置失败: {ConfigName}", configName);
-                }
-
-                throw;
-            }
-            finally
-            {
-                SelectedConfig.PropertyChanged += ConfigPropertyChanged;
-            }
-
-            return true;
+            return config;
         }
         catch (Exception e)
         {
             _logger.LogDebug(e, "重读一条龙配置失败: {ConfigName}", configName);
-            return false;
+            return null;
         }
     }
 

--- a/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs
@@ -407,11 +407,26 @@ public partial class OneDragonFlowViewModel : ViewModel
             return;
         }
 
+        var configName = SelectedConfig.Name;
+
         // 切换预设时重新从磁盘读取所选配置：用户在运行中外部编辑的文件才能生效，
         // 也避免后续自动保存把内存中的旧值覆盖回文件（#3235）。
-        var diskConfig = ReadOneDragonConfigFromDisk(SelectedConfig.Name);
+        //
+        // SelectedConfig 是预设下拉框的 TwoWay 绑定源：这里赋入新实例后，绑定会异步回写
+        // ComboBox.SelectedItem 并再次触发本命令（且每次重读都会产生新实例）。
+        // 因此重读后先记录配置名，等这次由回写引起的重入到达时按同名直接消费掉，避免持续重读（Code Review #3639）。
+        if (_lastReloadedConfigName == configName)
+        {
+            _lastReloadedConfigName = null;
+            SetSomeSelectedConfig(SelectedConfig);
+            SelectedTask = null;
+            return;
+        }
+
+        var diskConfig = ReadOneDragonConfigFromDisk(configName);
         if (diskConfig != null)
         {
+            _lastReloadedConfigName = configName;
             var index = ConfigList.IndexOf(SelectedConfig);
             if (index >= 0)
             {
@@ -426,7 +441,13 @@ public partial class OneDragonFlowViewModel : ViewModel
     }
 
     /// <summary>
-    /// 按配置名重读 <see cref="OneDragonFlowConfigFolder" /> 下的文件；文件缺失或解析失败时返回 null（沿用内存中的实例）。
+    /// 上一次重读所选预设时记录的配置名，用于拦住 SelectedConfig 回写导致的命令重入。
+    /// </summary>
+    private string? _lastReloadedConfigName;
+
+    /// <summary>
+    /// 按配置名重读 <see cref="OneDragonFlowConfigFolder" /> 下的文件；文件缺失、解析失败或
+    /// 名称与来源文件不一致时返回 null（沿用内存中的实例）。
     /// </summary>
     private OneDragonFlowConfig? ReadOneDragonConfigFromDisk(string configName)
     {
@@ -439,7 +460,16 @@ public partial class OneDragonFlowViewModel : ViewModel
             }
 
             var json = File.ReadAllText(filePath);
-            return JsonConvert.DeserializeObject<OneDragonFlowConfig>(json);
+            var config = JsonConvert.DeserializeObject<OneDragonFlowConfig>(json);
+            // 仅接受与来源文件名一致的非空 Name：否则后续保存会用对象里的 Name 生成路径，
+            // 导致原预设文件未被更新或写入错误的 .json 文件。
+            if (config == null || string.IsNullOrEmpty(config.Name) || config.Name != configName)
+            {
+                _logger.LogDebug("忽略重读的一条龙配置，名称与来源文件不一致: {ConfigName}", configName);
+                return null;
+            }
+
+            return config;
         }
         catch (Exception e)
         {


### PR DESCRIPTION
## 问题

#3235：切换一条龙预设（如从「循环A」切到「循环B」）后，每日秘境/自动首领等配置界面的级联下拉框仍显示上一个预设的值（如仍显示「荒废织造坞」），需要手动点开一次下拉才会纠正。

## 根因一：级联下拉显示缓存不监听程序化值变化

此类级联下拉（`CascadingComboBox`）折叠态的展示文案由 `DomainCascadingComboBoxBehavior` 缓存的 `LastCommittedText` 决定（`BetterGenshinImpact/View/Behavior/DomainCascadingComboBoxBehavior.cs`），而该缓存只在交互事件（`Loaded`/`SelectionChanged`/`DropDownOpened`/`DropDownClosed`/清除按钮）中刷新。

切换一条龙预设是程序化替换 `SelectedConfig` → 绑定把新值写入 `SelectedCascadingItem` 依赖属性，但**不触发上述交互事件**，于是展示文案停留在上一个预设提交的值。

## 根因二：切换预设不重读磁盘

`User/OneDragon/{Name}.json` 只在进入页面时（`OnNavigatedTo` → `InitConfigList`）读取一次；切换预设（`OnConfigDropDownChanged`）从不重新反序列化。用户运行中外部编辑的预设文件不生效，且后续任何 UI 修改触发自动保存时，会用内存中的旧值覆盖外部编辑内容。

## 修复

1. **`DomainCascadingComboBoxBehavior`**：通过 `DependencyPropertyDescriptor` 订阅 `CascadingComboBox.SelectedCascadingItemProperty` 的 `ValueChanged`，值被程序化修改时异步刷新提交文案（与 `DropDownOpened` 相同的刷新语义）。一处改动覆盖 OneDragonFlowPage 的全部级联框与 TaskSettingsPage 的同类下拉。

2. **`OneDragonFlowViewModel.OnConfigDropDownChanged`**：切换预设时按名把磁盘 JSON 反序列化为**全新实例**并整体替换 `SelectedConfig`（同步替换 `ConfigList` 中对应元素），校验 `Name` 非空且与来源文件名一致。

   - 活对象永不被部分修改：解析/转换失败只发生在临时实例上，失败即沿用内存实例（Debug 日志），集合/列表均为全新反序列化结果，等同完整重载该预设；
   - `SelectedConfig` 是预设下拉框 TwoWay 绑定源：替换实例会使绑定回写并再次触发本命令——用守卫 + 赋值后同步泵完 DataBind 优先级的绑定回写拦截这次重入，并按（配置名+文件内容）幂等跳过重复事件，快速切换也安全；
   - 文件缺失、解析失败或名称不一致时沿用内存实例并记录 Debug 日志，避免后续保存写入错误的 `.json` 文件。

## 变更

- `BetterGenshinImpact/View/Behavior/DomainCascadingComboBoxBehavior.cs`：程序化值变化时刷新折叠文案；
- `BetterGenshinImpact/ViewModel/Pages/OneDragonFlowViewModel.cs`：切换预设重读磁盘 + 防重入与名称校验。

## 验证

- `dotnet build BetterGenshinImpact.sln -c Debug`：0 错误；
- 无 XAML 改动（行为类一处生效于全部级联框）；
- 已按 Greptile 代码评审意见补充防重入与名称校验（`a271e6c6`）。

> 说明：修复 2 让“运行中编辑 JSON 后切预设”立即生效；若上游不希望支持运行中外部编辑，也可只保留修复 1（显示刷新），告知后我可拆分。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复程序化切换预设后，下拉框折叠状态的显示文本未及时同步的问题。
  * 优化配置重新加载流程，避免重复触发配置切换操作。
  * 配置文件缺失、解析失败、名称不匹配或读取异常时，继续保留当前有效配置。
  * 配置切换异常时，避免应用不完整或错误的配置状态。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->