### PR TITLE
fix：锚点未开时，错误点击导至后续传送失败

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoTrackPath/TpTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoTrackPath/TpTask.cs
@@ -1248,6 +1248,18 @@ public class TpTask
             catch (TeleportPanelNotOpenedException e)
             {
                 // 同一视野内点击后未出现面板，重试只会重复点击同一位置。
+                // 抛出异常前切回地面图层并按下 ESC 退出大地图，避免影响后续路径追踪任务
+                try
+                {
+                    await SwitchToGroundMapLayerIfNeeded();
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogDebug("尝试切回地面图层失败: {Message}", ex.Message);
+                }
+    
+                Simulation.SendInput.Keyboard.KeyPress(User32.VK.VK_ESCAPE);
+                await Delay(300, ct);
                 throw;
             }
             catch (TpPointNotActivate e)

--- a/BetterGenshinImpact/GameTask/AutoTrackPath/TpTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoTrackPath/TpTask.cs
@@ -1248,18 +1248,11 @@ public class TpTask
             catch (TeleportPanelNotOpenedException e)
             {
                 // 同一视野内点击后未出现面板，重试只会重复点击同一位置。
-                // 抛出异常前切回地面图层并按下 ESC 退出大地图，避免影响后续路径追踪任务
-                try
-                {
-                    await SwitchToGroundMapLayerIfNeeded();
-                }
-                catch (Exception ex)
-                {
-                    Logger.LogDebug("尝试切回地面图层失败: {Message}", ex.Message);
-                }
-    
+                
+                // 抛出异常按下 ESC 退出大地图，避免影响后续路径追踪任务
                 Simulation.SendInput.Keyboard.KeyPress(User32.VK.VK_ESCAPE);
                 await Delay(300, ct);
+                
                 throw;
             }
             catch (TpPointNotActivate e)


### PR DESCRIPTION
未激活点位的详情面板会遮挡后续地图操作

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 传送面板未打开时，系统会退出大地图并等待后重新报告异常。
  * 调整异常处理流程，避免在该情况下执行额外的地图图层切换操作。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->