### PR TITLE
fix：卡在“进入钓鱼模式失败”处……

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoFishing/Behaviours.PartII.cs
+++ b/BetterGenshinImpact/GameTask/AutoFishing/Behaviours.PartII.cs
@@ -339,6 +339,13 @@ namespace BetterGenshinImpact.GameTask.AutoFishing
                 return Status.Running;
             }
 
+            // 如果未检测到退出钓鱼按钮，说明不在钓鱼模式，直接成功退出
+            if (imageRegion.Find(RecognitionAssets.Get("AutoFishing", "ExitFishingButton", imageRegion)).IsEmpty())
+            {
+                _logger.LogInformation("未检测到退出钓鱼按钮，可能不在钓鱼模式，直接退出");
+                return Status.Success;
+            }
+
             if (Bv.FindF(imageRegion, _fishingLocalizedString))
             {
                 _logger.LogInformation("退出完成");


### PR DESCRIPTION
https://github.com/babalae/better-genshin-impact/issues/3641

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 当系统检测到当前不在钓鱼模式时，将提前结束退出流程，避免执行不必要的按键和点击操作。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->