### PR TITLE
feat: 修改默认的图标识别模型

### DIFF
--- a/BetterGenshinImpact/BetterGenshinImpact.csproj
+++ b/BetterGenshinImpact/BetterGenshinImpact.csproj
@@ -43,7 +43,7 @@
 
 		<PackageReference Include="BetterGI.VCRuntime" Version="14.44.35208" />
 		<PackageReference Include="BetterGI.Assets.Map" Version="1.0.22" />
-        <PackageReference Include="BetterGI.Assets.Model" Version="1.0.33" />
+        <PackageReference Include="BetterGI.Assets.Model" Version="1.0.34" />
 		<PackageReference Include="BetterGI.Assets.Other" Version="1.0.25" />
 
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />

--- a/BetterGenshinImpact/Core/Config/OtherConfig.cs
+++ b/BetterGenshinImpact/Core/Config/OtherConfig.cs
@@ -1,6 +1,7 @@
 using System;
 using BetterGenshinImpact.Core.Recognition;
 using BetterGenshinImpact.Model;
+using BetterGenshinImpact.GameTask.Common.Job;
 using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace BetterGenshinImpact.Core.Config;
@@ -21,6 +22,9 @@ public partial class OtherConfig : ObservableObject
     //服务器时区偏移量
     [ObservableProperty]
     private TimeSpan _serverTimeZoneOffset = TimeSpan.FromHours(8);
+    //物品图标识别模型
+    [ObservableProperty]
+    private ItemIconRecognitionMode _itemIconRecognitionMode = ItemIconRecognitionMode.Item;
     [ObservableProperty]
     private AutoRestart _autoRestartConfig = new();
     //锄地规划

--- a/BetterGenshinImpact/GameTask/AutoArtifactSalvage/AutoArtifactSalvageTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoArtifactSalvage/AutoArtifactSalvageTask.cs
@@ -307,7 +307,7 @@ public class AutoArtifactSalvageTask : ISoloTask
                 ra5.ClickTo(315, 190);
                 await Delay(1000, ct);
                 // 遍历套装Grid勾选套装
-                using InferenceSession session = GridIconsAccuracyTestTask.LoadModel(out Dictionary<string, float[]> prototypes);
+                using IItemIconRecognizer iconRecognizer = ItemIconRecognizerFactory.CreateConfigured();
                 ArtifactSetFilterScreen gridScreen = new ArtifactSetFilterScreen(new GridParams(new Rect(40, 100, 1300, 852), 2, 3, 40, 40, 0.024), this.logger, this.ct);
                 string drawKey = "ArtifactSetFilter";
                 var drawRectList = new List<RectDrawable>();
@@ -319,7 +319,7 @@ public class AutoArtifactSalvageTask : ISoloTask
                     {
                         using ImageRegion itemRegion = pageRegion.DeriveCrop(itemRect);
                         using Mat img125 = GetGridIconsTask.CropResizeArtifactSetFilterGridIcon(itemRegion);
-                        (string? predName, _) = GridIconsAccuracyTestTask.Infer(img125, session, prototypes);
+                        string? predName = iconRecognizer.Recognize(img125);
                         if (predName == null)
                         {
                             var rectDrawable = itemRegion.SelfToRectDrawable(drawKey);

--- a/BetterGenshinImpact/GameTask/AutoEat/AutoEatTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoEat/AutoEatTask.cs
@@ -85,7 +85,7 @@ public class AutoEatTask : BaseIndependentTask, ISoloTask<int?>
             await new ReturnMainUiTask().Start(ct);
             await AutoArtifactSalvageTask.OpenInventory(GridScreenName.Food, _input, _logger, _ct);
 
-            using InferenceSession session = GridIconsAccuracyTestTask.LoadModel(out Dictionary<string, float[]> prototypes);
+            using IItemIconRecognizer iconRecognizer = ItemIconRecognizerFactory.CreateConfigured();
 
             GridScreen gridScreen = new GridScreen(GridParams.Templates[GridScreenName.Food], _logger, _ct);
             gridScreen.OnAfterTurnToNewPage += GridScreen.DrawItemsAfterTurnToNewPage;
@@ -97,8 +97,7 @@ public class AutoEatTask : BaseIndependentTask, ISoloTask<int?>
                 {
                     using ImageRegion itemRegion = pageRegion.DeriveCrop(itemRect);
                     using Mat icon = itemRegion.SrcMat.GetGridIcon();
-                    var result = GridIconsAccuracyTestTask.Infer(icon, session, prototypes);
-                    string predName = result.Item1;
+                    string? predName = iconRecognizer.Recognize(icon);
                     if (predName == _taskParam.FoodName)
                     {
                         // 点击item

--- a/BetterGenshinImpact/GameTask/AutoFishing/AutoFishingTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFishing/AutoFishingTask.cs
@@ -4,13 +4,11 @@ using BetterGenshinImpact.Core.Recognition.ONNX;
 using BetterGenshinImpact.Core.Simulator;
 using BetterGenshinImpact.GameTask.Common;
 using BetterGenshinImpact.GameTask.Common.Job;
-using BetterGenshinImpact.GameTask.GetGridIcons;
 using CsTrees;
 using CsTrees.Composites;
 using Fischless.WindowsInput;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.ML.OnnxRuntime;
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -41,7 +39,7 @@ namespace BetterGenshinImpact.GameTask.AutoFishing
             this._ct = ct;
 
             IOcrService ocrService = OcrFactory.Paddle;
-            using InferenceSession session = GridIconsAccuracyTestTask.LoadModel(out Dictionary<string, float[]> prototypes);
+            using IItemIconRecognizer itemRecognizer = ItemIconRecognizerFactory.CreateConfigured();
 
             CsTrees.Blackboard.Blackboard blackboard = new CsTrees.Blackboard.Blackboard();
 
@@ -69,7 +67,7 @@ namespace BetterGenshinImpact.GameTask.AutoFishing
                                     .End()
                                     .Try("进入钓鱼模式")
                                         .Sequence("-", memory: true)
-                                            .EnterFishingMode("进入钓鱼模式", _logger, input, session, prototypes, cultureInfo: param.GameCultureInfo, stringLocalizer: param.StringLocalizer)
+                                            .EnterFishingMode("进入钓鱼模式", _logger, input, itemRecognizer, cultureInfo: param.GameCultureInfo, stringLocalizer: param.StringLocalizer)
                                             .SuccessIsRunning(@"\")
                                                 .Sequence("一直钓鱼直到没鱼", memory: false)
                                                     .FailureIsSuccess(@"总是成功")
@@ -82,7 +80,7 @@ namespace BetterGenshinImpact.GameTask.AutoFishing
                                                                 .End()
                                                                 .FindFishTimeout("确认初始状态和找到鱼", 10, _logger)
                                                             .End()
-                                                            .ChooseBait("选择鱼饵", _logger, TaskContext.Instance().SystemInfo, input, session, prototypes)
+                                                            .ChooseBait("选择鱼饵", _logger, TaskContext.Instance().SystemInfo, input, itemRecognizer)
                                                             .Try("抛竿等待上钩提竿")
                                                                 .Sequence("抛竿等待上钩", memory: true)
                                                                     .Parallel("抛竿直到成功或出错", policy: new ParallelPolicy.SuccessOnOne())
@@ -150,7 +148,7 @@ namespace BetterGenshinImpact.GameTask.AutoFishing
                                 .PushLeaf(() => new TurnAround("转圈圈调整视角", blackboard, _logger, param.SaveScreenshotOnKeyTick, input))
                                 .PushLeaf(() => new FindFishTimeout("找到鱼", 20, blackboard, _logger, param.SaveScreenshotOnKeyTick))
                             .End()
-                            .PushLeaf(() => new EnterFishingMode("进入钓鱼模式", blackboard, _logger, param.SaveScreenshotOnKeyTick, input, session, prototypes, cultureInfo: param.GameCultureInfo, stringLocalizer: param.StringLocalizer))
+                            .PushLeaf(() => new EnterFishingMode("进入钓鱼模式", blackboard, _logger, param.SaveScreenshotOnKeyTick, input, itemRecognizer, cultureInfo: param.GameCultureInfo, stringLocalizer: param.StringLocalizer))
                             .UntilFailed(@"\")
                                 .Sequence("一直钓鱼直到没鱼")
                                     .AlwaysSucceed(@"\")
@@ -165,7 +163,7 @@ namespace BetterGenshinImpact.GameTask.AutoFishing
                                                 .End()
                                                 .PushLeaf(() => new FindFishTimeout("确认初始状态和找到鱼", 10, blackboard, _logger, param.SaveScreenshotOnKeyTick))
                                             .End()
-                                            .PushLeaf(() => new ChooseBait("选择鱼饵", blackboard, _logger, param.SaveScreenshotOnKeyTick, TaskContext.Instance().SystemInfo, input, session, prototypes))
+                                            .PushLeaf(() => new ChooseBait("选择鱼饵", blackboard, _logger, param.SaveScreenshotOnKeyTick, TaskContext.Instance().SystemInfo, input, itemRecognizer))
                                             .MySimpleParallel("抛竿直到成功或出错", policy: SimpleParallelPolicy.OnlyOneMustSucceed)
                                                 .UntilSuccess("重复抛竿")
                                                     .Sequence("-")

--- a/BetterGenshinImpact/GameTask/AutoFishing/AutoFishingTaskCatalog.cs
+++ b/BetterGenshinImpact/GameTask/AutoFishing/AutoFishingTaskCatalog.cs
@@ -1,15 +1,14 @@
 using BetterGenshinImpact.Core.Recognition.OCR;
 using BetterGenshinImpact.Core.Recognition.ONNX;
 using BetterGenshinImpact.GameTask.Model;
+using BetterGenshinImpact.GameTask.Common.Job;
 using BetterGenshinImpact.View.Drawable;
 using CsTrees.Blackboard;
 using CsTrees.FluentBuilder;
 using Fischless.WindowsInput;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
-using Microsoft.ML.OnnxRuntime;
 using System;
-using System.Collections.Generic;
 using System.Globalization;
 
 namespace BetterGenshinImpact.GameTask.AutoFishing
@@ -58,12 +57,11 @@ namespace BetterGenshinImpact.GameTask.AutoFishing
             string name,
             ILogger logger,
             IInputSimulator input,
-            InferenceSession session,
-            Dictionary<string, float[]> prototypes,
+            IItemIconRecognizer itemRecognizer,
             Blackboard blackboard,
             TimeProvider? timeProvider = null,
             CultureInfo? cultureInfo = null,
-            IStringLocalizer? stringLocalizer = null) => new EnterFishingMode(name, logger, input, session, prototypes, blackboard, timeProvider, cultureInfo, stringLocalizer);
+            IStringLocalizer? stringLocalizer = null) => new EnterFishingMode(name, logger, input, itemRecognizer, blackboard, timeProvider, cultureInfo, stringLocalizer);
 
         public CheckInitalState CheckInitalState(
             string name,
@@ -77,10 +75,9 @@ namespace BetterGenshinImpact.GameTask.AutoFishing
             ILogger logger,
             ISystemInfo systemInfo,
             IInputSimulator input,
-            InferenceSession session,
-            Dictionary<string, float[]> prototypes,
+            IItemIconRecognizer itemRecognizer,
             Blackboard blackboard,
-            TimeProvider? timeProvider = null) => new ChooseBait(name, logger, systemInfo, input, session, prototypes, blackboard, timeProvider);
+            TimeProvider? timeProvider = null) => new ChooseBait(name, logger, systemInfo, input, itemRecognizer, blackboard, timeProvider);
 
         public LiftRod LiftRod(
             string name,

--- a/BetterGenshinImpact/GameTask/AutoFishing/Behaviours.PartII.cs
+++ b/BetterGenshinImpact/GameTask/AutoFishing/Behaviours.PartII.cs
@@ -3,8 +3,8 @@ using BetterGenshinImpact.Core.Recognition.ONNX;
 using BetterGenshinImpact.Core.Simulator;
 using BetterGenshinImpact.GameTask.AutoFishing.Model;
 using BetterGenshinImpact.GameTask.Common;
+using BetterGenshinImpact.GameTask.Common.Job;
 using BetterGenshinImpact.GameTask.Common.BgiVision;
-using BetterGenshinImpact.GameTask.GetGridIcons;
 using BetterGenshinImpact.GameTask.Model.Area;
 using BetterGenshinImpact.Helpers;
 using BetterGenshinImpact.Helpers.Extensions;
@@ -201,8 +201,7 @@ namespace BetterGenshinImpact.GameTask.AutoFishing
     {
         private readonly ILogger _logger;
         private readonly IInputSimulator _input;
-        private readonly InferenceSession _session;
-        private readonly Dictionary<string, float[]> _prototypes;
+        private readonly IItemIconRecognizer _itemRecognizer;
         private readonly TimeProvider _timeProvider;
         private DateTimeOffset? _pressFWaitEndTime;
         private DateTimeOffset? _clickWhiteConfirmButtonWaitEndTime;
@@ -225,12 +224,11 @@ namespace BetterGenshinImpact.GameTask.AutoFishing
         [BlackboardKey(Access = Access.Write)]
         public BehaviourKeyAccess<bool> PitchReset { get; private set; } = null!;
 
-        private EnterFishingMode(string name, ILogger logger, IInputSimulator input, InferenceSession session, Dictionary<string, float[]> prototypes, TimeProvider? timeProvider = null, CultureInfo? cultureInfo = null, IStringLocalizer? stringLocalizer = null) : base(name)
+        private EnterFishingMode(string name, ILogger logger, IInputSimulator input, IItemIconRecognizer itemRecognizer, TimeProvider? timeProvider = null, CultureInfo? cultureInfo = null, IStringLocalizer? stringLocalizer = null) : base(name)
         {
             _logger = logger;
             _input = input;
-            _session = session;
-            _prototypes = prototypes;
+            _itemRecognizer = itemRecognizer;
             _timeProvider = timeProvider ?? TimeProvider.System;
             _fishingLocalizedString = stringLocalizer == null ? "钓鱼" : stringLocalizer.WithCultureGet(cultureInfo, "钓鱼");
         }
@@ -261,7 +259,7 @@ namespace BetterGenshinImpact.GameTask.AutoFishing
                 // 经验算在 16:9 常见分辨率（720p/1080p/1440p）下 Y+H 不会超出图像高度，暂不加钳位
                 using Mat subMat = imageRegion.SrcMat.SubMat(new Rect((int)(0.824 * imageRegion.Width), (int)(0.669 * imageRegion.Height), (int)(0.065 * imageRegion.Width), (int)(0.065 * imageRegion.Width)));
                 using Mat resized = subMat.Resize(new Size(125, 125));
-                (string? predName, _) = GridIconsAccuracyTestTask.Infer(resized, _session, _prototypes);
+                string? predName = _itemRecognizer.Recognize(resized);
                 if (predName!.TryGetEnumValueFromDescription(out BaitType? parsedBait))
                 {
                     SelectedBait.Set(parsedBait);

--- a/BetterGenshinImpact/GameTask/AutoFishing/Behaviours.cs
+++ b/BetterGenshinImpact/GameTask/AutoFishing/Behaviours.cs
@@ -5,7 +5,7 @@ using BetterGenshinImpact.Core.Recognition.OpenCv;
 using BetterGenshinImpact.Core.Simulator;
 using BetterGenshinImpact.GameTask.AutoFishing.Model;
 using BetterGenshinImpact.GameTask.Common;
-using BetterGenshinImpact.GameTask.GetGridIcons;
+using BetterGenshinImpact.GameTask.Common.Job;
 using BetterGenshinImpact.GameTask.Model;
 using BetterGenshinImpact.GameTask.Model.Area;
 using BetterGenshinImpact.GameTask.Model.GameUI;
@@ -139,8 +139,7 @@ namespace BetterGenshinImpact.GameTask.AutoFishing
     {
         private readonly ISystemInfo systemInfo;
         private readonly IInputSimulator input;
-        private readonly InferenceSession session;
-        private readonly Dictionary<string, float[]> prototypes;
+        private readonly IItemIconRecognizer itemRecognizer;
         private readonly ILogger logger;
         private readonly TimeProvider timeProvider;
         private DateTimeOffset? chooseBaitUIOpenWaitEndTime; // 等待选鱼饵界面出现并尝试找鱼饵的结束时间
@@ -178,13 +177,12 @@ namespace BetterGenshinImpact.GameTask.AutoFishing
         [BlackboardKey(Access = Access.Read)]
         public BehaviourKeyAccess<Action<int>> Sleep { get; private set; } = null!;
 
-        private ChooseBait(string name, ILogger logger, ISystemInfo systemInfo, IInputSimulator input, InferenceSession session, Dictionary<string, float[]> prototypes, TimeProvider? timeProvider = null) : base(name)
+        private ChooseBait(string name, ILogger logger, ISystemInfo systemInfo, IInputSimulator input, IItemIconRecognizer itemRecognizer, TimeProvider? timeProvider = null) : base(name)
         {
             this.logger = logger;
             this.systemInfo = systemInfo;
             this.input = input;
-            this.session = session;
-            this.prototypes = prototypes;
+            this.itemRecognizer = itemRecognizer;
             this.timeProvider = timeProvider ?? TimeProvider.System;
         }
 
@@ -307,7 +305,7 @@ namespace BetterGenshinImpact.GameTask.AutoFishing
             {
                 using ImageRegion resRa = singleRowGrid.DeriveCrop(box);
                 using Mat img125 = resRa.SrcMat.GetGridIcon();
-                (string? predName, _) = GridIconsAccuracyTestTask.Infer(img125, this.session, this.prototypes);
+                string? predName = itemRecognizer.Recognize(img125);
                 if (predName != null && !availableBaitNames.Contains(predName))
                 {
                     predName = null;
@@ -316,7 +314,9 @@ namespace BetterGenshinImpact.GameTask.AutoFishing
             }
         }
 
-        private static readonly FrozenSet<string> availableBaitNames = Enum.GetValues(typeof(BaitType)).Cast<BaitType>().Select(bt => bt.GetDescription()).ToFrozenSet();
+        private static readonly FrozenSet<string> availableBaitNames = Enum.GetValues<BaitType>()
+            .Select(bt => bt.GetDescription())
+            .ToFrozenSet();
     }
 
     [Obsolete]

--- a/BetterGenshinImpact/GameTask/Common/Job/CountInventoryItemParam.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/CountInventoryItemParam.cs
@@ -16,13 +16,14 @@ public class CountInventoryItemParam
 
     public List<string> ItemNames { get; set; } = [];
 
-    public ItemIconRecognitionMode IconRecognitionMode { get; set; } = ItemIconRecognitionMode.GridIcon;
+    public ItemIconRecognitionMode IconRecognitionMode { get; set; }
 
     /// <summary>
     /// 供脚本创建后逐项赋值；参数校验在任务消费参数时执行。
     /// </summary>
     public CountInventoryItemParam()
     {
+        IconRecognitionMode = TaskContext.Instance().Config.OtherConfig.ItemIconRecognitionMode;
     }
 
     public IEnumerable<string>? GetItemNamesOrNull()

--- a/BetterGenshinImpact/GameTask/Common/Job/CraftMaterialTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/CraftMaterialTask.cs
@@ -324,7 +324,7 @@ public class CraftMaterialTask
     /// <returns>找到并选中目标材料时返回 true。</returns>
     private async Task<bool> TryFindAndSelectMaterial()
     {
-        using ItemRecognizer itemRecognizer = new();
+        using IItemIconRecognizer itemRecognizer = ItemIconRecognizerFactory.CreateConfigured();
         GridScreen gridScreen = new(GridParams.Templates[GridScreenName.Crafting], _logger, _ct);
         gridScreen.OnAfterTurnToNewPage += GridScreen.DrawItemsAfterTurnToNewPage;
         gridScreen.OnBeforeScroll += () => VisionContext.Instance().DrawContent.ClearAll();
@@ -335,8 +335,8 @@ public class CraftMaterialTask
             {
                 using ImageRegion itemRegion = pageRegion.DeriveCrop(itemRect);
                 using Mat icon = itemRegion.SrcMat.GetGridIcon();
-                var candidate = itemRecognizer.Match(icon);
-                if (candidate.Score < 0.75 || candidate.Name != _materialName)
+                string? recognizedName = itemRecognizer.Recognize(icon);
+                if (recognizedName != _materialName)
                 {
                     continue;
                 }

--- a/BetterGenshinImpact/GameTask/Common/Job/ItemIconRecognizer.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/ItemIconRecognizer.cs
@@ -26,13 +26,31 @@ internal sealed record ItemIconCandidate(string Name, double Score, int QualityL
     public static readonly ItemIconCandidate Empty = new(string.Empty, double.MinValue, -1);
 }
 
-internal interface IItemIconRecognizer : IDisposable
+/// <summary>
+/// 物品图标识别器。实现类持有 ONNX 会话等重资源，
+/// 由 <see cref="ItemIconRecognizerFactory"/> 创建新实例，调用方负责用完 Dispose。
+/// </summary>
+public interface IItemIconRecognizer : IDisposable
 {
     string? Recognize(Mat icon);
 }
 
-internal static class ItemIconRecognizerFactory
+/// <summary>
+/// 物品图标识别器工厂。按指定模式创建识别器新实例。
+/// </summary>
+public static class ItemIconRecognizerFactory
 {
+    /// <summary>
+    /// 按当前全局设置（OtherConfig.ItemIconRecognitionMode）创建识别器。
+    /// </summary>
+    public static IItemIconRecognizer CreateConfigured()
+    {
+        return Create(TaskContext.Instance().Config.OtherConfig.ItemIconRecognitionMode);
+    }
+
+    /// <summary>
+    /// 创建指定模式的识别器新实例；调用方负责用完 Dispose。
+    /// </summary>
     public static IItemIconRecognizer Create(ItemIconRecognitionMode mode)
     {
         return mode switch
@@ -85,7 +103,7 @@ internal sealed class ItemRecognizer : IItemIconRecognizer
     /// <summary>
     /// 初始化物品图标模型和原型表。
     /// </summary>
-    internal ItemRecognizer()
+    public ItemRecognizer()
     {
         _session = new InferenceSession(Global.Absolute(@"Assets\Model\ItemV2\item.onnx"));
         _prototypes = LoadIconPrototypes();
@@ -97,7 +115,7 @@ internal sealed class ItemRecognizer : IItemIconRecognizer
     /// <param name="mat">125×125 的 BGR 图标图像。</param>
     /// <returns>最高分图标候选。</returns>
     /// <exception cref="ArgumentOutOfRangeException">图标尺寸不是 125×125。</exception>
-    internal ItemIconCandidate Match(Mat mat)
+    private ItemIconCandidate Match(Mat mat)
     {
         if (mat.Size().Width != InputSize || mat.Size().Height != InputSize)
         {
@@ -179,16 +197,34 @@ internal sealed class ItemRecognizer : IItemIconRecognizer
         };
         parser.SetDelimiters(",");
 
-        var headers = parser.ReadFields()!;
+        var headers = parser.ReadFields();
+        if (headers == null)
+        {
+            throw new InvalidDataException("ItemV2/item.csv 为空或缺少表头行。");
+        }
         int nameIndex = Array.FindIndex(headers, h => string.Equals(h?.Trim(), "item_name", StringComparison.OrdinalIgnoreCase));
         int itemClassIdIndex = Array.FindIndex(headers, h => string.Equals(h?.Trim(), "item_class_id", StringComparison.OrdinalIgnoreCase));
         int qualityLevelIndex = Array.FindIndex(headers, h => string.Equals(h?.Trim(), "quality_level", StringComparison.OrdinalIgnoreCase));
         int embeddingIndex = Array.FindIndex(headers, h => string.Equals(h?.Trim(), "embedding", StringComparison.OrdinalIgnoreCase));
 
+        if (nameIndex < 0 || itemClassIdIndex < 0 || qualityLevelIndex < 0 || embeddingIndex < 0)
+        {
+            throw new InvalidDataException("ItemV2/item.csv 缺少必要字段：item_name、item_class_id、quality_level 或 embedding。");
+        }
+
         List<IconPrototype> prototypes = [];
         while (!parser.EndOfData)
         {
-            var columns = parser.ReadFields()!;
+            var columns = parser.ReadFields();
+            if (columns == null)
+            {
+                continue;
+            }
+
+            if (columns.Length <= Math.Max(Math.Max(nameIndex, itemClassIdIndex), Math.Max(qualityLevelIndex, embeddingIndex)))
+            {
+                throw new InvalidDataException("ItemV2/item.csv 存在字段数量不足的数据行。");
+            }
             prototypes.Add(ParseIconPrototype(columns, nameIndex, itemClassIdIndex, qualityLevelIndex, embeddingIndex));
         }
 

--- a/BetterGenshinImpact/GameTask/Common/Reward/RewardResultRecognizer.cs
+++ b/BetterGenshinImpact/GameTask/Common/Reward/RewardResultRecognizer.cs
@@ -24,7 +24,6 @@ public class RewardResultRecognizer
     private static readonly Lazy<RewardResultRecognizer> _instance = new(() => new RewardResultRecognizer());
     public static RewardResultRecognizer Instance => _instance.Value;
 
-    private readonly ItemRecognizer _itemRecognizer;
     private readonly ILogger<RewardResultRecognizer> _logger = App.GetLogger<RewardResultRecognizer>();
     private static readonly Scalar RewardMaskLower = new(0, 0, 190);
     private static readonly Scalar RewardMaskUpper = new(179, 20, 249);
@@ -46,7 +45,6 @@ public class RewardResultRecognizer
 
     private RewardResultRecognizer()
     {
-        _itemRecognizer = new ItemRecognizer();
     }
 
     /// <summary>
@@ -66,6 +64,9 @@ public class RewardResultRecognizer
         // 上一页原始奖励，用于判断翻页后的重复卡片。
         List<RewardItem>? previousPageRewards = null;
 
+        // 整轮识别共用一个识别器实例，用完销毁，不常驻内存。
+        using IItemIconRecognizer iconRecognizer = ItemIconRecognizerFactory.CreateConfigured();
+
         for (int currentPage = 1; currentPage <= maxPages; currentPage++)
         {
             if (currentPage > 1)
@@ -74,7 +75,7 @@ public class RewardResultRecognizer
             }
 
             using var screen = CaptureRewardPageScreen();
-            var pageResult = RecognizeRewardPage(screen);
+            var pageResult = RecognizeRewardPage(screen, iconRecognizer);
             SaveRewardDebugImage(currentPage, screen.SrcMat, pageResult.CardRects);
 
             if (pageResult.Rewards.Count == 0)
@@ -139,12 +140,13 @@ public class RewardResultRecognizer
     /// 识别单页奖励截图。
     /// </summary>
     /// <param name="screen">当前页全屏截图。</param>
+    /// <param name="iconRecognizer">物品图标识别器。</param>
     /// <returns>本页奖励与卡片位置。</returns>
-    private RewardPageRecognitionResult RecognizeRewardPage(ImageRegion screen)
+    private RewardPageRecognitionResult RecognizeRewardPage(ImageRegion screen, IItemIconRecognizer iconRecognizer)
     {
         using var bandMat = new Mat(screen.SrcMat, new Rect(220, 444, 1480, 220));
         var cardRects = DetectCardRects(bandMat);
-        var recognizedRewards = RecognizeRewards(bandMat, cardRects);
+        var recognizedRewards = RecognizeRewards(bandMat, cardRects, iconRecognizer);
         return new RewardPageRecognitionResult(recognizedRewards, cardRects);
     }
 
@@ -319,8 +321,9 @@ public class RewardResultRecognizer
     /// </summary>
     /// <param name="bandMat">奖励条带。</param>
     /// <param name="cardRects">已定位的卡片矩形。</param>
+    /// <param name="iconRecognizer">物品图标识别器。</param>
     /// <param name="ocrService">OCR 服务，为空时使用 Paddle OCR。</param>
-    private List<RecognizedReward> RecognizeRewards(Mat bandMat, List<Rect> cardRects, IOcrService? ocrService = null)
+    private List<RecognizedReward> RecognizeRewards(Mat bandMat, List<Rect> cardRects, IItemIconRecognizer iconRecognizer, IOcrService? ocrService = null)
     {
         ocrService ??= OcrFactory.Paddle;
 
@@ -341,39 +344,40 @@ public class RewardResultRecognizer
             using var cardMat = new Mat(bandMat, cardRect);
 
             // === 图标识别===
-            var iconMatch = RecognizeIcon(cardMat, cardIdx);
-            if (iconMatch.Score < 0.75)
+            var iconName = RecognizeIcon(iconRecognizer, cardMat, cardIdx);
+            if (iconName == null)
             {
-                _logger.LogWarning("奖励识别：已跳过一个奖励图标，识别为={Name}，可信度={Score:F2}", iconMatch.Name, iconMatch.Score);
+                _logger.LogWarning("奖励识别：已跳过一个未识别的奖励图标");
                 continue;
             }
 
             // === 数量 OCR ===
             var count = RecognizeCountByOcr(cardMat, ocrService, cardIdx);
 
-            results.Add(new RecognizedReward(iconMatch.Name, count, iconMatch.QualityLevel));
+            results.Add(new RecognizedReward(iconName, count));
         }
 
         return results;
     }
 
     /// <summary>
-    /// 识别单张奖励卡片图标。
+    /// 识别单张奖励卡片图标的名称。
     /// </summary>
+    /// <param name="iconRecognizer">物品图标识别器。</param>
     /// <param name="cardMat">奖励卡片图像。</param>
     /// <param name="cardIdx">卡片序号。</param>
-    /// <returns>图标候选结果。</returns>
-    private ItemIconCandidate RecognizeIcon(Mat cardMat, int cardIdx)
+    /// <returns>奖励名称；未识别时返回 null。</returns>
+    private string? RecognizeIcon(IItemIconRecognizer iconRecognizer, Mat cardMat, int cardIdx)
     {
         try
         {
             using Mat icon = cardMat.GetGridIcon(); // 归一化为 125×125
-            return _itemRecognizer.Match(icon);
+            return iconRecognizer.Recognize(icon);
         }
         catch (Exception ex)
         {
             _logger.LogDebug(ex, "奖励识别：卡片 {CardIndex} 图标识别异常，已忽略", cardIdx);
-            return ItemIconCandidate.Empty;
+            return null;
         }
     }
 

--- a/BetterGenshinImpact/View/Pages/CommonSettingsPage.xaml
+++ b/BetterGenshinImpact/View/Pages/CommonSettingsPage.xaml
@@ -1770,6 +1770,28 @@
                               SelectedValuePath="Item1"
                               DisplayMemberPath="Item2" />
                 </Grid>
+                <Grid Margin="16,0,16,12">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <ui:TextBlock Grid.Row="0" Grid.Column="0" FontTypography="Body"
+                                  Text="图标识别模型" TextWrapping="Wrap" />
+                    <ui:TextBlock Grid.Row="1" Grid.Column="0"
+                                  Foreground="{ui:ThemeResource TextFillColorTertiaryBrush}"
+                                  Text="默认ItemV2且推荐，如果出现问题可尝试切换，GridIcon 在合成台与背包计数任务中识别不全"
+                                  TextWrapping="Wrap" />
+                    <ComboBox Grid.Row="0" Grid.RowSpan="2" Grid.Column="1"
+                              MinWidth="120" Margin="0,0,36,0"
+                              ItemsSource="{Binding ItemIconRecognitionModes}"
+                              SelectedValuePath="Key"
+                              DisplayMemberPath="Value"
+                              SelectedValue="{Binding Config.OtherConfig.ItemIconRecognitionMode, Mode=TwoWay}" />
+                </Grid>
                 <ui:CardExpander Margin="16,0,52,12"
                                  ContentPadding="0"
                                  Icon="{ui:SymbolIcon SquareHintSparkles24}">

--- a/BetterGenshinImpact/ViewModel/Pages/CommonSettingsPageViewModel.cs
+++ b/BetterGenshinImpact/ViewModel/Pages/CommonSettingsPageViewModel.cs
@@ -19,6 +19,7 @@ using BetterGenshinImpact.Core.Script;
 using BetterGenshinImpact.GameTask;
 using BetterGenshinImpact.GameTask.AutoTrackPath;
 using BetterGenshinImpact.GameTask.Common.Element.Assets;
+using BetterGenshinImpact.GameTask.Common.Job;
 using BetterGenshinImpact.GameTask.LogParse;
 using BetterGenshinImpact.Helpers;
 using BetterGenshinImpact.Helpers.Http;
@@ -67,6 +68,13 @@ public partial class CommonSettingsPageViewModel : ViewModel
         Tuple.Create(TimeSpan.FromHours(1), "欧服 UTC+01"),
         Tuple.Create(TimeSpan.FromHours(-5), "美服 UTC-05")
     ];
+
+    public IReadOnlyDictionary<ItemIconRecognitionMode, string> ItemIconRecognitionModes { get; } =
+        new Dictionary<ItemIconRecognitionMode, string>
+        {
+            [ItemIconRecognitionMode.Item] = "ItemV2",
+            [ItemIconRecognitionMode.GridIcon] = "GridIcon"
+        };
 
     public CommonSettingsPageViewModel(IConfigService configService, INavigationService navigationService,
         NotificationService notificationService, CustomHtmlMaskService customHtmlMaskService,

--- a/Test/BetterGenshinImpact.UnitTest/GameTaskTests/AutoFishingTests/BehavioursTests.ChooseBait.cs
+++ b/Test/BetterGenshinImpact.UnitTest/GameTaskTests/AutoFishingTests/BehavioursTests.ChooseBait.cs
@@ -30,7 +30,7 @@ namespace BetterGenshinImpact.UnitTest.GameTaskTests.AutoFishingTests
             FakeSystemInfo systemInfo = new FakeSystemInfo(new Vanara.PInvoke.RECT(0, 0, mat.Width, mat.Height), 1);
 
             //
-            ChooseBait sut = new ChooseBait("-", new FakeLogger(), systemInfo, new FakeInputSimulator(), this.session, this.prototypes, new Blackboard());
+            ChooseBait sut = new ChooseBait("-", new FakeLogger(), systemInfo, new FakeInputSimulator(), itemRecognizer, new Blackboard());
             var result = sut.FindBait(imageRegion).OrderBy(r => r.Item1.X).ToArray();
 
             //
@@ -67,7 +67,7 @@ namespace BetterGenshinImpact.UnitTest.GameTaskTests.AutoFishingTests
                     .Sequence("用例", false)
                         .SetSleep("设置sleep方法", _ => { })
                         .LeafWithBlackboard(bb => new ScreenshotQueue("用例", [imageRegion, imageRegion], bb!))
-                        .ChooseBait("-", new FakeLogger(), systemInfo, new FakeInputSimulator(), this.session, this.prototypes)
+                        .ChooseBait("-", new FakeLogger(), systemInfo, new FakeInputSimulator(), itemRecognizer)
                     .End()
                 .End()
                 .Build();
@@ -113,7 +113,7 @@ namespace BetterGenshinImpact.UnitTest.GameTaskTests.AutoFishingTests
                     .Sequence("用例", false)
                         .SetSleep("设置sleep方法", _ => { })
                         .LeafWithBlackboard(bb => new ScreenshotQueue("用例", [imageRegion, imageRegion, imageRegion], bb!))
-                        .ChooseBait("-", new FakeLogger(), systemInfo, new FakeInputSimulator(), this.session, this.prototypes, fakeTimeProvider)
+                        .ChooseBait("-", new FakeLogger(), systemInfo, new FakeInputSimulator(), itemRecognizer, fakeTimeProvider)
                     .End()
                 .End()
                 .Build();
@@ -179,7 +179,7 @@ namespace BetterGenshinImpact.UnitTest.GameTaskTests.AutoFishingTests
                     .Sequence("用例", false)
                         .SetSleep("设置sleep方法", _ => { })
                         .LeafWithBlackboard(bb => new ScreenshotQueue("用例", Enumerable.Repeat(imageRegion, 10), bb!))
-                        .ChooseBait("-", new FakeLogger(), systemInfo, new FakeInputSimulator(), this.session, this.prototypes, fakeTimeProvider)
+                        .ChooseBait("-", new FakeLogger(), systemInfo, new FakeInputSimulator(), itemRecognizer, fakeTimeProvider)
                     .End()
                 .End()
                 .Build();
@@ -299,7 +299,7 @@ namespace BetterGenshinImpact.UnitTest.GameTaskTests.AutoFishingTests
                     .Sequence("用例", false)
                         .SetSleep("设置sleep方法", _ => { })
                         .LeafWithBlackboard(bb => new ScreenshotQueue("用例", Enumerable.Repeat(imageRegion, 8), bb!))
-                        .ChooseBait("-", new FakeLogger(), systemInfo, new FakeInputSimulator(), this.session, this.prototypes, fakeTimeProvider)
+                        .ChooseBait("-", new FakeLogger(), systemInfo, new FakeInputSimulator(), itemRecognizer, fakeTimeProvider)
                     .End()
                 .End()
                 .Build();

--- a/Test/BetterGenshinImpact.UnitTest/GameTaskTests/AutoFishingTests/BehavioursTests.cs
+++ b/Test/BetterGenshinImpact.UnitTest/GameTaskTests/AutoFishingTests/BehavioursTests.cs
@@ -1,10 +1,10 @@
 using BetterGenshinImpact.Core.Recognition.OCR;
 using BetterGenshinImpact.Core.Recognition.ONNX;
 using BetterGenshinImpact.GameTask.AutoFishing;
+using BetterGenshinImpact.GameTask.Common.Job;
 using BetterGenshinImpact.UnitTest.CoreTests.RecognitionTests.OCRTests;
 using BetterGenshinImpact.UnitTest.GameTaskTests.GetGridIconsTests;
 using Microsoft.Extensions.Localization;
-using Microsoft.ML.OnnxRuntime;
 
 namespace BetterGenshinImpact.UnitTest.GameTaskTests.AutoFishingTests
 {
@@ -15,18 +15,16 @@ namespace BetterGenshinImpact.UnitTest.GameTaskTests.AutoFishingTests
         private static BgiYoloPredictor predictor;
 #pragma warning restore CS8618 // 在退出构造函数时，不可为 null 的字段必须包含非 null 值。请考虑添加 "required" 修饰符或声明为可为 null。
 
-        private readonly PaddleFixture paddle; 
+        private readonly PaddleFixture paddle;
         private readonly IStringLocalizer<AutoFishingTask> stringLocalizer;
-        private readonly InferenceSession session;
-        private readonly Dictionary<string, float[]> prototypes;
+        private static readonly Lazy<ItemRecognizer> itemRecognizerLazy = new(() => new ItemRecognizer());
+        private static ItemRecognizer itemRecognizer => itemRecognizerLazy.Value;
 
 
         public BehavioursTests(PaddleFixture paddle, TorchFixture torch, LocalizationFixture localization, GridIconModelFixture iconModel)
         {
             this.paddle = paddle;
             this.stringLocalizer = localization.CreateStringLocalizer<AutoFishingTask>();
-            this.session = iconModel.modelLoader.Value.session;
-            this.prototypes = iconModel.modelLoader.Value.prototypes;
         }
 
         private IOcrService OcrService => paddle.Get();


### PR DESCRIPTION
将默认使用的图标识别模型改为ItemV2，设置界面增加了切换选项。
切换鱼饵图标识别有点小问题，需要更新资源
因为临近游戏版本更新，资源准备等版本更新后再更新，这个PR先挂着

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 在“其他设置”中新增图标识别模型选项，支持在物品图标与网格图标模式间切换。
  - 物品计数、材料选择、钓鱼、自动进食、圣遗物筛选及奖励识别均支持使用所选识别模式。

- **改进**
  - 优化图标识别配置的统一管理与复用。
  - 增强识别数据读取时的格式校验，减少无效数据导致的问题。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->