### PR TITLE
feat: 自动识别item所属背包页,根据物品的顺序提前结束扫描计数

### DIFF
--- a/BetterGenshinImpact/Core/Script/Dependence/Dispatcher.cs
+++ b/BetterGenshinImpact/Core/Script/Dependence/Dispatcher.cs
@@ -280,31 +280,24 @@ public class Dispatcher
                     {
                         throw new NullReferenceException($"{nameof(soloTask.Config)}为空");
                     }
-                    GridScreenName gridScreenName = ScriptObjectConverter.GetValue((ScriptObject)soloTask.Config, "gridScreenName", (GridScreenName?)null) ?? throw new Exception("gridScreenName为空或错误");
-                    string? itemName = ScriptObjectConverter.GetValue((ScriptObject)soloTask.Config, "itemName", (string?)null);
+                    GridScreenName? gridScreenName = ScriptObjectConverter.GetValue((ScriptObject)soloTask.Config, "gridScreenName", (GridScreenName?)null);
+                    bool stopByItemSort = ScriptObjectConverter.GetValue((ScriptObject)soloTask.Config, "stopByItemSort", false);
                     IEnumerable<string>? itemNames = ScriptObjectConverter.GetValue<string>((ScriptObject)soloTask.Config, "itemNames");
                     CountInventoryItemParam param = new()
                     {
                         GridScreenName = gridScreenName,
-                        ItemName = itemName,
+                        StopByItemSort = stopByItemSort,
                         ItemNames = itemNames?.ToList() ?? []
                     };
 
                     var result = await new CountInventoryItem(param).Start(cancellationToken);
-                    if (param.ItemName != null)
+                    dynamic expando = new ExpandoObject();
+                    var expandoDict = (IDictionary<string, object>)expando;
+                    foreach (var kvp in (Dictionary<string, int>)result)
                     {
-                        return result;
+                        expandoDict[kvp.Key] = kvp.Value;
                     }
-                    else
-                    {
-                        dynamic expando = new ExpandoObject();
-                        var expandoDict = (IDictionary<string, object>)expando;
-                        foreach (var kvp in (Dictionary<string, int>)result)
-                        {
-                            expandoDict[kvp.Key] = kvp.Value;
-                        }
-                        return expandoDict;
-                    }
+                    return expandoDict;
                 }
             default:
                 throw new ArgumentException($"未知的任务名称: {soloTask.Name}", nameof(soloTask.Name));
@@ -441,7 +434,7 @@ public class Dispatcher
     /// </summary>
     /// <param name="param">背包物品计数参数。</param>
     /// <param name="customCt">自定义取消令牌。</param>
-    /// <returns>单物品返回数量；多物品返回名称到数量的脚本对象。</returns>
+    /// <returns>返回名称到数量的脚本对象。</returns>
     public async Task<object?> RunCountInventoryItemTask(CountInventoryItemParam param, CancellationToken? customCt = null)
     {
         if (param == null)
@@ -452,20 +445,13 @@ public class Dispatcher
         CancellationToken cancellationToken = customCt ?? CancellationContext.Instance.Cts.Token;
         object result = await new CountInventoryItem(param).Start(cancellationToken);
 
-        if (param.ItemName != null)
+        dynamic expando = new ExpandoObject();
+        var expandoDict = (IDictionary<string, object>)expando;
+        foreach (var kvp in (Dictionary<string, int>)result)
         {
-            return result;
+            expandoDict[kvp.Key] = kvp.Value;
         }
-        else
-        {
-            dynamic expando = new ExpandoObject();
-            var expandoDict = (IDictionary<string, object>)expando;
-            foreach (var kvp in (Dictionary<string, int>)result)
-            {
-                expandoDict[kvp.Key] = kvp.Value;
-            }
 
-            return expandoDict;
-        }
+        return expandoDict;
     }
 }

--- a/BetterGenshinImpact/GameTask/AutoArtifactSalvage/AutoArtifactSalvageTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoArtifactSalvage/AutoArtifactSalvageTask.cs
@@ -90,50 +90,7 @@ public class AutoArtifactSalvageTask : ISoloTask
 
     public static async Task OpenInventory(GridScreenName gridScreenName, InputSimulator input, ILogger logger, CancellationToken ct)
     {
-        RecognitionObject? recognitionObjectChecked;
-        RecognitionObject? recognitionObjectUnchecked;
-
-        switch (gridScreenName)
-        {
-            case GridScreenName.Weapons:
-                recognitionObjectChecked = ElementRecognition.Get("BagWeaponChecked");
-                recognitionObjectUnchecked = ElementRecognition.Get("BagWeaponUnchecked");
-                break;
-            case GridScreenName.Artifacts:
-                recognitionObjectChecked = ElementRecognition.Get("BagArtifactChecked");
-                recognitionObjectUnchecked = ElementRecognition.Get("BagArtifactUnchecked");
-                break;
-            case GridScreenName.CharacterDevelopmentItems:
-                recognitionObjectChecked = ElementRecognition.Get("BagCharacterDevelopmentItemChecked");
-                recognitionObjectUnchecked = ElementRecognition.Get("BagCharacterDevelopmentItemUnchecked");
-                break;
-            case GridScreenName.Food:
-                recognitionObjectChecked = ElementRecognition.Get("BagFoodChecked");
-                recognitionObjectUnchecked = ElementRecognition.Get("BagFoodUnchecked");
-                break;
-            case GridScreenName.Materials:
-                recognitionObjectChecked = ElementRecognition.Get("BagMaterialChecked");
-                recognitionObjectUnchecked = ElementRecognition.Get("BagMaterialUnchecked");
-                break;
-            case GridScreenName.Gadget:
-                recognitionObjectChecked = ElementRecognition.Get("BagGadgetChecked");
-                recognitionObjectUnchecked = ElementRecognition.Get("BagGadgetUnchecked");
-                break;
-            case GridScreenName.Quest:
-                recognitionObjectChecked = ElementRecognition.Get("BagQuestChecked");
-                recognitionObjectUnchecked = ElementRecognition.Get("BagQuestUnchecked");
-                break;
-            case GridScreenName.PreciousItems:
-                recognitionObjectChecked = ElementRecognition.Get("BagPreciousItemChecked");
-                recognitionObjectUnchecked = ElementRecognition.Get("BagPreciousItemUnchecked");
-                break;
-            case GridScreenName.Furnishings:
-                recognitionObjectChecked = ElementRecognition.Get("BagFurnishingChecked");
-                recognitionObjectUnchecked = ElementRecognition.Get("BagFurnishingUnchecked");
-                break;
-            default:
-                throw new NotSupportedException($"背包不支持的界面：{gridScreenName.GetDescription()}");
-        }
+        var (recognitionObjectChecked, recognitionObjectUnchecked) = GetTabRecognitionObjects(gridScreenName);
 
         // B键打开背包
         input.SimulateAction(GIActions.OpenInventory);
@@ -184,6 +141,81 @@ public class AutoArtifactSalvageTask : ISoloTask
         }
 
 
+        await Delay(800, ct);
+    }
+
+    /// <summary>
+    /// 取背包分类 tab 的选中/未选中元素识别对象。
+    /// </summary>
+    /// <param name="gridScreenName">目标背包分类。</param>
+    /// <returns>(选中元素, 未选中元素)。</returns>
+    /// <exception cref="NotSupportedException">不支持分类时抛出。</exception>
+    private static (RecognitionObject Checked, RecognitionObject Unchecked) GetTabRecognitionObjects(GridScreenName gridScreenName)
+    {
+        return gridScreenName switch
+        {
+            GridScreenName.Weapons => (ElementRecognition.Get("BagWeaponChecked"), ElementRecognition.Get("BagWeaponUnchecked")),
+            GridScreenName.Artifacts => (ElementRecognition.Get("BagArtifactChecked"), ElementRecognition.Get("BagArtifactUnchecked")),
+            GridScreenName.CharacterDevelopmentItems => (ElementRecognition.Get("BagCharacterDevelopmentItemChecked"), ElementRecognition.Get("BagCharacterDevelopmentItemUnchecked")),
+            GridScreenName.Food => (ElementRecognition.Get("BagFoodChecked"), ElementRecognition.Get("BagFoodUnchecked")),
+            GridScreenName.Materials => (ElementRecognition.Get("BagMaterialChecked"), ElementRecognition.Get("BagMaterialUnchecked")),
+            GridScreenName.Gadget => (ElementRecognition.Get("BagGadgetChecked"), ElementRecognition.Get("BagGadgetUnchecked")),
+            GridScreenName.Quest => (ElementRecognition.Get("BagQuestChecked"), ElementRecognition.Get("BagQuestUnchecked")),
+            GridScreenName.PreciousItems => (ElementRecognition.Get("BagPreciousItemChecked"), ElementRecognition.Get("BagPreciousItemUnchecked")),
+            GridScreenName.Furnishings => (ElementRecognition.Get("BagFurnishingChecked"), ElementRecognition.Get("BagFurnishingUnchecked")),
+            _ => throw new NotSupportedException($"背包不支持的界面：{gridScreenName.GetDescription()}")
+        };
+    }
+
+    /// <summary>
+    /// 在已打开的背包界面内，切换到目标分类 tab（不返回主界面）。
+    /// 已在目标 tab 则直接返回；否则点击未选中按钮并等待切换完成。
+    /// </summary>
+    /// <param name="targetTab">目标背包分类。</param>
+    /// <param name="input">输入模拟器。</param>
+    /// <param name="logger">日志记录器。</param>
+    /// <param name="ct">取消令牌。</param>
+    public static async Task SwitchInventoryTab(GridScreenName targetTab, InputSimulator input, ILogger logger, CancellationToken ct)
+    {
+        var (checkedObj, uncheckedObj) = GetTabRecognitionObjects(targetTab);
+
+        // 已在目标 tab 则直接返回
+        using (var ra0 = CaptureToRectArea())
+        using (var checkedBtn0 = ra0.Find(checkedObj))
+        {
+            if (checkedBtn0.IsExist())
+            {
+                return;
+            }
+        }
+
+        // 查找并点击未选中按钮
+        bool clicked = false;
+        for (int attempt = 0; attempt < 5; attempt++)
+        {
+            using var ra = CaptureToRectArea();
+            using var uncheckedBtn = ra.Find(uncheckedObj);
+            if (uncheckedBtn.IsExist())
+            {
+                uncheckedBtn.Click();
+                clicked = true;
+                break;
+            }
+            await Delay(300, ct);
+        }
+
+        if (!clicked)
+        {
+            logger.LogError("未找到背包中{name}菜单按钮,切换分类失败", targetTab.GetDescription());
+            return;
+        }
+
+        // 等待目标 tab 变为选中状态
+        var switched = await NewRetry.WaitForElementAppear(checkedObj, retryAction: null, ct, maxAttemptCount: 5, retryInterval: 500);
+        if (!switched)
+        {
+            logger.LogWarning("切换到{name}后未能确认已选中,继续尝试扫描", targetTab.GetDescription());
+        }
         await Delay(800, ct);
     }
 

--- a/BetterGenshinImpact/GameTask/Common/Job/CountInventoryItem.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/CountInventoryItem.cs
@@ -24,10 +24,10 @@ namespace BetterGenshinImpact.GameTask.Common.Job
         private readonly ILogger logger = App.GetLogger<CountInventoryItem>();
         private readonly InputSimulator input = Simulation.SendInput;
         private CancellationToken ct;
-        private readonly GridScreenName gridScreenName;
-        private readonly string? itemName;
-        private readonly IReadOnlyCollection<string>? itemNames;
+        private readonly GridScreenName? gridScreenName;
+        private readonly IReadOnlyCollection<string> itemNames;
         private readonly ItemIconRecognitionMode iconRecognitionMode;
+        private readonly bool stopByItemSort;
 
         public CountInventoryItem(CountInventoryItemParam param)
         {
@@ -39,46 +39,200 @@ namespace BetterGenshinImpact.GameTask.Common.Job
             param.Validate();
 
             this.gridScreenName = param.GridScreenName;
-            this.itemName = param.ItemName;
-            this.itemNames = param.GetItemNamesOrNull()?.ToList();
+            List<string> distinctItemNames = param.ItemNames.Distinct().ToList();
+            if (distinctItemNames.Count != param.ItemNames.Count)
+            {
+                logger.LogWarning("目标物品列表存在重复名称，已自动去重：{original} → {distinct}", param.ItemNames.Count, distinctItemNames.Count);
+            }
+            this.itemNames = distinctItemNames;
             this.iconRecognitionMode = param.IconRecognitionMode;
+            this.stopByItemSort = param.StopByItemSort;
         }
 
         public async Task<object> Start(CancellationToken ct)
         {
             this.ct = ct;
 
-            if (this.itemName != null)
-            {
-                logger.LogInformation("打开背包并在{grid}寻找{name}……", this.gridScreenName, this.itemName!);
-            }
-            else
-            {
-                logger.LogInformation("打开背包并在{grid}寻找{first}等{count}类物品……", this.gridScreenName, this.itemNames!.First(), this.itemNames!.Count());
-            }
-            await new ReturnMainUiTask().Start(ct);
-            await AutoArtifactSalvageTask.OpenInventory(this.gridScreenName, input, logger, this.ct);
-
+            //构造扫描批次
+            List<(GridScreenName Page, List<string> PageItemNames)> pageBatches = BuildPageBatches();
             using IItemIconRecognizer iconRecognizer = ItemIconRecognizerFactory.Create(this.iconRecognitionMode);
+            Dictionary<string, int> results = new();
+            await new ReturnMainUiTask().Start(ct);
 
-            object result;
-            if (this.itemName != null)
+            //逐页扫描
+            for (int i = 0; i < pageBatches.Count; i++)
             {
-                result = await FindOne(iconRecognizer);
-            }
-            else
-            {
-                result = await FindMulti(iconRecognizer);
+                var (page, pageItemNames) = pageBatches[i];
+
+                logger.LogInformation("在{page}寻找{first}等，共{count}类物品……", page, pageItemNames.First(), pageItemNames.Count);
+
+                if (i == 0)
+                {
+                    await AutoArtifactSalvageTask.OpenInventory(page, input, logger, this.ct);
+                }
+                else
+                {
+                    await AutoArtifactSalvageTask.SwitchInventoryTab(page, input, logger, this.ct);
+                }
+
+                await ScanPageForTargets(iconRecognizer, page, pageItemNames, results);
+
+                var pageNotFound = pageItemNames.Except(results.Keys).ToList();
+                if (pageNotFound.Count > 0)
+                {
+                    logger.LogInformation("在{page}没有找到{name}", page, string.Join(", ", pageNotFound));
+                }
+
             }
 
             await new ReturnMainUiTask().Start(ct);
-
-            return result;
+            return results;
         }
 
-        private GridParams CreateGridParams()
+        /// <summary>
+        /// 构造扫描批次：传入 gridScreenName 时直接构造单批次；未传入时自动按所在背包页分组。
+        /// </summary>
+        /// <returns>按背包页顺序排序的批次列表。</returns>
+        private List<(GridScreenName Page, List<string> PageItemNames)> BuildPageBatches()
         {
-            return GridParams.Templates[this.gridScreenName];
+
+            if (this.gridScreenName.HasValue)
+            {
+                return [(this.gridScreenName.Value, this.itemNames.ToList())];
+            }
+
+            // 未传入 gridScreenName 时，自动按所在背包页分组
+            var batchesByPage = new Dictionary<GridScreenName, List<string>>();
+            List<string> skipped = [];
+            foreach (string name in this.itemNames)
+            {
+                if (ItemMetadataCache.TryGetPage(name, out GridScreenName page))
+                {
+                    if (!batchesByPage.TryGetValue(page, out var list))
+                    {
+                        list = [];
+                        batchesByPage[page] = list;
+                    }
+                    list.Add(name);
+                }
+                else
+                {
+                    skipped.Add(name);
+                }
+            }
+
+            if (skipped.Count > 0)
+            {
+                throw new InvalidOperationException($"以下目标物品无法解析所在的背包页面: {string.Join(", ", skipped)}");
+            }
+
+            var pageBatches = new List<(GridScreenName Page, List<string> PageItemNames)>();
+            foreach (GridScreenName page in Enum.GetValues<GridScreenName>().OrderBy(p => (int)p))
+            {
+                if (batchesByPage.TryGetValue(page, out var list))
+                {
+                    pageBatches.Add((page, list));
+                }
+            }
+
+            if (pageBatches.Count == 0)
+            {
+                throw new InvalidOperationException("无法解析任何目标物品所在的背包页面");
+            }
+
+            return pageBatches;
+        }
+
+        /// <summary>
+        /// 扫描当前页的目标物品
+        /// </summary>
+        /// <param name="iconRecognizer">物品图标识别器。</param>
+        /// <param name="page">当前扫描页面。</param>
+        /// <param name="pageItemNames">本页目标物品名列表。</param>
+        /// <param name="results">累积结果字典。</param>
+        private async Task ScanPageForTargets(IItemIconRecognizer iconRecognizer, GridScreenName page, List<string> pageItemNames, Dictionary<string, int> results)
+        {
+            GridScreen gridScreen = new GridScreen(CreateGridParams(page), logger, ct);
+            gridScreen.OnAfterTurnToNewPage += GridScreen.DrawItemsAfterTurnToNewPage;
+            gridScreen.OnBeforeScroll += () => VisionContext.Instance().DrawContent.ClearAll();
+
+            // 本页尚未找到的目标物品
+            List<string> notFound = pageItemNames.Where(name => !results.ContainsKey(name)).ToList();
+
+            try
+            {
+                // 如果包含武器页的武器经验道具，直接翻页到最底部
+                bool hasOre = pageItemNames.Any(name => name.StartsWith("精锻用"));
+                if (page == GridScreenName.Weapons && hasOre)
+                {
+                    await PreScrollToBottomForWeaponOre();
+                }
+
+                int? maxSortOfItem = ComputeMaxSortOfItem(page, pageItemNames);
+
+                await foreach ((ImageRegion pageRegion, Rect itemRect) in gridScreen)
+                {
+                    using ImageRegion itemRegion = pageRegion.DeriveCrop(itemRect);
+                    string? predName = RecognizeItemName(itemRegion, iconRecognizer);
+                    if (predName == null)
+                    {
+                        continue;
+                    }
+
+                    // 背包物品顺序固定；遍历到排序晚于目标的条目仍未找到目标，即可提前退出扫描。
+                    if (maxSortOfItem.HasValue
+                        && ItemMetadataCache.TryGetSortOrder(predName, out int predSort)
+                        && predSort > maxSortOfItem.Value)
+                    {
+                        logger.LogInformation("识别到 {name} 页有物品排序 (sort_order={sort}) 超过阈值 {threshold}，提前结束 {page} 扫描", predName, predSort, maxSortOfItem.Value, page);
+                        break;
+                    }
+
+                    if (pageItemNames.Contains(predName) && !results.ContainsKey(predName))
+                    {
+                        int count = ReadItemCount(itemRegion);
+                        results.TryAdd(predName, count);
+                        notFound.RemoveAll(n => n == predName);
+
+                        if (notFound.Count == 0)
+                        {
+                            break;
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                VisionContext.Instance().DrawContent.ClearAll();
+            }
+        }
+
+        private int? ComputeMaxSortOfItem(GridScreenName page, List<string> pageItemNames)
+        {
+            if (!this.stopByItemSort)
+            {
+                return null;
+            }
+
+            int maxSort = int.MinValue;
+            foreach (string pageItemName in pageItemNames)
+            {
+                if (!ItemMetadataCache.TryGetSortOrder(pageItemName, out int sort))
+                {
+                    logger.LogWarning("无法获取目标物品 {name} 在 {page} 的排序值，不启用按物品顺序提前结束扫描", pageItemName, page);
+                    return null;
+                }
+                if (sort > maxSort)
+                {
+                    maxSort = sort;
+                }
+            }
+            return maxSort;
+        }
+
+        private GridParams CreateGridParams(GridScreenName page)
+        {
+            return GridParams.Templates[page];
         }
 
         private async Task PreScrollToBottomForWeaponOre()
@@ -94,109 +248,11 @@ namespace BetterGenshinImpact.GameTask.Common.Job
             {
                 GlobalMethod.LeftButtonUp();
             }
-            var gridScroller = new GridScroller(CreateGridParams(), logger, input, ct);
+            var gridScroller = new GridScroller(GridParams.Templates[GridScreenName.Weapons], logger, input, ct);
             while (await gridScroller.TryVerticalScollDown((src, columns) => GridScreen.GridEnumerator.GetGridItems(src, columns)))
             {
                 await TaskControl.Delay(300, ct);
             }
-        }
-
-        private async Task<int> FindOne(IItemIconRecognizer iconRecognizer)
-        {
-            GridScreen gridScreen = new GridScreen(CreateGridParams(), logger, ct);
-            gridScreen.OnAfterTurnToNewPage += GridScreen.DrawItemsAfterTurnToNewPage;
-            gridScreen.OnBeforeScroll += () => VisionContext.Instance().DrawContent.ClearAll();
-            int? count = null;
-            try
-            {
-                //如果是武器页的武器经验道具，直接翻页到最底部
-                if (gridScreenName == GridScreenName.Weapons && itemName!.StartsWith("精锻用"))
-                {
-                    await PreScrollToBottomForWeaponOre();
-                }
-                
-                //开始识别
-                await foreach ((ImageRegion pageRegion, Rect itemRect) in gridScreen)
-                {
-                    using ImageRegion itemRegion = pageRegion.DeriveCrop(itemRect);
-                    string? predName = RecognizeItemName(itemRegion, iconRecognizer);
-                    if (predName == null)
-                    {
-                        continue;
-                    }
-
-                    if (predName == this.itemName!)
-                    {
-                        count = ReadItemCount(itemRegion);
-                        break;
-                    }
-                }
-            }
-            finally
-            {
-                VisionContext.Instance().DrawContent.ClearAll();
-            }
-            if (count == null)
-            {
-                count = -1;
-                logger.LogInformation("没有找到{name}", this.itemName!);
-            }
-            return count.Value;
-        }
-
-        private async Task<Dictionary<string, int>> FindMulti(IItemIconRecognizer iconRecognizer)
-        {
-            Dictionary<string, int> itemsCountDic = new Dictionary<string, int>();
-            List<string> notFoundItemNames = this.itemNames!.ToList();
-
-            GridScreen gridScreen = new GridScreen(CreateGridParams(), logger, ct);
-            gridScreen.OnAfterTurnToNewPage += GridScreen.DrawItemsAfterTurnToNewPage;
-            gridScreen.OnBeforeScroll += () => VisionContext.Instance().DrawContent.ClearAll();
-            try
-            {
-                //如果包含武器页的武器经验道具，直接翻页到最底部
-                bool hasOre = itemNames!.Any(name => name.StartsWith("精锻用"));
-                if (gridScreenName == GridScreenName.Weapons && hasOre)
-                {
-                    await PreScrollToBottomForWeaponOre();
-                }
-                await foreach ((ImageRegion pageRegion, Rect itemRect) in gridScreen)
-                {
-                    using ImageRegion itemRegion = pageRegion.DeriveCrop(itemRect);
-                    string? predName = RecognizeItemName(itemRegion, iconRecognizer);
-                    if (predName == null)
-                    {
-                        continue;
-                    }
-
-                    if (this.itemNames!.Contains(predName) && !itemsCountDic!.ContainsKey(predName))
-                    {
-                        int count = ReadItemCount(itemRegion);
-
-                        if (!itemsCountDic!.TryAdd(predName, count))
-                        {
-                            logger.LogWarning("重复的名称：{name}", predName);
-                        }
-
-                        notFoundItemNames.RemoveAll(n => n == predName);
-
-                        if (notFoundItemNames.Count <= 0)
-                        {
-                            break;
-                        }
-                    }
-                }
-            }
-            finally
-            {
-                VisionContext.Instance().DrawContent.ClearAll();
-            }
-
-            if (notFoundItemNames.Count > 0)
-            {
-                logger.LogInformation("没有找到{name}", String.Join(", ", notFoundItemNames));
-            }
-            return itemsCountDic;
         }
 
         private static string? RecognizeItemName(ImageRegion itemRegion, IItemIconRecognizer iconRecognizer)

--- a/BetterGenshinImpact/GameTask/Common/Job/CountInventoryItemParam.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/CountInventoryItemParam.cs
@@ -7,16 +7,21 @@ namespace BetterGenshinImpact.GameTask.Common.Job;
 
 /// <summary>
 /// 背包物品计数任务参数。
+/// <para><see cref="GridScreenName"/> 可选：传入时按指定页面扫描；为 null 时按 item.csv 的 page 自动分组多页扫描。</para>
+/// <para><see cref="StopByItemSort"/> 默认 false；显式置 true 时，若当前页所有目标物品都有有效 sort_order，则按目标最大 sort_order 提前结束本页扫描。</para>
 /// </summary>
 public class CountInventoryItemParam
 {
-    public GridScreenName GridScreenName { get; set; }
-
-    public string? ItemName { get; set; }
+    public GridScreenName? GridScreenName { get; set; }
 
     public List<string> ItemNames { get; set; } = [];
 
     public ItemIconRecognitionMode IconRecognitionMode { get; set; } = ItemIconRecognitionMode.GridIcon;
+
+    /// <summary>
+    /// 是否启用按物品排序提前停止；默认 false。详见类注释。
+    /// </summary>
+    public bool StopByItemSort { get; set; }
 
     /// <summary>
     /// 供脚本创建后逐项赋值；参数校验在任务消费参数时执行。
@@ -25,29 +30,14 @@ public class CountInventoryItemParam
     {
     }
 
-    public IEnumerable<string>? GetItemNamesOrNull()
-    {
-        return ItemNames.Count > 0 ? ItemNames : null;
-    }
-
     public void Validate()
     {
         ItemNames ??= [];
-        bool hasItemName = !string.IsNullOrWhiteSpace(ItemName);
         bool hasItemNames = ItemNames.Count > 0;
-        if (!hasItemName)
-        {
-            ItemName = null;
-        }
 
-        if (hasItemName && hasItemNames)
+        if (!hasItemNames)
         {
-            throw new ArgumentException($"参数{nameof(ItemName)}和{nameof(ItemNames)}不能同时使用");
-        }
-
-        if (!hasItemName && !hasItemNames)
-        {
-            throw new ArgumentException($"参数{nameof(ItemName)}和{nameof(ItemNames)}不能同时为空");
+            throw new ArgumentException($"参数{nameof(ItemNames)}不能为空");
         }
 
         if (ItemNames.Any(string.IsNullOrWhiteSpace))

--- a/BetterGenshinImpact/GameTask/Common/Job/CraftMaterialTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/CraftMaterialTask.cs
@@ -185,7 +185,7 @@ public class CraftMaterialTask
             return materialType;
         }
 
-        throw new InvalidOperationException($"未找到材料 {_materialName} 的材料类型，请传入 materialType 或检查 item.csv。");
+        throw new InvalidOperationException($"未找到材料 {_materialName} 的材料类型，请传入 materialType 或检查物品数据。");
     }
 
     /// <summary>

--- a/BetterGenshinImpact/GameTask/Common/Job/ItemMetadataCache.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/ItemMetadataCache.cs
@@ -1,0 +1,121 @@
+using BetterGenshinImpact.Core.Config;
+using BetterGenshinImpact.GameTask.Model.GameUI;
+using BetterGenshinImpact.Helpers.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualBasic.FileIO;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace BetterGenshinImpact.GameTask.Common.Job;
+
+/// <summary>
+/// item.csv 元数据缓存：按物品名反查背包页面与页内排序。
+/// 加载失败时返回空缓存，不影响既有任务。
+/// </summary>
+public static class ItemMetadataCache
+{
+    private record struct ItemEntry(GridScreenName Page, int? SortOrder);
+    private static readonly ILogger _logger = App.GetLogger<LoggerMarker>();
+    private static readonly Dictionary<string, ItemEntry> _entries = LoadEntriesOrEmpty();
+
+    /// <summary>
+    /// 仅用于日志分类的占位类型
+    /// </summary>
+    private sealed class LoggerMarker { }
+
+    /// <summary>
+    /// 查物品所属背包页面。
+    /// </summary>
+    /// <param name="itemName">物品名称。</param>
+    /// <param name="page">命中的背包页面。</param>
+    /// <returns>命中返回 true；否则 false。</returns>
+    public static bool TryGetPage(string itemName, out GridScreenName page)
+    {
+        if (_entries.TryGetValue(itemName, out var entry))
+        {
+            page = entry.Page;
+            return true;
+        }
+        page = default;
+        return false;
+    }
+
+    /// <summary>
+    /// 查物品页内排序；空/无效返回 false。
+    /// </summary>
+    /// <param name="itemName">物品名称。</param>
+    /// <param name="sortOrder">命中的页内排序。</param>
+    /// <returns>命中且有效返回 true；否则 false。</returns>
+    public static bool TryGetSortOrder(string itemName, out int sortOrder)
+    {
+        if (_entries.TryGetValue(itemName, out var entry) && entry.SortOrder.HasValue)
+        {
+            sortOrder = entry.SortOrder.Value;
+            return true;
+        }
+        sortOrder = 0;
+        return false;
+    }
+
+    /// <summary>
+    /// 容错加载：异常时记日志并返回空字典，避免影响进程启动。
+    /// </summary>
+    /// <returns>物品元数据字典。</returns>
+    private static Dictionary<string, ItemEntry> LoadEntriesOrEmpty()
+    {
+        try
+        {
+            return LoadEntries();
+        }
+        catch (Exception e)
+        {
+            _logger.LogWarning(e, "加载物品元数据失败，将无法按物品名解析背包页面与排序");
+            return new Dictionary<string, ItemEntry>();
+        }
+    }
+
+    /// <summary>
+    /// 读取 Assets/Model/ItemV2/item.csv，按 item_name 缓存 page 与 sort_order。
+    /// </summary>
+    /// <returns>物品元数据字典。</returns>
+    private static Dictionary<string, ItemEntry> LoadEntries()
+    {
+        var dict = new Dictionary<string, ItemEntry>();
+        using var parser = new TextFieldParser(Global.Absolute(@"Assets\Model\ItemV2\item.csv"), Encoding.UTF8)
+        {
+            TextFieldType = FieldType.Delimited,
+            HasFieldsEnclosedInQuotes = true,
+            TrimWhiteSpace = false
+        };
+        parser.SetDelimiters(",");
+
+        var headers = parser.ReadFields()!;
+        int nameIndex = Array.FindIndex(headers, h => string.Equals(h?.Trim(), "item_name", StringComparison.OrdinalIgnoreCase));
+        int pageIndex = Array.FindIndex(headers, h => string.Equals(h?.Trim(), "page", StringComparison.OrdinalIgnoreCase));
+        int sortOrderIndex = Array.FindIndex(headers, h => string.Equals(h?.Trim(), "sort_order", StringComparison.OrdinalIgnoreCase));
+
+        while (!parser.EndOfData)
+        {
+            var columns = parser.ReadFields()!;
+            string name = columns[nameIndex].Trim();
+            string pageStr = columns[pageIndex].Trim();
+            string sortStr = columns[sortOrderIndex].Trim();
+
+            if (!pageStr.TryGetEnumValueFromDescription(out GridScreenName? pageNullable) || pageNullable == null)
+            {
+                continue;
+            }
+
+            GridScreenName page = pageNullable.Value;
+            int? sortOrder = null;
+            if (!string.IsNullOrEmpty(sortStr) && int.TryParse(sortStr, out int parsed))
+            {
+                sortOrder = parsed;
+            }
+
+            dict[name] = new ItemEntry(page, sortOrder);
+        }
+        return dict;
+    }
+}


### PR DESCRIPTION
引入了破坏性更改，移除了CountInventoryItem的itemName，现在仅能使用itemNames，我看脚本仓库也没人在用了。
背包页名称gridScreenName参数改为可选，没有传入时自动查找。
现在可以不传入背包页名称的情况下，一次调用 查找不同页的item，减少打开关闭背包界面的次数。
因为item在背包页的排序是固定的，当扫描过对应顺序的位置没找到item时，允许提前结束背包计数。

需要资源文件中的两个新数据列
因为临近游戏版本更新，资源准备等版本更新后再更新，这个PR先挂着

```js
//使用示例，log输出内容有点小瑕疵
async function main() {
    const itemNames = [
        "精锻用杂矿",
        "蒙德土豆饼",
        "铁块",
        "迁风的苍翎"
    ];
    const param = new CountInventoryItemParam();
    param.StopByItemSort = true; //根据item的排序，提前结束背包计数
    param.IconRecognitionMode = ItemIconRecognitionMode.Item; 
    for (const itemName of itemNames) {
        param.ItemNames.Add(itemName);
    }

    const result = await dispatcher.runCountInventoryItemTask(param);
    const inventory = Object.fromEntries(Object.entries(result || {}));
    log.info("Inventory :{t}", inventory);
}

(async () => {
    try {
        await main();
    } catch (error) {
        log.error("Error:{t}", error);
    }
})();
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 库存物品统计支持跨多个背包分类批量扫描，并自动按物品所属分类处理。
  - 支持按物品排序提前结束扫描，减少不必要的查找。
  - 支持在背包页面间自动切换，统计结果统一以物品名称和数量返回。

- **变更**
  - 统计任务改为使用物品名称列表，不再支持单独的 `itemName` 参数；背包分类现可选填。

- **错误修复**
  - 优化材料类型无法识别时的提示文本。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->