### PR TITLE
fix: 修复复活恢复后未重试当前路径段

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
@@ -249,6 +249,10 @@ public class Avatar
             new TpTask(ct).TpToStatueOfTheSeven().WaitAsync(ct).GetAwaiter().GetResult();
             Logger.LogInformation("血量恢复完成。【设置】-【七天神像设置】可以修改回血相关配置。");
         }
+        catch (NormalEndException)
+        {
+            throw;
+        }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
             throw;

--- a/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
+++ b/BetterGenshinImpact/GameTask/AutoFight/Model/Avatar.cs
@@ -239,15 +239,27 @@ public class Avatar
     /// tp 到七天神像恢复
     /// </summary>
     /// <param name="ct"></param>
-    /// <param name="ex"></param>
+    /// <param name="retryException"></param>
     /// <exception cref="RetryException"></exception>
-    public static void TpForRecover(CancellationToken ct, Exception ex)
+    public static void TpForRecover(CancellationToken ct, RetryException retryException)
     {
-        // tp 到七天神像复活
-        var tpTask = new TpTask(ct);
-        tpTask.TpToStatueOfTheSeven().Wait(ct);
-        Logger.LogInformation("血量恢复完成。【设置】-【七天神像设置】可以修改回血相关配置。");
-        throw ex;
+        try
+        {
+            // tp 到七天神像复活。保留等待取消能力，同时避免 Wait 将原异常包装为 AggregateException。
+            new TpTask(ct).TpToStatueOfTheSeven().WaitAsync(ct).GetAwaiter().GetResult();
+            Logger.LogInformation("血量恢复完成。【设置】-【七天神像设置】可以修改回血相关配置。");
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // 一旦进入恢复流程，就不能返回原战斗循环；否则会从七天神像向旧战斗点执行回点。
+            Logger.LogWarning(ex, "前往七天神像恢复时发生异常，将重试当前任务");
+        }
+
+        throw retryException;
     }
 
     /// <summary>


### PR DESCRIPTION
## 问题原因

战斗中检测到复活后，`TpForRecover` 使用 `Task.Wait(CancellationToken)` 同步等待七天神像恢复任务。当恢复任务抛出异常时，异常会被包装为 `AggregateException`，导致上层无法识别 `RetryException`，JSON 战斗循环可能继续执行，并从七天神像向原战斗点回跑。

## 修改内容

- 使用 `WaitAsync(ct).GetAwaiter().GetResult()` 保留取消能力并避免异常包装。
- 保留外部取消异常的原始传播行为。
- 恢复流程发生其他异常时记录原因，并继续抛出调用方提供的 `RetryException`，确保当前任务进入重试而不是返回原战斗循环。
- 将重试参数类型从 `Exception` 收窄为 `RetryException`。

## 验证

- `dotnet build BetterGenshinImpact.sln -c Debug`
- 构建结果：0 个错误；存在主线已有警告。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug 修复**
  - 修复自动战斗传送恢复过程中正常结束异常可能被通用异常处理逻辑吞掉的问题。
  - 取消操作现可正常保留并向上层传递；其他异常的记录及重试处理行为保持不变。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->