### PR TITLE
fix: 解决用户拖动过角色筛选界面后，识别不到筛选控件的问题

### DIFF
--- a/BetterGenshinImpact/GameTask/Common/Job/SwitchCharacterStateMachineTask.cs
+++ b/BetterGenshinImpact/GameTask/Common/Job/SwitchCharacterStateMachineTask.cs
@@ -762,6 +762,11 @@ public sealed class SwitchCharacterStateMachineTask : StateMachineBase<SwitchCha
 
         if (!TryClickText(page, _pendingFilterElementType, GetElementFilterOptionsRoi()))
         {
+            // 点击滚动条使筛选界面滚动到最上方，解决用户拖动过筛选界面后，程序识别不到筛选控件的问题
+            if (CurrentStateRetryCount == 0)
+            { 
+                GameCaptureRegion.GameRegion1080PPosClick(796, 125);
+            }
             _logger.LogWarning("切换角色：未找到元素筛选项 {Text}", _pendingFilterElementType);
             return Task.FromResult(StateHandlerResult.Retry);
         }
@@ -786,6 +791,11 @@ public sealed class SwitchCharacterStateMachineTask : StateMachineBase<SwitchCha
 
         if (!TryClickText(page, _pendingFilterWeaponType, GetWeaponFilterOptionsRoi()))
         {
+            // 点击滚动条使筛选界面滚动到最上方，解决用户拖动过筛选界面后，程序识别不到筛选控件的问题
+            if (CurrentStateRetryCount == 0)
+            { 
+                GameCaptureRegion.GameRegion1080PPosClick(796, 125);
+            }
             _logger.LogWarning("切换角色：未找到武器筛选项 {Text}", _pendingFilterWeaponType);
             return Task.FromResult(StateHandlerResult.Retry);
         }


### PR DESCRIPTION
如果用户拖动过角色筛选界面（滚动条没有位于顶部），`switchCharacter`功能在筛选时会找不到筛选控件的位置，从而无法完成角色切换
<img width="1908" height="1044" alt="image" src="https://github.com/user-attachments/assets/5079895b-813d-4edd-81ab-61f18166d1fc" />

此PR会点击滚动条使筛选界面滚动到最上方，以修复此问题。修复后效果预览如下视频

https://github.com/user-attachments/assets/e4379fc3-c960-430c-aacf-4d792904be79



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **问题修复**
  * 优化元素筛选和武器筛选失败后的重试流程。
  * 重试时会将筛选界面滚动到顶部，提升程序在用户手动滚动筛选界面后的识别成功率。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->