### PR TITLE
fix(auto-pick): preserve English OCR interaction labels

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoPick/AutoPickTrigger.cs
+++ b/BetterGenshinImpact/GameTask/AutoPick/AutoPickTrigger.cs
@@ -8,6 +8,7 @@ using BetterGenshinImpact.GameTask.AutoPick.Assets;
 using BetterGenshinImpact.Helpers;
 using BetterGenshinImpact.Service;
 using BetterGenshinImpact.View.Windows;
+using System.Buffers;
 using Microsoft.Extensions.Logging;
 using OpenCvSharp;
 using System;
@@ -15,6 +16,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -559,18 +561,26 @@ public partial class AutoPickTrigger : ITaskTrigger
         while (start <= end)
         {
             char c = span[start];
-            if (c == '「' || char.IsLetterOrDigit(c)) // 引号或字母/数字
+            if (c == '「') // 引号
                 break;
-            start++;
+
+            if (IsLetterOrDigitAt(span, start, out var charsConsumed)) // 字母/数字
+                break;
+
+            start += charsConsumed;
         }
 
         // 2. 从右边开始，删除非文本字符
         while (end >= start)
         {
             char c = span[end];
-            if (c == '」' || c == '！' || c == '!' || char.IsLetterOrDigit(c)) // 引号、感叹号或字母/数字
+            if (c == '」' || c == '！' || c == '!') // 引号、感叹号
                 break;
-            end--;
+
+            if (IsLetterOrDigitAtEnd(span, end, out var charsConsumed)) // 字母/数字
+                break;
+
+            end -= charsConsumed;
         }
 
         // 如果所有字符都被删除了
@@ -608,5 +618,29 @@ public partial class AutoPickTrigger : ITaskTrigger
         }
 
         return cleanedSpan.ToString();
+    }
+
+    private static bool IsLetterOrDigitAt(ReadOnlySpan<char> span, int index, out int charsConsumed)
+    {
+        var status = Rune.DecodeFromUtf16(span[index..], out var rune, out charsConsumed);
+        if (status != OperationStatus.Done)
+        {
+            charsConsumed = Math.Max(charsConsumed, 1);
+            return false;
+        }
+
+        return Rune.IsLetterOrDigit(rune);
+    }
+
+    private static bool IsLetterOrDigitAtEnd(ReadOnlySpan<char> span, int end, out int charsConsumed)
+    {
+        var status = Rune.DecodeLastFromUtf16(span[..(end + 1)], out var rune, out charsConsumed);
+        if (status != OperationStatus.Done)
+        {
+            charsConsumed = Math.Max(charsConsumed, 1);
+            return false;
+        }
+
+        return Rune.IsLetterOrDigit(rune);
     }
 }

--- a/BetterGenshinImpact/GameTask/AutoPick/AutoPickTrigger.cs
+++ b/BetterGenshinImpact/GameTask/AutoPick/AutoPickTrigger.cs
@@ -504,13 +504,13 @@ public partial class AutoPickTrigger : ITaskTrigger
     /// <summary>
     /// 高性能处理OCR识别的文字结果
     /// 1. 替换【、[ 为「，替换】、] 为」
-    /// 2. 清理左边非「字符和中文的字符
-    /// 3. 清理右边非」字符和中文的字符  
+    /// 2. 清理左边非文本字符
+    /// 3. 清理右边非文本字符
     /// 4. 确保引号配对：有「必有」，有」必有「
     /// </summary>
     /// <param name="text">OCR识别的原始文字</param>
     /// <returns>处理后的文字</returns>
-    private static string ProcessOcrText(string text)
+    internal static string ProcessOcrText(string text)
     {
         if (string.IsNullOrEmpty(text))
             return text;
@@ -555,20 +555,20 @@ public partial class AutoPickTrigger : ITaskTrigger
         int start = 0;
         int end = span.Length - 1;
 
-        // 1. 从左边开始，删除非「字符和中文的字符
+        // 1. 从左边开始，删除非文本字符
         while (start <= end)
         {
             char c = span[start];
-            if (c == '「' || (c >= 0x4E00 && c <= 0x9FFF)) // 「字符或中文字符
+            if (c == '「' || char.IsLetterOrDigit(c)) // 引号或字母/数字
                 break;
             start++;
         }
 
-        // 2. 从右边开始，删除非」字符和中文的字符
+        // 2. 从右边开始，删除非文本字符
         while (end >= start)
         {
             char c = span[end];
-            if (c == '」' || c == '！' || (c >= 0x4E00 && c <= 0x9FFF)) // 」字符或中文字符
+            if (c == '」' || c == '！' || c == '!' || char.IsLetterOrDigit(c)) // 引号、感叹号或字母/数字
                 break;
             end--;
         }

--- a/Test/BetterGenshinImpact.UnitTest/GameTaskTests/AutoPickTriggerTests.cs
+++ b/Test/BetterGenshinImpact.UnitTest/GameTaskTests/AutoPickTriggerTests.cs
@@ -9,6 +9,14 @@ public class AutoPickTriggerTests
     [InlineData("  Mint  ", "Mint")]
     [InlineData("[Mint]", "「Mint」")]
     [InlineData("「Mint」", "「Mint」")]
+    [InlineData("Mint!", "Mint!")]
+    [InlineData("[Mint!]", "「Mint!」")]
+    [InlineData("𝒜Mint", "𝒜Mint")]
+    [InlineData("Mint𝒜", "Mint𝒜")]
+    [InlineData("𝒜", "𝒜")]
+    [InlineData("𝟙Mint", "𝟙Mint")]
+    [InlineData("Mint𝟙", "Mint𝟙")]
+    [InlineData("𝟙", "𝟙")]
     public void ProcessOcrText_PreservesEnglishInteractionText(string input, string expected)
     {
         Assert.Equal(expected, AutoPickTrigger.ProcessOcrText(input));

--- a/Test/BetterGenshinImpact.UnitTest/GameTaskTests/AutoPickTriggerTests.cs
+++ b/Test/BetterGenshinImpact.UnitTest/GameTaskTests/AutoPickTriggerTests.cs
@@ -1,0 +1,16 @@
+using BetterGenshinImpact.GameTask.AutoPick;
+
+namespace BetterGenshinImpact.UnitTest.GameTaskTests;
+
+public class AutoPickTriggerTests
+{
+    [Theory]
+    [InlineData("Mint", "Mint")]
+    [InlineData("  Mint  ", "Mint")]
+    [InlineData("[Mint]", "「Mint」")]
+    [InlineData("「Mint」", "「Mint」")]
+    public void ProcessOcrText_PreservesEnglishInteractionText(string input, string expected)
+    {
+        Assert.Equal(expected, AutoPickTrigger.ProcessOcrText(input));
+    }
+}


### PR DESCRIPTION
## Summary

The Auto Pickup OCR post-processing only treated CJK characters as valid text. As a result, Latin interaction labels such as `Mint` were trimmed to an empty string and could not trigger the configured pickup key.

This change:

- preserves Unicode letters and digits during OCR text trimming;
- keeps the existing bracket normalization and blacklist/icon safety flow unchanged;
- adds unit coverage for English labels and bracketed OCR output.

## Validation

- `dotnet restore .\BetterGenshinImpact.sln -p:Platform=x64`
- `dotnet test .\Test\BetterGenshinImpact.UnitTest\BetterGenshinImpact.UnitTest.csproj -c Debug -p:Platform=x64 --no-restore --filter FullyQualifiedName~AutoPickTriggerTests`
- Result: 4 passed

No Genshin Impact files or client protections are modified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 优化自动拾取文本识别，提升对英文、数字及补充平面 Unicode 字符的保留能力。
  * 改进文本清理，支持去除两侧空白，并规范方括号为中文引号，同时保留已有引号和英文感叹号。

* **测试**
  * 新增自动拾取文本处理测试，覆盖空白清理、括号转换、引号保留及特殊 Unicode 字符处理。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->