### PR TITLE
fix(ui): 修复按钮样式覆盖导致前景色出错

### DIFF
--- a/BetterGenshinImpact/View/Controls/Style/ListViewEx.xaml
+++ b/BetterGenshinImpact/View/Controls/Style/ListViewEx.xaml
@@ -1,9 +1,5 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:ui="http://schemas.lepo.co/wpfui/2022/xaml">
-    <ResourceDictionary.MergedDictionaries>
-        <ui:ControlsDictionary />
-    </ResourceDictionary.MergedDictionaries>
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Style x:Key="GridViewColumnHeaderDarkStyle" TargetType="{x:Type GridViewColumnHeader}">
         <Setter Property="Template">
             <Setter.Value>


### PR DESCRIPTION
可恶的WPF，bug都不知道修

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **修复**
  - 清理列表视图样式中的无效界面资源引用。
  - 保持其余控件样式不变，避免影响现有界面显示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->