### PR TITLE
fix: 退出钓鱼模式改用主界面识别判定，解决无F提示场景

### DIFF
--- a/BetterGenshinImpact/GameTask/AutoFishing/AutoFishingTask.cs
+++ b/BetterGenshinImpact/GameTask/AutoFishing/AutoFishingTask.cs
@@ -126,7 +126,7 @@ namespace BetterGenshinImpact.GameTask.AutoFishing
                                             .End()
                                         .End()
                                     .Finally()
-                                        .QuitFishingMode("退出钓鱼模式", _logger, input, param.GameCultureInfo, param.StringLocalizer)
+                                        .QuitFishingMode("退出钓鱼模式", _logger, input)
                                     .End()
                                 .End()
                                 .WholeProcessTimeout("检查整体超时", _logger, param.WholeProcessTimeoutSeconds)

--- a/BetterGenshinImpact/GameTask/AutoFishing/AutoFishingTaskCatalog.cs
+++ b/BetterGenshinImpact/GameTask/AutoFishing/AutoFishingTaskCatalog.cs
@@ -169,8 +169,6 @@ namespace BetterGenshinImpact.GameTask.AutoFishing
             string name,
             ILogger logger,
             IInputSimulator input,
-            Blackboard blackboard,
-            CultureInfo? cultureInfo = null,
-            IStringLocalizer? stringLocalizer = null) => new QuitFishingMode(name, logger, input, blackboard, cultureInfo, stringLocalizer);
+            Blackboard blackboard) => new QuitFishingMode(name, logger, input, blackboard);
     }
 }

--- a/BetterGenshinImpact/GameTask/AutoFishing/Behaviours.PartII.cs
+++ b/BetterGenshinImpact/GameTask/AutoFishing/Behaviours.PartII.cs
@@ -307,7 +307,6 @@ namespace BetterGenshinImpact.GameTask.AutoFishing
     {
         private readonly ILogger _logger;
         private readonly IInputSimulator _input;
-        private readonly string _fishingLocalizedString;
 
         [BlackboardKey(Access = Access.Read)]
         public BehaviourKeyAccess<ImageRegion> Screenshot { get; private set; } = null!;
@@ -318,11 +317,10 @@ namespace BetterGenshinImpact.GameTask.AutoFishing
         [BlackboardKey(Access = Access.Read)]
         public BehaviourKeyAccess<int> HandoffTimeSeconds { get; private set; } = null!;
 
-        private QuitFishingMode(string name, ILogger logger, IInputSimulator input, CultureInfo? cultureInfo = null, IStringLocalizer? stringLocalizer = null) : base(name)
+        private QuitFishingMode(string name, ILogger logger, IInputSimulator input) : base(name)
         {
             _logger = logger;
             _input = input;
-            _fishingLocalizedString = stringLocalizer == null ? "钓鱼" : stringLocalizer.WithCultureGet(cultureInfo, "钓鱼");
         }
 
         protected async override Task<Status> Update()
@@ -339,9 +337,9 @@ namespace BetterGenshinImpact.GameTask.AutoFishing
                 return Status.Running;
             }
 
-            if (Bv.FindF(imageRegion, _fishingLocalizedString))
+            if (Bv.IsInMainUi(imageRegion))
             {
-                _logger.LogInformation("退出完成");
+                _logger.LogInformation("已在主界面，退出完成");
                 return Status.Success;
             }
 


### PR DESCRIPTION
fix #3641
这样从状态上来说也更正确，退出钓鱼模式时，目标并不是要找F键，F键只是进入时要找的